### PR TITLE
Generate field comparisons directly

### DIFF
--- a/crates/libs/bindgen/src/structs.rs
+++ b/crates/libs/bindgen/src/structs.rs
@@ -136,35 +136,15 @@ fn gen_windows_traits(gen: &Gen, def: TypeDef, name: &TokenStream, cfg: &Cfg) ->
 fn gen_compare_traits(gen: &Gen, def: TypeDef, name: &TokenStream, cfg: &Cfg) -> TokenStream {
     let features = gen.cfg_features(cfg);
 
-    if gen.sys {
+    if gen.sys || gen.reader.type_def_has_explicit_layout(def) || gen.reader.type_def_has_packing(def) || gen.reader.type_def_has_callback(def) {
         quote! {}
-    } else if gen.reader.type_def_is_blittable(def) || gen.reader.type_def_flags(def).explicit_layout() || gen.reader.type_def_class_layout(def).is_some() {
-        quote! {
-            #features
-            impl ::core::cmp::PartialEq for #name {
-                fn eq(&self, other: &Self) -> bool {
-                    unsafe {
-                        ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<#name>()) == 0
-                    }
-                }
-            }
-            #features
-            impl ::core::cmp::Eq for #name {}
-        }
     } else {
-        let fields = gen.reader.type_def_fields(def).map(|f| {
+        let fields = gen.reader.type_def_fields(def).filter_map(|f| {
             let name = to_ident(gen.reader.field_name(f));
             if gen.reader.field_flags(f).literal() {
-                quote! {}
+                None
             } else {
-                let ty = gen.reader.field_type(f, Some(def));
-                if gen.reader.type_is_callback(&ty) {
-                    quote! {
-                        self.#name.map(|f| f as usize) == other.#name.map(|f| f as usize)
-                    }
-                } else {
-                    quote! { self.#name == other.#name }
-                }
+                Some(quote! { self.#name == other.#name })
             }
         });
 
@@ -188,19 +168,17 @@ fn gen_debug(gen: &Gen, def: TypeDef, ident: &TokenStream, cfg: &Cfg) -> TokenSt
         let name = ident.as_str();
         let features = gen.cfg_features(cfg);
 
-        let fields = gen.reader.type_def_fields(def).map(|f| {
+        let fields = gen.reader.type_def_fields(def).filter_map(|f| {
             if gen.reader.field_flags(f).literal() {
-                quote! {}
+                None
             } else {
                 let name = gen.reader.field_name(f);
                 let ident = to_ident(name);
                 let ty = gen.reader.field_type(f, Some(def));
-                if !ty.is_pointer() && gen.reader.type_is_callback(&ty) {
-                    quote! { .field(#name, &self.#ident.map(|f| f as usize)) }
-                } else if gen.reader.type_is_callback_array(&ty) {
-                    quote! {}
+                if gen.reader.type_has_callback(&ty) {
+                    None
                 } else {
-                    quote! { .field(#name, &self.#ident) }
+                    Some(quote! { .field(#name, &self.#ident) })
                 }
             }
         });

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
@@ -2368,7 +2368,7 @@ unsafe impl ::windows::core::RuntimeType for ResourceLayoutInfo {
 }
 impl ::core::cmp::PartialEq for ResourceLayoutInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ResourceLayoutInfo>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.ResourceSubtreeCount == other.ResourceSubtreeCount && self.NamedResourceCount == other.NamedResourceCount && self.Checksum == other.Checksum
     }
 }
 impl ::core::cmp::Eq for ResourceLayoutInfo {}

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -4511,7 +4511,7 @@ unsafe impl ::windows::core::RuntimeType for PackageInstallProgress {
 }
 impl ::core::cmp::PartialEq for PackageInstallProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PackageInstallProgress>()) == 0 }
+        self.PercentComplete == other.PercentComplete
     }
 }
 impl ::core::cmp::Eq for PackageInstallProgress {}
@@ -4551,7 +4551,7 @@ unsafe impl ::windows::core::RuntimeType for PackageVersion {
 }
 impl ::core::cmp::PartialEq for PackageVersion {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PackageVersion>()) == 0 }
+        self.Major == other.Major && self.Minor == other.Minor && self.Build == other.Build && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for PackageVersion {}

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -1470,7 +1470,7 @@ unsafe impl ::windows::core::RuntimeType for TextSegment {
 }
 impl ::core::cmp::PartialEq for TextSegment {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TextSegment>()) == 0 }
+        self.StartPosition == other.StartPosition && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for TextSegment {}

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -3893,7 +3893,7 @@ unsafe impl ::windows::core::RuntimeType for DisplayPresentationRate {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for DisplayPresentationRate {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DisplayPresentationRate>()) == 0 }
+        self.VerticalSyncRate == other.VerticalSyncRate && self.VerticalSyncsPerPresentation == other.VerticalSyncsPerPresentation
     }
 }
 #[cfg(feature = "Foundation_Numerics")]

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
@@ -2553,7 +2553,7 @@ unsafe impl ::windows::core::RuntimeType for BasicGeoposition {
 }
 impl ::core::cmp::PartialEq for BasicGeoposition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BasicGeoposition>()) == 0 }
+        self.Latitude == other.Latitude && self.Longitude == other.Longitude && self.Altitude == other.Altitude
     }
 }
 impl ::core::cmp::Eq for BasicGeoposition {}

--- a/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
@@ -1049,7 +1049,7 @@ unsafe impl ::windows::core::RuntimeType for GpioChangeCount {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for GpioChangeCount {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GpioChangeCount>()) == 0 }
+        self.Count == other.Count && self.RelativeTime == other.RelativeTime
     }
 }
 #[cfg(feature = "Foundation")]
@@ -1096,7 +1096,7 @@ unsafe impl ::windows::core::RuntimeType for GpioChangeRecord {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for GpioChangeRecord {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GpioChangeRecord>()) == 0 }
+        self.RelativeTime == other.RelativeTime && self.Edge == other.Edge
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
@@ -439,7 +439,7 @@ unsafe impl ::windows::core::RuntimeType for ProviderI2cTransferResult {
 }
 impl ::core::cmp::PartialEq for ProviderI2cTransferResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ProviderI2cTransferResult>()) == 0 }
+        self.Status == other.Status && self.BytesTransferred == other.BytesTransferred
     }
 }
 impl ::core::cmp::Eq for ProviderI2cTransferResult {}

--- a/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
@@ -593,7 +593,7 @@ unsafe impl ::windows::core::RuntimeType for I2cTransferResult {
 }
 impl ::core::cmp::PartialEq for I2cTransferResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<I2cTransferResult>()) == 0 }
+        self.Status == other.Status && self.BytesTransferred == other.BytesTransferred
     }
 }
 impl ::core::cmp::Eq for I2cTransferResult {}

--- a/crates/libs/windows/src/Windows/Devices/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/mod.rs
@@ -1364,7 +1364,7 @@ unsafe impl ::windows::core::RuntimeType for MouseDelta {
 }
 impl ::core::cmp::PartialEq for MouseDelta {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MouseDelta>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for MouseDelta {}
@@ -1408,7 +1408,7 @@ unsafe impl ::windows::core::RuntimeType for PointerDeviceUsage {
 }
 impl ::core::cmp::PartialEq for PointerDeviceUsage {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PointerDeviceUsage>()) == 0 }
+        self.UsagePage == other.UsagePage && self.Usage == other.Usage && self.MinLogical == other.MinLogical && self.MaxLogical == other.MaxLogical && self.MinPhysical == other.MinPhysical && self.MaxPhysical == other.MaxPhysical && self.Unit == other.Unit && self.PhysicalMultiplier == other.PhysicalMultiplier
     }
 }
 impl ::core::cmp::Eq for PointerDeviceUsage {}

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -13513,7 +13513,7 @@ unsafe impl ::windows::core::RuntimeType for SizeUInt32 {
 }
 impl ::core::cmp::PartialEq for SizeUInt32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SizeUInt32>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for SizeUInt32 {}

--- a/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
@@ -1713,7 +1713,7 @@ unsafe impl ::windows::core::RuntimeType for ImageScannerResolution {
 }
 impl ::core::cmp::PartialEq for ImageScannerResolution {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ImageScannerResolution>()) == 0 }
+        self.DpiX == other.DpiX && self.DpiY == other.DpiY
     }
 }
 impl ::core::cmp::Eq for ImageScannerResolution {}

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -5446,7 +5446,7 @@ unsafe impl ::windows::core::RuntimeType for SmsEncodedLength {
 }
 impl ::core::cmp::PartialEq for SmsEncodedLength {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SmsEncodedLength>()) == 0 }
+        self.SegmentCount == other.SegmentCount && self.CharacterCountLastSegment == other.CharacterCountLastSegment && self.CharactersPerSegment == other.CharactersPerSegment && self.ByteCountLastSegment == other.ByteCountLastSegment && self.BytesPerSegment == other.BytesPerSegment
     }
 }
 impl ::core::cmp::Eq for SmsEncodedLength {}

--- a/crates/libs/windows/src/Windows/Foundation/Numerics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Numerics/mod.rs
@@ -31,7 +31,7 @@ unsafe impl ::windows::core::RuntimeType for Matrix3x2 {
 }
 impl ::core::cmp::PartialEq for Matrix3x2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Matrix3x2>()) == 0 }
+        self.M11 == other.M11 && self.M12 == other.M12 && self.M21 == other.M21 && self.M22 == other.M22 && self.M31 == other.M31 && self.M32 == other.M32
     }
 }
 impl ::core::cmp::Eq for Matrix3x2 {}
@@ -221,7 +221,7 @@ unsafe impl ::windows::core::RuntimeType for Matrix4x4 {
 }
 impl ::core::cmp::PartialEq for Matrix4x4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Matrix4x4>()) == 0 }
+        self.M11 == other.M11 && self.M12 == other.M12 && self.M13 == other.M13 && self.M14 == other.M14 && self.M21 == other.M21 && self.M22 == other.M22 && self.M23 == other.M23 && self.M24 == other.M24 && self.M31 == other.M31 && self.M32 == other.M32 && self.M33 == other.M33 && self.M34 == other.M34 && self.M41 == other.M41 && self.M42 == other.M42 && self.M43 == other.M43 && self.M44 == other.M44
     }
 }
 impl ::core::cmp::Eq for Matrix4x4 {}
@@ -493,7 +493,7 @@ unsafe impl ::windows::core::RuntimeType for Plane {
 }
 impl ::core::cmp::PartialEq for Plane {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Plane>()) == 0 }
+        self.Normal == other.Normal && self.D == other.D
     }
 }
 impl ::core::cmp::Eq for Plane {}
@@ -533,7 +533,7 @@ unsafe impl ::windows::core::RuntimeType for Quaternion {
 }
 impl ::core::cmp::PartialEq for Quaternion {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Quaternion>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.W == other.W
     }
 }
 impl ::core::cmp::Eq for Quaternion {}
@@ -571,7 +571,7 @@ unsafe impl ::windows::core::RuntimeType for Rational {
 }
 impl ::core::cmp::PartialEq for Rational {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Rational>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for Rational {}
@@ -609,7 +609,7 @@ unsafe impl ::windows::core::RuntimeType for Vector2 {
 }
 impl ::core::cmp::PartialEq for Vector2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Vector2>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for Vector2 {}
@@ -821,7 +821,7 @@ unsafe impl ::windows::core::RuntimeType for Vector3 {
 }
 impl ::core::cmp::PartialEq for Vector3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Vector3>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z
     }
 }
 impl ::core::cmp::Eq for Vector3 {}
@@ -1037,7 +1037,7 @@ unsafe impl ::windows::core::RuntimeType for Vector4 {
 }
 impl ::core::cmp::PartialEq for Vector4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Vector4>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.W == other.W
     }
 }
 impl ::core::cmp::Eq for Vector4 {}

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -3342,7 +3342,7 @@ unsafe impl ::windows::core::RuntimeType for DateTime {
 }
 impl ::core::cmp::PartialEq for DateTime {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DateTime>()) == 0 }
+        self.UniversalTime == other.UniversalTime
     }
 }
 impl ::core::cmp::Eq for DateTime {}
@@ -3379,7 +3379,7 @@ unsafe impl ::windows::core::RuntimeType for EventRegistrationToken {
 }
 impl ::core::cmp::PartialEq for EventRegistrationToken {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EventRegistrationToken>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for EventRegistrationToken {}
@@ -3417,7 +3417,7 @@ unsafe impl ::windows::core::RuntimeType for Point {
 }
 impl ::core::cmp::PartialEq for Point {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Point>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for Point {}
@@ -3457,7 +3457,7 @@ unsafe impl ::windows::core::RuntimeType for Rect {
 }
 impl ::core::cmp::PartialEq for Rect {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Rect>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for Rect {}
@@ -3495,7 +3495,7 @@ unsafe impl ::windows::core::RuntimeType for Size {
 }
 impl ::core::cmp::PartialEq for Size {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Size>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for Size {}
@@ -3532,7 +3532,7 @@ unsafe impl ::windows::core::RuntimeType for TimeSpan {
 }
 impl ::core::cmp::PartialEq for TimeSpan {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimeSpan>()) == 0 }
+        self.Duration == other.Duration
     }
 }
 impl ::core::cmp::Eq for TimeSpan {}

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
@@ -1144,7 +1144,7 @@ unsafe impl ::windows::core::RuntimeType for GameControllerVersionInfo {
 }
 impl ::core::cmp::PartialEq for GameControllerVersionInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GameControllerVersionInfo>()) == 0 }
+        self.Major == other.Major && self.Minor == other.Minor && self.Build == other.Build && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for GameControllerVersionInfo {}
@@ -1182,7 +1182,7 @@ unsafe impl ::windows::core::RuntimeType for GipFirmwareUpdateProgress {
 }
 impl ::core::cmp::PartialEq for GipFirmwareUpdateProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GipFirmwareUpdateProgress>()) == 0 }
+        self.PercentCompleted == other.PercentCompleted && self.CurrentComponentId == other.CurrentComponentId
     }
 }
 impl ::core::cmp::Eq for GipFirmwareUpdateProgress {}

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -2829,7 +2829,7 @@ unsafe impl ::windows::core::RuntimeType for ArcadeStickReading {
 }
 impl ::core::cmp::PartialEq for ArcadeStickReading {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ArcadeStickReading>()) == 0 }
+        self.Timestamp == other.Timestamp && self.Buttons == other.Buttons
     }
 }
 impl ::core::cmp::Eq for ArcadeStickReading {}
@@ -2872,7 +2872,7 @@ unsafe impl ::windows::core::RuntimeType for FlightStickReading {
 }
 impl ::core::cmp::PartialEq for FlightStickReading {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FlightStickReading>()) == 0 }
+        self.Timestamp == other.Timestamp && self.Buttons == other.Buttons && self.HatSwitch == other.HatSwitch && self.Roll == other.Roll && self.Pitch == other.Pitch && self.Yaw == other.Yaw && self.Throttle == other.Throttle
     }
 }
 impl ::core::cmp::Eq for FlightStickReading {}
@@ -2916,7 +2916,7 @@ unsafe impl ::windows::core::RuntimeType for GamepadReading {
 }
 impl ::core::cmp::PartialEq for GamepadReading {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GamepadReading>()) == 0 }
+        self.Timestamp == other.Timestamp && self.Buttons == other.Buttons && self.LeftTrigger == other.LeftTrigger && self.RightTrigger == other.RightTrigger && self.LeftThumbstickX == other.LeftThumbstickX && self.LeftThumbstickY == other.LeftThumbstickY && self.RightThumbstickX == other.RightThumbstickX && self.RightThumbstickY == other.RightThumbstickY
     }
 }
 impl ::core::cmp::Eq for GamepadReading {}
@@ -2956,7 +2956,7 @@ unsafe impl ::windows::core::RuntimeType for GamepadVibration {
 }
 impl ::core::cmp::PartialEq for GamepadVibration {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GamepadVibration>()) == 0 }
+        self.LeftMotor == other.LeftMotor && self.RightMotor == other.RightMotor && self.LeftTrigger == other.LeftTrigger && self.RightTrigger == other.RightTrigger
     }
 }
 impl ::core::cmp::Eq for GamepadVibration {}
@@ -3000,7 +3000,7 @@ unsafe impl ::windows::core::RuntimeType for RacingWheelReading {
 }
 impl ::core::cmp::PartialEq for RacingWheelReading {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RacingWheelReading>()) == 0 }
+        self.Timestamp == other.Timestamp && self.Buttons == other.Buttons && self.PatternShifterGear == other.PatternShifterGear && self.Wheel == other.Wheel && self.Throttle == other.Throttle && self.Brake == other.Brake && self.Clutch == other.Clutch && self.Handbrake == other.Handbrake
     }
 }
 impl ::core::cmp::Eq for RacingWheelReading {}
@@ -3039,7 +3039,7 @@ unsafe impl ::windows::core::RuntimeType for UINavigationReading {
 }
 impl ::core::cmp::PartialEq for UINavigationReading {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UINavigationReading>()) == 0 }
+        self.Timestamp == other.Timestamp && self.RequiredButtons == other.RequiredButtons && self.OptionalButtons == other.OptionalButtons
     }
 }
 impl ::core::cmp::Eq for UINavigationReading {}

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
@@ -282,7 +282,7 @@ unsafe impl ::windows::core::RuntimeType for Direct3DMultisampleDescription {
 }
 impl ::core::cmp::PartialEq for Direct3DMultisampleDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Direct3DMultisampleDescription>()) == 0 }
+        self.Count == other.Count && self.Quality == other.Quality
     }
 }
 impl ::core::cmp::Eq for Direct3DMultisampleDescription {}
@@ -322,7 +322,7 @@ unsafe impl ::windows::core::RuntimeType for Direct3DSurfaceDescription {
 }
 impl ::core::cmp::PartialEq for Direct3DSurfaceDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Direct3DSurfaceDescription>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format && self.MultisampleDescription == other.MultisampleDescription
     }
 }
 impl ::core::cmp::Eq for Direct3DSurfaceDescription {}

--- a/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
@@ -498,7 +498,7 @@ unsafe impl ::windows::core::RuntimeType for HdmiDisplayHdr2086Metadata {
 }
 impl ::core::cmp::PartialEq for HdmiDisplayHdr2086Metadata {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HdmiDisplayHdr2086Metadata>()) == 0 }
+        self.RedPrimaryX == other.RedPrimaryX && self.RedPrimaryY == other.RedPrimaryY && self.GreenPrimaryX == other.GreenPrimaryX && self.GreenPrimaryY == other.GreenPrimaryY && self.BluePrimaryX == other.BluePrimaryX && self.BluePrimaryY == other.BluePrimaryY && self.WhitePointX == other.WhitePointX && self.WhitePointY == other.WhitePointY && self.MaxMasteringLuminance == other.MaxMasteringLuminance && self.MinMasteringLuminance == other.MinMasteringLuminance && self.MaxContentLightLevel == other.MaxContentLightLevel && self.MaxFrameAverageLightLevel == other.MaxFrameAverageLightLevel
     }
 }
 impl ::core::cmp::Eq for HdmiDisplayHdr2086Metadata {}

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -2022,7 +2022,7 @@ unsafe impl ::windows::core::RuntimeType for NitRange {
 }
 impl ::core::cmp::PartialEq for NitRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NitRange>()) == 0 }
+        self.MinNits == other.MinNits && self.MaxNits == other.MaxNits && self.StepSizeNits == other.StepSizeNits
     }
 }
 impl ::core::cmp::Eq for NitRange {}

--- a/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
@@ -2950,7 +2950,7 @@ unsafe impl ::windows::core::RuntimeType for HolographicAdapterId {
 }
 impl ::core::cmp::PartialEq for HolographicAdapterId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HolographicAdapterId>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for HolographicAdapterId {}
@@ -2987,7 +2987,7 @@ unsafe impl ::windows::core::RuntimeType for HolographicFrameId {
 }
 impl ::core::cmp::PartialEq for HolographicFrameId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HolographicFrameId>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for HolographicFrameId {}
@@ -3032,7 +3032,7 @@ unsafe impl ::windows::core::RuntimeType for HolographicStereoTransform {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for HolographicStereoTransform {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HolographicStereoTransform>()) == 0 }
+        self.Left == other.Left && self.Right == other.Right
     }
 }
 #[cfg(feature = "Foundation_Numerics")]

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
@@ -3318,7 +3318,7 @@ unsafe impl ::windows::core::RuntimeType for BitmapBounds {
 }
 impl ::core::cmp::PartialEq for BitmapBounds {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BitmapBounds>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for BitmapBounds {}
@@ -3358,7 +3358,7 @@ unsafe impl ::windows::core::RuntimeType for BitmapPlaneDescription {
 }
 impl ::core::cmp::PartialEq for BitmapPlaneDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BitmapPlaneDescription>()) == 0 }
+        self.StartIndex == other.StartIndex && self.Width == other.Width && self.Height == other.Height && self.Stride == other.Stride
     }
 }
 impl ::core::cmp::Eq for BitmapPlaneDescription {}
@@ -3396,7 +3396,7 @@ unsafe impl ::windows::core::RuntimeType for BitmapSize {
 }
 impl ::core::cmp::PartialEq for BitmapSize {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BitmapSize>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for BitmapSize {}

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -2738,7 +2738,7 @@ unsafe impl ::windows::core::RuntimeType for PrintPageDescription {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for PrintPageDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintPageDescription>()) == 0 }
+        self.PageSize == other.PageSize && self.ImageableRect == other.ImageableRect && self.DpiX == other.DpiX && self.DpiY == other.DpiY
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -3483,7 +3483,7 @@ unsafe impl ::windows::core::RuntimeType for Printing3DBufferDescription {
 }
 impl ::core::cmp::PartialEq for Printing3DBufferDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Printing3DBufferDescription>()) == 0 }
+        self.Format == other.Format && self.Stride == other.Stride
     }
 }
 impl ::core::cmp::Eq for Printing3DBufferDescription {}

--- a/crates/libs/windows/src/Windows/Graphics/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/mod.rs
@@ -82,7 +82,7 @@ unsafe impl ::windows::core::RuntimeType for DisplayAdapterId {
 }
 impl ::core::cmp::PartialEq for DisplayAdapterId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DisplayAdapterId>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for DisplayAdapterId {}
@@ -119,7 +119,7 @@ unsafe impl ::windows::core::RuntimeType for DisplayId {
 }
 impl ::core::cmp::PartialEq for DisplayId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DisplayId>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DisplayId {}
@@ -157,7 +157,7 @@ unsafe impl ::windows::core::RuntimeType for PointInt32 {
 }
 impl ::core::cmp::PartialEq for PointInt32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PointInt32>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for PointInt32 {}
@@ -197,7 +197,7 @@ unsafe impl ::windows::core::RuntimeType for RectInt32 {
 }
 impl ::core::cmp::PartialEq for RectInt32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RectInt32>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for RectInt32 {}
@@ -235,7 +235,7 @@ unsafe impl ::windows::core::RuntimeType for SizeInt32 {
 }
 impl ::core::cmp::PartialEq for SizeInt32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SizeInt32>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for SizeInt32 {}

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -4363,7 +4363,7 @@ unsafe impl ::windows::core::RuntimeType for DeploymentProgress {
 }
 impl ::core::cmp::PartialEq for DeploymentProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DeploymentProgress>()) == 0 }
+        self.state == other.state && self.percentage == other.percentage
     }
 }
 impl ::core::cmp::Eq for DeploymentProgress {}

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -12182,7 +12182,7 @@ unsafe impl ::windows::core::RuntimeType for WhiteBalanceGain {
 }
 impl ::core::cmp::PartialEq for WhiteBalanceGain {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WhiteBalanceGain>()) == 0 }
+        self.R == other.R && self.G == other.G && self.B == other.B
     }
 }
 impl ::core::cmp::Eq for WhiteBalanceGain {}

--- a/crates/libs/windows/src/Windows/Media/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/mod.rs
@@ -11665,7 +11665,7 @@ unsafe impl ::windows::core::RuntimeType for MseTimeRange {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for MseTimeRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MseTimeRange>()) == 0 }
+        self.Start == other.Start && self.End == other.End
     }
 }
 #[cfg(feature = "Foundation")]
@@ -11705,7 +11705,7 @@ unsafe impl ::windows::core::RuntimeType for TimedTextDouble {
 }
 impl ::core::cmp::PartialEq for TimedTextDouble {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimedTextDouble>()) == 0 }
+        self.Value == other.Value && self.Unit == other.Unit
     }
 }
 impl ::core::cmp::Eq for TimedTextDouble {}
@@ -11746,7 +11746,7 @@ unsafe impl ::windows::core::RuntimeType for TimedTextPadding {
 }
 impl ::core::cmp::PartialEq for TimedTextPadding {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimedTextPadding>()) == 0 }
+        self.Before == other.Before && self.After == other.After && self.Start == other.Start && self.End == other.End && self.Unit == other.Unit
     }
 }
 impl ::core::cmp::Eq for TimedTextPadding {}
@@ -11785,7 +11785,7 @@ unsafe impl ::windows::core::RuntimeType for TimedTextPoint {
 }
 impl ::core::cmp::PartialEq for TimedTextPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimedTextPoint>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Unit == other.Unit
     }
 }
 impl ::core::cmp::Eq for TimedTextPoint {}
@@ -11824,7 +11824,7 @@ unsafe impl ::windows::core::RuntimeType for TimedTextSize {
 }
 impl ::core::cmp::PartialEq for TimedTextSize {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimedTextSize>()) == 0 }
+        self.Height == other.Height && self.Width == other.Width && self.Unit == other.Unit
     }
 }
 impl ::core::cmp::Eq for TimedTextSize {}

--- a/crates/libs/windows/src/Windows/Media/Import/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Import/mod.rs
@@ -2443,7 +2443,7 @@ unsafe impl ::windows::core::RuntimeType for PhotoImportProgress {
 }
 impl ::core::cmp::PartialEq for PhotoImportProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PhotoImportProgress>()) == 0 }
+        self.ItemsImported == other.ItemsImported && self.TotalItemsToImport == other.TotalItemsToImport && self.BytesImported == other.BytesImported && self.TotalBytesToImport == other.TotalBytesToImport && self.ImportProgress == other.ImportProgress
     }
 }
 impl ::core::cmp::Eq for PhotoImportProgress {}

--- a/crates/libs/windows/src/Windows/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/mod.rs
@@ -4077,7 +4077,7 @@ unsafe impl ::windows::core::RuntimeType for MediaTimeRange {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for MediaTimeRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MediaTimeRange>()) == 0 }
+        self.Start == other.Start && self.End == other.End
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
@@ -2981,7 +2981,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundDownloadProgress {
 }
 impl ::core::cmp::PartialEq for BackgroundDownloadProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BackgroundDownloadProgress>()) == 0 }
+        self.BytesReceived == other.BytesReceived && self.TotalBytesToReceive == other.TotalBytesToReceive && self.Status == other.Status && self.HasResponseChanged == other.HasResponseChanged && self.HasRestarted == other.HasRestarted
     }
 }
 impl ::core::cmp::Eq for BackgroundDownloadProgress {}
@@ -3019,7 +3019,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundTransferFileRange {
 }
 impl ::core::cmp::PartialEq for BackgroundTransferFileRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BackgroundTransferFileRange>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for BackgroundTransferFileRange {}
@@ -3062,7 +3062,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundUploadProgress {
 }
 impl ::core::cmp::PartialEq for BackgroundUploadProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BackgroundUploadProgress>()) == 0 }
+        self.BytesReceived == other.BytesReceived && self.BytesSent == other.BytesSent && self.TotalBytesToReceive == other.TotalBytesToReceive && self.TotalBytesToSend == other.TotalBytesToSend && self.Status == other.Status && self.HasResponseChanged == other.HasResponseChanged && self.HasRestarted == other.HasRestarted
     }
 }
 impl ::core::cmp::Eq for BackgroundUploadProgress {}

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -3437,7 +3437,7 @@ unsafe impl ::windows::core::RuntimeType for NetworkUsageStates {
 }
 impl ::core::cmp::PartialEq for NetworkUsageStates {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NetworkUsageStates>()) == 0 }
+        self.Roaming == other.Roaming && self.Shared == other.Shared
     }
 }
 impl ::core::cmp::Eq for NetworkUsageStates {}

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -10117,7 +10117,7 @@ unsafe impl ::windows::core::RuntimeType for ESimProfileInstallProgress {
 }
 impl ::core::cmp::PartialEq for ESimProfileInstallProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ESimProfileInstallProgress>()) == 0 }
+        self.TotalSizeInBytes == other.TotalSizeInBytes && self.InstalledSizeInBytes == other.InstalledSizeInBytes
     }
 }
 impl ::core::cmp::Eq for ESimProfileInstallProgress {}
@@ -10162,7 +10162,7 @@ unsafe impl ::windows::core::RuntimeType for ProfileUsage {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for ProfileUsage {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ProfileUsage>()) == 0 }
+        self.UsageInMegabytes == other.UsageInMegabytes && self.LastSyncTime == other.LastSyncTime
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
@@ -5869,7 +5869,7 @@ unsafe impl ::windows::core::RuntimeType for BandwidthStatistics {
 }
 impl ::core::cmp::PartialEq for BandwidthStatistics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BandwidthStatistics>()) == 0 }
+        self.OutboundBitsPerSecond == other.OutboundBitsPerSecond && self.InboundBitsPerSecond == other.InboundBitsPerSecond && self.OutboundBitsPerSecondInstability == other.OutboundBitsPerSecondInstability && self.InboundBitsPerSecondInstability == other.InboundBitsPerSecondInstability && self.OutboundBandwidthPeaked == other.OutboundBandwidthPeaked && self.InboundBandwidthPeaked == other.InboundBandwidthPeaked
     }
 }
 impl ::core::cmp::Eq for BandwidthStatistics {}
@@ -5909,7 +5909,7 @@ unsafe impl ::windows::core::RuntimeType for RoundTripTimeStatistics {
 }
 impl ::core::cmp::PartialEq for RoundTripTimeStatistics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RoundTripTimeStatistics>()) == 0 }
+        self.Variance == other.Variance && self.Max == other.Max && self.Min == other.Min && self.Sum == other.Sum
     }
 }
 impl ::core::cmp::Eq for RoundTripTimeStatistics {}

--- a/crates/libs/windows/src/Windows/Perception/People/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/People/mod.rs
@@ -648,7 +648,7 @@ unsafe impl ::windows::core::RuntimeType for HandMeshVertex {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for HandMeshVertex {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HandMeshVertex>()) == 0 }
+        self.Position == other.Position && self.Normal == other.Normal
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -697,7 +697,7 @@ unsafe impl ::windows::core::RuntimeType for JointPose {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for JointPose {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JointPose>()) == 0 }
+        self.Orientation == other.Orientation && self.Position == other.Position && self.Radius == other.Radius && self.Accuracy == other.Accuracy
     }
 }
 #[cfg(feature = "Foundation_Numerics")]

--- a/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
@@ -2492,7 +2492,7 @@ unsafe impl ::windows::core::RuntimeType for SpatialBoundingBox {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for SpatialBoundingBox {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialBoundingBox>()) == 0 }
+        self.Center == other.Center && self.Extents == other.Extents
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -2543,7 +2543,7 @@ unsafe impl ::windows::core::RuntimeType for SpatialBoundingFrustum {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for SpatialBoundingFrustum {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialBoundingFrustum>()) == 0 }
+        self.Near == other.Near && self.Far == other.Far && self.Right == other.Right && self.Left == other.Left && self.Top == other.Top && self.Bottom == other.Bottom
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -2591,7 +2591,7 @@ unsafe impl ::windows::core::RuntimeType for SpatialBoundingOrientedBox {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for SpatialBoundingOrientedBox {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialBoundingOrientedBox>()) == 0 }
+        self.Center == other.Center && self.Extents == other.Extents && self.Orientation == other.Orientation
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -2638,7 +2638,7 @@ unsafe impl ::windows::core::RuntimeType for SpatialBoundingSphere {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for SpatialBoundingSphere {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialBoundingSphere>()) == 0 }
+        self.Center == other.Center && self.Radius == other.Radius
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -2685,7 +2685,7 @@ unsafe impl ::windows::core::RuntimeType for SpatialRay {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for SpatialRay {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialRay>()) == 0 }
+        self.Origin == other.Origin && self.Direction == other.Direction
     }
 }
 #[cfg(feature = "Foundation_Numerics")]

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -2453,7 +2453,7 @@ unsafe impl ::windows::core::RuntimeType for IsolatedWindowsEnvironmentCreatePro
 }
 impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentCreateProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IsolatedWindowsEnvironmentCreateProgress>()) == 0 }
+        self.State == other.State && self.PercentComplete == other.PercentComplete
     }
 }
 impl ::core::cmp::Eq for IsolatedWindowsEnvironmentCreateProgress {}

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -37934,7 +37934,7 @@ unsafe impl ::windows::core::RuntimeType for InkTrailPoint {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for InkTrailPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InkTrailPoint>()) == 0 }
+        self.Point == other.Point && self.Radius == other.Radius
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -6265,7 +6265,7 @@ unsafe impl ::windows::core::RuntimeType for CorePhysicalKeyStatus {
 }
 impl ::core::cmp::PartialEq for CorePhysicalKeyStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CorePhysicalKeyStatus>()) == 0 }
+        self.RepeatCount == other.RepeatCount && self.ScanCode == other.ScanCode && self.IsExtendedKey == other.IsExtendedKey && self.IsMenuKeyDown == other.IsMenuKeyDown && self.WasKeyDown == other.WasKeyDown && self.IsKeyReleased == other.IsKeyReleased
     }
 }
 impl ::core::cmp::Eq for CorePhysicalKeyStatus {}
@@ -6310,7 +6310,7 @@ unsafe impl ::windows::core::RuntimeType for CoreProximityEvaluation {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for CoreProximityEvaluation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CoreProximityEvaluation>()) == 0 }
+        self.Score == other.Score && self.AdjustedPoint == other.AdjustedPoint
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -1438,7 +1438,7 @@ unsafe impl ::windows::core::RuntimeType for InjectedInputPoint {
 }
 impl ::core::cmp::PartialEq for InjectedInputPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InjectedInputPoint>()) == 0 }
+        self.PositionX == other.PositionX && self.PositionY == other.PositionY
     }
 }
 impl ::core::cmp::Eq for InjectedInputPoint {}
@@ -1479,7 +1479,7 @@ unsafe impl ::windows::core::RuntimeType for InjectedInputPointerInfo {
 }
 impl ::core::cmp::PartialEq for InjectedInputPointerInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InjectedInputPointerInfo>()) == 0 }
+        self.PointerId == other.PointerId && self.PointerOptions == other.PointerOptions && self.PixelLocation == other.PixelLocation && self.TimeOffsetInMilliseconds == other.TimeOffsetInMilliseconds && self.PerformanceCount == other.PerformanceCount
     }
 }
 impl ::core::cmp::Eq for InjectedInputPointerInfo {}
@@ -1519,7 +1519,7 @@ unsafe impl ::windows::core::RuntimeType for InjectedInputRectangle {
 }
 impl ::core::cmp::PartialEq for InjectedInputRectangle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InjectedInputRectangle>()) == 0 }
+        self.Left == other.Left && self.Top == other.Top && self.Bottom == other.Bottom && self.Right == other.Right
     }
 }
 impl ::core::cmp::Eq for InjectedInputRectangle {}

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -5765,7 +5765,7 @@ unsafe impl ::windows::core::RuntimeType for CrossSlideThresholds {
 }
 impl ::core::cmp::PartialEq for CrossSlideThresholds {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CrossSlideThresholds>()) == 0 }
+        self.SelectionStart == other.SelectionStart && self.SpeedBumpStart == other.SpeedBumpStart && self.SpeedBumpEnd == other.SpeedBumpEnd && self.RearrangeStart == other.RearrangeStart
     }
 }
 impl ::core::cmp::Eq for CrossSlideThresholds {}
@@ -5812,7 +5812,7 @@ unsafe impl ::windows::core::RuntimeType for ManipulationDelta {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for ManipulationDelta {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ManipulationDelta>()) == 0 }
+        self.Translation == other.Translation && self.Scale == other.Scale && self.Rotation == other.Rotation && self.Expansion == other.Expansion
     }
 }
 #[cfg(feature = "Foundation")]
@@ -5860,7 +5860,7 @@ unsafe impl ::windows::core::RuntimeType for ManipulationVelocities {
 #[cfg(feature = "Foundation")]
 impl ::core::cmp::PartialEq for ManipulationVelocities {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ManipulationVelocities>()) == 0 }
+        self.Linear == other.Linear && self.Angular == other.Angular && self.Expansion == other.Expansion
     }
 }
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
@@ -2024,7 +2024,7 @@ unsafe impl ::windows::core::RuntimeType for CoreTextRange {
 }
 impl ::core::cmp::PartialEq for CoreTextRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CoreTextRange>()) == 0 }
+        self.StartCaretPosition == other.StartCaretPosition && self.EndCaretPosition == other.EndCaretPosition
     }
 }
 impl ::core::cmp::Eq for CoreTextRange {}

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -4357,7 +4357,7 @@ unsafe impl ::windows::core::RuntimeType for FontWeight {
 }
 impl ::core::cmp::PartialEq for FontWeight {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FontWeight>()) == 0 }
+        self.Weight == other.Weight
     }
 }
 impl ::core::cmp::Eq for FontWeight {}

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
@@ -888,7 +888,7 @@ unsafe impl ::windows::core::RuntimeType for AutomationAnnotationTypeRegistratio
 }
 impl ::core::cmp::PartialEq for AutomationAnnotationTypeRegistration {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AutomationAnnotationTypeRegistration>()) == 0 }
+        self.LocalId == other.LocalId
     }
 }
 impl ::core::cmp::Eq for AutomationAnnotationTypeRegistration {}
@@ -925,7 +925,7 @@ unsafe impl ::windows::core::RuntimeType for AutomationRemoteOperationOperandId 
 }
 impl ::core::cmp::PartialEq for AutomationRemoteOperationOperandId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AutomationRemoteOperationOperandId>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for AutomationRemoteOperationOperandId {}

--- a/crates/libs/windows/src/Windows/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/mod.rs
@@ -1338,7 +1338,7 @@ unsafe impl ::windows::core::RuntimeType for Color {
 }
 impl ::core::cmp::PartialEq for Color {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Color>()) == 0 }
+        self.A == other.A && self.R == other.R && self.G == other.G && self.B == other.B
     }
 }
 impl ::core::cmp::Eq for Color {}
@@ -1375,7 +1375,7 @@ unsafe impl ::windows::core::RuntimeType for WindowId {
 }
 impl ::core::cmp::PartialEq for WindowId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WindowId>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for WindowId {}

--- a/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
@@ -3645,7 +3645,7 @@ unsafe impl ::windows::core::RuntimeType for RetrievalProgress {
 }
 impl ::core::cmp::PartialEq for RetrievalProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RetrievalProgress>()) == 0 }
+        self.BytesRetrieved == other.BytesRetrieved && self.TotalBytesToRetrieve == other.TotalBytesToRetrieve
     }
 }
 impl ::core::cmp::Eq for RetrievalProgress {}
@@ -3685,7 +3685,7 @@ unsafe impl ::windows::core::RuntimeType for TransferProgress {
 }
 impl ::core::cmp::PartialEq for TransferProgress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TransferProgress>()) == 0 }
+        self.BytesSent == other.BytesSent && self.TotalBytesToSend == other.TotalBytesToSend && self.BytesRetrieved == other.BytesRetrieved && self.TotalBytesToRetrieve == other.TotalBytesToRetrieve
     }
 }
 impl ::core::cmp::Eq for TransferProgress {}

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -1980,7 +1980,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_CELU_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_CELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_CELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_CELU_OPERATOR_DESC {}
@@ -2012,7 +2012,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_ELU_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_ELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_ELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_ELU_OPERATOR_DESC {}
@@ -2043,7 +2043,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_HARDMAX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_HARDMAX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_HARDMAX_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_HARDMAX_OPERATOR_DESC {}
@@ -2076,7 +2076,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha && self.Beta == other.Beta
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC {}
@@ -2107,7 +2107,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_IDENTITY_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_IDENTITY_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_IDENTITY_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_IDENTITY_OPERATOR_DESC {}
@@ -2139,7 +2139,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC {}
@@ -2172,7 +2172,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_LINEAR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_LINEAR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_LINEAR_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha && self.Beta == other.Beta
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_LINEAR_OPERATOR_DESC {}
@@ -2203,7 +2203,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {}
@@ -2235,7 +2235,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.SlopeTensor == other.SlopeTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC {}
@@ -2268,7 +2268,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha && self.Beta == other.Beta
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC {}
@@ -2300,7 +2300,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {}
@@ -2331,7 +2331,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_RELU_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_RELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_RELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_RELU_OPERATOR_DESC {}
@@ -2364,7 +2364,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha && self.Gamma == other.Gamma
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC {}
@@ -2397,7 +2397,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha && self.Beta == other.Beta
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {}
@@ -2430,7 +2430,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SHRINK_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SHRINK_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SHRINK_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Bias == other.Bias && self.Threshold == other.Threshold
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SHRINK_OPERATOR_DESC {}
@@ -2461,7 +2461,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SIGMOID_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SIGMOID_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SIGMOID_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SIGMOID_OPERATOR_DESC {}
@@ -2492,7 +2492,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SOFTMAX_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {}
@@ -2524,7 +2524,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Steepness == other.Steepness
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC {}
@@ -2555,7 +2555,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {}
@@ -2586,7 +2586,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_TANH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_TANH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_TANH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_TANH_OPERATOR_DESC {}
@@ -2618,7 +2618,7 @@ unsafe impl ::windows::core::Abi for DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DE
 }
 impl ::core::cmp::PartialEq for DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC {}
@@ -2672,7 +2672,7 @@ unsafe impl ::windows::core::Abi for DML_ADAM_OPTIMIZER_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ADAM_OPTIMIZER_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ADAM_OPTIMIZER_OPERATOR_DESC>()) == 0 }
+        self.InputParametersTensor == other.InputParametersTensor && self.InputFirstMomentTensor == other.InputFirstMomentTensor && self.InputSecondMomentTensor == other.InputSecondMomentTensor && self.GradientTensor == other.GradientTensor && self.TrainingStepTensor == other.TrainingStepTensor && self.OutputParametersTensor == other.OutputParametersTensor && self.OutputFirstMomentTensor == other.OutputFirstMomentTensor && self.OutputSecondMomentTensor == other.OutputSecondMomentTensor && self.LearningRate == other.LearningRate && self.Beta1 == other.Beta1 && self.Beta2 == other.Beta2 && self.Epsilon == other.Epsilon
     }
 }
 impl ::core::cmp::Eq for DML_ADAM_OPTIMIZER_OPERATOR_DESC {}
@@ -2706,7 +2706,7 @@ unsafe impl ::windows::core::Abi for DML_ARGMAX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ARGMAX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ARGMAX_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.AxisCount == other.AxisCount && self.Axes == other.Axes && self.AxisDirection == other.AxisDirection
     }
 }
 impl ::core::cmp::Eq for DML_ARGMAX_OPERATOR_DESC {}
@@ -2740,7 +2740,7 @@ unsafe impl ::windows::core::Abi for DML_ARGMIN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ARGMIN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ARGMIN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.AxisCount == other.AxisCount && self.Axes == other.Axes && self.AxisDirection == other.AxisDirection
     }
 }
 impl ::core::cmp::Eq for DML_ARGMIN_OPERATOR_DESC {}
@@ -2783,7 +2783,7 @@ unsafe impl ::windows::core::Abi for DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.IncludePadding == other.IncludePadding
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2828,7 +2828,7 @@ unsafe impl ::windows::core::Abi for DML_AVERAGE_POOLING_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_AVERAGE_POOLING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_AVERAGE_POOLING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.IncludePadding == other.IncludePadding
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2878,7 +2878,7 @@ unsafe impl ::windows::core::Abi for DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC 
 }
 impl ::core::cmp::PartialEq for DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputGradientTensor == other.InputGradientTensor && self.MeanTensor == other.MeanTensor && self.VarianceTensor == other.VarianceTensor && self.ScaleTensor == other.ScaleTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.OutputScaleGradientTensor == other.OutputScaleGradientTensor && self.OutputBiasGradientTensor == other.OutputBiasGradientTensor && self.Epsilon == other.Epsilon
     }
 }
 impl ::core::cmp::Eq for DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC {}
@@ -2922,7 +2922,7 @@ unsafe impl ::windows::core::Abi for DML_BATCH_NORMALIZATION_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_BATCH_NORMALIZATION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BATCH_NORMALIZATION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.MeanTensor == other.MeanTensor && self.VarianceTensor == other.VarianceTensor && self.ScaleTensor == other.ScaleTensor && self.BiasTensor == other.BiasTensor && self.OutputTensor == other.OutputTensor && self.Spatial == other.Spatial && self.Epsilon == other.Epsilon && self.FusedActivation == other.FusedActivation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2955,7 +2955,7 @@ unsafe impl ::windows::core::Abi for DML_BINDING_DESC {
 }
 impl ::core::cmp::PartialEq for DML_BINDING_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BINDING_DESC>()) == 0 }
+        self.Type == other.Type && self.Desc == other.Desc
     }
 }
 impl ::core::cmp::Eq for DML_BINDING_DESC {}
@@ -2987,7 +2987,7 @@ unsafe impl ::windows::core::Abi for DML_BINDING_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for DML_BINDING_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BINDING_PROPERTIES>()) == 0 }
+        self.RequiredDescriptorCount == other.RequiredDescriptorCount && self.TemporaryResourceSize == other.TemporaryResourceSize && self.PersistentResourceSize == other.PersistentResourceSize
     }
 }
 impl ::core::cmp::Eq for DML_BINDING_PROPERTIES {}
@@ -3068,7 +3068,7 @@ unsafe impl ::windows::core::Abi for DML_BUFFER_ARRAY_BINDING {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for DML_BUFFER_ARRAY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BUFFER_ARRAY_BINDING>()) == 0 }
+        self.BindingCount == other.BindingCount && self.Bindings == other.Bindings
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -3144,7 +3144,7 @@ unsafe impl ::windows::core::Abi for DML_BUFFER_TENSOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_BUFFER_TENSOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_BUFFER_TENSOR_DESC>()) == 0 }
+        self.DataType == other.DataType && self.Flags == other.Flags && self.DimensionCount == other.DimensionCount && self.Sizes == other.Sizes && self.Strides == other.Strides && self.TotalTensorSizeInBytes == other.TotalTensorSizeInBytes && self.GuaranteedBaseOffsetAlignment == other.GuaranteedBaseOffsetAlignment
     }
 }
 impl ::core::cmp::Eq for DML_BUFFER_TENSOR_DESC {}
@@ -3175,7 +3175,7 @@ unsafe impl ::windows::core::Abi for DML_CAST_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_CAST_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_CAST_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_CAST_OPERATOR_DESC {}
@@ -3227,7 +3227,7 @@ unsafe impl ::windows::core::Abi for DML_CONVOLUTION_INTEGER_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_CONVOLUTION_INTEGER_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_CONVOLUTION_INTEGER_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputZeroPointTensor == other.InputZeroPointTensor && self.FilterTensor == other.FilterTensor && self.FilterZeroPointTensor == other.FilterZeroPointTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.Dilations == other.Dilations && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.GroupCount == other.GroupCount
     }
 }
 impl ::core::cmp::Eq for DML_CONVOLUTION_INTEGER_OPERATOR_DESC {}
@@ -3285,7 +3285,7 @@ unsafe impl ::windows::core::Abi for DML_CONVOLUTION_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_CONVOLUTION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_CONVOLUTION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.FilterTensor == other.FilterTensor && self.BiasTensor == other.BiasTensor && self.OutputTensor == other.OutputTensor && self.Mode == other.Mode && self.Direction == other.Direction && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.Dilations == other.Dilations && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.OutputPadding == other.OutputPadding && self.GroupCount == other.GroupCount && self.FusedActivation == other.FusedActivation
     }
 }
 impl ::core::cmp::Eq for DML_CONVOLUTION_OPERATOR_DESC {}
@@ -3325,7 +3325,7 @@ unsafe impl ::windows::core::Abi for DML_CUMULATIVE_PRODUCT_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_CUMULATIVE_PRODUCT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_CUMULATIVE_PRODUCT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis && self.AxisDirection == other.AxisDirection && self.HasExclusiveProduct == other.HasExclusiveProduct
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3367,7 +3367,7 @@ unsafe impl ::windows::core::Abi for DML_CUMULATIVE_SUMMATION_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_CUMULATIVE_SUMMATION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_CUMULATIVE_SUMMATION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis && self.AxisDirection == other.AxisDirection && self.HasExclusiveSum == other.HasExclusiveSum
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3402,7 +3402,7 @@ unsafe impl ::windows::core::Abi for DML_DEPTH_TO_SPACE1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_DEPTH_TO_SPACE1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_DEPTH_TO_SPACE1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.BlockSize == other.BlockSize && self.Order == other.Order
     }
 }
 impl ::core::cmp::Eq for DML_DEPTH_TO_SPACE1_OPERATOR_DESC {}
@@ -3434,7 +3434,7 @@ unsafe impl ::windows::core::Abi for DML_DEPTH_TO_SPACE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_DEPTH_TO_SPACE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_DEPTH_TO_SPACE_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.BlockSize == other.BlockSize
     }
 }
 impl ::core::cmp::Eq for DML_DEPTH_TO_SPACE_OPERATOR_DESC {}
@@ -3466,7 +3466,7 @@ unsafe impl ::windows::core::Abi for DML_DIAGONAL_MATRIX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_DIAGONAL_MATRIX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_DIAGONAL_MATRIX_OPERATOR_DESC>()) == 0 }
+        self.OutputTensor == other.OutputTensor && self.Offset == other.Offset && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DML_DIAGONAL_MATRIX_OPERATOR_DESC {}
@@ -3499,7 +3499,7 @@ unsafe impl ::windows::core::Abi for DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.OutputScaleTensor == other.OutputScaleTensor && self.OutputZeroPointTensor == other.OutputZeroPointTensor
     }
 }
 impl ::core::cmp::Eq for DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC {}
@@ -3531,7 +3531,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ABS_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ABS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ABS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ABS_OPERATOR_DESC {}
@@ -3563,7 +3563,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC {}
@@ -3595,7 +3595,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ACOS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {}
@@ -3628,7 +3628,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ADD1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ADD1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ADD1_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor && self.FusedActivation == other.FusedActivation
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ADD1_OPERATOR_DESC {}
@@ -3660,7 +3660,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ADD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ADD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ADD_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ADD_OPERATOR_DESC {}
@@ -3692,7 +3692,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ASINH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ASINH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ASINH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ASINH_OPERATOR_DESC {}
@@ -3724,7 +3724,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ASIN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {}
@@ -3756,7 +3756,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ATANH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ATANH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ATANH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ATANH_OPERATOR_DESC {}
@@ -3788,7 +3788,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ATAN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {}
@@ -3820,7 +3820,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC {}
@@ -3852,7 +3852,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {}
@@ -3883,7 +3883,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {}
@@ -3914,7 +3914,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {}
@@ -3946,7 +3946,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC {}
@@ -3978,7 +3978,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DE
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC {}
@@ -4010,7 +4010,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_D
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC {}
@@ -4042,7 +4042,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {}
@@ -4074,7 +4074,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_CEIL_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {}
@@ -4108,7 +4108,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.Min == other.Min && self.Max == other.Max
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC {}
@@ -4142,7 +4142,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_CLIP_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias && self.Min == other.Min && self.Max == other.Max
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {}
@@ -4175,7 +4175,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias && self.Exponent == other.Exponent
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC {}
@@ -4207,7 +4207,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_COSH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_COSH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_COSH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_COSH_OPERATOR_DESC {}
@@ -4239,7 +4239,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_COS_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_COS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_COS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_COS_OPERATOR_DESC {}
@@ -4272,7 +4272,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ScaleTensor == other.ScaleTensor && self.ZeroPointTensor == other.ZeroPointTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC {}
@@ -4304,7 +4304,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC {}
@@ -4336,7 +4336,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC {}
@@ -4368,7 +4368,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ERF_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ERF_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ERF_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ERF_OPERATOR_DESC {}
@@ -4400,7 +4400,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_EXP_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_EXP_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_EXP_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_EXP_OPERATOR_DESC {}
@@ -4432,7 +4432,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {}
@@ -4464,7 +4464,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {}
@@ -4497,7 +4497,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_IF_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_IF_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_IF_OPERATOR_DESC>()) == 0 }
+        self.ConditionTensor == other.ConditionTensor && self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_IF_OPERATOR_DESC {}
@@ -4529,7 +4529,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC 
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.InfinityMode == other.InfinityMode
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC {}
@@ -4560,7 +4560,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {}
@@ -4592,7 +4592,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC 
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC {}
@@ -4624,7 +4624,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DE
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC {}
@@ -4656,7 +4656,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERA
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC {}
@@ -4688,7 +4688,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQ
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC {}
@@ -4720,7 +4720,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC {}
@@ -4752,7 +4752,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC {}
@@ -4783,7 +4783,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC 
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC {}
@@ -4815,7 +4815,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC {}
@@ -4847,7 +4847,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC 
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC {}
@@ -4879,7 +4879,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_LOG_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_LOG_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_LOG_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_LOG_OPERATOR_DESC {}
@@ -4911,7 +4911,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MAX_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MAX_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MAX_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MAX_OPERATOR_DESC {}
@@ -4943,7 +4943,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MEAN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MEAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MEAN_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MEAN_OPERATOR_DESC {}
@@ -4975,7 +4975,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MIN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MIN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MIN_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MIN_OPERATOR_DESC {}
@@ -5007,7 +5007,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DES
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC {}
@@ -5039,7 +5039,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC {}
@@ -5071,7 +5071,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC {}
@@ -5104,7 +5104,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_POW_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_POW_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_POW_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ExponentTensor == other.ExponentTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_POW_OPERATOR_DESC {}
@@ -5142,7 +5142,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERA
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.AScaleTensor == other.AScaleTensor && self.AZeroPointTensor == other.AZeroPointTensor && self.BTensor == other.BTensor && self.BScaleTensor == other.BScaleTensor && self.BZeroPointTensor == other.BZeroPointTensor && self.OutputScaleTensor == other.OutputScaleTensor && self.OutputZeroPointTensor == other.OutputZeroPointTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC {}
@@ -5175,7 +5175,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_D
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ScaleTensor == other.ScaleTensor && self.ZeroPointTensor == other.ZeroPointTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC {}
@@ -5207,7 +5207,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_RECIP_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {}
@@ -5239,7 +5239,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_ROUND_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_ROUND_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_ROUND_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.RoundingMode == other.RoundingMode
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_ROUND_OPERATOR_DESC {}
@@ -5270,7 +5270,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_SIGN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {}
@@ -5302,7 +5302,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_SINH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_SINH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_SINH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_SINH_OPERATOR_DESC {}
@@ -5334,7 +5334,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_SIN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_SIN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_SIN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_SIN_OPERATOR_DESC {}
@@ -5366,7 +5366,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_SQRT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_SQRT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_SQRT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_SQRT_OPERATOR_DESC {}
@@ -5398,7 +5398,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {}
@@ -5430,7 +5430,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_TANH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_TANH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_TANH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_TANH_OPERATOR_DESC {}
@@ -5462,7 +5462,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_TAN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_TAN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_TAN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_TAN_OPERATOR_DESC {}
@@ -5495,7 +5495,7 @@ unsafe impl ::windows::core::Abi for DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleBias == other.ScaleBias && self.Min == other.Min
     }
 }
 impl ::core::cmp::Eq for DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC {}
@@ -5525,7 +5525,7 @@ unsafe impl ::windows::core::Abi for DML_FEATURE_DATA_FEATURE_LEVELS {
 }
 impl ::core::cmp::PartialEq for DML_FEATURE_DATA_FEATURE_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FEATURE_DATA_FEATURE_LEVELS>()) == 0 }
+        self.MaxSupportedFeatureLevel == other.MaxSupportedFeatureLevel
     }
 }
 impl ::core::cmp::Eq for DML_FEATURE_DATA_FEATURE_LEVELS {}
@@ -5561,7 +5561,7 @@ unsafe impl ::windows::core::Abi for DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT>()) == 0 }
+        self.IsSupported == other.IsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5594,7 +5594,7 @@ unsafe impl ::windows::core::Abi for DML_FEATURE_QUERY_FEATURE_LEVELS {
 }
 impl ::core::cmp::PartialEq for DML_FEATURE_QUERY_FEATURE_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FEATURE_QUERY_FEATURE_LEVELS>()) == 0 }
+        self.RequestedFeatureLevelCount == other.RequestedFeatureLevelCount && self.RequestedFeatureLevels == other.RequestedFeatureLevels
     }
 }
 impl ::core::cmp::Eq for DML_FEATURE_QUERY_FEATURE_LEVELS {}
@@ -5624,7 +5624,7 @@ unsafe impl ::windows::core::Abi for DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT 
 }
 impl ::core::cmp::PartialEq for DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT>()) == 0 }
+        self.DataType == other.DataType
     }
 }
 impl ::core::cmp::Eq for DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT {}
@@ -5649,12 +5649,6 @@ impl ::core::clone::Clone for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
 unsafe impl ::windows::core::Abi for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FILL_VALUE_CONSTANT_OPERATOR_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {}
 impl ::core::default::Default for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5677,12 +5671,6 @@ impl ::core::clone::Clone for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
 unsafe impl ::windows::core::Abi for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {}
 impl ::core::default::Default for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5712,7 +5700,7 @@ unsafe impl ::windows::core::Abi for DML_GATHER_ELEMENTS_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GATHER_ELEMENTS_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GATHER_ELEMENTS_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_GATHER_ELEMENTS_OPERATOR_DESC {}
@@ -5747,7 +5735,7 @@ unsafe impl ::windows::core::Abi for DML_GATHER_ND1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GATHER_ND1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GATHER_ND1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.OutputTensor == other.OutputTensor && self.InputDimensionCount == other.InputDimensionCount && self.IndicesDimensionCount == other.IndicesDimensionCount && self.BatchDimensionCount == other.BatchDimensionCount
     }
 }
 impl ::core::cmp::Eq for DML_GATHER_ND1_OPERATOR_DESC {}
@@ -5781,7 +5769,7 @@ unsafe impl ::windows::core::Abi for DML_GATHER_ND_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GATHER_ND_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GATHER_ND_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.OutputTensor == other.OutputTensor && self.InputDimensionCount == other.InputDimensionCount && self.IndicesDimensionCount == other.IndicesDimensionCount
     }
 }
 impl ::core::cmp::Eq for DML_GATHER_ND_OPERATOR_DESC {}
@@ -5815,7 +5803,7 @@ unsafe impl ::windows::core::Abi for DML_GATHER_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GATHER_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GATHER_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis && self.IndexDimensions == other.IndexDimensions
     }
 }
 impl ::core::cmp::Eq for DML_GATHER_OPERATOR_DESC {}
@@ -5853,7 +5841,7 @@ unsafe impl ::windows::core::Abi for DML_GEMM_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GEMM_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GEMM_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.BTensor == other.BTensor && self.CTensor == other.CTensor && self.OutputTensor == other.OutputTensor && self.TransA == other.TransA && self.TransB == other.TransB && self.Alpha == other.Alpha && self.Beta == other.Beta && self.FusedActivation == other.FusedActivation
     }
 }
 impl ::core::cmp::Eq for DML_GEMM_OPERATOR_DESC {}
@@ -5892,7 +5880,7 @@ unsafe impl ::windows::core::Abi for DML_GRAPH_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GRAPH_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GRAPH_DESC>()) == 0 }
+        self.InputCount == other.InputCount && self.OutputCount == other.OutputCount && self.NodeCount == other.NodeCount && self.Nodes == other.Nodes && self.InputEdgeCount == other.InputEdgeCount && self.InputEdges == other.InputEdges && self.OutputEdgeCount == other.OutputEdgeCount && self.OutputEdges == other.OutputEdges && self.IntermediateEdgeCount == other.IntermediateEdgeCount && self.IntermediateEdges == other.IntermediateEdges
     }
 }
 impl ::core::cmp::Eq for DML_GRAPH_DESC {}
@@ -5923,7 +5911,7 @@ unsafe impl ::windows::core::Abi for DML_GRAPH_EDGE_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GRAPH_EDGE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GRAPH_EDGE_DESC>()) == 0 }
+        self.Type == other.Type && self.Desc == other.Desc
     }
 }
 impl ::core::cmp::Eq for DML_GRAPH_EDGE_DESC {}
@@ -5954,7 +5942,7 @@ unsafe impl ::windows::core::Abi for DML_GRAPH_NODE_DESC {
 }
 impl ::core::cmp::PartialEq for DML_GRAPH_NODE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GRAPH_NODE_DESC>()) == 0 }
+        self.Type == other.Type && self.Desc == other.Desc
     }
 }
 impl ::core::cmp::Eq for DML_GRAPH_NODE_DESC {}
@@ -6014,7 +6002,7 @@ unsafe impl ::windows::core::Abi for DML_GRU_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_GRU_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_GRU_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.WeightTensor == other.WeightTensor && self.RecurrenceTensor == other.RecurrenceTensor && self.BiasTensor == other.BiasTensor && self.HiddenInitTensor == other.HiddenInitTensor && self.SequenceLengthsTensor == other.SequenceLengthsTensor && self.OutputSequenceTensor == other.OutputSequenceTensor && self.OutputSingleTensor == other.OutputSingleTensor && self.ActivationDescCount == other.ActivationDescCount && self.ActivationDescs == other.ActivationDescs && self.Direction == other.Direction && self.LinearBeforeReset == other.LinearBeforeReset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6049,7 +6037,7 @@ unsafe impl ::windows::core::Abi for DML_INPUT_GRAPH_EDGE_DESC {
 }
 impl ::core::cmp::PartialEq for DML_INPUT_GRAPH_EDGE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_INPUT_GRAPH_EDGE_DESC>()) == 0 }
+        self.GraphInputIndex == other.GraphInputIndex && self.ToNodeIndex == other.ToNodeIndex && self.ToNodeInputIndex == other.ToNodeInputIndex && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for DML_INPUT_GRAPH_EDGE_DESC {}
@@ -6083,7 +6071,7 @@ unsafe impl ::windows::core::Abi for DML_INTERMEDIATE_GRAPH_EDGE_DESC {
 }
 impl ::core::cmp::PartialEq for DML_INTERMEDIATE_GRAPH_EDGE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_INTERMEDIATE_GRAPH_EDGE_DESC>()) == 0 }
+        self.FromNodeIndex == other.FromNodeIndex && self.FromNodeOutputIndex == other.FromNodeOutputIndex && self.ToNodeIndex == other.ToNodeIndex && self.ToNodeInputIndex == other.ToNodeInputIndex && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for DML_INTERMEDIATE_GRAPH_EDGE_DESC {}
@@ -6116,7 +6104,7 @@ unsafe impl ::windows::core::Abi for DML_JOIN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_JOIN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_JOIN_OPERATOR_DESC>()) == 0 }
+        self.InputCount == other.InputCount && self.InputTensors == other.InputTensors && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_JOIN_OPERATOR_DESC {}
@@ -6159,7 +6147,7 @@ unsafe impl ::windows::core::Abi for DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERA
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.CrossChannel == other.CrossChannel && self.LocalSize == other.LocalSize && self.Alpha == other.Alpha && self.Beta == other.Beta && self.Bias == other.Bias
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6203,7 +6191,7 @@ unsafe impl ::windows::core::Abi for DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_D
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.CrossChannel == other.CrossChannel && self.LocalSize == other.LocalSize && self.Alpha == other.Alpha && self.Beta == other.Beta && self.Bias == other.Bias
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6239,7 +6227,7 @@ unsafe impl ::windows::core::Abi for DML_LP_NORMALIZATION_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_LP_NORMALIZATION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_LP_NORMALIZATION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis && self.Epsilon == other.Epsilon && self.P == other.P
     }
 }
 impl ::core::cmp::Eq for DML_LP_NORMALIZATION_OPERATOR_DESC {}
@@ -6276,7 +6264,7 @@ unsafe impl ::windows::core::Abi for DML_LP_POOLING_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_LP_POOLING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_LP_POOLING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.P == other.P
     }
 }
 impl ::core::cmp::Eq for DML_LP_POOLING_OPERATOR_DESC {}
@@ -6346,7 +6334,23 @@ unsafe impl ::windows::core::Abi for DML_LSTM_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_LSTM_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_LSTM_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor
+            && self.WeightTensor == other.WeightTensor
+            && self.RecurrenceTensor == other.RecurrenceTensor
+            && self.BiasTensor == other.BiasTensor
+            && self.HiddenInitTensor == other.HiddenInitTensor
+            && self.CellMemInitTensor == other.CellMemInitTensor
+            && self.SequenceLengthsTensor == other.SequenceLengthsTensor
+            && self.PeepholeTensor == other.PeepholeTensor
+            && self.OutputSequenceTensor == other.OutputSequenceTensor
+            && self.OutputSingleTensor == other.OutputSingleTensor
+            && self.OutputCellSingleTensor == other.OutputCellSingleTensor
+            && self.ActivationDescCount == other.ActivationDescCount
+            && self.ActivationDescs == other.ActivationDescs
+            && self.Direction == other.Direction
+            && self.ClipThreshold == other.ClipThreshold
+            && self.UseClipThreshold == other.UseClipThreshold
+            && self.CoupleInputForget == other.CoupleInputForget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6382,7 +6386,7 @@ unsafe impl ::windows::core::Abi for DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.AZeroPointTensor == other.AZeroPointTensor && self.BTensor == other.BTensor && self.BZeroPointTensor == other.BZeroPointTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {}
@@ -6419,7 +6423,7 @@ unsafe impl ::windows::core::Abi for DML_MAX_POOLING1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MAX_POOLING1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MAX_POOLING1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.OutputIndicesTensor == other.OutputIndicesTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding
     }
 }
 impl ::core::cmp::Eq for DML_MAX_POOLING1_OPERATOR_DESC {}
@@ -6457,7 +6461,7 @@ unsafe impl ::windows::core::Abi for DML_MAX_POOLING2_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MAX_POOLING2_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MAX_POOLING2_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.OutputIndicesTensor == other.OutputIndicesTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.Dilations == other.Dilations
     }
 }
 impl ::core::cmp::Eq for DML_MAX_POOLING2_OPERATOR_DESC {}
@@ -6495,7 +6499,7 @@ unsafe impl ::windows::core::Abi for DML_MAX_POOLING_GRAD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MAX_POOLING_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MAX_POOLING_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.Dilations == other.Dilations
     }
 }
 impl ::core::cmp::Eq for DML_MAX_POOLING_GRAD_OPERATOR_DESC {}
@@ -6531,7 +6535,7 @@ unsafe impl ::windows::core::Abi for DML_MAX_POOLING_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MAX_POOLING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MAX_POOLING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.WindowSize == other.WindowSize && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding
     }
 }
 impl ::core::cmp::Eq for DML_MAX_POOLING_OPERATOR_DESC {}
@@ -6563,7 +6567,7 @@ unsafe impl ::windows::core::Abi for DML_MAX_UNPOOLING_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_MAX_UNPOOLING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MAX_UNPOOLING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_MAX_UNPOOLING_OPERATOR_DESC {}
@@ -6607,7 +6611,7 @@ unsafe impl ::windows::core::Abi for DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_D
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ScaleTensor == other.ScaleTensor && self.BiasTensor == other.BiasTensor && self.OutputTensor == other.OutputTensor && self.AxisCount == other.AxisCount && self.Axes == other.Axes && self.NormalizeVariance == other.NormalizeVariance && self.Epsilon == other.Epsilon && self.FusedActivation == other.FusedActivation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6652,7 +6656,7 @@ unsafe impl ::windows::core::Abi for DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DE
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ScaleTensor == other.ScaleTensor && self.BiasTensor == other.BiasTensor && self.OutputTensor == other.OutputTensor && self.CrossChannel == other.CrossChannel && self.NormalizeVariance == other.NormalizeVariance && self.Epsilon == other.Epsilon && self.FusedActivation == other.FusedActivation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6686,7 +6690,7 @@ unsafe impl ::windows::core::Abi for DML_NONZERO_COORDINATES_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_NONZERO_COORDINATES_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_NONZERO_COORDINATES_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputCountTensor == other.OutputCountTensor && self.OutputCoordinatesTensor == other.OutputCoordinatesTensor
     }
 }
 impl ::core::cmp::Eq for DML_NONZERO_COORDINATES_OPERATOR_DESC {}
@@ -6719,7 +6723,7 @@ unsafe impl ::windows::core::Abi for DML_ONE_HOT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ONE_HOT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ONE_HOT_OPERATOR_DESC>()) == 0 }
+        self.IndicesTensor == other.IndicesTensor && self.ValuesTensor == other.ValuesTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_ONE_HOT_OPERATOR_DESC {}
@@ -6750,7 +6754,7 @@ unsafe impl ::windows::core::Abi for DML_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_OPERATOR_DESC>()) == 0 }
+        self.Type == other.Type && self.Desc == other.Desc
     }
 }
 impl ::core::cmp::Eq for DML_OPERATOR_DESC {}
@@ -6813,7 +6817,7 @@ unsafe impl ::windows::core::Abi for DML_OUTPUT_GRAPH_EDGE_DESC {
 }
 impl ::core::cmp::PartialEq for DML_OUTPUT_GRAPH_EDGE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_OUTPUT_GRAPH_EDGE_DESC>()) == 0 }
+        self.FromNodeIndex == other.FromNodeIndex && self.FromNodeOutputIndex == other.FromNodeOutputIndex && self.GraphOutputIndex == other.GraphOutputIndex && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for DML_OUTPUT_GRAPH_EDGE_DESC {}
@@ -6849,7 +6853,7 @@ unsafe impl ::windows::core::Abi for DML_PADDING_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_PADDING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_PADDING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.PaddingMode == other.PaddingMode && self.PaddingValue == other.PaddingValue && self.DimensionCount == other.DimensionCount && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding
     }
 }
 impl ::core::cmp::Eq for DML_PADDING_OPERATOR_DESC {}
@@ -6911,7 +6915,7 @@ unsafe impl ::windows::core::Abi for DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_D
 }
 impl ::core::cmp::PartialEq for DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.InputScaleTensor == other.InputScaleTensor && self.InputZeroPointTensor == other.InputZeroPointTensor && self.FilterTensor == other.FilterTensor && self.FilterScaleTensor == other.FilterScaleTensor && self.FilterZeroPointTensor == other.FilterZeroPointTensor && self.BiasTensor == other.BiasTensor && self.OutputScaleTensor == other.OutputScaleTensor && self.OutputZeroPointTensor == other.OutputZeroPointTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Strides == other.Strides && self.Dilations == other.Dilations && self.StartPadding == other.StartPadding && self.EndPadding == other.EndPadding && self.GroupCount == other.GroupCount
     }
 }
 impl ::core::cmp::Eq for DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC {}
@@ -6949,7 +6953,7 @@ unsafe impl ::windows::core::Abi for DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERAT
 }
 impl ::core::cmp::PartialEq for DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC>()) == 0 }
+        self.ATensor == other.ATensor && self.AScaleTensor == other.AScaleTensor && self.AZeroPointTensor == other.AZeroPointTensor && self.BTensor == other.BTensor && self.BScaleTensor == other.BScaleTensor && self.BZeroPointTensor == other.BZeroPointTensor && self.OutputScaleTensor == other.OutputScaleTensor && self.OutputZeroPointTensor == other.OutputZeroPointTensor && self.OutputTensor == other.OutputTensor
     }
 }
 impl ::core::cmp::Eq for DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC {}
@@ -6982,7 +6986,7 @@ unsafe impl ::windows::core::Abi for DML_RANDOM_GENERATOR_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_RANDOM_GENERATOR_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_RANDOM_GENERATOR_OPERATOR_DESC>()) == 0 }
+        self.InputStateTensor == other.InputStateTensor && self.OutputTensor == other.OutputTensor && self.OutputStateTensor == other.OutputStateTensor && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for DML_RANDOM_GENERATOR_OPERATOR_DESC {}
@@ -7016,7 +7020,7 @@ unsafe impl ::windows::core::Abi for DML_REDUCE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_REDUCE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_REDUCE_OPERATOR_DESC>()) == 0 }
+        self.Function == other.Function && self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.AxisCount == other.AxisCount && self.Axes == other.Axes
     }
 }
 impl ::core::cmp::Eq for DML_REDUCE_OPERATOR_DESC {}
@@ -7052,7 +7056,7 @@ unsafe impl ::windows::core::Abi for DML_RESAMPLE1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_RESAMPLE1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_RESAMPLE1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.InterpolationMode == other.InterpolationMode && self.DimensionCount == other.DimensionCount && self.Scales == other.Scales && self.InputPixelOffsets == other.InputPixelOffsets && self.OutputPixelOffsets == other.OutputPixelOffsets
     }
 }
 impl ::core::cmp::Eq for DML_RESAMPLE1_OPERATOR_DESC {}
@@ -7088,7 +7092,7 @@ unsafe impl ::windows::core::Abi for DML_RESAMPLE_GRAD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_RESAMPLE_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_RESAMPLE_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.InterpolationMode == other.InterpolationMode && self.DimensionCount == other.DimensionCount && self.Scales == other.Scales && self.InputPixelOffsets == other.InputPixelOffsets && self.OutputPixelOffsets == other.OutputPixelOffsets
     }
 }
 impl ::core::cmp::Eq for DML_RESAMPLE_GRAD_OPERATOR_DESC {}
@@ -7122,7 +7126,7 @@ unsafe impl ::windows::core::Abi for DML_RESAMPLE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_RESAMPLE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_RESAMPLE_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.InterpolationMode == other.InterpolationMode && self.ScaleCount == other.ScaleCount && self.Scales == other.Scales
     }
 }
 impl ::core::cmp::Eq for DML_RESAMPLE_OPERATOR_DESC {}
@@ -7155,7 +7159,7 @@ unsafe impl ::windows::core::Abi for DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.SequenceLengthsTensor == other.SequenceLengthsTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {}
@@ -7207,7 +7211,7 @@ unsafe impl ::windows::core::Abi for DML_RNN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_RNN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_RNN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.WeightTensor == other.WeightTensor && self.RecurrenceTensor == other.RecurrenceTensor && self.BiasTensor == other.BiasTensor && self.HiddenInitTensor == other.HiddenInitTensor && self.SequenceLengthsTensor == other.SequenceLengthsTensor && self.OutputSequenceTensor == other.OutputSequenceTensor && self.OutputSingleTensor == other.OutputSingleTensor && self.ActivationDescCount == other.ActivationDescCount && self.ActivationDescs == other.ActivationDescs && self.Direction == other.Direction
     }
 }
 impl ::core::cmp::Eq for DML_RNN_OPERATOR_DESC {}
@@ -7271,7 +7275,7 @@ unsafe impl ::windows::core::Abi for DML_ROI_ALIGN1_OPERATOR_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DML_ROI_ALIGN1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ROI_ALIGN1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ROITensor == other.ROITensor && self.BatchIndicesTensor == other.BatchIndicesTensor && self.OutputTensor == other.OutputTensor && self.ReductionFunction == other.ReductionFunction && self.InterpolationMode == other.InterpolationMode && self.SpatialScaleX == other.SpatialScaleX && self.SpatialScaleY == other.SpatialScaleY && self.InputPixelOffset == other.InputPixelOffset && self.OutputPixelOffset == other.OutputPixelOffset && self.OutOfBoundsInputValue == other.OutOfBoundsInputValue && self.MinimumSamplesPerOutput == other.MinimumSamplesPerOutput && self.MaximumSamplesPerOutput == other.MaximumSamplesPerOutput && self.AlignRegionsToCorners == other.AlignRegionsToCorners
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7325,7 +7329,7 @@ unsafe impl ::windows::core::Abi for DML_ROI_ALIGN_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ROI_ALIGN_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ROI_ALIGN_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ROITensor == other.ROITensor && self.BatchIndicesTensor == other.BatchIndicesTensor && self.OutputTensor == other.OutputTensor && self.ReductionFunction == other.ReductionFunction && self.InterpolationMode == other.InterpolationMode && self.SpatialScaleX == other.SpatialScaleX && self.SpatialScaleY == other.SpatialScaleY && self.OutOfBoundsInputValue == other.OutOfBoundsInputValue && self.MinimumSamplesPerOutput == other.MinimumSamplesPerOutput && self.MaximumSamplesPerOutput == other.MaximumSamplesPerOutput
     }
 }
 impl ::core::cmp::Eq for DML_ROI_ALIGN_OPERATOR_DESC {}
@@ -7359,7 +7363,7 @@ unsafe impl ::windows::core::Abi for DML_ROI_POOLING_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_ROI_POOLING_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_ROI_POOLING_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.ROITensor == other.ROITensor && self.OutputTensor == other.OutputTensor && self.SpatialScale == other.SpatialScale && self.PooledSize == other.PooledSize
     }
 }
 impl ::core::cmp::Eq for DML_ROI_POOLING_OPERATOR_DESC {}
@@ -7392,12 +7396,6 @@ impl ::core::clone::Clone for DML_SCALAR_UNION {
 unsafe impl ::windows::core::Abi for DML_SCALAR_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DML_SCALAR_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SCALAR_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DML_SCALAR_UNION {}
 impl ::core::default::Default for DML_SCALAR_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7425,7 +7423,7 @@ unsafe impl ::windows::core::Abi for DML_SCALE_BIAS {
 }
 impl ::core::cmp::PartialEq for DML_SCALE_BIAS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SCALE_BIAS>()) == 0 }
+        self.Scale == other.Scale && self.Bias == other.Bias
     }
 }
 impl ::core::cmp::Eq for DML_SCALE_BIAS {}
@@ -7460,7 +7458,7 @@ unsafe impl ::windows::core::Abi for DML_SCATTER_ND_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SCATTER_ND_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SCATTER_ND_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.UpdatesTensor == other.UpdatesTensor && self.OutputTensor == other.OutputTensor && self.InputDimensionCount == other.InputDimensionCount && self.IndicesDimensionCount == other.IndicesDimensionCount
     }
 }
 impl ::core::cmp::Eq for DML_SCATTER_ND_OPERATOR_DESC {}
@@ -7494,7 +7492,7 @@ unsafe impl ::windows::core::Abi for DML_SCATTER_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SCATTER_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SCATTER_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.IndicesTensor == other.IndicesTensor && self.UpdatesTensor == other.UpdatesTensor && self.OutputTensor == other.OutputTensor && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_SCATTER_OPERATOR_DESC {}
@@ -7525,7 +7523,7 @@ unsafe impl ::windows::core::Abi for DML_SIZE_2D {
 }
 impl ::core::cmp::PartialEq for DML_SIZE_2D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SIZE_2D>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for DML_SIZE_2D {}
@@ -7560,7 +7558,7 @@ unsafe impl ::windows::core::Abi for DML_SLICE1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SLICE1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SLICE1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.InputWindowOffsets == other.InputWindowOffsets && self.InputWindowSizes == other.InputWindowSizes && self.InputWindowStrides == other.InputWindowStrides
     }
 }
 impl ::core::cmp::Eq for DML_SLICE1_OPERATOR_DESC {}
@@ -7595,7 +7593,7 @@ unsafe impl ::windows::core::Abi for DML_SLICE_GRAD_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SLICE_GRAD_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SLICE_GRAD_OPERATOR_DESC>()) == 0 }
+        self.InputGradientTensor == other.InputGradientTensor && self.OutputGradientTensor == other.OutputGradientTensor && self.DimensionCount == other.DimensionCount && self.InputWindowOffsets == other.InputWindowOffsets && self.InputWindowSizes == other.InputWindowSizes && self.InputWindowStrides == other.InputWindowStrides
     }
 }
 impl ::core::cmp::Eq for DML_SLICE_GRAD_OPERATOR_DESC {}
@@ -7630,7 +7628,7 @@ unsafe impl ::windows::core::Abi for DML_SLICE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SLICE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SLICE_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.DimensionCount == other.DimensionCount && self.Offsets == other.Offsets && self.Sizes == other.Sizes && self.Strides == other.Strides
     }
 }
 impl ::core::cmp::Eq for DML_SLICE_OPERATOR_DESC {}
@@ -7663,7 +7661,7 @@ unsafe impl ::windows::core::Abi for DML_SPACE_TO_DEPTH1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SPACE_TO_DEPTH1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SPACE_TO_DEPTH1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.BlockSize == other.BlockSize && self.Order == other.Order
     }
 }
 impl ::core::cmp::Eq for DML_SPACE_TO_DEPTH1_OPERATOR_DESC {}
@@ -7695,7 +7693,7 @@ unsafe impl ::windows::core::Abi for DML_SPACE_TO_DEPTH_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SPACE_TO_DEPTH_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SPACE_TO_DEPTH_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.BlockSize == other.BlockSize
     }
 }
 impl ::core::cmp::Eq for DML_SPACE_TO_DEPTH_OPERATOR_DESC {}
@@ -7728,7 +7726,7 @@ unsafe impl ::windows::core::Abi for DML_SPLIT_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_SPLIT_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_SPLIT_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputCount == other.OutputCount && self.OutputTensors == other.OutputTensors && self.Axis == other.Axis
     }
 }
 impl ::core::cmp::Eq for DML_SPLIT_OPERATOR_DESC {}
@@ -7759,7 +7757,7 @@ unsafe impl ::windows::core::Abi for DML_TENSOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_TENSOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_TENSOR_DESC>()) == 0 }
+        self.Type == other.Type && self.Desc == other.Desc
     }
 }
 impl ::core::cmp::Eq for DML_TENSOR_DESC {}
@@ -7792,7 +7790,7 @@ unsafe impl ::windows::core::Abi for DML_TILE_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_TILE_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_TILE_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.RepeatsCount == other.RepeatsCount && self.Repeats == other.Repeats
     }
 }
 impl ::core::cmp::Eq for DML_TILE_OPERATOR_DESC {}
@@ -7827,7 +7825,7 @@ unsafe impl ::windows::core::Abi for DML_TOP_K1_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_TOP_K1_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_TOP_K1_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputValueTensor == other.OutputValueTensor && self.OutputIndexTensor == other.OutputIndexTensor && self.Axis == other.Axis && self.K == other.K && self.AxisDirection == other.AxisDirection
     }
 }
 impl ::core::cmp::Eq for DML_TOP_K1_OPERATOR_DESC {}
@@ -7861,7 +7859,7 @@ unsafe impl ::windows::core::Abi for DML_TOP_K_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_TOP_K_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_TOP_K_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputValueTensor == other.OutputValueTensor && self.OutputIndexTensor == other.OutputIndexTensor && self.Axis == other.Axis && self.K == other.K
     }
 }
 impl ::core::cmp::Eq for DML_TOP_K_OPERATOR_DESC {}
@@ -7894,7 +7892,7 @@ unsafe impl ::windows::core::Abi for DML_UPSAMPLE_2D_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_UPSAMPLE_2D_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_UPSAMPLE_2D_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.ScaleSize == other.ScaleSize && self.InterpolationMode == other.InterpolationMode
     }
 }
 impl ::core::cmp::Eq for DML_UPSAMPLE_2D_OPERATOR_DESC {}
@@ -7928,7 +7926,7 @@ unsafe impl ::windows::core::Abi for DML_VALUE_SCALE_2D_OPERATOR_DESC {
 }
 impl ::core::cmp::PartialEq for DML_VALUE_SCALE_2D_OPERATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DML_VALUE_SCALE_2D_OPERATOR_DESC>()) == 0 }
+        self.InputTensor == other.InputTensor && self.OutputTensor == other.OutputTensor && self.Scale == other.Scale && self.ChannelCount == other.ChannelCount && self.Bias == other.Bias
     }
 }
 impl ::core::cmp::Eq for DML_VALUE_SCALE_2D_OPERATOR_DESC {}

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -1392,7 +1392,7 @@ unsafe impl ::windows::core::Abi for MLOperatorAttribute {
 }
 impl ::core::cmp::PartialEq for MLOperatorAttribute {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorAttribute>()) == 0 }
+        self.name == other.name && self.r#type == other.r#type && self.required == other.required
     }
 }
 impl ::core::cmp::Eq for MLOperatorAttribute {}
@@ -1418,12 +1418,6 @@ impl ::core::clone::Clone for MLOperatorAttributeNameValue {
 unsafe impl ::windows::core::Abi for MLOperatorAttributeNameValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorAttributeNameValue {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorAttributeNameValue>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorAttributeNameValue {}
 impl ::core::default::Default for MLOperatorAttributeNameValue {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1446,12 +1440,6 @@ impl ::core::clone::Clone for MLOperatorAttributeNameValue_0 {
 unsafe impl ::windows::core::Abi for MLOperatorAttributeNameValue_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorAttributeNameValue_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorAttributeNameValue_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorAttributeNameValue_0 {}
 impl ::core::default::Default for MLOperatorAttributeNameValue_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1472,12 +1460,6 @@ impl ::core::clone::Clone for MLOperatorEdgeDescription {
 unsafe impl ::windows::core::Abi for MLOperatorEdgeDescription {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorEdgeDescription {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorEdgeDescription>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorEdgeDescription {}
 impl ::core::default::Default for MLOperatorEdgeDescription {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1498,12 +1480,6 @@ impl ::core::clone::Clone for MLOperatorEdgeDescription_0 {
 unsafe impl ::windows::core::Abi for MLOperatorEdgeDescription_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorEdgeDescription_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorEdgeDescription_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorEdgeDescription_0 {}
 impl ::core::default::Default for MLOperatorEdgeDescription_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1532,7 +1508,7 @@ unsafe impl ::windows::core::Abi for MLOperatorEdgeTypeConstraint {
 }
 impl ::core::cmp::PartialEq for MLOperatorEdgeTypeConstraint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorEdgeTypeConstraint>()) == 0 }
+        self.typeLabel == other.typeLabel && self.allowedTypes == other.allowedTypes && self.allowedTypeCount == other.allowedTypeCount
     }
 }
 impl ::core::cmp::Eq for MLOperatorEdgeTypeConstraint {}
@@ -1582,7 +1558,7 @@ unsafe impl ::windows::core::Abi for MLOperatorKernelDescription {
 }
 impl ::core::cmp::PartialEq for MLOperatorKernelDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorKernelDescription>()) == 0 }
+        self.domain == other.domain && self.name == other.name && self.minimumOperatorSetVersion == other.minimumOperatorSetVersion && self.executionType == other.executionType && self.typeConstraints == other.typeConstraints && self.typeConstraintCount == other.typeConstraintCount && self.defaultAttributes == other.defaultAttributes && self.defaultAttributeCount == other.defaultAttributeCount && self.options == other.options && self.executionOptions == other.executionOptions
     }
 }
 impl ::core::cmp::Eq for MLOperatorKernelDescription {}
@@ -1636,7 +1612,7 @@ unsafe impl ::windows::core::Abi for MLOperatorSchemaDescription {
 }
 impl ::core::cmp::PartialEq for MLOperatorSchemaDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorSchemaDescription>()) == 0 }
+        self.name == other.name && self.operatorSetVersionAtLastChange == other.operatorSetVersionAtLastChange && self.inputs == other.inputs && self.inputCount == other.inputCount && self.outputs == other.outputs && self.outputCount == other.outputCount && self.typeConstraints == other.typeConstraints && self.typeConstraintCount == other.typeConstraintCount && self.attributes == other.attributes && self.attributeCount == other.attributeCount && self.defaultAttributes == other.defaultAttributes && self.defaultAttributeCount == other.defaultAttributeCount
     }
 }
 impl ::core::cmp::Eq for MLOperatorSchemaDescription {}
@@ -1661,12 +1637,6 @@ impl ::core::clone::Clone for MLOperatorSchemaEdgeDescription {
 unsafe impl ::windows::core::Abi for MLOperatorSchemaEdgeDescription {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorSchemaEdgeDescription {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorSchemaEdgeDescription>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorSchemaEdgeDescription {}
 impl ::core::default::Default for MLOperatorSchemaEdgeDescription {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1688,12 +1658,6 @@ impl ::core::clone::Clone for MLOperatorSchemaEdgeDescription_0 {
 unsafe impl ::windows::core::Abi for MLOperatorSchemaEdgeDescription_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorSchemaEdgeDescription_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorSchemaEdgeDescription_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLOperatorSchemaEdgeDescription_0 {}
 impl ::core::default::Default for MLOperatorSchemaEdgeDescription_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1721,7 +1685,7 @@ unsafe impl ::windows::core::Abi for MLOperatorSetId {
 }
 impl ::core::cmp::PartialEq for MLOperatorSetId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLOperatorSetId>()) == 0 }
+        self.domain == other.domain && self.version == other.version
     }
 }
 impl ::core::cmp::Eq for MLOperatorSetId {}
@@ -1749,14 +1713,6 @@ unsafe impl ::windows::core::Abi for WINML_BINDING_DESC {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::cmp::PartialEq for WINML_BINDING_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        self.Name == other.Name && self.BindType == other.BindType && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::cmp::Eq for WINML_BINDING_DESC {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::default::Default for WINML_BINDING_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1782,14 +1738,6 @@ impl ::core::clone::Clone for WINML_BINDING_DESC_0 {
 unsafe impl ::windows::core::Abi for WINML_BINDING_DESC_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::cmp::PartialEq for WINML_BINDING_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_BINDING_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::cmp::Eq for WINML_BINDING_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::default::Default for WINML_BINDING_DESC_0 {
     fn default() -> Self {
@@ -1821,7 +1769,7 @@ unsafe impl ::windows::core::Abi for WINML_IMAGE_BINDING_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_IMAGE_BINDING_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_IMAGE_BINDING_DESC>()) == 0 }
+        self.ElementType == other.ElementType && self.NumDimensions == other.NumDimensions && self.pShape == other.pShape && self.DataSize == other.DataSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for WINML_IMAGE_BINDING_DESC {}
@@ -1853,7 +1801,7 @@ unsafe impl ::windows::core::Abi for WINML_IMAGE_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_IMAGE_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_IMAGE_VARIABLE_DESC>()) == 0 }
+        self.ElementType == other.ElementType && self.NumDimensions == other.NumDimensions && self.pShape == other.pShape
     }
 }
 impl ::core::cmp::Eq for WINML_IMAGE_VARIABLE_DESC {}
@@ -1880,12 +1828,6 @@ impl ::core::clone::Clone for WINML_MAP_BINDING_DESC {
 unsafe impl ::windows::core::Abi for WINML_MAP_BINDING_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINML_MAP_BINDING_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_MAP_BINDING_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINML_MAP_BINDING_DESC {}
 impl ::core::default::Default for WINML_MAP_BINDING_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1906,12 +1848,6 @@ impl ::core::clone::Clone for WINML_MAP_BINDING_DESC_0 {
 unsafe impl ::windows::core::Abi for WINML_MAP_BINDING_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINML_MAP_BINDING_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_MAP_BINDING_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINML_MAP_BINDING_DESC_0 {}
 impl ::core::default::Default for WINML_MAP_BINDING_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1934,12 +1870,6 @@ impl ::core::clone::Clone for WINML_MAP_BINDING_DESC_1 {
 unsafe impl ::windows::core::Abi for WINML_MAP_BINDING_DESC_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINML_MAP_BINDING_DESC_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_MAP_BINDING_DESC_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINML_MAP_BINDING_DESC_1 {}
 impl ::core::default::Default for WINML_MAP_BINDING_DESC_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1967,7 +1897,7 @@ unsafe impl ::windows::core::Abi for WINML_MAP_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_MAP_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_MAP_VARIABLE_DESC>()) == 0 }
+        self.KeyType == other.KeyType && self.Fields == other.Fields
     }
 }
 impl ::core::cmp::Eq for WINML_MAP_VARIABLE_DESC {}
@@ -2001,7 +1931,7 @@ unsafe impl ::windows::core::Abi for WINML_MODEL_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_MODEL_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_MODEL_DESC>()) == 0 }
+        self.Author == other.Author && self.Name == other.Name && self.Domain == other.Domain && self.Description == other.Description && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for WINML_MODEL_DESC {}
@@ -2065,12 +1995,6 @@ impl ::core::clone::Clone for WINML_SEQUENCE_BINDING_DESC {
 unsafe impl ::windows::core::Abi for WINML_SEQUENCE_BINDING_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINML_SEQUENCE_BINDING_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_SEQUENCE_BINDING_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINML_SEQUENCE_BINDING_DESC {}
 impl ::core::default::Default for WINML_SEQUENCE_BINDING_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2093,12 +2017,6 @@ impl ::core::clone::Clone for WINML_SEQUENCE_BINDING_DESC_0 {
 unsafe impl ::windows::core::Abi for WINML_SEQUENCE_BINDING_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINML_SEQUENCE_BINDING_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_SEQUENCE_BINDING_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINML_SEQUENCE_BINDING_DESC_0 {}
 impl ::core::default::Default for WINML_SEQUENCE_BINDING_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2125,7 +2043,7 @@ unsafe impl ::windows::core::Abi for WINML_SEQUENCE_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_SEQUENCE_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_SEQUENCE_VARIABLE_DESC>()) == 0 }
+        self.ElementType == other.ElementType
     }
 }
 impl ::core::cmp::Eq for WINML_SEQUENCE_VARIABLE_DESC {}
@@ -2159,7 +2077,7 @@ unsafe impl ::windows::core::Abi for WINML_TENSOR_BINDING_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_TENSOR_BINDING_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_TENSOR_BINDING_DESC>()) == 0 }
+        self.DataType == other.DataType && self.NumDimensions == other.NumDimensions && self.pShape == other.pShape && self.DataSize == other.DataSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for WINML_TENSOR_BINDING_DESC {}
@@ -2191,7 +2109,7 @@ unsafe impl ::windows::core::Abi for WINML_TENSOR_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for WINML_TENSOR_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_TENSOR_VARIABLE_DESC>()) == 0 }
+        self.ElementType == other.ElementType && self.NumDimensions == other.NumDimensions && self.pShape == other.pShape
     }
 }
 impl ::core::cmp::Eq for WINML_TENSOR_VARIABLE_DESC {}
@@ -2223,14 +2141,6 @@ unsafe impl ::windows::core::Abi for WINML_VARIABLE_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINML_VARIABLE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_VARIABLE_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINML_VARIABLE_DESC {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINML_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2257,14 +2167,6 @@ impl ::core::clone::Clone for WINML_VARIABLE_DESC_0 {
 unsafe impl ::windows::core::Abi for WINML_VARIABLE_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINML_VARIABLE_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINML_VARIABLE_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINML_VARIABLE_DESC_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINML_VARIABLE_DESC_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -1441,7 +1441,7 @@ unsafe impl ::windows::core::Abi for COLUMNSTATUS {
 }
 impl ::core::cmp::PartialEq for COLUMNSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLUMNSTATUS>()) == 0 }
+        self.cPropCount == other.cPropCount && self.cPropsLoaded == other.cPropsLoaded
     }
 }
 impl ::core::cmp::Eq for COLUMNSTATUS {}
@@ -1473,14 +1473,6 @@ unsafe impl ::windows::core::Abi for CProperty {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CProperty {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CProperty>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CProperty {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CProperty {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1506,14 +1498,6 @@ impl ::core::clone::Clone for CProperty_0 {
 unsafe impl ::windows::core::Abi for CProperty_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CProperty_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CProperty_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CProperty_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CProperty_0 {
     fn default() -> Self {
@@ -1550,7 +1534,7 @@ unsafe impl ::windows::core::Abi for HHNTRACK {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::cmp::PartialEq for HHNTRACK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HHNTRACK>()) == 0 }
+        self.hdr == other.hdr && self.pszCurUrl == other.pszCurUrl && self.idAction == other.idAction && self.phhWinType == other.phhWinType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
@@ -1589,7 +1573,7 @@ unsafe impl ::windows::core::Abi for HHN_NOTIFY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::cmp::PartialEq for HHN_NOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HHN_NOTIFY>()) == 0 }
+        self.hdr == other.hdr && self.pszUrl == other.pszUrl
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
@@ -1634,7 +1618,7 @@ unsafe impl ::windows::core::Abi for HH_AKLINK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HH_AKLINK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_AKLINK>()) == 0 }
+        self.cbStruct == other.cbStruct && self.fReserved == other.fReserved && self.pszKeywords == other.pszKeywords && self.pszUrl == other.pszUrl && self.pszMsgText == other.pszMsgText && self.pszMsgTitle == other.pszMsgTitle && self.pszWindow == other.pszWindow && self.fIndexOnFail == other.fIndexOnFail
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1668,7 +1652,7 @@ unsafe impl ::windows::core::Abi for HH_ENUM_CAT {
 }
 impl ::core::cmp::PartialEq for HH_ENUM_CAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_ENUM_CAT>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pszCatName == other.pszCatName && self.pszCatDescription == other.pszCatDescription
     }
 }
 impl ::core::cmp::Eq for HH_ENUM_CAT {}
@@ -1702,7 +1686,7 @@ unsafe impl ::windows::core::Abi for HH_ENUM_IT {
 }
 impl ::core::cmp::PartialEq for HH_ENUM_IT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_ENUM_IT>()) == 0 }
+        self.cbStruct == other.cbStruct && self.iType == other.iType && self.pszCatName == other.pszCatName && self.pszITName == other.pszITName && self.pszITDescription == other.pszITDescription
     }
 }
 impl ::core::cmp::Eq for HH_ENUM_IT {}
@@ -1745,7 +1729,7 @@ unsafe impl ::windows::core::Abi for HH_FTS_QUERY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HH_FTS_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_FTS_QUERY>()) == 0 }
+        self.cbStruct == other.cbStruct && self.fUniCodeStrings == other.fUniCodeStrings && self.pszSearchQuery == other.pszSearchQuery && self.iProximity == other.iProximity && self.fStemmedSearch == other.fStemmedSearch && self.fTitleOnly == other.fTitleOnly && self.fExecute == other.fExecute && self.pszWindow == other.pszWindow
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1773,14 +1757,6 @@ impl ::core::clone::Clone for HH_GLOBAL_PROPERTY {
 unsafe impl ::windows::core::Abi for HH_GLOBAL_PROPERTY {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for HH_GLOBAL_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.var == other.var
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for HH_GLOBAL_PROPERTY {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for HH_GLOBAL_PROPERTY {
     fn default() -> Self {
@@ -1822,7 +1798,7 @@ unsafe impl ::windows::core::Abi for HH_POPUP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HH_POPUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_POPUP>()) == 0 }
+        self.cbStruct == other.cbStruct && self.hinst == other.hinst && self.idString == other.idString && self.pszText == other.pszText && self.pt == other.pt && self.clrForeground == other.clrForeground && self.clrBackground == other.clrBackground && self.rcMargins == other.rcMargins && self.pszFont == other.pszFont
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1856,7 +1832,7 @@ unsafe impl ::windows::core::Abi for HH_SET_INFOTYPE {
 }
 impl ::core::cmp::PartialEq for HH_SET_INFOTYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_SET_INFOTYPE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pszCatName == other.pszCatName && self.pszInfoTypeName == other.pszInfoTypeName
     }
 }
 impl ::core::cmp::Eq for HH_SET_INFOTYPE {}
@@ -1964,7 +1940,42 @@ unsafe impl ::windows::core::Abi for HH_WINTYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HH_WINTYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HH_WINTYPE>()) == 0 }
+        self.cbStruct == other.cbStruct
+            && self.fUniCodeStrings == other.fUniCodeStrings
+            && self.pszType == other.pszType
+            && self.fsValidMembers == other.fsValidMembers
+            && self.fsWinProperties == other.fsWinProperties
+            && self.pszCaption == other.pszCaption
+            && self.dwStyles == other.dwStyles
+            && self.dwExStyles == other.dwExStyles
+            && self.rcWindowPos == other.rcWindowPos
+            && self.nShowState == other.nShowState
+            && self.hwndHelp == other.hwndHelp
+            && self.hwndCaller == other.hwndCaller
+            && self.paInfoTypes == other.paInfoTypes
+            && self.hwndToolBar == other.hwndToolBar
+            && self.hwndNavigation == other.hwndNavigation
+            && self.hwndHTML == other.hwndHTML
+            && self.iNavWidth == other.iNavWidth
+            && self.rcHTML == other.rcHTML
+            && self.pszToc == other.pszToc
+            && self.pszIndex == other.pszIndex
+            && self.pszFile == other.pszFile
+            && self.pszHome == other.pszHome
+            && self.fsToolBarFlags == other.fsToolBarFlags
+            && self.fNotExpanded == other.fNotExpanded
+            && self.curNavType == other.curNavType
+            && self.tabpos == other.tabpos
+            && self.idNotify == other.idNotify
+            && self.tabOrder == other.tabOrder
+            && self.cHistory == other.cHistory
+            && self.pszJump1 == other.pszJump1
+            && self.pszJump2 == other.pszJump2
+            && self.pszUrlJump1 == other.pszUrlJump1
+            && self.pszUrlJump2 == other.pszUrlJump2
+            && self.rcMinSize == other.rcMinSize
+            && self.cbInfoTypes == other.cbInfoTypes
+            && self.pszCustomTabs == other.pszCustomTabs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2005,7 +2016,7 @@ unsafe impl ::windows::core::Abi for ROWSTATUS {
 }
 impl ::core::cmp::PartialEq for ROWSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROWSTATUS>()) == 0 }
+        self.lRowFirst == other.lRowFirst && self.cRows == other.cRows && self.cProperties == other.cProperties && self.cRowsTotal == other.cRowsTotal
     }
 }
 impl ::core::cmp::Eq for ROWSTATUS {}

--- a/crates/libs/windows/src/Windows/Win32/Data/RightsManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/RightsManagement/mod.rs
@@ -1171,7 +1171,7 @@ unsafe impl ::windows::core::Abi for DRMBOUNDLICENSEPARAMS {
 }
 impl ::core::cmp::PartialEq for DRMBOUNDLICENSEPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRMBOUNDLICENSEPARAMS>()) == 0 }
+        self.uVersion == other.uVersion && self.hEnablingPrincipal == other.hEnablingPrincipal && self.hSecureStore == other.hSecureStore && self.wszRightsRequested == other.wszRightsRequested && self.wszRightsGroup == other.wszRightsGroup && self.idResource == other.idResource && self.cAuthenticatorCount == other.cAuthenticatorCount && self.rghAuthenticators == other.rghAuthenticators && self.wszDefaultEnablingPrincipalCredentials == other.wszDefaultEnablingPrincipalCredentials && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DRMBOUNDLICENSEPARAMS {}
@@ -1203,7 +1203,7 @@ unsafe impl ::windows::core::Abi for DRMID {
 }
 impl ::core::cmp::PartialEq for DRMID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRMID>()) == 0 }
+        self.uVersion == other.uVersion && self.wszIDType == other.wszIDType && self.wszID == other.wszID
     }
 }
 impl ::core::cmp::Eq for DRMID {}
@@ -1235,7 +1235,7 @@ unsafe impl ::windows::core::Abi for DRM_ACTSERV_INFO {
 }
 impl ::core::cmp::PartialEq for DRM_ACTSERV_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_ACTSERV_INFO>()) == 0 }
+        self.uVersion == other.uVersion && self.wszPubKey == other.wszPubKey && self.wszURL == other.wszURL
     }
 }
 impl ::core::cmp::Eq for DRM_ACTSERV_INFO {}
@@ -1269,7 +1269,7 @@ unsafe impl ::windows::core::Abi for DRM_CLIENT_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for DRM_CLIENT_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_CLIENT_VERSION_INFO>()) == 0 }
+        self.uStructVersion == other.uStructVersion && self.dwVersion == other.dwVersion && self.wszHierarchy == other.wszHierarchy && self.wszProductId == other.wszProductId && self.wszProductDescription == other.wszProductDescription
     }
 }
 impl ::core::cmp::Eq for DRM_CLIENT_VERSION_INFO {}
@@ -1304,7 +1304,7 @@ unsafe impl ::windows::core::Abi for DRM_LICENSE_ACQ_DATA {
 }
 impl ::core::cmp::PartialEq for DRM_LICENSE_ACQ_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_LICENSE_ACQ_DATA>()) == 0 }
+        self.uVersion == other.uVersion && self.wszURL == other.wszURL && self.wszLocalFilename == other.wszLocalFilename && self.pbPostData == other.pbPostData && self.dwPostDataSize == other.dwPostDataSize && self.wszFriendlyName == other.wszFriendlyName
     }
 }
 impl ::core::cmp::Eq for DRM_LICENSE_ACQ_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
@@ -14754,7 +14754,7 @@ unsafe impl ::windows::core::Abi for XHR_CERT {
 }
 impl ::core::cmp::PartialEq for XHR_CERT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XHR_CERT>()) == 0 }
+        self.cbCert == other.cbCert && self.pbCert == other.pbCert
     }
 }
 impl ::core::cmp::Eq for XHR_CERT {}
@@ -14795,7 +14795,7 @@ unsafe impl ::windows::core::Abi for XHR_COOKIE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for XHR_COOKIE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XHR_COOKIE>()) == 0 }
+        self.pwszUrl == other.pwszUrl && self.pwszName == other.pwszName && self.pwszValue == other.pwszValue && self.pwszP3PPolicy == other.pwszP3PPolicy && self.ftExpires == other.ftExpires && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14916,7 +14916,28 @@ unsafe impl ::windows::core::Abi for __msxml6_ReferenceRemainingTypes__ {
 }
 impl ::core::cmp::PartialEq for __msxml6_ReferenceRemainingTypes__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<__msxml6_ReferenceRemainingTypes__>()) == 0 }
+        self.__tagDomNodeType__ == other.__tagDomNodeType__
+            && self.__domNodeType__ == other.__domNodeType__
+            && self.__serverXmlHttpOptionEnum__ == other.__serverXmlHttpOptionEnum__
+            && self.__serverXmlHttpOption__ == other.__serverXmlHttpOption__
+            && self.__serverCertOptionEnum__ == other.__serverCertOptionEnum__
+            && self.__serverCertOption__ == other.__serverCertOption__
+            && self.__proxySettingEnum__ == other.__proxySettingEnum__
+            && self.__proxySetting__ == other.__proxySetting__
+            && self.__somItemTypeEnum__ == other.__somItemTypeEnum__
+            && self.__somItemType__ == other.__somItemType__
+            && self.__schemaUseEnum__ == other.__schemaUseEnum__
+            && self.__schemaUse__ == other.__schemaUse__
+            && self.__schemaDerivationMethodEnum__ == other.__schemaDerivationMethodEnum__
+            && self.__schemaDerivationMethod__ == other.__schemaDerivationMethod__
+            && self.__schemaContentTypeEnum__ == other.__schemaContentTypeEnum__
+            && self.__schemaContentType__ == other.__schemaContentType__
+            && self.__schemaProcessContentsEnum__ == other.__schemaProcessContentsEnum__
+            && self.__schemaProcessContents__ == other.__schemaProcessContents__
+            && self.__schemaWhitespaceEnum__ == other.__schemaWhitespaceEnum__
+            && self.__schemaWhitespace__ == other.__schemaWhitespace__
+            && self.__schemaTypeVarietyEnum__ == other.__schemaTypeVarietyEnum__
+            && self.__schemaTypeVariety__ == other.__schemaTypeVariety__
     }
 }
 impl ::core::cmp::Eq for __msxml6_ReferenceRemainingTypes__ {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
@@ -6330,18 +6330,12 @@ impl ::core::clone::Clone for alljoyn_aboutdatalistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_aboutdatalistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_aboutdatalistener_callbacks").field("about_datalistener_getaboutdata", &self.about_datalistener_getaboutdata.map(|f| f as usize)).field("about_datalistener_getannouncedaboutdata", &self.about_datalistener_getannouncedaboutdata.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_aboutdatalistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_aboutdatalistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_aboutdatalistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_aboutdatalistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_aboutdatalistener_callbacks {}
 impl ::core::default::Default for alljoyn_aboutdatalistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6387,18 +6381,12 @@ impl ::core::clone::Clone for alljoyn_aboutlistener_callback {
 }
 impl ::core::fmt::Debug for alljoyn_aboutlistener_callback {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_aboutlistener_callback").field("about_listener_announced", &self.about_listener_announced.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_aboutlistener_callback").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_aboutlistener_callback {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_aboutlistener_callback {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_aboutlistener_callback>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_aboutlistener_callback {}
 impl ::core::default::Default for alljoyn_aboutlistener_callback {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6525,18 +6513,12 @@ impl ::core::clone::Clone for alljoyn_applicationstatelistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_applicationstatelistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_applicationstatelistener_callbacks").field("state", &self.state.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_applicationstatelistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_applicationstatelistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_applicationstatelistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_applicationstatelistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_applicationstatelistener_callbacks {}
 impl ::core::default::Default for alljoyn_applicationstatelistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6585,18 +6567,12 @@ impl ::core::clone::Clone for alljoyn_authlistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_authlistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_authlistener_callbacks").field("request_credentials", &self.request_credentials.map(|f| f as usize)).field("verify_credentials", &self.verify_credentials.map(|f| f as usize)).field("security_violation", &self.security_violation.map(|f| f as usize)).field("authentication_complete", &self.authentication_complete.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_authlistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_authlistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_authlistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_authlistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_authlistener_callbacks {}
 impl ::core::default::Default for alljoyn_authlistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6618,18 +6594,12 @@ impl ::core::clone::Clone for alljoyn_authlistenerasync_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_authlistenerasync_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_authlistenerasync_callbacks").field("request_credentials", &self.request_credentials.map(|f| f as usize)).field("verify_credentials", &self.verify_credentials.map(|f| f as usize)).field("security_violation", &self.security_violation.map(|f| f as usize)).field("authentication_complete", &self.authentication_complete.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_authlistenerasync_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_authlistenerasync_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_authlistenerasync_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_authlistenerasync_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_authlistenerasync_callbacks {}
 impl ::core::default::Default for alljoyn_authlistenerasync_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6736,27 +6706,12 @@ impl ::core::clone::Clone for alljoyn_buslistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_buslistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_buslistener_callbacks")
-            .field("listener_registered", &self.listener_registered.map(|f| f as usize))
-            .field("listener_unregistered", &self.listener_unregistered.map(|f| f as usize))
-            .field("found_advertised_name", &self.found_advertised_name.map(|f| f as usize))
-            .field("lost_advertised_name", &self.lost_advertised_name.map(|f| f as usize))
-            .field("name_owner_changed", &self.name_owner_changed.map(|f| f as usize))
-            .field("bus_stopping", &self.bus_stopping.map(|f| f as usize))
-            .field("bus_disconnected", &self.bus_disconnected.map(|f| f as usize))
-            .field("property_changed", &self.property_changed.map(|f| f as usize))
-            .finish()
+        f.debug_struct("alljoyn_buslistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_buslistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_buslistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_buslistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_buslistener_callbacks {}
 impl ::core::default::Default for alljoyn_buslistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6805,18 +6760,12 @@ impl ::core::clone::Clone for alljoyn_busobject_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_busobject_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_busobject_callbacks").field("property_get", &self.property_get.map(|f| f as usize)).field("property_set", &self.property_set.map(|f| f as usize)).field("object_registered", &self.object_registered.map(|f| f as usize)).field("object_unregistered", &self.object_unregistered.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_busobject_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_busobject_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_busobject_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_busobject_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_busobject_callbacks {}
 impl ::core::default::Default for alljoyn_busobject_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6836,18 +6785,12 @@ impl ::core::clone::Clone for alljoyn_busobject_methodentry {
 }
 impl ::core::fmt::Debug for alljoyn_busobject_methodentry {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_busobject_methodentry").field("member", &self.member).field("method_handler", &self.method_handler.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_busobject_methodentry").field("member", &self.member).finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_busobject_methodentry {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_busobject_methodentry {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_busobject_methodentry>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_busobject_methodentry {}
 impl ::core::default::Default for alljoyn_busobject_methodentry {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6878,7 +6821,7 @@ unsafe impl ::windows::core::Abi for alljoyn_certificateid {
 }
 impl ::core::cmp::PartialEq for alljoyn_certificateid {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_certificateid>()) == 0 }
+        self.serial == other.serial && self.serialLen == other.serialLen && self.issuerPublicKey == other.issuerPublicKey && self.issuerAki == other.issuerAki && self.issuerAkiLen == other.issuerAkiLen
     }
 }
 impl ::core::cmp::Eq for alljoyn_certificateid {}
@@ -6909,7 +6852,7 @@ unsafe impl ::windows::core::Abi for alljoyn_certificateidarray {
 }
 impl ::core::cmp::PartialEq for alljoyn_certificateidarray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_certificateidarray>()) == 0 }
+        self.count == other.count && self.ids == other.ids
     }
 }
 impl ::core::cmp::Eq for alljoyn_certificateidarray {}
@@ -6999,7 +6942,7 @@ unsafe impl ::windows::core::Abi for alljoyn_interfacedescription_member {
 }
 impl ::core::cmp::PartialEq for alljoyn_interfacedescription_member {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_interfacedescription_member>()) == 0 }
+        self.iface == other.iface && self.memberType == other.memberType && self.name == other.name && self.signature == other.signature && self.returnSignature == other.returnSignature && self.argNames == other.argNames && self.internal_member == other.internal_member
     }
 }
 impl ::core::cmp::Eq for alljoyn_interfacedescription_member {}
@@ -7032,7 +6975,7 @@ unsafe impl ::windows::core::Abi for alljoyn_interfacedescription_property {
 }
 impl ::core::cmp::PartialEq for alljoyn_interfacedescription_property {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_interfacedescription_property>()) == 0 }
+        self.name == other.name && self.signature == other.signature && self.access == other.access && self.internal_property == other.internal_property
     }
 }
 impl ::core::cmp::Eq for alljoyn_interfacedescription_property {}
@@ -7109,18 +7052,12 @@ impl ::core::clone::Clone for alljoyn_keystorelistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_keystorelistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_keystorelistener_callbacks").field("load_request", &self.load_request.map(|f| f as usize)).field("store_request", &self.store_request.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_keystorelistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_keystorelistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_keystorelistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_keystorelistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_keystorelistener_callbacks {}
 impl ::core::default::Default for alljoyn_keystorelistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7142,18 +7079,12 @@ impl ::core::clone::Clone for alljoyn_keystorelistener_with_synchronization_call
 }
 impl ::core::fmt::Debug for alljoyn_keystorelistener_with_synchronization_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_keystorelistener_with_synchronization_callbacks").field("load_request", &self.load_request.map(|f| f as usize)).field("store_request", &self.store_request.map(|f| f as usize)).field("acquire_exclusive_lock", &self.acquire_exclusive_lock.map(|f| f as usize)).field("release_exclusive_lock", &self.release_exclusive_lock.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_keystorelistener_with_synchronization_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_keystorelistener_with_synchronization_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_keystorelistener_with_synchronization_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_keystorelistener_with_synchronization_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_keystorelistener_with_synchronization_callbacks {}
 impl ::core::default::Default for alljoyn_keystorelistener_with_synchronization_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7181,7 +7112,7 @@ unsafe impl ::windows::core::Abi for alljoyn_manifestarray {
 }
 impl ::core::cmp::PartialEq for alljoyn_manifestarray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_manifestarray>()) == 0 }
+        self.count == other.count && self.xmls == other.xmls
     }
 }
 impl ::core::cmp::Eq for alljoyn_manifestarray {}
@@ -7312,18 +7243,12 @@ impl ::core::clone::Clone for alljoyn_observerlistener_callback {
 }
 impl ::core::fmt::Debug for alljoyn_observerlistener_callback {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_observerlistener_callback").field("object_discovered", &self.object_discovered.map(|f| f as usize)).field("object_lost", &self.object_lost.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_observerlistener_callback").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_observerlistener_callback {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_observerlistener_callback {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_observerlistener_callback>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_observerlistener_callback {}
 impl ::core::default::Default for alljoyn_observerlistener_callback {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7372,18 +7297,12 @@ impl ::core::clone::Clone for alljoyn_permissionconfigurationlistener_callbacks 
 }
 impl ::core::fmt::Debug for alljoyn_permissionconfigurationlistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_permissionconfigurationlistener_callbacks").field("factory_reset", &self.factory_reset.map(|f| f as usize)).field("policy_changed", &self.policy_changed.map(|f| f as usize)).field("start_management", &self.start_management.map(|f| f as usize)).field("end_management", &self.end_management.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_permissionconfigurationlistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_permissionconfigurationlistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_permissionconfigurationlistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_permissionconfigurationlistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_permissionconfigurationlistener_callbacks {}
 impl ::core::default::Default for alljoyn_permissionconfigurationlistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7457,18 +7376,12 @@ impl ::core::clone::Clone for alljoyn_pinglistener_callback {
 }
 impl ::core::fmt::Debug for alljoyn_pinglistener_callback {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_pinglistener_callback").field("destination_found", &self.destination_found.map(|f| f as usize)).field("destination_lost", &self.destination_lost.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_pinglistener_callback").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_pinglistener_callback {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_pinglistener_callback {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_pinglistener_callback>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_pinglistener_callback {}
 impl ::core::default::Default for alljoyn_pinglistener_callback {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7597,18 +7510,12 @@ impl ::core::clone::Clone for alljoyn_sessionlistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_sessionlistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_sessionlistener_callbacks").field("session_lost", &self.session_lost.map(|f| f as usize)).field("session_member_added", &self.session_member_added.map(|f| f as usize)).field("session_member_removed", &self.session_member_removed.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_sessionlistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_sessionlistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_sessionlistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_sessionlistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_sessionlistener_callbacks {}
 impl ::core::default::Default for alljoyn_sessionlistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7682,18 +7589,12 @@ impl ::core::clone::Clone for alljoyn_sessionportlistener_callbacks {
 }
 impl ::core::fmt::Debug for alljoyn_sessionportlistener_callbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("alljoyn_sessionportlistener_callbacks").field("accept_session_joiner", &self.accept_session_joiner.map(|f| f as usize)).field("session_joined", &self.session_joined.map(|f| f as usize)).finish()
+        f.debug_struct("alljoyn_sessionportlistener_callbacks").finish()
     }
 }
 unsafe impl ::windows::core::Abi for alljoyn_sessionportlistener_callbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for alljoyn_sessionportlistener_callbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<alljoyn_sessionportlistener_callbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for alljoyn_sessionportlistener_callbacks {}
 impl ::core::default::Default for alljoyn_sessionportlistener_callbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -823,12 +823,6 @@ impl ::core::clone::Clone for WINBIO_ACCOUNT_POLICY {
 unsafe impl ::windows::core::Abi for WINBIO_ACCOUNT_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_ACCOUNT_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ACCOUNT_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_ACCOUNT_POLICY {}
 impl ::core::default::Default for WINBIO_ACCOUNT_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -856,7 +850,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ADAPTER_INTERFACE_VERSION {
 }
 impl ::core::cmp::PartialEq for WINBIO_ADAPTER_INTERFACE_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ADAPTER_INTERFACE_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for WINBIO_ADAPTER_INTERFACE_VERSION {}
@@ -887,7 +881,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ANTI_SPOOF_POLICY {
 }
 impl ::core::cmp::PartialEq for WINBIO_ANTI_SPOOF_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ANTI_SPOOF_POLICY>()) == 0 }
+        self.Action == other.Action && self.Source == other.Source
     }
 }
 impl ::core::cmp::Eq for WINBIO_ANTI_SPOOF_POLICY {}
@@ -921,14 +915,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT {
     fn default() -> Self {
@@ -974,14 +960,6 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1016,7 +994,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_0>()) == 0 }
+        self.Sample == other.Sample && self.SampleSize == other.SampleSize && self.RejectDetail == other.RejectDetail
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1061,7 +1039,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_1>()) == 0 }
+        self.Component == other.Component && self.ControlCode == other.ControlCode && self.OperationStatus == other.OperationStatus && self.SendBuffer == other.SendBuffer && self.SendBufferSize == other.SendBufferSize && self.ReceiveBuffer == other.ReceiveBuffer && self.ReceiveBufferSize == other.ReceiveBufferSize && self.ReceiveDataSize == other.ReceiveDataSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1091,14 +1069,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_2 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_2 {
     fn default() -> Self {
@@ -1132,7 +1102,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_3>()) == 0 }
+        self.SubFactor == other.SubFactor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1170,7 +1140,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_4>()) == 0 }
+        self.RejectDetail == other.RejectDetail
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1200,14 +1170,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_5 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_5 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_5>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_5 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_5 {
     fn default() -> Self {
@@ -1241,7 +1203,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_6>()) == 0 }
+        self.SelectorValue == other.SelectorValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1280,7 +1242,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_7 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_7>()) == 0 }
+        self.UnitCount == other.UnitCount && self.UnitSchemaArray == other.UnitSchemaArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1319,7 +1281,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_8 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_8>()) == 0 }
+        self.StorageCount == other.StorageCount && self.StorageSchemaArray == other.StorageSchemaArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1350,14 +1312,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_9 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_9 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_9 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_9>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_9 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_9 {
     fn default() -> Self {
@@ -1392,7 +1346,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_10 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_10>()) == 0 }
+        self.BspCount == other.BspCount && self.BspSchemaArray == other.BspSchemaArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1421,14 +1375,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_11 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_11 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_11 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_11>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_11 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_11 {
     fn default() -> Self {
@@ -1459,14 +1405,6 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_12 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_12 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_12>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_12 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_12 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1491,14 +1429,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_13 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_13 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_13 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_13>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_13 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_13 {
     fn default() -> Self {
@@ -1527,14 +1457,6 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_14 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_14 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_14>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_14 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_14 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1560,14 +1482,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_15 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_15 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_15 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_15>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_15 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_15 {
     fn default() -> Self {
@@ -1603,7 +1517,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_16 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_16>()) == 0 }
+        self.ChangeType == other.ChangeType && self.PresenceCount == other.PresenceCount && self.PresenceArray == other.PresenceArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1641,7 +1555,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_17 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_17 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_17>()) == 0 }
+        self.ExtendedStatus == other.ExtendedStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1675,14 +1589,6 @@ impl ::core::clone::Clone for WINBIO_ASYNC_RESULT_0_18 {
 unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_18 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_18 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_18>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_ASYNC_RESULT_0_18 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_ASYNC_RESULT_0_18 {
     fn default() -> Self {
@@ -1718,7 +1624,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_19 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_19 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_19>()) == 0 }
+        self.Match == other.Match && self.RejectDetail == other.RejectDetail && self.Ticket == other.Ticket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1757,7 +1663,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ASYNC_RESULT_0_20 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_ASYNC_RESULT_0_20 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ASYNC_RESULT_0_20>()) == 0 }
+        self.Match == other.Match && self.RejectDetail == other.RejectDetail
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1819,7 +1725,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BDB_ANSI_381_HEADER {
 }
 impl ::core::cmp::PartialEq for WINBIO_BDB_ANSI_381_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BDB_ANSI_381_HEADER>()) == 0 }
+        self.RecordLength == other.RecordLength && self.FormatIdentifier == other.FormatIdentifier && self.VersionNumber == other.VersionNumber && self.ProductId == other.ProductId && self.CaptureDeviceId == other.CaptureDeviceId && self.ImageAcquisitionLevel == other.ImageAcquisitionLevel && self.HorizontalScanResolution == other.HorizontalScanResolution && self.VerticalScanResolution == other.VerticalScanResolution && self.HorizontalImageResolution == other.HorizontalImageResolution && self.VerticalImageResolution == other.VerticalImageResolution && self.ElementCount == other.ElementCount && self.ScaleUnits == other.ScaleUnits && self.PixelDepth == other.PixelDepth && self.ImageCompressionAlg == other.ImageCompressionAlg && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WINBIO_BDB_ANSI_381_HEADER {}
@@ -1857,7 +1763,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BDB_ANSI_381_RECORD {
 }
 impl ::core::cmp::PartialEq for WINBIO_BDB_ANSI_381_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BDB_ANSI_381_RECORD>()) == 0 }
+        self.BlockLength == other.BlockLength && self.HorizontalLineLength == other.HorizontalLineLength && self.VerticalLineLength == other.VerticalLineLength && self.Position == other.Position && self.CountOfViews == other.CountOfViews && self.ViewNumber == other.ViewNumber && self.ImageQuality == other.ImageQuality && self.ImpressionType == other.ImpressionType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WINBIO_BDB_ANSI_381_RECORD {}
@@ -1890,7 +1796,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BIR {
 }
 impl ::core::cmp::PartialEq for WINBIO_BIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BIR>()) == 0 }
+        self.HeaderBlock == other.HeaderBlock && self.StandardDataBlock == other.StandardDataBlock && self.VendorDataBlock == other.VendorDataBlock && self.SignatureBlock == other.SignatureBlock
     }
 }
 impl ::core::cmp::Eq for WINBIO_BIR {}
@@ -1921,7 +1827,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BIR_DATA {
 }
 impl ::core::cmp::PartialEq for WINBIO_BIR_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BIR_DATA>()) == 0 }
+        self.Size == other.Size && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for WINBIO_BIR_DATA {}
@@ -1975,7 +1881,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BIR_HEADER {
 }
 impl ::core::cmp::PartialEq for WINBIO_BIR_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BIR_HEADER>()) == 0 }
+        self.ValidFields == other.ValidFields && self.HeaderVersion == other.HeaderVersion && self.PatronHeaderVersion == other.PatronHeaderVersion && self.DataFlags == other.DataFlags && self.Type == other.Type && self.Subtype == other.Subtype && self.Purpose == other.Purpose && self.DataQuality == other.DataQuality && self.CreationDate == other.CreationDate && self.ValidityPeriod == other.ValidityPeriod && self.BiometricDataFormat == other.BiometricDataFormat && self.ProductId == other.ProductId
     }
 }
 impl ::core::cmp::Eq for WINBIO_BIR_HEADER {}
@@ -2006,7 +1912,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BIR_HEADER_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_BIR_HEADER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BIR_HEADER_0>()) == 0 }
+        self.BeginDate == other.BeginDate && self.EndDate == other.EndDate
     }
 }
 impl ::core::cmp::Eq for WINBIO_BIR_HEADER_0 {}
@@ -2037,7 +1943,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BLANK_PAYLOAD {
 }
 impl ::core::cmp::PartialEq for WINBIO_BLANK_PAYLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BLANK_PAYLOAD>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult
     }
 }
 impl ::core::cmp::Eq for WINBIO_BLANK_PAYLOAD {}
@@ -2071,7 +1977,7 @@ unsafe impl ::windows::core::Abi for WINBIO_BSP_SCHEMA {
 }
 impl ::core::cmp::PartialEq for WINBIO_BSP_SCHEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_BSP_SCHEMA>()) == 0 }
+        self.BiometricFactor == other.BiometricFactor && self.BspId == other.BspId && self.Description == other.Description && self.Vendor == other.Vendor && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for WINBIO_BSP_SCHEMA {}
@@ -2103,7 +2009,7 @@ unsafe impl ::windows::core::Abi for WINBIO_CALIBRATION_INFO {
 }
 impl ::core::cmp::PartialEq for WINBIO_CALIBRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_CALIBRATION_INFO>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.CalibrationData == other.CalibrationData
     }
 }
 impl ::core::cmp::Eq for WINBIO_CALIBRATION_INFO {}
@@ -2137,7 +2043,7 @@ unsafe impl ::windows::core::Abi for WINBIO_CAPTURE_DATA {
 }
 impl ::core::cmp::PartialEq for WINBIO_CAPTURE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_CAPTURE_DATA>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.SensorStatus == other.SensorStatus && self.RejectDetail == other.RejectDetail && self.CaptureData == other.CaptureData
     }
 }
 impl ::core::cmp::Eq for WINBIO_CAPTURE_DATA {}
@@ -2171,7 +2077,7 @@ unsafe impl ::windows::core::Abi for WINBIO_CAPTURE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for WINBIO_CAPTURE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_CAPTURE_PARAMETERS>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.Purpose == other.Purpose && self.Format == other.Format && self.VendorFormat == other.VendorFormat && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WINBIO_CAPTURE_PARAMETERS {}
@@ -2202,7 +2108,7 @@ unsafe impl ::windows::core::Abi for WINBIO_DATA {
 }
 impl ::core::cmp::PartialEq for WINBIO_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_DATA>()) == 0 }
+        self.Size == other.Size && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WINBIO_DATA {}
@@ -2235,7 +2141,7 @@ unsafe impl ::windows::core::Abi for WINBIO_DIAGNOSTICS {
 }
 impl ::core::cmp::PartialEq for WINBIO_DIAGNOSTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_DIAGNOSTICS>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.SensorStatus == other.SensorStatus && self.VendorDiagnostics == other.VendorDiagnostics
     }
 }
 impl ::core::cmp::Eq for WINBIO_DIAGNOSTICS {}
@@ -2270,7 +2176,7 @@ unsafe impl ::windows::core::Abi for WINBIO_ENCRYPTED_CAPTURE_PARAMS {
 }
 impl ::core::cmp::PartialEq for WINBIO_ENCRYPTED_CAPTURE_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ENCRYPTED_CAPTURE_PARAMS>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.Purpose == other.Purpose && self.Format == other.Format && self.VendorFormat == other.VendorFormat && self.Flags == other.Flags && self.NonceSize == other.NonceSize
     }
 }
 impl ::core::cmp::Eq for WINBIO_ENCRYPTED_CAPTURE_PARAMS {}
@@ -2340,67 +2246,13 @@ impl ::core::clone::Clone for WINBIO_ENGINE_INTERFACE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WINBIO_ENGINE_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINBIO_ENGINE_INTERFACE")
-            .field("Version", &self.Version)
-            .field("Type", &self.Type)
-            .field("Size", &self.Size)
-            .field("AdapterId", &self.AdapterId)
-            .field("Attach", &self.Attach.map(|f| f as usize))
-            .field("Detach", &self.Detach.map(|f| f as usize))
-            .field("ClearContext", &self.ClearContext.map(|f| f as usize))
-            .field("QueryPreferredFormat", &self.QueryPreferredFormat.map(|f| f as usize))
-            .field("QueryIndexVectorSize", &self.QueryIndexVectorSize.map(|f| f as usize))
-            .field("QueryHashAlgorithms", &self.QueryHashAlgorithms.map(|f| f as usize))
-            .field("SetHashAlgorithm", &self.SetHashAlgorithm.map(|f| f as usize))
-            .field("QuerySampleHint", &self.QuerySampleHint.map(|f| f as usize))
-            .field("AcceptSampleData", &self.AcceptSampleData.map(|f| f as usize))
-            .field("ExportEngineData", &self.ExportEngineData.map(|f| f as usize))
-            .field("VerifyFeatureSet", &self.VerifyFeatureSet.map(|f| f as usize))
-            .field("IdentifyFeatureSet", &self.IdentifyFeatureSet.map(|f| f as usize))
-            .field("CreateEnrollment", &self.CreateEnrollment.map(|f| f as usize))
-            .field("UpdateEnrollment", &self.UpdateEnrollment.map(|f| f as usize))
-            .field("GetEnrollmentStatus", &self.GetEnrollmentStatus.map(|f| f as usize))
-            .field("GetEnrollmentHash", &self.GetEnrollmentHash.map(|f| f as usize))
-            .field("CheckForDuplicate", &self.CheckForDuplicate.map(|f| f as usize))
-            .field("CommitEnrollment", &self.CommitEnrollment.map(|f| f as usize))
-            .field("DiscardEnrollment", &self.DiscardEnrollment.map(|f| f as usize))
-            .field("ControlUnit", &self.ControlUnit.map(|f| f as usize))
-            .field("ControlUnitPrivileged", &self.ControlUnitPrivileged.map(|f| f as usize))
-            .field("NotifyPowerChange", &self.NotifyPowerChange.map(|f| f as usize))
-            .field("Reserved_1", &self.Reserved_1.map(|f| f as usize))
-            .field("PipelineInit", &self.PipelineInit.map(|f| f as usize))
-            .field("PipelineCleanup", &self.PipelineCleanup.map(|f| f as usize))
-            .field("Activate", &self.Activate.map(|f| f as usize))
-            .field("Deactivate", &self.Deactivate.map(|f| f as usize))
-            .field("QueryExtendedInfo", &self.QueryExtendedInfo.map(|f| f as usize))
-            .field("IdentifyAll", &self.IdentifyAll.map(|f| f as usize))
-            .field("SetEnrollmentSelector", &self.SetEnrollmentSelector.map(|f| f as usize))
-            .field("SetEnrollmentParameters", &self.SetEnrollmentParameters.map(|f| f as usize))
-            .field("QueryExtendedEnrollmentStatus", &self.QueryExtendedEnrollmentStatus.map(|f| f as usize))
-            .field("RefreshCache", &self.RefreshCache.map(|f| f as usize))
-            .field("SelectCalibrationFormat", &self.SelectCalibrationFormat.map(|f| f as usize))
-            .field("QueryCalibrationData", &self.QueryCalibrationData.map(|f| f as usize))
-            .field("SetAccountPolicy", &self.SetAccountPolicy.map(|f| f as usize))
-            .field("CreateKey", &self.CreateKey.map(|f| f as usize))
-            .field("IdentifyFeatureSetSecure", &self.IdentifyFeatureSetSecure.map(|f| f as usize))
-            .field("AcceptPrivateSensorTypeInfo", &self.AcceptPrivateSensorTypeInfo.map(|f| f as usize))
-            .field("CreateEnrollmentAuthenticated", &self.CreateEnrollmentAuthenticated.map(|f| f as usize))
-            .field("IdentifyFeatureSetAuthenticated", &self.IdentifyFeatureSetAuthenticated.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINBIO_ENGINE_INTERFACE").field("Version", &self.Version).field("Type", &self.Type).field("Size", &self.Size).field("AdapterId", &self.AdapterId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WINBIO_ENGINE_INTERFACE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WINBIO_ENGINE_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_ENGINE_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WINBIO_ENGINE_INTERFACE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WINBIO_ENGINE_INTERFACE {
     fn default() -> Self {
@@ -2422,12 +2274,6 @@ impl ::core::clone::Clone for WINBIO_EVENT {
 unsafe impl ::windows::core::Abi for WINBIO_EVENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EVENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EVENT {}
 impl ::core::default::Default for WINBIO_EVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2449,12 +2295,6 @@ impl ::core::clone::Clone for WINBIO_EVENT_0 {
 unsafe impl ::windows::core::Abi for WINBIO_EVENT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EVENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EVENT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EVENT_0 {}
 impl ::core::default::Default for WINBIO_EVENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2481,7 +2321,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EVENT_0_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EVENT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EVENT_0_0>()) == 0 }
+        self.ErrorCode == other.ErrorCode
     }
 }
 impl ::core::cmp::Eq for WINBIO_EVENT_0_0 {}
@@ -2507,12 +2347,6 @@ impl ::core::clone::Clone for WINBIO_EVENT_0_1 {
 unsafe impl ::windows::core::Abi for WINBIO_EVENT_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EVENT_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EVENT_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EVENT_0_1 {}
 impl ::core::default::Default for WINBIO_EVENT_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2540,7 +2374,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EVENT_0_2 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EVENT_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EVENT_0_2>()) == 0 }
+        self.UnitId == other.UnitId && self.RejectDetail == other.RejectDetail
     }
 }
 impl ::core::cmp::Eq for WINBIO_EVENT_0_2 {}
@@ -2565,12 +2399,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_ENGINE_INFO {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO {}
 impl ::core::default::Default for WINBIO_EXTENDED_ENGINE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2594,12 +2422,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_ENGINE_INFO_0 {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0 {}
 impl ::core::default::Default for WINBIO_EXTENDED_ENGINE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2627,7 +2449,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_0>()) == 0 }
+        self.Capabilities == other.Capabilities && self.EnrollmentRequirements == other.EnrollmentRequirements
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_0 {}
@@ -2657,7 +2479,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_0_0>()) == 0 }
+        self.Null == other.Null
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {}
@@ -2688,7 +2510,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_1 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_1>()) == 0 }
+        self.Capabilities == other.Capabilities && self.EnrollmentRequirements == other.EnrollmentRequirements
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_1 {}
@@ -2723,7 +2545,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_1_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_1_0>()) == 0 }
+        self.GeneralSamples == other.GeneralSamples && self.Center == other.Center && self.TopEdge == other.TopEdge && self.BottomEdge == other.BottomEdge && self.LeftEdge == other.LeftEdge && self.RightEdge == other.RightEdge
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_1_0 {}
@@ -2754,7 +2576,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_2 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_2>()) == 0 }
+        self.Capabilities == other.Capabilities && self.EnrollmentRequirements == other.EnrollmentRequirements
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_2 {}
@@ -2784,7 +2606,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_2_0>()) == 0 }
+        self.Null == other.Null
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {}
@@ -2815,7 +2637,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_3 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_3>()) == 0 }
+        self.Capabilities == other.Capabilities && self.EnrollmentRequirements == other.EnrollmentRequirements
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_3 {}
@@ -2845,7 +2667,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENGINE_INFO_0_3_0>()) == 0 }
+        self.Null == other.Null
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {}
@@ -2876,7 +2698,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_PARAMETERS>()) == 0 }
+        self.Size == other.Size && self.SubFactor == other.SubFactor
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_ENROLLMENT_PARAMETERS {}
@@ -2909,14 +2731,6 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_EXTENDED_ENROLLMENT_STATUS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_EXTENDED_ENROLLMENT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2944,14 +2758,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
     fn default() -> Self {
@@ -2987,7 +2793,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0>()) == 0 }
+        self.BoundingBox == other.BoundingBox && self.Distance == other.Distance && self.OpaqueEngineData == other.OpaqueEngineData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3026,7 +2832,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0>()) == 0 }
+        self.AdapterId == other.AdapterId && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3069,7 +2875,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_1>()) == 0 }
+        self.GeneralSamples == other.GeneralSamples && self.Center == other.Center && self.TopEdge == other.TopEdge && self.BottomEdge == other.BottomEdge && self.LeftEdge == other.LeftEdge && self.RightEdge == other.RightEdge
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3125,7 +2931,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2>()) == 0 }
+        self.EyeBoundingBox_1 == other.EyeBoundingBox_1 && self.EyeBoundingBox_2 == other.EyeBoundingBox_2 && self.PupilCenter_1 == other.PupilCenter_1 && self.PupilCenter_2 == other.PupilCenter_2 && self.Distance == other.Distance && self.GridPointCompletionPercent == other.GridPointCompletionPercent && self.GridPointIndex == other.GridPointIndex && self.Point3D == other.Point3D && self.StopCaptureAndShowCriticalFeedback == other.StopCaptureAndShowCriticalFeedback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3165,7 +2971,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3203,7 +3009,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3235,14 +3041,6 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_EXTENDED_SENSOR_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_EXTENDED_SENSOR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3270,14 +3068,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_SENSOR_INFO_0 {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_EXTENDED_SENSOR_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_EXTENDED_SENSOR_INFO_0 {
     fn default() -> Self {
@@ -3314,7 +3104,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0_0>()) == 0 }
+        self.FrameSize == other.FrameSize && self.FrameOffset == other.FrameOffset && self.MandatoryOrientation == other.MandatoryOrientation && self.HardwareInfo == other.HardwareInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3354,7 +3144,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0_0_0>()) == 0 }
+        self.ColorSensorId == other.ColorSensorId && self.InfraredSensorId == other.InfraredSensorId && self.InfraredSensorRotationAngle == other.InfraredSensorRotationAngle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3392,7 +3182,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0_1>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3432,7 +3222,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0_2>()) == 0 }
+        self.FrameSize == other.FrameSize && self.FrameOffset == other.FrameOffset && self.MandatoryOrientation == other.MandatoryOrientation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3470,7 +3260,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_SENSOR_INFO_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_SENSOR_INFO_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_SENSOR_INFO_0_3>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3497,12 +3287,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_STORAGE_INFO {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO {}
 impl ::core::default::Default for WINBIO_EXTENDED_STORAGE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3526,12 +3310,6 @@ impl ::core::clone::Clone for WINBIO_EXTENDED_STORAGE_INFO_0 {
 unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO_0 {}
 impl ::core::default::Default for WINBIO_EXTENDED_STORAGE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3558,7 +3336,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO_0_0>()) == 0 }
+        self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO_0_0 {}
@@ -3588,7 +3366,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO_0_1 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO_0_1>()) == 0 }
+        self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO_0_1 {}
@@ -3618,7 +3396,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO_0_2 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO_0_2>()) == 0 }
+        self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO_0_2 {}
@@ -3648,7 +3426,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_STORAGE_INFO_0_3 {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_STORAGE_INFO_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_STORAGE_INFO_0_3>()) == 0 }
+        self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_STORAGE_INFO_0_3 {}
@@ -3679,7 +3457,7 @@ unsafe impl ::windows::core::Abi for WINBIO_EXTENDED_UNIT_STATUS {
 }
 impl ::core::cmp::PartialEq for WINBIO_EXTENDED_UNIT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_EXTENDED_UNIT_STATUS>()) == 0 }
+        self.Availability == other.Availability && self.ReasonCode == other.ReasonCode
     }
 }
 impl ::core::cmp::Eq for WINBIO_EXTENDED_UNIT_STATUS {}
@@ -3716,7 +3494,7 @@ unsafe impl ::windows::core::Abi for WINBIO_FP_BU_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_FP_BU_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_FP_BU_STATE>()) == 0 }
+        self.SensorAttached == other.SensorAttached && self.CreationResult == other.CreationResult
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3791,70 +3569,13 @@ impl ::core::clone::Clone for WINBIO_FRAMEWORK_INTERFACE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WINBIO_FRAMEWORK_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINBIO_FRAMEWORK_INTERFACE")
-            .field("Version", &self.Version)
-            .field("Type", &self.Type)
-            .field("Size", &self.Size)
-            .field("AdapterId", &self.AdapterId)
-            .field("SetUnitStatus", &self.SetUnitStatus.map(|f| f as usize))
-            .field("VsmStorageAttach", &self.VsmStorageAttach.map(|f| f as usize))
-            .field("VsmStorageDetach", &self.VsmStorageDetach.map(|f| f as usize))
-            .field("VsmStorageClearContext", &self.VsmStorageClearContext.map(|f| f as usize))
-            .field("VsmStorageCreateDatabase", &self.VsmStorageCreateDatabase.map(|f| f as usize))
-            .field("VsmStorageOpenDatabase", &self.VsmStorageOpenDatabase.map(|f| f as usize))
-            .field("VsmStorageCloseDatabase", &self.VsmStorageCloseDatabase.map(|f| f as usize))
-            .field("VsmStorageDeleteRecord", &self.VsmStorageDeleteRecord.map(|f| f as usize))
-            .field("VsmStorageNotifyPowerChange", &self.VsmStorageNotifyPowerChange.map(|f| f as usize))
-            .field("VsmStoragePipelineInit", &self.VsmStoragePipelineInit.map(|f| f as usize))
-            .field("VsmStoragePipelineCleanup", &self.VsmStoragePipelineCleanup.map(|f| f as usize))
-            .field("VsmStorageActivate", &self.VsmStorageActivate.map(|f| f as usize))
-            .field("VsmStorageDeactivate", &self.VsmStorageDeactivate.map(|f| f as usize))
-            .field("VsmStorageQueryExtendedInfo", &self.VsmStorageQueryExtendedInfo.map(|f| f as usize))
-            .field("VsmStorageCacheClear", &self.VsmStorageCacheClear.map(|f| f as usize))
-            .field("VsmStorageCacheImportBegin", &self.VsmStorageCacheImportBegin.map(|f| f as usize))
-            .field("VsmStorageCacheImportNext", &self.VsmStorageCacheImportNext.map(|f| f as usize))
-            .field("VsmStorageCacheImportEnd", &self.VsmStorageCacheImportEnd.map(|f| f as usize))
-            .field("VsmStorageCacheExportBegin", &self.VsmStorageCacheExportBegin.map(|f| f as usize))
-            .field("VsmStorageCacheExportNext", &self.VsmStorageCacheExportNext.map(|f| f as usize))
-            .field("VsmStorageCacheExportEnd", &self.VsmStorageCacheExportEnd.map(|f| f as usize))
-            .field("VsmSensorAttach", &self.VsmSensorAttach.map(|f| f as usize))
-            .field("VsmSensorDetach", &self.VsmSensorDetach.map(|f| f as usize))
-            .field("VsmSensorClearContext", &self.VsmSensorClearContext.map(|f| f as usize))
-            .field("VsmSensorPushDataToEngine", &self.VsmSensorPushDataToEngine.map(|f| f as usize))
-            .field("VsmSensorNotifyPowerChange", &self.VsmSensorNotifyPowerChange.map(|f| f as usize))
-            .field("VsmSensorPipelineInit", &self.VsmSensorPipelineInit.map(|f| f as usize))
-            .field("VsmSensorPipelineCleanup", &self.VsmSensorPipelineCleanup.map(|f| f as usize))
-            .field("VsmSensorActivate", &self.VsmSensorActivate.map(|f| f as usize))
-            .field("VsmSensorDeactivate", &self.VsmSensorDeactivate.map(|f| f as usize))
-            .field("VsmSensorAsyncImportRawBuffer", &self.VsmSensorAsyncImportRawBuffer.map(|f| f as usize))
-            .field("VsmSensorAsyncImportSecureBuffer", &self.VsmSensorAsyncImportSecureBuffer.map(|f| f as usize))
-            .field("Reserved1", &self.Reserved1.map(|f| f as usize))
-            .field("Reserved2", &self.Reserved2.map(|f| f as usize))
-            .field("Reserved3", &self.Reserved3.map(|f| f as usize))
-            .field("Reserved4", &self.Reserved4.map(|f| f as usize))
-            .field("Reserved5", &self.Reserved5.map(|f| f as usize))
-            .field("AllocateMemory", &self.AllocateMemory.map(|f| f as usize))
-            .field("FreeMemory", &self.FreeMemory.map(|f| f as usize))
-            .field("GetProperty", &self.GetProperty.map(|f| f as usize))
-            .field("LockAndValidateSecureBuffer", &self.LockAndValidateSecureBuffer.map(|f| f as usize))
-            .field("ReleaseSecureBuffer", &self.ReleaseSecureBuffer.map(|f| f as usize))
-            .field("QueryAuthorizedEnrollments", &self.QueryAuthorizedEnrollments.map(|f| f as usize))
-            .field("DecryptSample", &self.DecryptSample.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINBIO_FRAMEWORK_INTERFACE").field("Version", &self.Version).field("Type", &self.Type).field("Size", &self.Size).field("AdapterId", &self.AdapterId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WINBIO_FRAMEWORK_INTERFACE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WINBIO_FRAMEWORK_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_FRAMEWORK_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WINBIO_FRAMEWORK_INTERFACE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WINBIO_FRAMEWORK_INTERFACE {
     fn default() -> Self {
@@ -3885,7 +3606,7 @@ unsafe impl ::windows::core::Abi for WINBIO_GESTURE_METADATA {
 }
 impl ::core::cmp::PartialEq for WINBIO_GESTURE_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_GESTURE_METADATA>()) == 0 }
+        self.Size == other.Size && self.BiometricType == other.BiometricType && self.MatchType == other.MatchType && self.ProtectionType == other.ProtectionType
     }
 }
 impl ::core::cmp::Eq for WINBIO_GESTURE_METADATA {}
@@ -3917,7 +3638,7 @@ unsafe impl ::windows::core::Abi for WINBIO_GET_INDICATOR {
 }
 impl ::core::cmp::PartialEq for WINBIO_GET_INDICATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_GET_INDICATOR>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.IndicatorStatus == other.IndicatorStatus
     }
 }
 impl ::core::cmp::Eq for WINBIO_GET_INDICATOR {}
@@ -3941,12 +3662,6 @@ impl ::core::clone::Clone for WINBIO_IDENTITY {
 unsafe impl ::windows::core::Abi for WINBIO_IDENTITY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_IDENTITY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_IDENTITY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_IDENTITY {}
 impl ::core::default::Default for WINBIO_IDENTITY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3970,12 +3685,6 @@ impl ::core::clone::Clone for WINBIO_IDENTITY_0 {
 unsafe impl ::windows::core::Abi for WINBIO_IDENTITY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_IDENTITY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_IDENTITY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_IDENTITY_0 {}
 impl ::core::default::Default for WINBIO_IDENTITY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4003,7 +3712,7 @@ unsafe impl ::windows::core::Abi for WINBIO_IDENTITY_0_0 {
 }
 impl ::core::cmp::PartialEq for WINBIO_IDENTITY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_IDENTITY_0_0>()) == 0 }
+        self.Size == other.Size && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WINBIO_IDENTITY_0_0 {}
@@ -4035,7 +3744,7 @@ unsafe impl ::windows::core::Abi for WINBIO_NOTIFY_WAKE {
 }
 impl ::core::cmp::PartialEq for WINBIO_NOTIFY_WAKE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_NOTIFY_WAKE>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.Reason == other.Reason
     }
 }
 impl ::core::cmp::Eq for WINBIO_NOTIFY_WAKE {}
@@ -4091,7 +3800,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PIPELINE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for WINBIO_PIPELINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PIPELINE>()) == 0 }
+        self.SensorHandle == other.SensorHandle && self.EngineHandle == other.EngineHandle && self.StorageHandle == other.StorageHandle && self.SensorInterface == other.SensorInterface && self.EngineInterface == other.EngineInterface && self.StorageInterface == other.StorageInterface && self.SensorContext == other.SensorContext && self.EngineContext == other.EngineContext && self.StorageContext == other.StorageContext && self.FrameworkInterface == other.FrameworkInterface
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -4129,14 +3838,6 @@ unsafe impl ::windows::core::Abi for WINBIO_PRESENCE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_PRESENCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_PRESENCE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_PRESENCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4170,7 +3871,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PRESENCE_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_PRESENCE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE_0>()) == 0 }
+        self.Size == other.Size && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4200,14 +3901,6 @@ impl ::core::clone::Clone for WINBIO_PRESENCE_PROPERTIES {
 unsafe impl ::windows::core::Abi for WINBIO_PRESENCE_PROPERTIES {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINBIO_PRESENCE_PROPERTIES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE_PROPERTIES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINBIO_PRESENCE_PROPERTIES {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINBIO_PRESENCE_PROPERTIES {
     fn default() -> Self {
@@ -4243,7 +3936,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PRESENCE_PROPERTIES_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_PRESENCE_PROPERTIES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE_PROPERTIES_0>()) == 0 }
+        self.BoundingBox == other.BoundingBox && self.Distance == other.Distance && self.OpaqueEngineData == other.OpaqueEngineData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4282,7 +3975,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PRESENCE_PROPERTIES_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_PRESENCE_PROPERTIES_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE_PROPERTIES_0_0>()) == 0 }
+        self.AdapterId == other.AdapterId && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4324,7 +4017,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PRESENCE_PROPERTIES_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINBIO_PRESENCE_PROPERTIES_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRESENCE_PROPERTIES_1>()) == 0 }
+        self.EyeBoundingBox_1 == other.EyeBoundingBox_1 && self.EyeBoundingBox_2 == other.EyeBoundingBox_2 && self.PupilCenter_1 == other.PupilCenter_1 && self.PupilCenter_2 == other.PupilCenter_2 && self.Distance == other.Distance
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4358,7 +4051,7 @@ unsafe impl ::windows::core::Abi for WINBIO_PRIVATE_SENSOR_TYPE_INFO {
 }
 impl ::core::cmp::PartialEq for WINBIO_PRIVATE_SENSOR_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PRIVATE_SENSOR_TYPE_INFO>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.PrivateSensorTypeInfo == other.PrivateSensorTypeInfo
     }
 }
 impl ::core::cmp::Eq for WINBIO_PRIVATE_SENSOR_TYPE_INFO {}
@@ -4386,12 +4079,6 @@ impl ::core::clone::Clone for WINBIO_PROTECTION_POLICY {
 unsafe impl ::windows::core::Abi for WINBIO_PROTECTION_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINBIO_PROTECTION_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_PROTECTION_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINBIO_PROTECTION_POLICY {}
 impl ::core::default::Default for WINBIO_PROTECTION_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4419,7 +4106,7 @@ unsafe impl ::windows::core::Abi for WINBIO_REGISTERED_FORMAT {
 }
 impl ::core::cmp::PartialEq for WINBIO_REGISTERED_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_REGISTERED_FORMAT>()) == 0 }
+        self.Owner == other.Owner && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for WINBIO_REGISTERED_FORMAT {}
@@ -4452,7 +4139,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SECURE_BUFFER_HEADER_V1 {
 }
 impl ::core::cmp::PartialEq for WINBIO_SECURE_BUFFER_HEADER_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SECURE_BUFFER_HEADER_V1>()) == 0 }
+        self.Type == other.Type && self.Size == other.Size && self.Flags == other.Flags && self.ValidationTag == other.ValidationTag
     }
 }
 impl ::core::cmp::Eq for WINBIO_SECURE_BUFFER_HEADER_V1 {}
@@ -4487,7 +4174,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SECURE_CONNECTION_DATA {
 }
 impl ::core::cmp::PartialEq for WINBIO_SECURE_CONNECTION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SECURE_CONNECTION_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Flags == other.Flags && self.ModelCertificateSize == other.ModelCertificateSize && self.IntermediateCA1Size == other.IntermediateCA1Size && self.IntermediateCA2Size == other.IntermediateCA2Size
     }
 }
 impl ::core::cmp::Eq for WINBIO_SECURE_CONNECTION_DATA {}
@@ -4519,7 +4206,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SECURE_CONNECTION_PARAMS {
 }
 impl ::core::cmp::PartialEq for WINBIO_SECURE_CONNECTION_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SECURE_CONNECTION_PARAMS>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.Version == other.Version && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WINBIO_SECURE_CONNECTION_PARAMS {}
@@ -4573,7 +4260,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SENSOR_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for WINBIO_SENSOR_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SENSOR_ATTRIBUTES>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.WinBioVersion == other.WinBioVersion && self.SensorType == other.SensorType && self.SensorSubType == other.SensorSubType && self.Capabilities == other.Capabilities && self.ManufacturerName == other.ManufacturerName && self.ModelName == other.ModelName && self.SerialNumber == other.SerialNumber && self.FirmwareVersion == other.FirmwareVersion && self.SupportedFormatEntries == other.SupportedFormatEntries && self.SupportedFormat == other.SupportedFormat
     }
 }
 impl ::core::cmp::Eq for WINBIO_SENSOR_ATTRIBUTES {}
@@ -4633,57 +4320,13 @@ impl ::core::clone::Clone for WINBIO_SENSOR_INTERFACE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WINBIO_SENSOR_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINBIO_SENSOR_INTERFACE")
-            .field("Version", &self.Version)
-            .field("Type", &self.Type)
-            .field("Size", &self.Size)
-            .field("AdapterId", &self.AdapterId)
-            .field("Attach", &self.Attach.map(|f| f as usize))
-            .field("Detach", &self.Detach.map(|f| f as usize))
-            .field("ClearContext", &self.ClearContext.map(|f| f as usize))
-            .field("QueryStatus", &self.QueryStatus.map(|f| f as usize))
-            .field("Reset", &self.Reset.map(|f| f as usize))
-            .field("SetMode", &self.SetMode.map(|f| f as usize))
-            .field("SetIndicatorStatus", &self.SetIndicatorStatus.map(|f| f as usize))
-            .field("GetIndicatorStatus", &self.GetIndicatorStatus.map(|f| f as usize))
-            .field("StartCapture", &self.StartCapture.map(|f| f as usize))
-            .field("FinishCapture", &self.FinishCapture.map(|f| f as usize))
-            .field("ExportSensorData", &self.ExportSensorData.map(|f| f as usize))
-            .field("Cancel", &self.Cancel.map(|f| f as usize))
-            .field("PushDataToEngine", &self.PushDataToEngine.map(|f| f as usize))
-            .field("ControlUnit", &self.ControlUnit.map(|f| f as usize))
-            .field("ControlUnitPrivileged", &self.ControlUnitPrivileged.map(|f| f as usize))
-            .field("NotifyPowerChange", &self.NotifyPowerChange.map(|f| f as usize))
-            .field("PipelineInit", &self.PipelineInit.map(|f| f as usize))
-            .field("PipelineCleanup", &self.PipelineCleanup.map(|f| f as usize))
-            .field("Activate", &self.Activate.map(|f| f as usize))
-            .field("Deactivate", &self.Deactivate.map(|f| f as usize))
-            .field("QueryExtendedInfo", &self.QueryExtendedInfo.map(|f| f as usize))
-            .field("QueryCalibrationFormats", &self.QueryCalibrationFormats.map(|f| f as usize))
-            .field("SetCalibrationFormat", &self.SetCalibrationFormat.map(|f| f as usize))
-            .field("AcceptCalibrationData", &self.AcceptCalibrationData.map(|f| f as usize))
-            .field("AsyncImportRawBuffer", &self.AsyncImportRawBuffer.map(|f| f as usize))
-            .field("AsyncImportSecureBuffer", &self.AsyncImportSecureBuffer.map(|f| f as usize))
-            .field("QueryPrivateSensorType", &self.QueryPrivateSensorType.map(|f| f as usize))
-            .field("ConnectSecure", &self.ConnectSecure.map(|f| f as usize))
-            .field("StartCaptureEx", &self.StartCaptureEx.map(|f| f as usize))
-            .field("StartNotifyWake", &self.StartNotifyWake.map(|f| f as usize))
-            .field("FinishNotifyWake", &self.FinishNotifyWake.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINBIO_SENSOR_INTERFACE").field("Version", &self.Version).field("Type", &self.Type).field("Size", &self.Size).field("AdapterId", &self.AdapterId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WINBIO_SENSOR_INTERFACE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WINBIO_SENSOR_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SENSOR_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WINBIO_SENSOR_INTERFACE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WINBIO_SENSOR_INTERFACE {
     fn default() -> Self {
@@ -4712,7 +4355,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SET_INDICATOR {
 }
 impl ::core::cmp::PartialEq for WINBIO_SET_INDICATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SET_INDICATOR>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.IndicatorStatus == other.IndicatorStatus
     }
 }
 impl ::core::cmp::Eq for WINBIO_SET_INDICATOR {}
@@ -4771,56 +4414,13 @@ impl ::core::clone::Clone for WINBIO_STORAGE_INTERFACE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WINBIO_STORAGE_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINBIO_STORAGE_INTERFACE")
-            .field("Version", &self.Version)
-            .field("Type", &self.Type)
-            .field("Size", &self.Size)
-            .field("AdapterId", &self.AdapterId)
-            .field("Attach", &self.Attach.map(|f| f as usize))
-            .field("Detach", &self.Detach.map(|f| f as usize))
-            .field("ClearContext", &self.ClearContext.map(|f| f as usize))
-            .field("CreateDatabase", &self.CreateDatabase.map(|f| f as usize))
-            .field("EraseDatabase", &self.EraseDatabase.map(|f| f as usize))
-            .field("OpenDatabase", &self.OpenDatabase.map(|f| f as usize))
-            .field("CloseDatabase", &self.CloseDatabase.map(|f| f as usize))
-            .field("GetDataFormat", &self.GetDataFormat.map(|f| f as usize))
-            .field("GetDatabaseSize", &self.GetDatabaseSize.map(|f| f as usize))
-            .field("AddRecord", &self.AddRecord.map(|f| f as usize))
-            .field("DeleteRecord", &self.DeleteRecord.map(|f| f as usize))
-            .field("QueryBySubject", &self.QueryBySubject.map(|f| f as usize))
-            .field("QueryByContent", &self.QueryByContent.map(|f| f as usize))
-            .field("GetRecordCount", &self.GetRecordCount.map(|f| f as usize))
-            .field("FirstRecord", &self.FirstRecord.map(|f| f as usize))
-            .field("NextRecord", &self.NextRecord.map(|f| f as usize))
-            .field("GetCurrentRecord", &self.GetCurrentRecord.map(|f| f as usize))
-            .field("ControlUnit", &self.ControlUnit.map(|f| f as usize))
-            .field("ControlUnitPrivileged", &self.ControlUnitPrivileged.map(|f| f as usize))
-            .field("NotifyPowerChange", &self.NotifyPowerChange.map(|f| f as usize))
-            .field("PipelineInit", &self.PipelineInit.map(|f| f as usize))
-            .field("PipelineCleanup", &self.PipelineCleanup.map(|f| f as usize))
-            .field("Activate", &self.Activate.map(|f| f as usize))
-            .field("Deactivate", &self.Deactivate.map(|f| f as usize))
-            .field("QueryExtendedInfo", &self.QueryExtendedInfo.map(|f| f as usize))
-            .field("NotifyDatabaseChange", &self.NotifyDatabaseChange.map(|f| f as usize))
-            .field("Reserved1", &self.Reserved1.map(|f| f as usize))
-            .field("Reserved2", &self.Reserved2.map(|f| f as usize))
-            .field("UpdateRecordBegin", &self.UpdateRecordBegin.map(|f| f as usize))
-            .field("UpdateRecordCommit", &self.UpdateRecordCommit.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINBIO_STORAGE_INTERFACE").field("Version", &self.Version).field("Type", &self.Type).field("Size", &self.Size).field("AdapterId", &self.AdapterId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WINBIO_STORAGE_INTERFACE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WINBIO_STORAGE_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_STORAGE_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WINBIO_STORAGE_INTERFACE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WINBIO_STORAGE_INTERFACE {
     fn default() -> Self {
@@ -4855,7 +4455,7 @@ unsafe impl ::windows::core::Abi for WINBIO_STORAGE_RECORD {
 }
 impl ::core::cmp::PartialEq for WINBIO_STORAGE_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_STORAGE_RECORD>()) == 0 }
+        self.Identity == other.Identity && self.SubFactor == other.SubFactor && self.IndexVector == other.IndexVector && self.IndexElementCount == other.IndexElementCount && self.TemplateBlob == other.TemplateBlob && self.TemplateBlobSize == other.TemplateBlobSize && self.PayloadBlob == other.PayloadBlob && self.PayloadBlobSize == other.PayloadBlobSize
     }
 }
 impl ::core::cmp::Eq for WINBIO_STORAGE_RECORD {}
@@ -4890,7 +4490,7 @@ unsafe impl ::windows::core::Abi for WINBIO_STORAGE_SCHEMA {
 }
 impl ::core::cmp::PartialEq for WINBIO_STORAGE_SCHEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_STORAGE_SCHEMA>()) == 0 }
+        self.BiometricFactor == other.BiometricFactor && self.DatabaseId == other.DatabaseId && self.DataFormat == other.DataFormat && self.Attributes == other.Attributes && self.FilePath == other.FilePath && self.ConnectionString == other.ConnectionString
     }
 }
 impl ::core::cmp::Eq for WINBIO_STORAGE_SCHEMA {}
@@ -4923,7 +4523,7 @@ unsafe impl ::windows::core::Abi for WINBIO_SUPPORTED_ALGORITHMS {
 }
 impl ::core::cmp::PartialEq for WINBIO_SUPPORTED_ALGORITHMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_SUPPORTED_ALGORITHMS>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.WinBioHresult == other.WinBioHresult && self.NumberOfAlgorithms == other.NumberOfAlgorithms && self.AlgorithmData == other.AlgorithmData
     }
 }
 impl ::core::cmp::Eq for WINBIO_SUPPORTED_ALGORITHMS {}
@@ -4975,7 +4575,7 @@ unsafe impl ::windows::core::Abi for WINBIO_UNIT_SCHEMA {
 }
 impl ::core::cmp::PartialEq for WINBIO_UNIT_SCHEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_UNIT_SCHEMA>()) == 0 }
+        self.UnitId == other.UnitId && self.PoolType == other.PoolType && self.BiometricFactor == other.BiometricFactor && self.SensorSubType == other.SensorSubType && self.Capabilities == other.Capabilities && self.DeviceInstanceId == other.DeviceInstanceId && self.Description == other.Description && self.Manufacturer == other.Manufacturer && self.Model == other.Model && self.SerialNumber == other.SerialNumber && self.FirmwareVersion == other.FirmwareVersion
     }
 }
 impl ::core::cmp::Eq for WINBIO_UNIT_SCHEMA {}
@@ -5006,7 +4606,7 @@ unsafe impl ::windows::core::Abi for WINBIO_UPDATE_FIRMWARE {
 }
 impl ::core::cmp::PartialEq for WINBIO_UPDATE_FIRMWARE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_UPDATE_FIRMWARE>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.FirmwareData == other.FirmwareData
     }
 }
 impl ::core::cmp::Eq for WINBIO_UPDATE_FIRMWARE {}
@@ -5037,7 +4637,7 @@ unsafe impl ::windows::core::Abi for WINBIO_VERSION {
 }
 impl ::core::cmp::PartialEq for WINBIO_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINBIO_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for WINBIO_VERSION {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -2325,12 +2325,6 @@ impl ::core::clone::Clone for BLUETOOTH_ADDRESS {
 unsafe impl ::windows::core::Abi for BLUETOOTH_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BLUETOOTH_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BLUETOOTH_ADDRESS {}
 impl ::core::default::Default for BLUETOOTH_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2351,12 +2345,6 @@ impl ::core::clone::Clone for BLUETOOTH_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for BLUETOOTH_ADDRESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BLUETOOTH_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_ADDRESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BLUETOOTH_ADDRESS_0 {}
 impl ::core::default::Default for BLUETOOTH_ADDRESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2379,12 +2367,6 @@ impl ::core::clone::Clone for BLUETOOTH_AUTHENTICATE_RESPONSE {
 unsafe impl ::windows::core::Abi for BLUETOOTH_AUTHENTICATE_RESPONSE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BLUETOOTH_AUTHENTICATE_RESPONSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_AUTHENTICATE_RESPONSE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BLUETOOTH_AUTHENTICATE_RESPONSE {}
 impl ::core::default::Default for BLUETOOTH_AUTHENTICATE_RESPONSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2407,12 +2389,6 @@ impl ::core::clone::Clone for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
 unsafe impl ::windows::core::Abi for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_AUTHENTICATE_RESPONSE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {}
 impl ::core::default::Default for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2441,14 +2417,6 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2473,14 +2441,6 @@ impl ::core::clone::Clone for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
 unsafe impl ::windows::core::Abi for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
     fn default() -> Self {
@@ -2509,7 +2469,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_COD_PAIRS {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_COD_PAIRS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_COD_PAIRS>()) == 0 }
+        self.ulCODMask == other.ulCODMask && self.pcszDescription == other.pcszDescription
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_COD_PAIRS {}
@@ -2544,14 +2504,6 @@ impl ::core::clone::Clone for BLUETOOTH_DEVICE_INFO {
 unsafe impl ::windows::core::Abi for BLUETOOTH_DEVICE_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_DEVICE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_DEVICE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_DEVICE_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_DEVICE_INFO {
     fn default() -> Self {
@@ -2592,7 +2544,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_DEVICE_SEARCH_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BLUETOOTH_DEVICE_SEARCH_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_DEVICE_SEARCH_PARAMS>()) == 0 }
+        self.dwSize == other.dwSize && self.fReturnAuthenticated == other.fReturnAuthenticated && self.fReturnRemembered == other.fReturnRemembered && self.fReturnUnknown == other.fReturnUnknown && self.fReturnConnected == other.fReturnConnected && self.fIssueInquiry == other.fIssueInquiry && self.cTimeoutMultiplier == other.cTimeoutMultiplier && self.hRadio == other.hRadio
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2624,7 +2576,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_FIND_RADIO_PARAMS {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_FIND_RADIO_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_FIND_RADIO_PARAMS>()) == 0 }
+        self.dwSize == other.dwSize
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_FIND_RADIO_PARAMS {}
@@ -2656,7 +2608,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_GATT_VALUE_CHANGED_EVENT {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_GATT_VALUE_CHANGED_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_GATT_VALUE_CHANGED_EVENT>()) == 0 }
+        self.ChangedAttributeHandle == other.ChangedAttributeHandle && self.CharacteristicValueDataSize == other.CharacteristicValueDataSize && self.CharacteristicValue == other.CharacteristicValue
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_GATT_VALUE_CHANGED_EVENT {}
@@ -2685,14 +2637,6 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRA
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2720,14 +2664,6 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_LOCAL_SERVICE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_LOCAL_SERVICE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_LOCAL_SERVICE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_LOCAL_SERVICE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_LOCAL_SERVICE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2754,7 +2690,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_NUMERIC_COMPARISON_INFO {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_NUMERIC_COMPARISON_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_NUMERIC_COMPARISON_INFO>()) == 0 }
+        self.NumericValue == other.NumericValue
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_NUMERIC_COMPARISON_INFO {}
@@ -2785,7 +2721,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_OOB_DATA_INFO {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_OOB_DATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_OOB_DATA_INFO>()) == 0 }
+        self.C == other.C && self.R == other.R
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_OOB_DATA_INFO {}
@@ -2815,7 +2751,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_PASSKEY_INFO {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_PASSKEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_PASSKEY_INFO>()) == 0 }
+        self.passkey == other.passkey
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_PASSKEY_INFO {}
@@ -2846,7 +2782,7 @@ unsafe impl ::windows::core::Abi for BLUETOOTH_PIN_INFO {
 }
 impl ::core::cmp::PartialEq for BLUETOOTH_PIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_PIN_INFO>()) == 0 }
+        self.pin == other.pin && self.pinLength == other.pinLength
     }
 }
 impl ::core::cmp::Eq for BLUETOOTH_PIN_INFO {}
@@ -2874,12 +2810,6 @@ impl ::core::clone::Clone for BLUETOOTH_RADIO_INFO {
 unsafe impl ::windows::core::Abi for BLUETOOTH_RADIO_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BLUETOOTH_RADIO_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_RADIO_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BLUETOOTH_RADIO_INFO {}
 impl ::core::default::Default for BLUETOOTH_RADIO_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2928,7 +2858,6 @@ impl ::core::fmt::Debug for BLUETOOTH_SELECT_DEVICE_PARAMS {
             .field("fShowUnknown", &self.fShowUnknown)
             .field("fAddNewDeviceWizard", &self.fAddNewDeviceWizard)
             .field("fSkipServicesPage", &self.fSkipServicesPage)
-            .field("pfnDeviceCallback", &self.pfnDeviceCallback.map(|f| f as usize))
             .field("pvParam", &self.pvParam)
             .field("cNumDevices", &self.cNumDevices)
             .field("pDevices", &self.pDevices)
@@ -2939,14 +2868,6 @@ impl ::core::fmt::Debug for BLUETOOTH_SELECT_DEVICE_PARAMS {
 unsafe impl ::windows::core::Abi for BLUETOOTH_SELECT_DEVICE_PARAMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BLUETOOTH_SELECT_DEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLUETOOTH_SELECT_DEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BLUETOOTH_SELECT_DEVICE_PARAMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BLUETOOTH_SELECT_DEVICE_PARAMS {
     fn default() -> Self {
@@ -2983,7 +2904,7 @@ unsafe impl ::windows::core::Abi for BTH_DEVICE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BTH_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_DEVICE_INFO>()) == 0 }
+        self.flags == other.flags && self.address == other.address && self.classOfDevice == other.classOfDevice && self.name == other.name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3017,7 +2938,7 @@ unsafe impl ::windows::core::Abi for BTH_HCI_EVENT_INFO {
 }
 impl ::core::cmp::PartialEq for BTH_HCI_EVENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_HCI_EVENT_INFO>()) == 0 }
+        self.bthAddress == other.bthAddress && self.connectionType == other.connectionType && self.connected == other.connected
     }
 }
 impl ::core::cmp::Eq for BTH_HCI_EVENT_INFO {}
@@ -3041,12 +2962,6 @@ impl ::core::clone::Clone for BTH_INFO_REQ {
 unsafe impl ::windows::core::Abi for BTH_INFO_REQ {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_INFO_REQ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_INFO_REQ>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_INFO_REQ {}
 impl ::core::default::Default for BTH_INFO_REQ {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3068,12 +2983,6 @@ impl ::core::clone::Clone for BTH_INFO_RSP {
 unsafe impl ::windows::core::Abi for BTH_INFO_RSP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_INFO_RSP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_INFO_RSP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_INFO_RSP {}
 impl ::core::default::Default for BTH_INFO_RSP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3094,12 +3003,6 @@ impl ::core::clone::Clone for BTH_INFO_RSP_0 {
 unsafe impl ::windows::core::Abi for BTH_INFO_RSP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_INFO_RSP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_INFO_RSP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_INFO_RSP_0 {}
 impl ::core::default::Default for BTH_INFO_RSP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3129,7 +3032,7 @@ unsafe impl ::windows::core::Abi for BTH_L2CAP_EVENT_INFO {
 }
 impl ::core::cmp::PartialEq for BTH_L2CAP_EVENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_L2CAP_EVENT_INFO>()) == 0 }
+        self.bthAddress == other.bthAddress && self.psm == other.psm && self.connected == other.connected && self.initiated == other.initiated
     }
 }
 impl ::core::cmp::Eq for BTH_L2CAP_EVENT_INFO {}
@@ -3168,14 +3071,6 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_CHARACTERISTIC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_CHARACTERISTIC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_CHARACTERISTIC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_CHARACTERISTIC {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_CHARACTERISTIC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3203,7 +3098,7 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_CHARACTERISTIC_VALUE {
 }
 impl ::core::cmp::PartialEq for BTH_LE_GATT_CHARACTERISTIC_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_CHARACTERISTIC_VALUE>()) == 0 }
+        self.DataSize == other.DataSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for BTH_LE_GATT_CHARACTERISTIC_VALUE {}
@@ -3235,14 +3130,6 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3271,14 +3158,6 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_DESCRIPTOR_VALUE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_DESCRIPTOR_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3305,14 +3184,6 @@ impl ::core::clone::Clone for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
 unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
     fn default() -> Self {
@@ -3347,7 +3218,7 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE_0_0>()) == 0 }
+        self.IsReliableWriteEnabled == other.IsReliableWriteEnabled && self.IsAuxiliariesWritable == other.IsAuxiliariesWritable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3380,14 +3251,6 @@ impl ::core::clone::Clone for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
 unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE_0_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
     fn default() -> Self {
@@ -3422,7 +3285,7 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE_0_2>()) == 0 }
+        self.IsSubscribeToNotification == other.IsSubscribeToNotification && self.IsSubscribeToIndication == other.IsSubscribeToIndication
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3460,7 +3323,7 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_DESCRIPTOR_VALUE_0_3>()) == 0 }
+        self.IsBroadcast == other.IsBroadcast
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3491,14 +3354,6 @@ unsafe impl ::windows::core::Abi for BTH_LE_GATT_SERVICE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_GATT_SERVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_GATT_SERVICE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_GATT_SERVICE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_GATT_SERVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3523,14 +3378,6 @@ impl ::core::clone::Clone for BTH_LE_UUID {
 unsafe impl ::windows::core::Abi for BTH_LE_UUID {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_UUID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_UUID>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_UUID {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_UUID {
     fn default() -> Self {
@@ -3557,14 +3404,6 @@ unsafe impl ::windows::core::Abi for BTH_LE_UUID_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_LE_UUID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_LE_UUID_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_LE_UUID_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_LE_UUID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3586,12 +3425,6 @@ impl ::core::clone::Clone for BTH_PING_REQ {
 unsafe impl ::windows::core::Abi for BTH_PING_REQ {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_PING_REQ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_PING_REQ>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_PING_REQ {}
 impl ::core::default::Default for BTH_PING_REQ {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3619,7 +3452,7 @@ unsafe impl ::windows::core::Abi for BTH_PING_RSP {
 }
 impl ::core::cmp::PartialEq for BTH_PING_RSP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_PING_RSP>()) == 0 }
+        self.dataLen == other.dataLen && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for BTH_PING_RSP {}
@@ -3643,12 +3476,6 @@ impl ::core::clone::Clone for BTH_QUERY_DEVICE {
 unsafe impl ::windows::core::Abi for BTH_QUERY_DEVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_QUERY_DEVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_QUERY_DEVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_QUERY_DEVICE {}
 impl ::core::default::Default for BTH_QUERY_DEVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3672,12 +3499,6 @@ impl ::core::clone::Clone for BTH_QUERY_SERVICE {
 unsafe impl ::windows::core::Abi for BTH_QUERY_SERVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BTH_QUERY_SERVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_QUERY_SERVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BTH_QUERY_SERVICE {}
 impl ::core::default::Default for BTH_QUERY_SERVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3711,7 +3532,7 @@ unsafe impl ::windows::core::Abi for BTH_RADIO_IN_RANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BTH_RADIO_IN_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_RADIO_IN_RANGE>()) == 0 }
+        self.deviceInfo == other.deviceInfo && self.previousDeviceFlags == other.previousDeviceFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3745,14 +3566,6 @@ impl ::core::clone::Clone for BTH_SET_SERVICE {
 unsafe impl ::windows::core::Abi for BTH_SET_SERVICE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BTH_SET_SERVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BTH_SET_SERVICE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BTH_SET_SERVICE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BTH_SET_SERVICE {
     fn default() -> Self {
@@ -3806,12 +3619,6 @@ impl ::core::clone::Clone for RFCOMM_COMMAND {
 unsafe impl ::windows::core::Abi for RFCOMM_COMMAND {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFCOMM_COMMAND {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFCOMM_COMMAND>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFCOMM_COMMAND {}
 impl ::core::default::Default for RFCOMM_COMMAND {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3833,12 +3640,6 @@ impl ::core::clone::Clone for RFCOMM_COMMAND_0 {
 unsafe impl ::windows::core::Abi for RFCOMM_COMMAND_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFCOMM_COMMAND_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFCOMM_COMMAND_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFCOMM_COMMAND_0 {}
 impl ::core::default::Default for RFCOMM_COMMAND_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3866,7 +3667,7 @@ unsafe impl ::windows::core::Abi for RFCOMM_MSC_DATA {
 }
 impl ::core::cmp::PartialEq for RFCOMM_MSC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFCOMM_MSC_DATA>()) == 0 }
+        self.Signals == other.Signals && self.Break == other.Break
     }
 }
 impl ::core::cmp::Eq for RFCOMM_MSC_DATA {}
@@ -3896,7 +3697,7 @@ unsafe impl ::windows::core::Abi for RFCOMM_RLS_DATA {
 }
 impl ::core::cmp::PartialEq for RFCOMM_RLS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFCOMM_RLS_DATA>()) == 0 }
+        self.LineStatus == other.LineStatus
     }
 }
 impl ::core::cmp::Eq for RFCOMM_RLS_DATA {}
@@ -3932,7 +3733,7 @@ unsafe impl ::windows::core::Abi for RFCOMM_RPN_DATA {
 }
 impl ::core::cmp::PartialEq for RFCOMM_RPN_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFCOMM_RPN_DATA>()) == 0 }
+        self.Baud == other.Baud && self.Data == other.Data && self.FlowControl == other.FlowControl && self.XonChar == other.XonChar && self.XoffChar == other.XoffChar && self.ParameterMask1 == other.ParameterMask1 && self.ParameterMask2 == other.ParameterMask2
     }
 }
 impl ::core::cmp::Eq for RFCOMM_RPN_DATA {}
@@ -3961,14 +3762,6 @@ impl ::core::clone::Clone for SDP_ELEMENT_DATA {
 unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SDP_ELEMENT_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SDP_ELEMENT_DATA {
     fn default() -> Self {
@@ -4011,14 +3804,6 @@ unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SDP_ELEMENT_DATA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SDP_ELEMENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4052,7 +3837,7 @@ unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA_0_0>()) == 0 }
+        self.value == other.value && self.length == other.length
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4091,7 +3876,7 @@ unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA_0_1>()) == 0 }
+        self.value == other.value && self.length == other.length
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4130,7 +3915,7 @@ unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA_0_2>()) == 0 }
+        self.value == other.value && self.length == other.length
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4169,7 +3954,7 @@ unsafe impl ::windows::core::Abi for SDP_ELEMENT_DATA_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SDP_ELEMENT_DATA_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ELEMENT_DATA_0_3>()) == 0 }
+        self.value == other.value && self.length == other.length
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4202,7 +3987,7 @@ unsafe impl ::windows::core::Abi for SDP_LARGE_INTEGER_16 {
 }
 impl ::core::cmp::PartialEq for SDP_LARGE_INTEGER_16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_LARGE_INTEGER_16>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for SDP_LARGE_INTEGER_16 {}
@@ -4234,7 +4019,7 @@ unsafe impl ::windows::core::Abi for SDP_STRING_TYPE_DATA {
 }
 impl ::core::cmp::PartialEq for SDP_STRING_TYPE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_STRING_TYPE_DATA>()) == 0 }
+        self.encoding == other.encoding && self.mibeNum == other.mibeNum && self.attributeId == other.attributeId
     }
 }
 impl ::core::cmp::Eq for SDP_STRING_TYPE_DATA {}
@@ -4265,7 +4050,7 @@ unsafe impl ::windows::core::Abi for SDP_ULARGE_INTEGER_16 {
 }
 impl ::core::cmp::PartialEq for SDP_ULARGE_INTEGER_16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDP_ULARGE_INTEGER_16>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for SDP_ULARGE_INTEGER_16 {}
@@ -4291,12 +4076,6 @@ impl ::core::clone::Clone for SOCKADDR_BTH {
 unsafe impl ::windows::core::Abi for SOCKADDR_BTH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SOCKADDR_BTH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_BTH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SOCKADDR_BTH {}
 impl ::core::default::Default for SOCKADDR_BTH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4324,7 +4103,7 @@ unsafe impl ::windows::core::Abi for SdpAttributeRange {
 }
 impl ::core::cmp::PartialEq for SdpAttributeRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SdpAttributeRange>()) == 0 }
+        self.minAttribute == other.minAttribute && self.maxAttribute == other.maxAttribute
     }
 }
 impl ::core::cmp::Eq for SdpAttributeRange {}
@@ -4348,12 +4127,6 @@ impl ::core::clone::Clone for SdpQueryUuid {
 unsafe impl ::windows::core::Abi for SdpQueryUuid {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SdpQueryUuid {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SdpQueryUuid>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SdpQueryUuid {}
 impl ::core::default::Default for SdpQueryUuid {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4375,12 +4148,6 @@ impl ::core::clone::Clone for SdpQueryUuidUnion {
 unsafe impl ::windows::core::Abi for SdpQueryUuidUnion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SdpQueryUuidUnion {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SdpQueryUuidUnion>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SdpQueryUuidUnion {}
 impl ::core::default::Default for SdpQueryUuidUnion {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
@@ -1168,7 +1168,7 @@ unsafe impl ::windows::core::Abi for COMMCONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMMCONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMMCONFIG>()) == 0 }
+        self.dwSize == other.dwSize && self.wVersion == other.wVersion && self.wReserved == other.wReserved && self.dcb == other.dcb && self.dwProviderSubType == other.dwProviderSubType && self.dwProviderOffset == other.dwProviderOffset && self.dwProviderSize == other.dwProviderSize && self.wcProviderData == other.wcProviderData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1236,7 +1236,24 @@ unsafe impl ::windows::core::Abi for COMMPROP {
 }
 impl ::core::cmp::PartialEq for COMMPROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMMPROP>()) == 0 }
+        self.wPacketLength == other.wPacketLength
+            && self.wPacketVersion == other.wPacketVersion
+            && self.dwServiceMask == other.dwServiceMask
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwMaxTxQueue == other.dwMaxTxQueue
+            && self.dwMaxRxQueue == other.dwMaxRxQueue
+            && self.dwMaxBaud == other.dwMaxBaud
+            && self.dwProvSubType == other.dwProvSubType
+            && self.dwProvCapabilities == other.dwProvCapabilities
+            && self.dwSettableParams == other.dwSettableParams
+            && self.dwSettableBaud == other.dwSettableBaud
+            && self.wSettableData == other.wSettableData
+            && self.wSettableStopParity == other.wSettableStopParity
+            && self.dwCurrentTxQueue == other.dwCurrentTxQueue
+            && self.dwCurrentRxQueue == other.dwCurrentRxQueue
+            && self.dwProvSpec1 == other.dwProvSpec1
+            && self.dwProvSpec2 == other.dwProvSpec2
+            && self.wcProvChar == other.wcProvChar
     }
 }
 impl ::core::cmp::Eq for COMMPROP {}
@@ -1270,7 +1287,7 @@ unsafe impl ::windows::core::Abi for COMMTIMEOUTS {
 }
 impl ::core::cmp::PartialEq for COMMTIMEOUTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMMTIMEOUTS>()) == 0 }
+        self.ReadIntervalTimeout == other.ReadIntervalTimeout && self.ReadTotalTimeoutMultiplier == other.ReadTotalTimeoutMultiplier && self.ReadTotalTimeoutConstant == other.ReadTotalTimeoutConstant && self.WriteTotalTimeoutMultiplier == other.WriteTotalTimeoutMultiplier && self.WriteTotalTimeoutConstant == other.WriteTotalTimeoutConstant
     }
 }
 impl ::core::cmp::Eq for COMMTIMEOUTS {}
@@ -1302,7 +1319,7 @@ unsafe impl ::windows::core::Abi for COMSTAT {
 }
 impl ::core::cmp::PartialEq for COMSTAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMSTAT>()) == 0 }
+        self._bitfield == other._bitfield && self.cbInQue == other.cbInQue && self.cbOutQue == other.cbOutQue
     }
 }
 impl ::core::cmp::Eq for COMSTAT {}
@@ -1368,7 +1385,7 @@ unsafe impl ::windows::core::Abi for DCB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DCB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCB>()) == 0 }
+        self.DCBlength == other.DCBlength && self.BaudRate == other.BaudRate && self._bitfield == other._bitfield && self.wReserved == other.wReserved && self.XonLim == other.XonLim && self.XoffLim == other.XoffLim && self.ByteSize == other.ByteSize && self.Parity == other.Parity && self.StopBits == other.StopBits && self.XonChar == other.XonChar && self.XoffChar == other.XoffChar && self.ErrorChar == other.ErrorChar && self.EofChar == other.EofChar && self.EvtChar == other.EvtChar && self.wReserved1 == other.wReserved1
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1440,7 +1457,26 @@ unsafe impl ::windows::core::Abi for MODEMDEVCAPS {
 }
 impl ::core::cmp::PartialEq for MODEMDEVCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODEMDEVCAPS>()) == 0 }
+        self.dwActualSize == other.dwActualSize
+            && self.dwRequiredSize == other.dwRequiredSize
+            && self.dwDevSpecificOffset == other.dwDevSpecificOffset
+            && self.dwDevSpecificSize == other.dwDevSpecificSize
+            && self.dwModemProviderVersion == other.dwModemProviderVersion
+            && self.dwModemManufacturerOffset == other.dwModemManufacturerOffset
+            && self.dwModemManufacturerSize == other.dwModemManufacturerSize
+            && self.dwModemModelOffset == other.dwModemModelOffset
+            && self.dwModemModelSize == other.dwModemModelSize
+            && self.dwModemVersionOffset == other.dwModemVersionOffset
+            && self.dwModemVersionSize == other.dwModemVersionSize
+            && self.dwDialOptions == other.dwDialOptions
+            && self.dwCallSetupFailTimer == other.dwCallSetupFailTimer
+            && self.dwInactivityTimeout == other.dwInactivityTimeout
+            && self.dwSpeakerVolume == other.dwSpeakerVolume
+            && self.dwSpeakerMode == other.dwSpeakerMode
+            && self.dwModemOptions == other.dwModemOptions
+            && self.dwMaxDTERate == other.dwMaxDTERate
+            && self.dwMaxDCERate == other.dwMaxDCERate
+            && self.abVariablePortion == other.abVariablePortion
     }
 }
 impl ::core::cmp::Eq for MODEMDEVCAPS {}
@@ -1494,7 +1530,7 @@ unsafe impl ::windows::core::Abi for MODEMSETTINGS {
 }
 impl ::core::cmp::PartialEq for MODEMSETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODEMSETTINGS>()) == 0 }
+        self.dwActualSize == other.dwActualSize && self.dwRequiredSize == other.dwRequiredSize && self.dwDevSpecificOffset == other.dwDevSpecificOffset && self.dwDevSpecificSize == other.dwDevSpecificSize && self.dwCallSetupFailTimer == other.dwCallSetupFailTimer && self.dwInactivityTimeout == other.dwInactivityTimeout && self.dwSpeakerVolume == other.dwSpeakerVolume && self.dwSpeakerMode == other.dwSpeakerMode && self.dwPreferredModemOptions == other.dwPreferredModemOptions && self.dwNegotiatedModemOptions == other.dwNegotiatedModemOptions && self.dwNegotiatedDCERate == other.dwNegotiatedDCERate && self.abVariablePortion == other.abVariablePortion
     }
 }
 impl ::core::cmp::Eq for MODEMSETTINGS {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -8430,12 +8430,6 @@ impl ::core::clone::Clone for BUSNUMBER_DES {
 unsafe impl ::windows::core::Abi for BUSNUMBER_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BUSNUMBER_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUSNUMBER_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BUSNUMBER_DES {}
 impl ::core::default::Default for BUSNUMBER_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8458,12 +8452,6 @@ impl ::core::clone::Clone for BUSNUMBER_RANGE {
 unsafe impl ::windows::core::Abi for BUSNUMBER_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BUSNUMBER_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUSNUMBER_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BUSNUMBER_RANGE {}
 impl ::core::default::Default for BUSNUMBER_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8484,12 +8472,6 @@ impl ::core::clone::Clone for BUSNUMBER_RESOURCE {
 unsafe impl ::windows::core::Abi for BUSNUMBER_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BUSNUMBER_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUSNUMBER_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BUSNUMBER_RESOURCE {}
 impl ::core::default::Default for BUSNUMBER_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8518,14 +8500,6 @@ unsafe impl ::windows::core::Abi for CABINET_INFO_A {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for CABINET_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINET_INFO_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for CABINET_INFO_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for CABINET_INFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8554,14 +8528,6 @@ unsafe impl ::windows::core::Abi for CABINET_INFO_A {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for CABINET_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINET_INFO_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for CABINET_INFO_A {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for CABINET_INFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8589,14 +8555,6 @@ impl ::core::clone::Clone for CABINET_INFO_W {
 unsafe impl ::windows::core::Abi for CABINET_INFO_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for CABINET_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINET_INFO_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for CABINET_INFO_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for CABINET_INFO_W {
     fn default() -> Self {
@@ -8626,14 +8584,6 @@ unsafe impl ::windows::core::Abi for CABINET_INFO_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for CABINET_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINET_INFO_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for CABINET_INFO_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for CABINET_INFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8655,12 +8605,6 @@ impl ::core::clone::Clone for CM_NOTIFY_EVENT_DATA {
 unsafe impl ::windows::core::Abi for CM_NOTIFY_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CM_NOTIFY_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CM_NOTIFY_EVENT_DATA {}
 impl ::core::default::Default for CM_NOTIFY_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8682,12 +8626,6 @@ impl ::core::clone::Clone for CM_NOTIFY_EVENT_DATA_0 {
 unsafe impl ::windows::core::Abi for CM_NOTIFY_EVENT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CM_NOTIFY_EVENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_EVENT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CM_NOTIFY_EVENT_DATA_0 {}
 impl ::core::default::Default for CM_NOTIFY_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8717,7 +8655,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_EVENT_DATA_0_0 {
 }
 impl ::core::cmp::PartialEq for CM_NOTIFY_EVENT_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_EVENT_DATA_0_0>()) == 0 }
+        self.EventGuid == other.EventGuid && self.NameOffset == other.NameOffset && self.DataSize == other.DataSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for CM_NOTIFY_EVENT_DATA_0_0 {}
@@ -8747,7 +8685,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_EVENT_DATA_0_1 {
 }
 impl ::core::cmp::PartialEq for CM_NOTIFY_EVENT_DATA_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_EVENT_DATA_0_1>()) == 0 }
+        self.InstanceId == other.InstanceId
     }
 }
 impl ::core::cmp::Eq for CM_NOTIFY_EVENT_DATA_0_1 {}
@@ -8778,7 +8716,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_EVENT_DATA_0_2 {
 }
 impl ::core::cmp::PartialEq for CM_NOTIFY_EVENT_DATA_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_EVENT_DATA_0_2>()) == 0 }
+        self.ClassGuid == other.ClassGuid && self.SymbolicLink == other.SymbolicLink
     }
 }
 impl ::core::cmp::Eq for CM_NOTIFY_EVENT_DATA_0_2 {}
@@ -8810,14 +8748,6 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_FILTER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CM_NOTIFY_FILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_FILTER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CM_NOTIFY_FILTER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CM_NOTIFY_FILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8843,14 +8773,6 @@ impl ::core::clone::Clone for CM_NOTIFY_FILTER_0 {
 unsafe impl ::windows::core::Abi for CM_NOTIFY_FILTER_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CM_NOTIFY_FILTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_FILTER_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CM_NOTIFY_FILTER_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CM_NOTIFY_FILTER_0 {
     fn default() -> Self {
@@ -8884,7 +8806,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_FILTER_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CM_NOTIFY_FILTER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_FILTER_0_0>()) == 0 }
+        self.hTarget == other.hTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8922,7 +8844,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_FILTER_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CM_NOTIFY_FILTER_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_FILTER_0_1>()) == 0 }
+        self.InstanceId == other.InstanceId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8960,7 +8882,7 @@ unsafe impl ::windows::core::Abi for CM_NOTIFY_FILTER_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CM_NOTIFY_FILTER_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_NOTIFY_FILTER_0_2>()) == 0 }
+        self.ClassGuid == other.ClassGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8997,16 +8919,6 @@ unsafe impl ::windows::core::Abi for COINSTALLER_CONTEXT_DATA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COINSTALLER_CONTEXT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COINSTALLER_CONTEXT_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COINSTALLER_CONTEXT_DATA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COINSTALLER_CONTEXT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9036,16 +8948,6 @@ impl ::core::clone::Clone for COINSTALLER_CONTEXT_DATA {
 unsafe impl ::windows::core::Abi for COINSTALLER_CONTEXT_DATA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COINSTALLER_CONTEXT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COINSTALLER_CONTEXT_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COINSTALLER_CONTEXT_DATA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COINSTALLER_CONTEXT_DATA {
@@ -9085,7 +8987,7 @@ unsafe impl ::windows::core::Abi for CONFLICT_DETAILS_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONFLICT_DETAILS_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFLICT_DETAILS_A>()) == 0 }
+        self.CD_ulSize == other.CD_ulSize && self.CD_ulMask == other.CD_ulMask && self.CD_dnDevInst == other.CD_dnDevInst && self.CD_rdResDes == other.CD_rdResDes && self.CD_ulFlags == other.CD_ulFlags && self.CD_szDescription == other.CD_szDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9122,7 +9024,7 @@ unsafe impl ::windows::core::Abi for CONFLICT_DETAILS_W {
 }
 impl ::core::cmp::PartialEq for CONFLICT_DETAILS_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFLICT_DETAILS_W>()) == 0 }
+        self.CD_ulSize == other.CD_ulSize && self.CD_ulMask == other.CD_ulMask && self.CD_dnDevInst == other.CD_dnDevInst && self.CD_rdResDes == other.CD_rdResDes && self.CD_ulFlags == other.CD_ulFlags && self.CD_szDescription == other.CD_szDescription
     }
 }
 impl ::core::cmp::Eq for CONFLICT_DETAILS_W {}
@@ -9151,12 +9053,6 @@ impl ::core::clone::Clone for CONNECTION_DES {
 unsafe impl ::windows::core::Abi for CONNECTION_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CONNECTION_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTION_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CONNECTION_DES {}
 impl ::core::default::Default for CONNECTION_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9176,12 +9072,6 @@ impl ::core::clone::Clone for CONNECTION_RESOURCE {
 unsafe impl ::windows::core::Abi for CONNECTION_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CONNECTION_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTION_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CONNECTION_RESOURCE {}
 impl ::core::default::Default for CONNECTION_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9206,12 +9096,6 @@ impl ::core::clone::Clone for CS_DES {
 unsafe impl ::windows::core::Abi for CS_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CS_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CS_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CS_DES {}
 impl ::core::default::Default for CS_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9231,12 +9115,6 @@ impl ::core::clone::Clone for CS_RESOURCE {
 unsafe impl ::windows::core::Abi for CS_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CS_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CS_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CS_RESOURCE {}
 impl ::core::default::Default for CS_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9261,12 +9139,6 @@ impl ::core::clone::Clone for DEVPRIVATE_DES {
 unsafe impl ::windows::core::Abi for DEVPRIVATE_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVPRIVATE_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPRIVATE_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVPRIVATE_DES {}
 impl ::core::default::Default for DEVPRIVATE_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9288,12 +9160,6 @@ impl ::core::clone::Clone for DEVPRIVATE_RANGE {
 unsafe impl ::windows::core::Abi for DEVPRIVATE_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVPRIVATE_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPRIVATE_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVPRIVATE_RANGE {}
 impl ::core::default::Default for DEVPRIVATE_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9314,12 +9180,6 @@ impl ::core::clone::Clone for DEVPRIVATE_RESOURCE {
 unsafe impl ::windows::core::Abi for DEVPRIVATE_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVPRIVATE_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPRIVATE_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVPRIVATE_RESOURCE {}
 impl ::core::default::Default for DEVPRIVATE_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9342,12 +9202,6 @@ impl ::core::clone::Clone for DMA_DES {
 unsafe impl ::windows::core::Abi for DMA_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DMA_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMA_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DMA_DES {}
 impl ::core::default::Default for DMA_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9369,12 +9223,6 @@ impl ::core::clone::Clone for DMA_RANGE {
 unsafe impl ::windows::core::Abi for DMA_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DMA_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMA_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DMA_RANGE {}
 impl ::core::default::Default for DMA_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9395,12 +9243,6 @@ impl ::core::clone::Clone for DMA_RESOURCE {
 unsafe impl ::windows::core::Abi for DMA_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DMA_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMA_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DMA_RESOURCE {}
 impl ::core::default::Default for DMA_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9428,14 +9270,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_A {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FILEPATHS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FILEPATHS_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FILEPATHS_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9463,14 +9297,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_A {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FILEPATHS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FILEPATHS_A {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for FILEPATHS_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9501,14 +9327,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_SIGNERINFO_A {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FILEPATHS_SIGNERINFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_SIGNERINFO_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FILEPATHS_SIGNERINFO_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FILEPATHS_SIGNERINFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9539,14 +9357,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_SIGNERINFO_A {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FILEPATHS_SIGNERINFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_SIGNERINFO_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FILEPATHS_SIGNERINFO_A {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for FILEPATHS_SIGNERINFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9577,14 +9387,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_SIGNERINFO_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FILEPATHS_SIGNERINFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_SIGNERINFO_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FILEPATHS_SIGNERINFO_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FILEPATHS_SIGNERINFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9615,14 +9417,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_SIGNERINFO_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FILEPATHS_SIGNERINFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_SIGNERINFO_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FILEPATHS_SIGNERINFO_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for FILEPATHS_SIGNERINFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9650,14 +9444,6 @@ unsafe impl ::windows::core::Abi for FILEPATHS_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FILEPATHS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FILEPATHS_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FILEPATHS_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9684,14 +9470,6 @@ impl ::core::clone::Clone for FILEPATHS_W {
 unsafe impl ::windows::core::Abi for FILEPATHS_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FILEPATHS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEPATHS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FILEPATHS_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for FILEPATHS_W {
     fn default() -> Self {
@@ -9726,16 +9504,6 @@ impl ::core::clone::Clone for FILE_IN_CABINET_INFO_A {
 unsafe impl ::windows::core::Abi for FILE_IN_CABINET_INFO_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILE_IN_CABINET_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_IN_CABINET_INFO_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILE_IN_CABINET_INFO_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILE_IN_CABINET_INFO_A {
@@ -9771,16 +9539,6 @@ impl ::core::clone::Clone for FILE_IN_CABINET_INFO_A {
 unsafe impl ::windows::core::Abi for FILE_IN_CABINET_INFO_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILE_IN_CABINET_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_IN_CABINET_INFO_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILE_IN_CABINET_INFO_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILE_IN_CABINET_INFO_A {
@@ -9812,14 +9570,6 @@ impl ::core::clone::Clone for FILE_IN_CABINET_INFO_W {
 unsafe impl ::windows::core::Abi for FILE_IN_CABINET_INFO_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FILE_IN_CABINET_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_IN_CABINET_INFO_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FILE_IN_CABINET_INFO_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FILE_IN_CABINET_INFO_W {
     fn default() -> Self {
@@ -9850,14 +9600,6 @@ impl ::core::clone::Clone for FILE_IN_CABINET_INFO_W {
 unsafe impl ::windows::core::Abi for FILE_IN_CABINET_INFO_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FILE_IN_CABINET_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_IN_CABINET_INFO_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FILE_IN_CABINET_INFO_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for FILE_IN_CABINET_INFO_W {
     fn default() -> Self {
@@ -9944,12 +9686,6 @@ impl ::core::clone::Clone for HWPROFILEINFO_W {
 unsafe impl ::windows::core::Abi for HWPROFILEINFO_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HWPROFILEINFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HWPROFILEINFO_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HWPROFILEINFO_W {}
 impl ::core::default::Default for HWPROFILEINFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9975,14 +9711,6 @@ impl ::core::clone::Clone for HWProfileInfo_sA {
 unsafe impl ::windows::core::Abi for HWProfileInfo_sA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HWProfileInfo_sA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HWProfileInfo_sA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HWProfileInfo_sA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HWProfileInfo_sA {
     fn default() -> Self {
@@ -10011,14 +9739,6 @@ unsafe impl ::windows::core::Abi for INFCONTEXT {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for INFCONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFCONTEXT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for INFCONTEXT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for INFCONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10046,14 +9766,6 @@ unsafe impl ::windows::core::Abi for INFCONTEXT {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for INFCONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFCONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for INFCONTEXT {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for INFCONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10077,12 +9789,6 @@ impl ::core::clone::Clone for IO_DES {
 unsafe impl ::windows::core::Abi for IO_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IO_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IO_DES {}
 impl ::core::default::Default for IO_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10107,12 +9813,6 @@ impl ::core::clone::Clone for IO_RANGE {
 unsafe impl ::windows::core::Abi for IO_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IO_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IO_RANGE {}
 impl ::core::default::Default for IO_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10133,12 +9833,6 @@ impl ::core::clone::Clone for IO_RESOURCE {
 unsafe impl ::windows::core::Abi for IO_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IO_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IO_RESOURCE {}
 impl ::core::default::Default for IO_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10162,12 +9856,6 @@ impl ::core::clone::Clone for IRQ_DES_32 {
 unsafe impl ::windows::core::Abi for IRQ_DES_32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IRQ_DES_32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IRQ_DES_32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IRQ_DES_32 {}
 impl ::core::default::Default for IRQ_DES_32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10191,12 +9879,6 @@ impl ::core::clone::Clone for IRQ_DES_64 {
 unsafe impl ::windows::core::Abi for IRQ_DES_64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IRQ_DES_64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IRQ_DES_64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IRQ_DES_64 {}
 impl ::core::default::Default for IRQ_DES_64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10218,12 +9900,6 @@ impl ::core::clone::Clone for IRQ_RANGE {
 unsafe impl ::windows::core::Abi for IRQ_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IRQ_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IRQ_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IRQ_RANGE {}
 impl ::core::default::Default for IRQ_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10244,12 +9920,6 @@ impl ::core::clone::Clone for IRQ_RESOURCE_32 {
 unsafe impl ::windows::core::Abi for IRQ_RESOURCE_32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IRQ_RESOURCE_32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IRQ_RESOURCE_32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IRQ_RESOURCE_32 {}
 impl ::core::default::Default for IRQ_RESOURCE_32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10270,12 +9940,6 @@ impl ::core::clone::Clone for IRQ_RESOURCE_64 {
 unsafe impl ::windows::core::Abi for IRQ_RESOURCE_64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IRQ_RESOURCE_64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IRQ_RESOURCE_64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IRQ_RESOURCE_64 {}
 impl ::core::default::Default for IRQ_RESOURCE_64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10300,12 +9964,6 @@ impl ::core::clone::Clone for MEM_DES {
 unsafe impl ::windows::core::Abi for MEM_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_DES {}
 impl ::core::default::Default for MEM_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10330,12 +9988,6 @@ impl ::core::clone::Clone for MEM_LARGE_DES {
 unsafe impl ::windows::core::Abi for MEM_LARGE_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_LARGE_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_LARGE_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_LARGE_DES {}
 impl ::core::default::Default for MEM_LARGE_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10360,12 +10012,6 @@ impl ::core::clone::Clone for MEM_LARGE_RANGE {
 unsafe impl ::windows::core::Abi for MEM_LARGE_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_LARGE_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_LARGE_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_LARGE_RANGE {}
 impl ::core::default::Default for MEM_LARGE_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10386,12 +10032,6 @@ impl ::core::clone::Clone for MEM_LARGE_RESOURCE {
 unsafe impl ::windows::core::Abi for MEM_LARGE_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_LARGE_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_LARGE_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_LARGE_RESOURCE {}
 impl ::core::default::Default for MEM_LARGE_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10416,12 +10056,6 @@ impl ::core::clone::Clone for MEM_RANGE {
 unsafe impl ::windows::core::Abi for MEM_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_RANGE {}
 impl ::core::default::Default for MEM_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10442,12 +10076,6 @@ impl ::core::clone::Clone for MEM_RESOURCE {
 unsafe impl ::windows::core::Abi for MEM_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MEM_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MEM_RESOURCE {}
 impl ::core::default::Default for MEM_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10473,12 +10101,6 @@ impl ::core::clone::Clone for MFCARD_DES {
 unsafe impl ::windows::core::Abi for MFCARD_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFCARD_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCARD_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFCARD_DES {}
 impl ::core::default::Default for MFCARD_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10498,12 +10120,6 @@ impl ::core::clone::Clone for MFCARD_RESOURCE {
 unsafe impl ::windows::core::Abi for MFCARD_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFCARD_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCARD_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFCARD_RESOURCE {}
 impl ::core::default::Default for MFCARD_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10532,12 +10148,6 @@ impl ::core::clone::Clone for PCCARD_DES {
 unsafe impl ::windows::core::Abi for PCCARD_DES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PCCARD_DES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PCCARD_DES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PCCARD_DES {}
 impl ::core::default::Default for PCCARD_DES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10557,12 +10167,6 @@ impl ::core::clone::Clone for PCCARD_RESOURCE {
 unsafe impl ::windows::core::Abi for PCCARD_RESOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PCCARD_RESOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PCCARD_RESOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PCCARD_RESOURCE {}
 impl ::core::default::Default for PCCARD_RESOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10592,14 +10196,6 @@ unsafe impl ::windows::core::Abi for SOURCE_MEDIA_A {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SOURCE_MEDIA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCE_MEDIA_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SOURCE_MEDIA_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SOURCE_MEDIA_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10629,14 +10225,6 @@ unsafe impl ::windows::core::Abi for SOURCE_MEDIA_A {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SOURCE_MEDIA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCE_MEDIA_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SOURCE_MEDIA_A {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SOURCE_MEDIA_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10666,14 +10254,6 @@ unsafe impl ::windows::core::Abi for SOURCE_MEDIA_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SOURCE_MEDIA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCE_MEDIA_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SOURCE_MEDIA_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SOURCE_MEDIA_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10703,14 +10283,6 @@ unsafe impl ::windows::core::Abi for SOURCE_MEDIA_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SOURCE_MEDIA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCE_MEDIA_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SOURCE_MEDIA_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SOURCE_MEDIA_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10745,16 +10317,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V1 {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V1>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V1 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10789,16 +10351,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V1 {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V1>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V1 {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10835,16 +10387,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V2 {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V2>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V2 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10873,16 +10415,6 @@ impl ::core::clone::Clone for SP_ALTPLATFORM_INFO_V2_0 {
 unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V2_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V2_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V2_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V2_0 {
@@ -10921,16 +10453,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V2 {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V2>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V2 {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10959,16 +10481,6 @@ impl ::core::clone::Clone for SP_ALTPLATFORM_INFO_V2_0 {
 unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V2_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V2_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V2_0 {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V2_0 {
@@ -11005,14 +10517,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V3 {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V3>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V3 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11037,14 +10541,6 @@ impl ::core::clone::Clone for SP_ALTPLATFORM_INFO_V3_0 {
 unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V3_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V3_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V3_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V3_0 {
     fn default() -> Self {
@@ -11080,14 +10576,6 @@ unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V3 {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V3>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V3 {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11112,14 +10600,6 @@ impl ::core::clone::Clone for SP_ALTPLATFORM_INFO_V3_0 {
 unsafe impl ::windows::core::Abi for SP_ALTPLATFORM_INFO_V3_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_ALTPLATFORM_INFO_V3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ALTPLATFORM_INFO_V3_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_ALTPLATFORM_INFO_V3_0 {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_ALTPLATFORM_INFO_V3_0 {
     fn default() -> Self {
@@ -11152,16 +10632,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V1_A {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V1_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V1_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V1_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11193,16 +10663,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V1_A {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V1_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V1_A {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V1_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11229,14 +10689,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V1_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V1_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V1_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V1_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11263,14 +10715,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V1_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V1_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V1_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V1_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11303,16 +10747,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V2_A {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V2_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V2_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V2_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11345,16 +10779,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V2_A {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V2_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V2_A {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V2_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11382,14 +10806,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V2_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V2_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V2_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V2_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11417,14 +10833,6 @@ unsafe impl ::windows::core::Abi for SP_BACKUP_QUEUE_PARAMS_V2_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_BACKUP_QUEUE_PARAMS_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_BACKUP_QUEUE_PARAMS_V2_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_BACKUP_QUEUE_PARAMS_V2_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_BACKUP_QUEUE_PARAMS_V2_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11456,16 +10864,6 @@ unsafe impl ::windows::core::Abi for SP_CLASSIMAGELIST_DATA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_Controls")]
-impl ::core::cmp::PartialEq for SP_CLASSIMAGELIST_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_CLASSIMAGELIST_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_Controls")]
-impl ::core::cmp::Eq for SP_CLASSIMAGELIST_DATA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_Controls")]
 impl ::core::default::Default for SP_CLASSIMAGELIST_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11497,16 +10895,6 @@ unsafe impl ::windows::core::Abi for SP_CLASSIMAGELIST_DATA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_Controls")]
-impl ::core::cmp::PartialEq for SP_CLASSIMAGELIST_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_CLASSIMAGELIST_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_Controls")]
-impl ::core::cmp::Eq for SP_CLASSIMAGELIST_DATA {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_Controls")]
 impl ::core::default::Default for SP_CLASSIMAGELIST_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11532,14 +10920,6 @@ unsafe impl ::windows::core::Abi for SP_CLASSINSTALL_HEADER {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_CLASSINSTALL_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_CLASSINSTALL_HEADER>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_CLASSINSTALL_HEADER {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_CLASSINSTALL_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11565,14 +10945,6 @@ unsafe impl ::windows::core::Abi for SP_CLASSINSTALL_HEADER {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_CLASSINSTALL_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_CLASSINSTALL_HEADER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_CLASSINSTALL_HEADER {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_CLASSINSTALL_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11604,16 +10976,6 @@ unsafe impl ::windows::core::Abi for SP_DETECTDEVICE_PARAMS {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DETECTDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DETECTDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DETECTDEVICE_PARAMS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DETECTDEVICE_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11645,16 +11007,6 @@ unsafe impl ::windows::core::Abi for SP_DETECTDEVICE_PARAMS {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DETECTDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DETECTDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DETECTDEVICE_PARAMS {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DETECTDEVICE_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11682,14 +11034,6 @@ unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DATA {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DATA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11717,14 +11061,6 @@ unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DATA {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DATA {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11755,16 +11091,6 @@ unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DETAIL_DATA_A {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11795,16 +11121,6 @@ unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DETAIL_DATA_A {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11830,14 +11146,6 @@ unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DETAIL_DATA_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11862,14 +11170,6 @@ impl ::core::clone::Clone for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
 unsafe impl ::windows::core::Abi for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_DEVICE_INTERFACE_DETAIL_DATA_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
     fn default() -> Self {
@@ -11897,14 +11197,6 @@ impl ::core::clone::Clone for SP_DEVINFO_DATA {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_DATA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_DEVINFO_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_DEVINFO_DATA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_DEVINFO_DATA {
     fn default() -> Self {
@@ -11932,14 +11224,6 @@ impl ::core::clone::Clone for SP_DEVINFO_DATA {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_DATA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_DEVINFO_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_DEVINFO_DATA {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_DEVINFO_DATA {
     fn default() -> Self {
@@ -11971,16 +11255,6 @@ impl ::core::clone::Clone for SP_DEVINFO_LIST_DETAIL_DATA_A {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_LIST_DETAIL_DATA_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINFO_LIST_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_LIST_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINFO_LIST_DETAIL_DATA_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINFO_LIST_DETAIL_DATA_A {
@@ -12013,16 +11287,6 @@ impl ::core::clone::Clone for SP_DEVINFO_LIST_DETAIL_DATA_A {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_LIST_DETAIL_DATA_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINFO_LIST_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_LIST_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINFO_LIST_DETAIL_DATA_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINFO_LIST_DETAIL_DATA_A {
@@ -12055,16 +11319,6 @@ impl ::core::clone::Clone for SP_DEVINFO_LIST_DETAIL_DATA_W {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_LIST_DETAIL_DATA_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINFO_LIST_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_LIST_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINFO_LIST_DETAIL_DATA_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINFO_LIST_DETAIL_DATA_W {
@@ -12097,16 +11351,6 @@ impl ::core::clone::Clone for SP_DEVINFO_LIST_DETAIL_DATA_W {
 unsafe impl ::windows::core::Abi for SP_DEVINFO_LIST_DETAIL_DATA_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINFO_LIST_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINFO_LIST_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINFO_LIST_DETAIL_DATA_W {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINFO_LIST_DETAIL_DATA_W {
@@ -12145,16 +11389,6 @@ impl ::core::clone::Clone for SP_DEVINSTALL_PARAMS_A {
 unsafe impl ::windows::core::Abi for SP_DEVINSTALL_PARAMS_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINSTALL_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINSTALL_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINSTALL_PARAMS_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINSTALL_PARAMS_A {
@@ -12193,16 +11427,6 @@ impl ::core::clone::Clone for SP_DEVINSTALL_PARAMS_A {
 unsafe impl ::windows::core::Abi for SP_DEVINSTALL_PARAMS_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINSTALL_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINSTALL_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINSTALL_PARAMS_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINSTALL_PARAMS_A {
@@ -12241,16 +11465,6 @@ impl ::core::clone::Clone for SP_DEVINSTALL_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_DEVINSTALL_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINSTALL_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINSTALL_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINSTALL_PARAMS_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINSTALL_PARAMS_W {
@@ -12289,16 +11503,6 @@ impl ::core::clone::Clone for SP_DEVINSTALL_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_DEVINSTALL_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DEVINSTALL_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DEVINSTALL_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DEVINSTALL_PARAMS_W {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DEVINSTALL_PARAMS_W {
@@ -12333,16 +11537,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V1_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V1_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V1_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V1_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V1_A {
@@ -12377,16 +11571,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V1_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V1_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V1_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V1_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V1_A {
@@ -12417,14 +11601,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V1_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V1_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V1_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V1_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_DRVINFO_DATA_V1_W {
     fn default() -> Self {
@@ -12454,14 +11630,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V1_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V1_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V1_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V1_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V1_W {
     fn default() -> Self {
@@ -12497,16 +11665,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V2_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V2_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V2_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V2_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V2_A {
@@ -12543,16 +11701,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V2_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V2_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V2_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V2_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V2_A {
@@ -12589,16 +11737,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V2_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V2_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V2_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V2_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V2_W {
@@ -12635,16 +11773,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DATA_V2_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DATA_V2_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DATA_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DATA_V2_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DATA_V2_W {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DATA_V2_W {
@@ -12682,16 +11810,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DETAIL_DATA_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DETAIL_DATA_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DETAIL_DATA_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DETAIL_DATA_A {
@@ -12729,16 +11847,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DETAIL_DATA_A {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DETAIL_DATA_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DETAIL_DATA_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DETAIL_DATA_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DETAIL_DATA_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DETAIL_DATA_A {
@@ -12776,16 +11884,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DETAIL_DATA_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DETAIL_DATA_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DETAIL_DATA_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DETAIL_DATA_W {
@@ -12823,16 +11921,6 @@ impl ::core::clone::Clone for SP_DRVINFO_DETAIL_DATA_W {
 unsafe impl ::windows::core::Abi for SP_DRVINFO_DETAIL_DATA_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_DRVINFO_DETAIL_DATA_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINFO_DETAIL_DATA_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_DRVINFO_DETAIL_DATA_W {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_DRVINFO_DETAIL_DATA_W {
@@ -12862,14 +11950,6 @@ impl ::core::clone::Clone for SP_DRVINSTALL_PARAMS {
 unsafe impl ::windows::core::Abi for SP_DRVINSTALL_PARAMS {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_DRVINSTALL_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINSTALL_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_DRVINSTALL_PARAMS {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_DRVINSTALL_PARAMS {
     fn default() -> Self {
@@ -12898,14 +11978,6 @@ impl ::core::clone::Clone for SP_DRVINSTALL_PARAMS {
 unsafe impl ::windows::core::Abi for SP_DRVINSTALL_PARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_DRVINSTALL_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_DRVINSTALL_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_DRVINSTALL_PARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_DRVINSTALL_PARAMS {
     fn default() -> Self {
@@ -12932,14 +12004,6 @@ impl ::core::clone::Clone for SP_ENABLECLASS_PARAMS {
 unsafe impl ::windows::core::Abi for SP_ENABLECLASS_PARAMS {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_ENABLECLASS_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ENABLECLASS_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_ENABLECLASS_PARAMS {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_ENABLECLASS_PARAMS {
     fn default() -> Self {
@@ -12966,14 +12030,6 @@ impl ::core::clone::Clone for SP_ENABLECLASS_PARAMS {
 unsafe impl ::windows::core::Abi for SP_ENABLECLASS_PARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_ENABLECLASS_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ENABLECLASS_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_ENABLECLASS_PARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_ENABLECLASS_PARAMS {
     fn default() -> Self {
@@ -13009,14 +12065,6 @@ impl ::core::clone::Clone for SP_FILE_COPY_PARAMS_A {
 unsafe impl ::windows::core::Abi for SP_FILE_COPY_PARAMS_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_FILE_COPY_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_FILE_COPY_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_FILE_COPY_PARAMS_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_FILE_COPY_PARAMS_A {
     fn default() -> Self {
@@ -13052,14 +12100,6 @@ impl ::core::clone::Clone for SP_FILE_COPY_PARAMS_A {
 unsafe impl ::windows::core::Abi for SP_FILE_COPY_PARAMS_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_FILE_COPY_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_FILE_COPY_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_FILE_COPY_PARAMS_A {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_FILE_COPY_PARAMS_A {
     fn default() -> Self {
@@ -13095,14 +12135,6 @@ impl ::core::clone::Clone for SP_FILE_COPY_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_FILE_COPY_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_FILE_COPY_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_FILE_COPY_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_FILE_COPY_PARAMS_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_FILE_COPY_PARAMS_W {
     fn default() -> Self {
@@ -13138,14 +12170,6 @@ impl ::core::clone::Clone for SP_FILE_COPY_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_FILE_COPY_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_FILE_COPY_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_FILE_COPY_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_FILE_COPY_PARAMS_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_FILE_COPY_PARAMS_W {
     fn default() -> Self {
@@ -13172,14 +12196,6 @@ impl ::core::clone::Clone for SP_INF_INFORMATION {
 unsafe impl ::windows::core::Abi for SP_INF_INFORMATION {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_INF_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_INF_INFORMATION {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_INF_INFORMATION {
     fn default() -> Self {
@@ -13206,14 +12222,6 @@ impl ::core::clone::Clone for SP_INF_INFORMATION {
 unsafe impl ::windows::core::Abi for SP_INF_INFORMATION {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_INF_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_INF_INFORMATION {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_INF_INFORMATION {
     fn default() -> Self {
@@ -13245,16 +12253,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V1_A {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V1_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V1_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V1_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V1_A {
@@ -13287,16 +12285,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V1_A {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V1_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V1_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V1_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V1_A {
@@ -13325,14 +12313,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V1_W {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V1_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V1_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V1_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V1_W {
     fn default() -> Self {
@@ -13360,14 +12340,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V1_W {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V1_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V1_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V1_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V1_W {
     fn default() -> Self {
@@ -13400,16 +12372,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V2_A {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V2_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V2_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V2_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V2_A {
@@ -13443,16 +12405,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V2_A {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V2_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V2_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V2_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V2_A {
@@ -13482,14 +12434,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V2_W {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V2_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V2_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V2_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V2_W {
     fn default() -> Self {
@@ -13518,14 +12462,6 @@ impl ::core::clone::Clone for SP_INF_SIGNER_INFO_V2_W {
 unsafe impl ::windows::core::Abi for SP_INF_SIGNER_INFO_V2_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_INF_SIGNER_INFO_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INF_SIGNER_INFO_V2_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_INF_SIGNER_INFO_V2_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_INF_SIGNER_INFO_V2_W {
     fn default() -> Self {
@@ -13561,16 +12497,6 @@ impl ::core::clone::Clone for SP_INSTALLWIZARD_DATA {
 unsafe impl ::windows::core::Abi for SP_INSTALLWIZARD_DATA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for SP_INSTALLWIZARD_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INSTALLWIZARD_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for SP_INSTALLWIZARD_DATA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for SP_INSTALLWIZARD_DATA {
@@ -13607,16 +12533,6 @@ impl ::core::clone::Clone for SP_INSTALLWIZARD_DATA {
 unsafe impl ::windows::core::Abi for SP_INSTALLWIZARD_DATA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for SP_INSTALLWIZARD_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_INSTALLWIZARD_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for SP_INSTALLWIZARD_DATA {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for SP_INSTALLWIZARD_DATA {
@@ -13650,16 +12566,6 @@ impl ::core::clone::Clone for SP_NEWDEVICEWIZARD_DATA {
 unsafe impl ::windows::core::Abi for SP_NEWDEVICEWIZARD_DATA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for SP_NEWDEVICEWIZARD_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_NEWDEVICEWIZARD_DATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for SP_NEWDEVICEWIZARD_DATA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for SP_NEWDEVICEWIZARD_DATA {
@@ -13693,16 +12599,6 @@ impl ::core::clone::Clone for SP_NEWDEVICEWIZARD_DATA {
 unsafe impl ::windows::core::Abi for SP_NEWDEVICEWIZARD_DATA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for SP_NEWDEVICEWIZARD_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_NEWDEVICEWIZARD_DATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for SP_NEWDEVICEWIZARD_DATA {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for SP_NEWDEVICEWIZARD_DATA {
@@ -13734,16 +12630,6 @@ impl ::core::clone::Clone for SP_ORIGINAL_FILE_INFO_A {
 unsafe impl ::windows::core::Abi for SP_ORIGINAL_FILE_INFO_A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_ORIGINAL_FILE_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ORIGINAL_FILE_INFO_A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_ORIGINAL_FILE_INFO_A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_ORIGINAL_FILE_INFO_A {
@@ -13775,16 +12661,6 @@ impl ::core::clone::Clone for SP_ORIGINAL_FILE_INFO_A {
 unsafe impl ::windows::core::Abi for SP_ORIGINAL_FILE_INFO_A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_ORIGINAL_FILE_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ORIGINAL_FILE_INFO_A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_ORIGINAL_FILE_INFO_A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_ORIGINAL_FILE_INFO_A {
@@ -13812,14 +12688,6 @@ impl ::core::clone::Clone for SP_ORIGINAL_FILE_INFO_W {
 unsafe impl ::windows::core::Abi for SP_ORIGINAL_FILE_INFO_W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_ORIGINAL_FILE_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ORIGINAL_FILE_INFO_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_ORIGINAL_FILE_INFO_W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_ORIGINAL_FILE_INFO_W {
     fn default() -> Self {
@@ -13846,14 +12714,6 @@ impl ::core::clone::Clone for SP_ORIGINAL_FILE_INFO_W {
 unsafe impl ::windows::core::Abi for SP_ORIGINAL_FILE_INFO_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_ORIGINAL_FILE_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_ORIGINAL_FILE_INFO_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_ORIGINAL_FILE_INFO_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_ORIGINAL_FILE_INFO_W {
     fn default() -> Self {
@@ -13880,14 +12740,6 @@ unsafe impl ::windows::core::Abi for SP_POWERMESSAGEWAKE_PARAMS_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_POWERMESSAGEWAKE_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_POWERMESSAGEWAKE_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_POWERMESSAGEWAKE_PARAMS_A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_POWERMESSAGEWAKE_PARAMS_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13913,14 +12765,6 @@ unsafe impl ::windows::core::Abi for SP_POWERMESSAGEWAKE_PARAMS_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_POWERMESSAGEWAKE_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_POWERMESSAGEWAKE_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_POWERMESSAGEWAKE_PARAMS_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_POWERMESSAGEWAKE_PARAMS_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13945,14 +12789,6 @@ impl ::core::clone::Clone for SP_POWERMESSAGEWAKE_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_POWERMESSAGEWAKE_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_POWERMESSAGEWAKE_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_POWERMESSAGEWAKE_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_POWERMESSAGEWAKE_PARAMS_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_POWERMESSAGEWAKE_PARAMS_W {
     fn default() -> Self {
@@ -13980,14 +12816,6 @@ impl ::core::clone::Clone for SP_PROPCHANGE_PARAMS {
 unsafe impl ::windows::core::Abi for SP_PROPCHANGE_PARAMS {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_PROPCHANGE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_PROPCHANGE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_PROPCHANGE_PARAMS {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_PROPCHANGE_PARAMS {
     fn default() -> Self {
@@ -14015,14 +12843,6 @@ impl ::core::clone::Clone for SP_PROPCHANGE_PARAMS {
 unsafe impl ::windows::core::Abi for SP_PROPCHANGE_PARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_PROPCHANGE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_PROPCHANGE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_PROPCHANGE_PARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_PROPCHANGE_PARAMS {
     fn default() -> Self {
@@ -14050,14 +12870,6 @@ impl ::core::clone::Clone for SP_PROPSHEETPAGE_REQUEST {
 unsafe impl ::windows::core::Abi for SP_PROPSHEETPAGE_REQUEST {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_PROPSHEETPAGE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_PROPSHEETPAGE_REQUEST>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_PROPSHEETPAGE_REQUEST {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_PROPSHEETPAGE_REQUEST {
     fn default() -> Self {
@@ -14085,14 +12897,6 @@ impl ::core::clone::Clone for SP_PROPSHEETPAGE_REQUEST {
 unsafe impl ::windows::core::Abi for SP_PROPSHEETPAGE_REQUEST {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_PROPSHEETPAGE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_PROPSHEETPAGE_REQUEST>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_PROPSHEETPAGE_REQUEST {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_PROPSHEETPAGE_REQUEST {
     fn default() -> Self {
@@ -14120,14 +12924,6 @@ impl ::core::clone::Clone for SP_REGISTER_CONTROL_STATUSA {
 unsafe impl ::windows::core::Abi for SP_REGISTER_CONTROL_STATUSA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_REGISTER_CONTROL_STATUSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REGISTER_CONTROL_STATUSA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_REGISTER_CONTROL_STATUSA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_REGISTER_CONTROL_STATUSA {
     fn default() -> Self {
@@ -14155,14 +12951,6 @@ impl ::core::clone::Clone for SP_REGISTER_CONTROL_STATUSA {
 unsafe impl ::windows::core::Abi for SP_REGISTER_CONTROL_STATUSA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_REGISTER_CONTROL_STATUSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REGISTER_CONTROL_STATUSA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_REGISTER_CONTROL_STATUSA {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_REGISTER_CONTROL_STATUSA {
     fn default() -> Self {
@@ -14190,14 +12978,6 @@ impl ::core::clone::Clone for SP_REGISTER_CONTROL_STATUSW {
 unsafe impl ::windows::core::Abi for SP_REGISTER_CONTROL_STATUSW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_REGISTER_CONTROL_STATUSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REGISTER_CONTROL_STATUSW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_REGISTER_CONTROL_STATUSW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_REGISTER_CONTROL_STATUSW {
     fn default() -> Self {
@@ -14225,14 +13005,6 @@ impl ::core::clone::Clone for SP_REGISTER_CONTROL_STATUSW {
 unsafe impl ::windows::core::Abi for SP_REGISTER_CONTROL_STATUSW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_REGISTER_CONTROL_STATUSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REGISTER_CONTROL_STATUSW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_REGISTER_CONTROL_STATUSW {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_REGISTER_CONTROL_STATUSW {
     fn default() -> Self {
@@ -14259,14 +13031,6 @@ impl ::core::clone::Clone for SP_REMOVEDEVICE_PARAMS {
 unsafe impl ::windows::core::Abi for SP_REMOVEDEVICE_PARAMS {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_REMOVEDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REMOVEDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_REMOVEDEVICE_PARAMS {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_REMOVEDEVICE_PARAMS {
     fn default() -> Self {
@@ -14293,14 +13057,6 @@ impl ::core::clone::Clone for SP_REMOVEDEVICE_PARAMS {
 unsafe impl ::windows::core::Abi for SP_REMOVEDEVICE_PARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_REMOVEDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_REMOVEDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_REMOVEDEVICE_PARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_REMOVEDEVICE_PARAMS {
     fn default() -> Self {
@@ -14331,14 +13087,6 @@ unsafe impl ::windows::core::Abi for SP_SELECTDEVICE_PARAMS_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_SELECTDEVICE_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_SELECTDEVICE_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_SELECTDEVICE_PARAMS_A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_SELECTDEVICE_PARAMS_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14367,14 +13115,6 @@ unsafe impl ::windows::core::Abi for SP_SELECTDEVICE_PARAMS_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_SELECTDEVICE_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_SELECTDEVICE_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_SELECTDEVICE_PARAMS_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_SELECTDEVICE_PARAMS_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14403,14 +13143,6 @@ unsafe impl ::windows::core::Abi for SP_SELECTDEVICE_PARAMS_W {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_SELECTDEVICE_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_SELECTDEVICE_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_SELECTDEVICE_PARAMS_W {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_SELECTDEVICE_PARAMS_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14436,14 +13168,6 @@ impl ::core::clone::Clone for SP_TROUBLESHOOTER_PARAMS_A {
 unsafe impl ::windows::core::Abi for SP_TROUBLESHOOTER_PARAMS_A {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SP_TROUBLESHOOTER_PARAMS_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_TROUBLESHOOTER_PARAMS_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SP_TROUBLESHOOTER_PARAMS_A {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SP_TROUBLESHOOTER_PARAMS_A {
     fn default() -> Self {
@@ -14471,14 +13195,6 @@ unsafe impl ::windows::core::Abi for SP_TROUBLESHOOTER_PARAMS_W {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_TROUBLESHOOTER_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_TROUBLESHOOTER_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_TROUBLESHOOTER_PARAMS_W {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_TROUBLESHOOTER_PARAMS_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14504,14 +13220,6 @@ impl ::core::clone::Clone for SP_TROUBLESHOOTER_PARAMS_W {
 unsafe impl ::windows::core::Abi for SP_TROUBLESHOOTER_PARAMS_W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_TROUBLESHOOTER_PARAMS_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_TROUBLESHOOTER_PARAMS_W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_TROUBLESHOOTER_PARAMS_W {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_TROUBLESHOOTER_PARAMS_W {
     fn default() -> Self {
@@ -14539,14 +13247,6 @@ unsafe impl ::windows::core::Abi for SP_UNREMOVEDEVICE_PARAMS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SP_UNREMOVEDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_UNREMOVEDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SP_UNREMOVEDEVICE_PARAMS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SP_UNREMOVEDEVICE_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14572,14 +13272,6 @@ impl ::core::clone::Clone for SP_UNREMOVEDEVICE_PARAMS {
 unsafe impl ::windows::core::Abi for SP_UNREMOVEDEVICE_PARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SP_UNREMOVEDEVICE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SP_UNREMOVEDEVICE_PARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SP_UNREMOVEDEVICE_PARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SP_UNREMOVEDEVICE_PARAMS {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
@@ -515,7 +515,7 @@ unsafe impl ::windows::core::Abi for DEVPROP_FILTER_EXPRESSION {
 #[cfg(feature = "Win32_Devices_Properties")]
 impl ::core::cmp::PartialEq for DEVPROP_FILTER_EXPRESSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPROP_FILTER_EXPRESSION>()) == 0 }
+        self.Operator == other.Operator && self.Property == other.Property
     }
 }
 #[cfg(feature = "Win32_Devices_Properties")]
@@ -556,7 +556,7 @@ unsafe impl ::windows::core::Abi for DEV_OBJECT {
 #[cfg(feature = "Win32_Devices_Properties")]
 impl ::core::cmp::PartialEq for DEV_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_OBJECT>()) == 0 }
+        self.ObjectType == other.ObjectType && self.pszObjectId == other.pszObjectId && self.cPropertyCount == other.cPropertyCount && self.pProperties == other.pProperties
     }
 }
 #[cfg(feature = "Win32_Devices_Properties")]
@@ -597,7 +597,7 @@ unsafe impl ::windows::core::Abi for DEV_QUERY_PARAMETER {
 #[cfg(feature = "Win32_Devices_Properties")]
 impl ::core::cmp::PartialEq for DEV_QUERY_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_QUERY_PARAMETER>()) == 0 }
+        self.Key == other.Key && self.Type == other.Type && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 #[cfg(feature = "Win32_Devices_Properties")]
@@ -628,14 +628,6 @@ unsafe impl ::windows::core::Abi for DEV_QUERY_RESULT_ACTION_DATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Devices_Properties")]
-impl ::core::cmp::PartialEq for DEV_QUERY_RESULT_ACTION_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_QUERY_RESULT_ACTION_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Devices_Properties")]
-impl ::core::cmp::Eq for DEV_QUERY_RESULT_ACTION_DATA {}
-#[cfg(feature = "Win32_Devices_Properties")]
 impl ::core::default::Default for DEV_QUERY_RESULT_ACTION_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -660,14 +652,6 @@ impl ::core::clone::Clone for DEV_QUERY_RESULT_ACTION_DATA_0 {
 unsafe impl ::windows::core::Abi for DEV_QUERY_RESULT_ACTION_DATA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Devices_Properties")]
-impl ::core::cmp::PartialEq for DEV_QUERY_RESULT_ACTION_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_QUERY_RESULT_ACTION_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Devices_Properties")]
-impl ::core::cmp::Eq for DEV_QUERY_RESULT_ACTION_DATA_0 {}
 #[cfg(feature = "Win32_Devices_Properties")]
 impl ::core::default::Default for DEV_QUERY_RESULT_ACTION_DATA_0 {
     fn default() -> Self {
@@ -695,7 +679,7 @@ unsafe impl ::windows::core::Abi for HDEVQUERY__ {
 }
 impl ::core::cmp::PartialEq for HDEVQUERY__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDEVQUERY__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDEVQUERY__ {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -3707,7 +3707,7 @@ unsafe impl ::windows::core::Abi for Adapter {
 }
 impl ::core::cmp::PartialEq for Adapter {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Adapter>()) == 0 }
+        self.AdapterName == other.AdapterName && self.numSources == other.numSources && self.sources == other.sources
     }
 }
 impl ::core::cmp::Eq for Adapter {}
@@ -3738,7 +3738,7 @@ unsafe impl ::windows::core::Abi for Adapters {
 }
 impl ::core::cmp::PartialEq for Adapters {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Adapters>()) == 0 }
+        self.numAdapters == other.numAdapters && self.adapter == other.adapter
     }
 }
 impl ::core::cmp::Eq for Adapters {}
@@ -3770,7 +3770,7 @@ unsafe impl ::windows::core::Abi for BACKLIGHT_REDUCTION_GAMMA_RAMP {
 }
 impl ::core::cmp::PartialEq for BACKLIGHT_REDUCTION_GAMMA_RAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BACKLIGHT_REDUCTION_GAMMA_RAMP>()) == 0 }
+        self.R == other.R && self.G == other.G && self.B == other.B
     }
 }
 impl ::core::cmp::Eq for BACKLIGHT_REDUCTION_GAMMA_RAMP {}
@@ -3801,7 +3801,7 @@ unsafe impl ::windows::core::Abi for BANK_POSITION {
 }
 impl ::core::cmp::PartialEq for BANK_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BANK_POSITION>()) == 0 }
+        self.ReadBankPosition == other.ReadBankPosition && self.WriteBankPosition == other.WriteBankPosition
     }
 }
 impl ::core::cmp::Eq for BANK_POSITION {}
@@ -3837,7 +3837,7 @@ unsafe impl ::windows::core::Abi for BLENDOBJ {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for BLENDOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLENDOBJ>()) == 0 }
+        self.BlendFunction == other.BlendFunction
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3870,7 +3870,7 @@ unsafe impl ::windows::core::Abi for BRIGHTNESS_LEVEL {
 }
 impl ::core::cmp::PartialEq for BRIGHTNESS_LEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BRIGHTNESS_LEVEL>()) == 0 }
+        self.Count == other.Count && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for BRIGHTNESS_LEVEL {}
@@ -3902,7 +3902,7 @@ unsafe impl ::windows::core::Abi for BRIGHTNESS_NIT_RANGE {
 }
 impl ::core::cmp::PartialEq for BRIGHTNESS_NIT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BRIGHTNESS_NIT_RANGE>()) == 0 }
+        self.MinLevelInMillinit == other.MinLevelInMillinit && self.MaxLevelInMillinit == other.MaxLevelInMillinit && self.StepSizeInMillinit == other.StepSizeInMillinit
     }
 }
 impl ::core::cmp::Eq for BRIGHTNESS_NIT_RANGE {}
@@ -3935,7 +3935,7 @@ unsafe impl ::windows::core::Abi for BRIGHTNESS_NIT_RANGES {
 }
 impl ::core::cmp::PartialEq for BRIGHTNESS_NIT_RANGES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BRIGHTNESS_NIT_RANGES>()) == 0 }
+        self.NormalRangeCount == other.NormalRangeCount && self.RangeCount == other.RangeCount && self.PreferredMaximumBrightness == other.PreferredMaximumBrightness && self.SupportedRanges == other.SupportedRanges
     }
 }
 impl ::core::cmp::Eq for BRIGHTNESS_NIT_RANGES {}
@@ -3967,7 +3967,7 @@ unsafe impl ::windows::core::Abi for BRUSHOBJ {
 }
 impl ::core::cmp::PartialEq for BRUSHOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BRUSHOBJ>()) == 0 }
+        self.iSolidColor == other.iSolidColor && self.pvRbrush == other.pvRbrush && self.flColorType == other.flColorType
     }
 }
 impl ::core::cmp::Eq for BRUSHOBJ {}
@@ -4007,7 +4007,7 @@ unsafe impl ::windows::core::Abi for CDDDXGK_REDIRBITMAPPRESENTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CDDDXGK_REDIRBITMAPPRESENTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CDDDXGK_REDIRBITMAPPRESENTINFO>()) == 0 }
+        self.NumDirtyRects == other.NumDirtyRects && self.DirtyRect == other.DirtyRect && self.NumContexts == other.NumContexts && self.hContext == other.hContext && self.bDoNotSynchronizeWithDxContent == other.bDoNotSynchronizeWithDxContent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4038,14 +4038,6 @@ unsafe impl ::windows::core::Abi for CHAR_IMAGE_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
-impl ::core::cmp::PartialEq for CHAR_IMAGE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHAR_IMAGE_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
-impl ::core::cmp::Eq for CHAR_IMAGE_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
 impl ::core::default::Default for CHAR_IMAGE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4073,7 +4065,7 @@ unsafe impl ::windows::core::Abi for CHROMATICITY_COORDINATE {
 }
 impl ::core::cmp::PartialEq for CHROMATICITY_COORDINATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHROMATICITY_COORDINATE>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for CHROMATICITY_COORDINATE {}
@@ -4105,7 +4097,7 @@ unsafe impl ::windows::core::Abi for CIECHROMA {
 }
 impl ::core::cmp::PartialEq for CIECHROMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CIECHROMA>()) == 0 }
+        self.x == other.x && self.y == other.y && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for CIECHROMA {}
@@ -4139,7 +4131,7 @@ unsafe impl ::windows::core::Abi for CLIPLINE {
 }
 impl ::core::cmp::PartialEq for CLIPLINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIPLINE>()) == 0 }
+        self.ptfxA == other.ptfxA && self.ptfxB == other.ptfxB && self.lStyleState == other.lStyleState && self.c == other.c && self.arun == other.arun
     }
 }
 impl ::core::cmp::Eq for CLIPLINE {}
@@ -4180,7 +4172,7 @@ unsafe impl ::windows::core::Abi for CLIPOBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLIPOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIPOBJ>()) == 0 }
+        self.iUniq == other.iUniq && self.rclBounds == other.rclBounds && self.iDComplexity == other.iDComplexity && self.iFComplexity == other.iFComplexity && self.iMode == other.iMode && self.fjOptions == other.fjOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4244,7 +4236,7 @@ unsafe impl ::windows::core::Abi for COLORINFO {
 }
 impl ::core::cmp::PartialEq for COLORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORINFO>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue && self.Cyan == other.Cyan && self.Magenta == other.Magenta && self.Yellow == other.Yellow && self.AlignmentWhite == other.AlignmentWhite && self.RedGamma == other.RedGamma && self.GreenGamma == other.GreenGamma && self.BlueGamma == other.BlueGamma && self.MagentaInCyanDye == other.MagentaInCyanDye && self.YellowInCyanDye == other.YellowInCyanDye && self.CyanInMagentaDye == other.CyanInMagentaDye && self.YellowInMagentaDye == other.YellowInMagentaDye && self.CyanInYellowDye == other.CyanInYellowDye && self.MagentaInYellowDye == other.MagentaInYellowDye
     }
 }
 impl ::core::cmp::Eq for COLORINFO {}
@@ -4268,12 +4260,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4296,12 +4282,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_0 {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_0 {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4322,12 +4302,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_1DLUT_CAP {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_1DLUT_CAP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_1DLUT_CAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_1DLUT_CAP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_1DLUT_CAP {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_1DLUT_CAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4356,7 +4330,7 @@ unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_3x4 {
 }
 impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_3x4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_3x4>()) == 0 }
+        self.ColorMatrix3x4 == other.ColorMatrix3x4 && self.ScalarMultiplier == other.ScalarMultiplier && self.LookupTable1D == other.LookupTable1D
     }
 }
 impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_3x4 {}
@@ -4382,12 +4356,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_DATA_CAP {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_DATA_CAP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_DATA_CAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_DATA_CAP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_DATA_CAP {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_DATA_CAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4409,12 +4377,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_DATA_CAP_0 {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_DATA_CAP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_DATA_CAP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_DATA_CAP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_DATA_CAP_0 {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_DATA_CAP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4441,7 +4403,7 @@ unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_DATA_CAP_0_0 {
 }
 impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_DATA_CAP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_DATA_CAP_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_DATA_CAP_0_0 {}
@@ -4471,7 +4433,7 @@ unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_DATA_CAP_0_1 {
 }
 impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_DATA_CAP_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_DATA_CAP_0_1>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_DATA_CAP_0_1 {}
@@ -4495,12 +4457,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_MATRIX_CAP {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_MATRIX_CAP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_MATRIX_CAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_MATRIX_CAP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_MATRIX_CAP {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_MATRIX_CAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4521,12 +4477,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_MATRIX_CAP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4553,7 +4503,7 @@ unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {
 }
 impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_MATRIX_CAP_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {}
@@ -4588,7 +4538,7 @@ unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_MATRIX_V2 {
 }
 impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_MATRIX_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_MATRIX_V2>()) == 0 }
+        self.StageControlLookupTable1DDegamma == other.StageControlLookupTable1DDegamma && self.LookupTable1DDegamma == other.LookupTable1DDegamma && self.StageControlColorMatrix3x3 == other.StageControlColorMatrix3x3 && self.ColorMatrix3x3 == other.ColorMatrix3x3 && self.StageControlLookupTable1DRegamma == other.StageControlLookupTable1DRegamma && self.LookupTable1DRegamma == other.LookupTable1DRegamma
     }
 }
 impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_MATRIX_V2 {}
@@ -4613,12 +4563,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_SET_INPUT {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_SET_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_SET_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_SET_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_SET_INPUT {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_SET_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4641,12 +4585,6 @@ impl ::core::clone::Clone for COLORSPACE_TRANSFORM_TARGET_CAPS {
 unsafe impl ::windows::core::Abi for COLORSPACE_TRANSFORM_TARGET_CAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLORSPACE_TRANSFORM_TARGET_CAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSPACE_TRANSFORM_TARGET_CAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLORSPACE_TRANSFORM_TARGET_CAPS {}
 impl ::core::default::Default for COLORSPACE_TRANSFORM_TARGET_CAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4677,7 +4615,7 @@ unsafe impl ::windows::core::Abi for DEVHTADJDATA {
 }
 impl ::core::cmp::PartialEq for DEVHTADJDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVHTADJDATA>()) == 0 }
+        self.DeviceFlags == other.DeviceFlags && self.DeviceXDPI == other.DeviceXDPI && self.DeviceYDPI == other.DeviceYDPI && self.pDefHTInfo == other.pDefHTInfo && self.pAdjHTInfo == other.pAdjHTInfo
     }
 }
 impl ::core::cmp::Eq for DEVHTADJDATA {}
@@ -4710,7 +4648,7 @@ unsafe impl ::windows::core::Abi for DEVHTINFO {
 }
 impl ::core::cmp::PartialEq for DEVHTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVHTINFO>()) == 0 }
+        self.HTFlags == other.HTFlags && self.HTPatternSize == other.HTPatternSize && self.DevPelsDPI == other.DevPelsDPI && self.ColorInfo == other.ColorInfo
     }
 }
 impl ::core::cmp::Eq for DEVHTINFO {}
@@ -4755,7 +4693,7 @@ unsafe impl ::windows::core::Abi for DEVINFO {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for DEVINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVINFO>()) == 0 }
+        self.flGraphicsCaps == other.flGraphicsCaps && self.lfDefaultFont == other.lfDefaultFont && self.lfAnsiVarFont == other.lfAnsiVarFont && self.lfAnsiFixFont == other.lfAnsiFixFont && self.cFonts == other.cFonts && self.iDitherFormat == other.iDitherFormat && self.cxDither == other.cxDither && self.cyDither == other.cyDither && self.hpalDefault == other.hpalDefault && self.flGraphicsCaps2 == other.flGraphicsCaps2
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4852,7 +4790,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_2DREGION {
 }
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_2DREGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_2DREGION>()) == 0 }
+        self.cx == other.cx && self.cy == other.cy
     }
 }
 impl ::core::cmp::Eq for DISPLAYCONFIG_2DREGION {}
@@ -4889,7 +4827,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_ADAPTER_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_ADAPTER_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_ADAPTER_NAME>()) == 0 }
+        self.header == other.header && self.adapterDevicePath == other.adapterDevicePath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4929,7 +4867,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_DESKTOP_IMAGE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_DESKTOP_IMAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_DESKTOP_IMAGE_INFO>()) == 0 }
+        self.PathSourceSize == other.PathSourceSize && self.DesktopImageRegion == other.DesktopImageRegion && self.DesktopImageClip == other.DesktopImageClip
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4970,7 +4908,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_DEVICE_INFO_HEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_DEVICE_INFO_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_DEVICE_INFO_HEADER>()) == 0 }
+        self.r#type == other.r#type && self.size == other.size && self.adapterId == other.adapterId && self.id == other.id
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5003,14 +4941,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5035,14 +4965,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
     fn default() -> Self {
@@ -5076,7 +4998,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -5107,14 +5029,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5139,14 +5053,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
     fn default() -> Self {
@@ -5180,7 +5086,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5213,14 +5119,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_MODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_MODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_MODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_MODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_MODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5247,14 +5145,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_MODE_INFO_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_MODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_MODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_MODE_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_MODE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5280,14 +5170,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_PATH_INFO {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_PATH_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_PATH_INFO {
     fn default() -> Self {
@@ -5316,14 +5198,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_SOURCE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_SOURCE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_SOURCE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_PATH_SOURCE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_PATH_SOURCE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5348,14 +5222,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_SOURCE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
     fn default() -> Self {
@@ -5389,7 +5255,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_SOURCE_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_SOURCE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_SOURCE_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5428,14 +5294,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_TARGET_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_TARGET_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_TARGET_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_PATH_TARGET_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_PATH_TARGET_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5460,14 +5318,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_TARGET_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_PATH_TARGET_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
     fn default() -> Self {
@@ -5501,7 +5351,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_PATH_TARGET_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_PATH_TARGET_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_PATH_TARGET_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5534,7 +5384,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_RATIONAL {
 }
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_RATIONAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_RATIONAL>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for DISPLAYCONFIG_RATIONAL {}
@@ -5571,7 +5421,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SDR_WHITE_LEVEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SDR_WHITE_LEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SDR_WHITE_LEVEL>()) == 0 }
+        self.header == other.header && self.SDRWhiteLevel == other.SDRWhiteLevel
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5602,14 +5452,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5634,14 +5476,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
     fn default() -> Self {
@@ -5675,7 +5509,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0 
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5709,14 +5543,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5741,14 +5567,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
     fn default() -> Self {
@@ -5782,7 +5600,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5813,14 +5631,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_TARGET_PERSISTENCE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5845,14 +5655,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
     fn default() -> Self {
@@ -5886,7 +5688,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5925,7 +5727,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SOURCE_DEVICE_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SOURCE_DEVICE_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SOURCE_DEVICE_NAME>()) == 0 }
+        self.header == other.header && self.viewGdiDeviceName == other.viewGdiDeviceName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5966,7 +5768,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SOURCE_MODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SOURCE_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SOURCE_MODE>()) == 0 }
+        self.width == other.width && self.height == other.height && self.pixelFormat == other.pixelFormat && self.position == other.position
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5997,14 +5799,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6029,14 +5823,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
     fn default() -> Self {
@@ -6070,7 +5856,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6109,7 +5895,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_BASE_TYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_BASE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_BASE_TYPE>()) == 0 }
+        self.header == other.header && self.baseOutputTechnology == other.baseOutputTechnology
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6146,14 +5932,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_DEVICE_NAME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_DEVICE_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_DEVICE_NAME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_DEVICE_NAME {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_TARGET_DEVICE_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6173,12 +5951,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {}
 impl ::core::default::Default for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6199,12 +5971,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {}
 impl ::core::default::Default for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6231,7 +5997,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 
 }
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 {}
@@ -6254,12 +6020,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_TARGET_MODE {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_MODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_MODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_MODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_MODE {}
 impl ::core::default::Default for DISPLAYCONFIG_TARGET_MODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6287,14 +6047,6 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_TARGET_PREFERRED_MODE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_TARGET_PREFERRED_MODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_TARGET_PREFERRED_MODE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISPLAYCONFIG_TARGET_PREFERRED_MODE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISPLAYCONFIG_TARGET_PREFERRED_MODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6320,12 +6072,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_VIDEO_SIGNAL_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {}
 impl ::core::default::Default for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6346,12 +6092,6 @@ impl ::core::clone::Clone for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
 unsafe impl ::windows::core::Abi for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {}
 impl ::core::default::Default for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6378,7 +6118,7 @@ unsafe impl ::windows::core::Abi for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {}
@@ -6410,7 +6150,7 @@ unsafe impl ::windows::core::Abi for DISPLAY_BRIGHTNESS {
 }
 impl ::core::cmp::PartialEq for DISPLAY_BRIGHTNESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAY_BRIGHTNESS>()) == 0 }
+        self.ucDisplayPolicy == other.ucDisplayPolicy && self.ucACBrightness == other.ucACBrightness && self.ucDCBrightness == other.ucDCBrightness
     }
 }
 impl ::core::cmp::Eq for DISPLAY_BRIGHTNESS {}
@@ -6447,7 +6187,7 @@ unsafe impl ::windows::core::Abi for DRH_APIBITMAPDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRH_APIBITMAPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRH_APIBITMAPDATA>()) == 0 }
+        self.pso == other.pso && self.b == other.b
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6478,21 +6218,13 @@ impl ::core::clone::Clone for DRIVEROBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DRIVEROBJ {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DRIVEROBJ").field("pvObj", &self.pvObj).field("pFreeProc", &self.pFreeProc.map(|f| f as usize)).field("hdev", &self.hdev).field("dhpdev", &self.dhpdev).finish()
+        f.debug_struct("DRIVEROBJ").field("pvObj", &self.pvObj).field("hdev", &self.hdev).field("dhpdev", &self.dhpdev).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DRIVEROBJ {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRIVEROBJ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVEROBJ>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRIVEROBJ {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRIVEROBJ {
     fn default() -> Self {
@@ -6522,7 +6254,7 @@ unsafe impl ::windows::core::Abi for DRVENABLEDATA {
 }
 impl ::core::cmp::PartialEq for DRVENABLEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRVENABLEDATA>()) == 0 }
+        self.iDriverVersion == other.iDriverVersion && self.c == other.c && self.pdrvfn == other.pdrvfn
     }
 }
 impl ::core::cmp::Eq for DRVENABLEDATA {}
@@ -6545,18 +6277,12 @@ impl ::core::clone::Clone for DRVFN {
 }
 impl ::core::fmt::Debug for DRVFN {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DRVFN").field("iFunc", &self.iFunc).field("pfn", &self.pfn.map(|f| f as usize)).finish()
+        f.debug_struct("DRVFN").field("iFunc", &self.iFunc).finish()
     }
 }
 unsafe impl ::windows::core::Abi for DRVFN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DRVFN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRVFN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DRVFN {}
 impl ::core::default::Default for DRVFN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6587,7 +6313,7 @@ unsafe impl ::windows::core::Abi for DXGK_WIN32K_PARAM_DATA {
 }
 impl ::core::cmp::PartialEq for DXGK_WIN32K_PARAM_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGK_WIN32K_PARAM_DATA>()) == 0 }
+        self.PathsArray == other.PathsArray && self.ModesArray == other.ModesArray && self.NumPathArrayElements == other.NumPathArrayElements && self.NumModeArrayElements == other.NumModeArrayElements && self.SDCFlags == other.SDCFlags
     }
 }
 impl ::core::cmp::Eq for DXGK_WIN32K_PARAM_DATA {}
@@ -6616,14 +6342,6 @@ unsafe impl ::windows::core::Abi for DisplayMode {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DisplayMode {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DisplayMode>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DisplayMode {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DisplayMode {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6648,14 +6366,6 @@ impl ::core::clone::Clone for DisplayModes {
 unsafe impl ::windows::core::Abi for DisplayModes {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DisplayModes {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DisplayModes>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DisplayModes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DisplayModes {
     fn default() -> Self {
@@ -6692,7 +6402,7 @@ unsafe impl ::windows::core::Abi for EMFINFO {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for EMFINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMFINFO>()) == 0 }
+        self.nSize == other.nSize && self.hdc == other.hdc && self.pvEMF == other.pvEMF && self.pvCurrentRecord == other.pvCurrentRecord
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -6725,7 +6435,7 @@ unsafe impl ::windows::core::Abi for ENGSAFESEMAPHORE {
 }
 impl ::core::cmp::PartialEq for ENGSAFESEMAPHORE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENGSAFESEMAPHORE>()) == 0 }
+        self.hsem == other.hsem && self.lCount == other.lCount
     }
 }
 impl ::core::cmp::Eq for ENGSAFESEMAPHORE {}
@@ -6756,7 +6466,7 @@ unsafe impl ::windows::core::Abi for ENG_EVENT {
 }
 impl ::core::cmp::PartialEq for ENG_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENG_EVENT>()) == 0 }
+        self.pKEvent == other.pKEvent && self.fFlags == other.fFlags
     }
 }
 impl ::core::cmp::Eq for ENG_EVENT {}
@@ -6793,7 +6503,7 @@ unsafe impl ::windows::core::Abi for ENG_TIME_FIELDS {
 }
 impl ::core::cmp::PartialEq for ENG_TIME_FIELDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENG_TIME_FIELDS>()) == 0 }
+        self.usYear == other.usYear && self.usMonth == other.usMonth && self.usDay == other.usDay && self.usHour == other.usHour && self.usMinute == other.usMinute && self.usSecond == other.usSecond && self.usMilliseconds == other.usMilliseconds && self.usWeekday == other.usWeekday
     }
 }
 impl ::core::cmp::Eq for ENG_TIME_FIELDS {}
@@ -6830,7 +6540,7 @@ unsafe impl ::windows::core::Abi for ENUMRECTS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENUMRECTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMRECTS>()) == 0 }
+        self.c == other.c && self.arcl == other.arcl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6912,7 +6622,28 @@ unsafe impl ::windows::core::Abi for FD_DEVICEMETRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FD_DEVICEMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_DEVICEMETRICS>()) == 0 }
+        self.flRealizedType == other.flRealizedType
+            && self.pteBase == other.pteBase
+            && self.pteSide == other.pteSide
+            && self.lD == other.lD
+            && self.fxMaxAscender == other.fxMaxAscender
+            && self.fxMaxDescender == other.fxMaxDescender
+            && self.ptlUnderline1 == other.ptlUnderline1
+            && self.ptlStrikeOut == other.ptlStrikeOut
+            && self.ptlULThickness == other.ptlULThickness
+            && self.ptlSOThickness == other.ptlSOThickness
+            && self.cxMax == other.cxMax
+            && self.cyMax == other.cyMax
+            && self.cjGlyphMax == other.cjGlyphMax
+            && self.fdxQuantized == other.fdxQuantized
+            && self.lNonLinearExtLeading == other.lNonLinearExtLeading
+            && self.lNonLinearIntLeading == other.lNonLinearIntLeading
+            && self.lNonLinearMaxCharWidth == other.lNonLinearMaxCharWidth
+            && self.lNonLinearAvgCharWidth == other.lNonLinearAvgCharWidth
+            && self.lMinA == other.lMinA
+            && self.lMinC == other.lMinC
+            && self.lMinD == other.lMinD
+            && self.alReserved == other.alReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6947,7 +6678,7 @@ unsafe impl ::windows::core::Abi for FD_GLYPHATTR {
 }
 impl ::core::cmp::PartialEq for FD_GLYPHATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_GLYPHATTR>()) == 0 }
+        self.cjThis == other.cjThis && self.cGlyphs == other.cGlyphs && self.iMode == other.iMode && self.aGlyphAttr == other.aGlyphAttr
     }
 }
 impl ::core::cmp::Eq for FD_GLYPHATTR {}
@@ -6981,7 +6712,7 @@ unsafe impl ::windows::core::Abi for FD_GLYPHSET {
 }
 impl ::core::cmp::PartialEq for FD_GLYPHSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_GLYPHSET>()) == 0 }
+        self.cjThis == other.cjThis && self.flAccel == other.flAccel && self.cGlyphsSupported == other.cGlyphsSupported && self.cRuns == other.cRuns && self.awcrun == other.awcrun
     }
 }
 impl ::core::cmp::Eq for FD_GLYPHSET {}
@@ -7013,7 +6744,7 @@ unsafe impl ::windows::core::Abi for FD_KERNINGPAIR {
 }
 impl ::core::cmp::PartialEq for FD_KERNINGPAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_KERNINGPAIR>()) == 0 }
+        self.wcFirst == other.wcFirst && self.wcSecond == other.wcSecond && self.fwdKern == other.fwdKern
     }
 }
 impl ::core::cmp::Eq for FD_KERNINGPAIR {}
@@ -7046,7 +6777,7 @@ unsafe impl ::windows::core::Abi for FD_LIGATURE {
 }
 impl ::core::cmp::PartialEq for FD_LIGATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_LIGATURE>()) == 0 }
+        self.culThis == other.culThis && self.ulType == other.ulType && self.cLigatures == other.cLigatures && self.alig == other.alig
     }
 }
 impl ::core::cmp::Eq for FD_LIGATURE {}
@@ -7085,7 +6816,7 @@ unsafe impl ::windows::core::Abi for FD_XFORM {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for FD_XFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_XFORM>()) == 0 }
+        self.eXX == other.eXX && self.eXY == other.eXY && self.eYX == other.eYX && self.eYY == other.eYY
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -7126,7 +6857,7 @@ unsafe impl ::windows::core::Abi for FD_XFORM {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for FD_XFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_XFORM>()) == 0 }
+        self.eXX == other.eXX && self.eXY == other.eXY && self.eYX == other.eYX && self.eYY == other.eYY
     }
 }
 #[cfg(target_arch = "x86")]
@@ -7165,7 +6896,7 @@ unsafe impl ::windows::core::Abi for FLOATOBJ {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for FLOATOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOATOBJ>()) == 0 }
+        self.ul1 == other.ul1 && self.ul2 == other.ul2
     }
 }
 #[cfg(target_arch = "x86")]
@@ -7208,7 +6939,7 @@ unsafe impl ::windows::core::Abi for FLOATOBJ_XFORM {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for FLOATOBJ_XFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOATOBJ_XFORM>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22 && self.eDx == other.eDx && self.eDy == other.eDy
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -7251,7 +6982,7 @@ unsafe impl ::windows::core::Abi for FLOATOBJ_XFORM {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for FLOATOBJ_XFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOATOBJ_XFORM>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22 && self.eDx == other.eDx && self.eDy == other.eDy
     }
 }
 #[cfg(target_arch = "x86")]
@@ -7282,14 +7013,6 @@ unsafe impl ::windows::core::Abi for FLOAT_LONG {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for FLOAT_LONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOAT_LONG>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for FLOAT_LONG {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for FLOAT_LONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7314,14 +7037,6 @@ impl ::core::clone::Clone for FLOAT_LONG {
 unsafe impl ::windows::core::Abi for FLOAT_LONG {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for FLOAT_LONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOAT_LONG>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for FLOAT_LONG {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for FLOAT_LONG {
     fn default() -> Self {
@@ -7363,7 +7078,7 @@ unsafe impl ::windows::core::Abi for FONTDIFF {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FONTDIFF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTDIFF>()) == 0 }
+        self.jReserved1 == other.jReserved1 && self.jReserved2 == other.jReserved2 && self.jReserved3 == other.jReserved3 && self.bWeight == other.bWeight && self.usWinWeight == other.usWinWeight && self.fsSelection == other.fsSelection && self.fwdAveCharWidth == other.fwdAveCharWidth && self.fwdMaxCharInc == other.fwdMaxCharInc && self.ptlCaret == other.ptlCaret
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7401,7 +7116,7 @@ unsafe impl ::windows::core::Abi for FONTINFO {
 }
 impl ::core::cmp::PartialEq for FONTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTINFO>()) == 0 }
+        self.cjThis == other.cjThis && self.flCaps == other.flCaps && self.cGlyphsSupported == other.cGlyphsSupported && self.cjMaxGlyph1 == other.cjMaxGlyph1 && self.cjMaxGlyph4 == other.cjMaxGlyph4 && self.cjMaxGlyph8 == other.cjMaxGlyph8 && self.cjMaxGlyph32 == other.cjMaxGlyph32
     }
 }
 impl ::core::cmp::Eq for FONTINFO {}
@@ -7446,7 +7161,7 @@ unsafe impl ::windows::core::Abi for FONTOBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FONTOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTOBJ>()) == 0 }
+        self.iUniq == other.iUniq && self.iFace == other.iFace && self.cxMax == other.cxMax && self.flFontType == other.flFontType && self.iTTUniq == other.iTTUniq && self.iFile == other.iFile && self.sizLogResPpi == other.sizLogResPpi && self.ulStyleSize == other.ulStyleSize && self.pvConsumer == other.pvConsumer && self.pvProducer == other.pvProducer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7480,7 +7195,7 @@ unsafe impl ::windows::core::Abi for FONTSIM {
 }
 impl ::core::cmp::PartialEq for FONTSIM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTSIM>()) == 0 }
+        self.dpBold == other.dpBold && self.dpItalic == other.dpItalic && self.dpBoldItalic == other.dpBoldItalic
     }
 }
 impl ::core::cmp::Eq for FONTSIM {}
@@ -7517,7 +7232,7 @@ unsafe impl ::windows::core::Abi for FONT_IMAGE_INFO {
 #[cfg(feature = "Win32_System_Console")]
 impl ::core::cmp::PartialEq for FONT_IMAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONT_IMAGE_INFO>()) == 0 }
+        self.FontSize == other.FontSize && self.ImageBits == other.ImageBits
     }
 }
 #[cfg(feature = "Win32_System_Console")]
@@ -7557,7 +7272,7 @@ unsafe impl ::windows::core::Abi for FSCNTL_SCREEN_INFO {
 #[cfg(feature = "Win32_System_Console")]
 impl ::core::cmp::PartialEq for FSCNTL_SCREEN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCNTL_SCREEN_INFO>()) == 0 }
+        self.Position == other.Position && self.ScreenSize == other.ScreenSize && self.nNumberOfChars == other.nNumberOfChars
     }
 }
 #[cfg(feature = "Win32_System_Console")]
@@ -7596,7 +7311,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_COPY_FRAME_BUFFER {
 #[cfg(feature = "Win32_System_Console")]
 impl ::core::cmp::PartialEq for FSVIDEO_COPY_FRAME_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_COPY_FRAME_BUFFER>()) == 0 }
+        self.SrcScreen == other.SrcScreen && self.DestScreen == other.DestScreen
     }
 }
 #[cfg(feature = "Win32_System_Console")]
@@ -7629,7 +7344,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_CURSOR_POSITION {
 }
 impl ::core::cmp::PartialEq for FSVIDEO_CURSOR_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_CURSOR_POSITION>()) == 0 }
+        self.Coord == other.Coord && self.dwType == other.dwType
     }
 }
 impl ::core::cmp::Eq for FSVIDEO_CURSOR_POSITION {}
@@ -7660,7 +7375,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_MODE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FSVIDEO_MODE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_MODE_INFORMATION>()) == 0 }
+        self.VideoMode == other.VideoMode && self.VideoMemory == other.VideoMemory
     }
 }
 impl ::core::cmp::Eq for FSVIDEO_MODE_INFORMATION {}
@@ -7697,7 +7412,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_REVERSE_MOUSE_POINTER {
 #[cfg(feature = "Win32_System_Console")]
 impl ::core::cmp::PartialEq for FSVIDEO_REVERSE_MOUSE_POINTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_REVERSE_MOUSE_POINTER>()) == 0 }
+        self.Screen == other.Screen && self.dwType == other.dwType
     }
 }
 #[cfg(feature = "Win32_System_Console")]
@@ -7736,7 +7451,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_SCREEN_INFORMATION {
 #[cfg(feature = "Win32_System_Console")]
 impl ::core::cmp::PartialEq for FSVIDEO_SCREEN_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_SCREEN_INFORMATION>()) == 0 }
+        self.ScreenSize == other.ScreenSize && self.FontSize == other.FontSize
     }
 }
 #[cfg(feature = "Win32_System_Console")]
@@ -7775,7 +7490,7 @@ unsafe impl ::windows::core::Abi for FSVIDEO_WRITE_TO_FRAME_BUFFER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
 impl ::core::cmp::PartialEq for FSVIDEO_WRITE_TO_FRAME_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSVIDEO_WRITE_TO_FRAME_BUFFER>()) == 0 }
+        self.SrcBuffer == other.SrcBuffer && self.DestScreen == other.DestScreen
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
@@ -7809,7 +7524,7 @@ unsafe impl ::windows::core::Abi for GAMMARAMP {
 }
 impl ::core::cmp::PartialEq for GAMMARAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GAMMARAMP>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue
     }
 }
 impl ::core::cmp::Eq for GAMMARAMP {}
@@ -7841,7 +7556,7 @@ unsafe impl ::windows::core::Abi for GAMMA_RAMP_DXGI_1 {
 }
 impl ::core::cmp::PartialEq for GAMMA_RAMP_DXGI_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GAMMA_RAMP_DXGI_1>()) == 0 }
+        self.Scale == other.Scale && self.Offset == other.Offset && self.GammaCurve == other.GammaCurve
     }
 }
 impl ::core::cmp::Eq for GAMMA_RAMP_DXGI_1 {}
@@ -7873,7 +7588,7 @@ unsafe impl ::windows::core::Abi for GAMMA_RAMP_RGB {
 }
 impl ::core::cmp::PartialEq for GAMMA_RAMP_RGB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GAMMA_RAMP_RGB>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue
     }
 }
 impl ::core::cmp::Eq for GAMMA_RAMP_RGB {}
@@ -7905,7 +7620,7 @@ unsafe impl ::windows::core::Abi for GAMMA_RAMP_RGB256x3x16 {
 }
 impl ::core::cmp::PartialEq for GAMMA_RAMP_RGB256x3x16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GAMMA_RAMP_RGB256x3x16>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue
     }
 }
 impl ::core::cmp::Eq for GAMMA_RAMP_RGB256x3x16 {}
@@ -8031,7 +7746,51 @@ unsafe impl ::windows::core::Abi for GDIINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GDIINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GDIINFO>()) == 0 }
+        self.ulVersion == other.ulVersion
+            && self.ulTechnology == other.ulTechnology
+            && self.ulHorzSize == other.ulHorzSize
+            && self.ulVertSize == other.ulVertSize
+            && self.ulHorzRes == other.ulHorzRes
+            && self.ulVertRes == other.ulVertRes
+            && self.cBitsPixel == other.cBitsPixel
+            && self.cPlanes == other.cPlanes
+            && self.ulNumColors == other.ulNumColors
+            && self.flRaster == other.flRaster
+            && self.ulLogPixelsX == other.ulLogPixelsX
+            && self.ulLogPixelsY == other.ulLogPixelsY
+            && self.flTextCaps == other.flTextCaps
+            && self.ulDACRed == other.ulDACRed
+            && self.ulDACGreen == other.ulDACGreen
+            && self.ulDACBlue == other.ulDACBlue
+            && self.ulAspectX == other.ulAspectX
+            && self.ulAspectY == other.ulAspectY
+            && self.ulAspectXY == other.ulAspectXY
+            && self.xStyleStep == other.xStyleStep
+            && self.yStyleStep == other.yStyleStep
+            && self.denStyleStep == other.denStyleStep
+            && self.ptlPhysOffset == other.ptlPhysOffset
+            && self.szlPhysSize == other.szlPhysSize
+            && self.ulNumPalReg == other.ulNumPalReg
+            && self.ciDevice == other.ciDevice
+            && self.ulDevicePelsDPI == other.ulDevicePelsDPI
+            && self.ulPrimaryOrder == other.ulPrimaryOrder
+            && self.ulHTPatternSize == other.ulHTPatternSize
+            && self.ulHTOutputFormat == other.ulHTOutputFormat
+            && self.flHTFlags == other.flHTFlags
+            && self.ulVRefresh == other.ulVRefresh
+            && self.ulBltAlignment == other.ulBltAlignment
+            && self.ulPanningHorzRes == other.ulPanningHorzRes
+            && self.ulPanningVertRes == other.ulPanningVertRes
+            && self.xPanningAlignment == other.xPanningAlignment
+            && self.yPanningAlignment == other.yPanningAlignment
+            && self.cxHTPat == other.cxHTPat
+            && self.cyHTPat == other.cyHTPat
+            && self.pHTPatA == other.pHTPatA
+            && self.pHTPatB == other.pHTPatB
+            && self.pHTPatC == other.pHTPatC
+            && self.flShadeBlend == other.flShadeBlend
+            && self.ulPhysicalPixelCharacteristics == other.ulPhysicalPixelCharacteristics
+            && self.ulPhysicalPixelGamma == other.ulPhysicalPixelGamma
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8071,7 +7830,7 @@ unsafe impl ::windows::core::Abi for GLYPHBITS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GLYPHBITS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHBITS>()) == 0 }
+        self.ptlOrigin == other.ptlOrigin && self.sizlBitmap == other.sizlBitmap && self.aj == other.aj
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8109,14 +7868,6 @@ unsafe impl ::windows::core::Abi for GLYPHDATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GLYPHDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHDATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GLYPHDATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GLYPHDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8141,14 +7892,6 @@ impl ::core::clone::Clone for GLYPHDEF {
 unsafe impl ::windows::core::Abi for GLYPHDEF {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GLYPHDEF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHDEF>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GLYPHDEF {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GLYPHDEF {
     fn default() -> Self {
@@ -8184,7 +7927,7 @@ unsafe impl ::windows::core::Abi for GLYPHPOS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GLYPHPOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHPOS>()) == 0 }
+        self.hg == other.hg && self.pgdf == other.pgdf && self.ptl == other.ptl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8413,7 +8156,7 @@ unsafe impl ::windows::core::Abi for IFIEXTRA {
 }
 impl ::core::cmp::PartialEq for IFIEXTRA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IFIEXTRA>()) == 0 }
+        self.ulIdentifier == other.ulIdentifier && self.dpFontSig == other.dpFontSig && self.cig == other.cig && self.dpDesignVector == other.dpDesignVector && self.dpAxesInfoW == other.dpAxesInfoW && self.aulReserved == other.aulReserved
     }
 }
 impl ::core::cmp::Eq for IFIEXTRA {}
@@ -8575,7 +8318,66 @@ unsafe impl ::windows::core::Abi for IFIMETRICS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for IFIMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IFIMETRICS>()) == 0 }
+        self.cjThis == other.cjThis
+            && self.cjIfiExtra == other.cjIfiExtra
+            && self.dpwszFamilyName == other.dpwszFamilyName
+            && self.dpwszStyleName == other.dpwszStyleName
+            && self.dpwszFaceName == other.dpwszFaceName
+            && self.dpwszUniqueName == other.dpwszUniqueName
+            && self.dpFontSim == other.dpFontSim
+            && self.lEmbedId == other.lEmbedId
+            && self.lItalicAngle == other.lItalicAngle
+            && self.lCharBias == other.lCharBias
+            && self.dpCharSets == other.dpCharSets
+            && self.jWinCharSet == other.jWinCharSet
+            && self.jWinPitchAndFamily == other.jWinPitchAndFamily
+            && self.usWinWeight == other.usWinWeight
+            && self.flInfo == other.flInfo
+            && self.fsSelection == other.fsSelection
+            && self.fsType == other.fsType
+            && self.fwdUnitsPerEm == other.fwdUnitsPerEm
+            && self.fwdLowestPPEm == other.fwdLowestPPEm
+            && self.fwdWinAscender == other.fwdWinAscender
+            && self.fwdWinDescender == other.fwdWinDescender
+            && self.fwdMacAscender == other.fwdMacAscender
+            && self.fwdMacDescender == other.fwdMacDescender
+            && self.fwdMacLineGap == other.fwdMacLineGap
+            && self.fwdTypoAscender == other.fwdTypoAscender
+            && self.fwdTypoDescender == other.fwdTypoDescender
+            && self.fwdTypoLineGap == other.fwdTypoLineGap
+            && self.fwdAveCharWidth == other.fwdAveCharWidth
+            && self.fwdMaxCharInc == other.fwdMaxCharInc
+            && self.fwdCapHeight == other.fwdCapHeight
+            && self.fwdXHeight == other.fwdXHeight
+            && self.fwdSubscriptXSize == other.fwdSubscriptXSize
+            && self.fwdSubscriptYSize == other.fwdSubscriptYSize
+            && self.fwdSubscriptXOffset == other.fwdSubscriptXOffset
+            && self.fwdSubscriptYOffset == other.fwdSubscriptYOffset
+            && self.fwdSuperscriptXSize == other.fwdSuperscriptXSize
+            && self.fwdSuperscriptYSize == other.fwdSuperscriptYSize
+            && self.fwdSuperscriptXOffset == other.fwdSuperscriptXOffset
+            && self.fwdSuperscriptYOffset == other.fwdSuperscriptYOffset
+            && self.fwdUnderscoreSize == other.fwdUnderscoreSize
+            && self.fwdUnderscorePosition == other.fwdUnderscorePosition
+            && self.fwdStrikeoutSize == other.fwdStrikeoutSize
+            && self.fwdStrikeoutPosition == other.fwdStrikeoutPosition
+            && self.chFirstChar == other.chFirstChar
+            && self.chLastChar == other.chLastChar
+            && self.chDefaultChar == other.chDefaultChar
+            && self.chBreakChar == other.chBreakChar
+            && self.wcFirstChar == other.wcFirstChar
+            && self.wcLastChar == other.wcLastChar
+            && self.wcDefaultChar == other.wcDefaultChar
+            && self.wcBreakChar == other.wcBreakChar
+            && self.ptlBaseline == other.ptlBaseline
+            && self.ptlAspect == other.ptlAspect
+            && self.ptlCaret == other.ptlCaret
+            && self.rclFontBox == other.rclFontBox
+            && self.achVendId == other.achVendId
+            && self.cKerningPairs == other.cKerningPairs
+            && self.ulPanoseCulture == other.ulPanoseCulture
+            && self.panose == other.panose
+            && self.Align == other.Align
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -8739,7 +8541,65 @@ unsafe impl ::windows::core::Abi for IFIMETRICS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for IFIMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IFIMETRICS>()) == 0 }
+        self.cjThis == other.cjThis
+            && self.cjIfiExtra == other.cjIfiExtra
+            && self.dpwszFamilyName == other.dpwszFamilyName
+            && self.dpwszStyleName == other.dpwszStyleName
+            && self.dpwszFaceName == other.dpwszFaceName
+            && self.dpwszUniqueName == other.dpwszUniqueName
+            && self.dpFontSim == other.dpFontSim
+            && self.lEmbedId == other.lEmbedId
+            && self.lItalicAngle == other.lItalicAngle
+            && self.lCharBias == other.lCharBias
+            && self.dpCharSets == other.dpCharSets
+            && self.jWinCharSet == other.jWinCharSet
+            && self.jWinPitchAndFamily == other.jWinPitchAndFamily
+            && self.usWinWeight == other.usWinWeight
+            && self.flInfo == other.flInfo
+            && self.fsSelection == other.fsSelection
+            && self.fsType == other.fsType
+            && self.fwdUnitsPerEm == other.fwdUnitsPerEm
+            && self.fwdLowestPPEm == other.fwdLowestPPEm
+            && self.fwdWinAscender == other.fwdWinAscender
+            && self.fwdWinDescender == other.fwdWinDescender
+            && self.fwdMacAscender == other.fwdMacAscender
+            && self.fwdMacDescender == other.fwdMacDescender
+            && self.fwdMacLineGap == other.fwdMacLineGap
+            && self.fwdTypoAscender == other.fwdTypoAscender
+            && self.fwdTypoDescender == other.fwdTypoDescender
+            && self.fwdTypoLineGap == other.fwdTypoLineGap
+            && self.fwdAveCharWidth == other.fwdAveCharWidth
+            && self.fwdMaxCharInc == other.fwdMaxCharInc
+            && self.fwdCapHeight == other.fwdCapHeight
+            && self.fwdXHeight == other.fwdXHeight
+            && self.fwdSubscriptXSize == other.fwdSubscriptXSize
+            && self.fwdSubscriptYSize == other.fwdSubscriptYSize
+            && self.fwdSubscriptXOffset == other.fwdSubscriptXOffset
+            && self.fwdSubscriptYOffset == other.fwdSubscriptYOffset
+            && self.fwdSuperscriptXSize == other.fwdSuperscriptXSize
+            && self.fwdSuperscriptYSize == other.fwdSuperscriptYSize
+            && self.fwdSuperscriptXOffset == other.fwdSuperscriptXOffset
+            && self.fwdSuperscriptYOffset == other.fwdSuperscriptYOffset
+            && self.fwdUnderscoreSize == other.fwdUnderscoreSize
+            && self.fwdUnderscorePosition == other.fwdUnderscorePosition
+            && self.fwdStrikeoutSize == other.fwdStrikeoutSize
+            && self.fwdStrikeoutPosition == other.fwdStrikeoutPosition
+            && self.chFirstChar == other.chFirstChar
+            && self.chLastChar == other.chLastChar
+            && self.chDefaultChar == other.chDefaultChar
+            && self.chBreakChar == other.chBreakChar
+            && self.wcFirstChar == other.wcFirstChar
+            && self.wcLastChar == other.wcLastChar
+            && self.wcDefaultChar == other.wcDefaultChar
+            && self.wcBreakChar == other.wcBreakChar
+            && self.ptlBaseline == other.ptlBaseline
+            && self.ptlAspect == other.ptlAspect
+            && self.ptlCaret == other.ptlCaret
+            && self.rclFontBox == other.rclFontBox
+            && self.achVendId == other.achVendId
+            && self.cKerningPairs == other.cKerningPairs
+            && self.ulPanoseCulture == other.ulPanoseCulture
+            && self.panose == other.panose
     }
 }
 #[cfg(target_arch = "x86")]
@@ -8782,7 +8642,7 @@ unsafe impl ::windows::core::Abi for INDIRECT_DISPLAY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INDIRECT_DISPLAY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INDIRECT_DISPLAY_INFO>()) == 0 }
+        self.DisplayAdapterLuid == other.DisplayAdapterLuid && self.Flags == other.Flags && self.NumMonitors == other.NumMonitors && self.DisplayAdapterTargetBase == other.DisplayAdapterTargetBase
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8817,7 +8677,7 @@ unsafe impl ::windows::core::Abi for LIGATURE {
 }
 impl ::core::cmp::PartialEq for LIGATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE>()) == 0 }
+        self.culSize == other.culSize && self.pwsz == other.pwsz && self.chglyph == other.chglyph && self.ahglyph == other.ahglyph
     }
 }
 impl ::core::cmp::Eq for LIGATURE {}
@@ -8852,14 +8712,6 @@ unsafe impl ::windows::core::Abi for LINEATTRS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for LINEATTRS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEATTRS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for LINEATTRS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for LINEATTRS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8891,14 +8743,6 @@ unsafe impl ::windows::core::Abi for LINEATTRS {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for LINEATTRS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEATTRS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for LINEATTRS {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for LINEATTRS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8920,12 +8764,6 @@ impl ::core::clone::Clone for MC_TIMING_REPORT {
 unsafe impl ::windows::core::Abi for MC_TIMING_REPORT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MC_TIMING_REPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MC_TIMING_REPORT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MC_TIMING_REPORT {}
 impl ::core::default::Default for MC_TIMING_REPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8988,7 +8826,24 @@ unsafe impl ::windows::core::Abi for MIPI_DSI_CAPS {
 }
 impl ::core::cmp::PartialEq for MIPI_DSI_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_CAPS>()) == 0 }
+        self.DSITypeMajor == other.DSITypeMajor
+            && self.DSITypeMinor == other.DSITypeMinor
+            && self.SpecVersionMajor == other.SpecVersionMajor
+            && self.SpecVersionMinor == other.SpecVersionMinor
+            && self.SpecVersionPatch == other.SpecVersionPatch
+            && self.TargetMaximumReturnPacketSize == other.TargetMaximumReturnPacketSize
+            && self.ResultCodeFlags == other.ResultCodeFlags
+            && self.ResultCodeStatus == other.ResultCodeStatus
+            && self.Revision == other.Revision
+            && self.Level == other.Level
+            && self.DeviceClassHi == other.DeviceClassHi
+            && self.DeviceClassLo == other.DeviceClassLo
+            && self.ManufacturerHi == other.ManufacturerHi
+            && self.ManufacturerLo == other.ManufacturerLo
+            && self.ProductHi == other.ProductHi
+            && self.ProductLo == other.ProductLo
+            && self.LengthHi == other.LengthHi
+            && self.LengthLo == other.LengthLo
     }
 }
 impl ::core::cmp::Eq for MIPI_DSI_CAPS {}
@@ -9014,12 +8869,6 @@ impl ::core::clone::Clone for MIPI_DSI_PACKET {
 unsafe impl ::windows::core::Abi for MIPI_DSI_PACKET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_PACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_PACKET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_PACKET {}
 impl ::core::default::Default for MIPI_DSI_PACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9040,12 +8889,6 @@ impl ::core::clone::Clone for MIPI_DSI_PACKET_0 {
 unsafe impl ::windows::core::Abi for MIPI_DSI_PACKET_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_PACKET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_PACKET_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_PACKET_0 {}
 impl ::core::default::Default for MIPI_DSI_PACKET_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9072,7 +8915,7 @@ unsafe impl ::windows::core::Abi for MIPI_DSI_PACKET_0_0 {
 }
 impl ::core::cmp::PartialEq for MIPI_DSI_PACKET_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_PACKET_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIPI_DSI_PACKET_0_0 {}
@@ -9096,12 +8939,6 @@ impl ::core::clone::Clone for MIPI_DSI_PACKET_1 {
 unsafe impl ::windows::core::Abi for MIPI_DSI_PACKET_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_PACKET_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_PACKET_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_PACKET_1 {}
 impl ::core::default::Default for MIPI_DSI_PACKET_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9129,7 +8966,7 @@ unsafe impl ::windows::core::Abi for MIPI_DSI_PACKET_1_0 {
 }
 impl ::core::cmp::PartialEq for MIPI_DSI_PACKET_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_PACKET_1_0>()) == 0 }
+        self.Data0 == other.Data0 && self.Data1 == other.Data1
     }
 }
 impl ::core::cmp::Eq for MIPI_DSI_PACKET_1_0 {}
@@ -9153,12 +8990,6 @@ impl ::core::clone::Clone for MIPI_DSI_RESET {
 unsafe impl ::windows::core::Abi for MIPI_DSI_RESET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_RESET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_RESET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_RESET {}
 impl ::core::default::Default for MIPI_DSI_RESET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9179,12 +9010,6 @@ impl ::core::clone::Clone for MIPI_DSI_RESET_0 {
 unsafe impl ::windows::core::Abi for MIPI_DSI_RESET_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_RESET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_RESET_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_RESET_0 {}
 impl ::core::default::Default for MIPI_DSI_RESET_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9211,7 +9036,7 @@ unsafe impl ::windows::core::Abi for MIPI_DSI_RESET_0_0 {
 }
 impl ::core::cmp::PartialEq for MIPI_DSI_RESET_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_RESET_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIPI_DSI_RESET_0_0 {}
@@ -9242,12 +9067,6 @@ impl ::core::clone::Clone for MIPI_DSI_TRANSMISSION {
 unsafe impl ::windows::core::Abi for MIPI_DSI_TRANSMISSION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIPI_DSI_TRANSMISSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_TRANSMISSION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIPI_DSI_TRANSMISSION {}
 impl ::core::default::Default for MIPI_DSI_TRANSMISSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9274,7 +9093,7 @@ unsafe impl ::windows::core::Abi for MIPI_DSI_TRANSMISSION_0 {
 }
 impl ::core::cmp::PartialEq for MIPI_DSI_TRANSMISSION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIPI_DSI_TRANSMISSION_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIPI_DSI_TRANSMISSION_0 {}
@@ -9305,7 +9124,7 @@ unsafe impl ::windows::core::Abi for OUTPUT_WIRE_FORMAT {
 }
 impl ::core::cmp::PartialEq for OUTPUT_WIRE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OUTPUT_WIRE_FORMAT>()) == 0 }
+        self.ColorEncoding == other.ColorEncoding && self.BitsPerPixel == other.BitsPerPixel
     }
 }
 impl ::core::cmp::Eq for OUTPUT_WIRE_FORMAT {}
@@ -9335,7 +9154,7 @@ unsafe impl ::windows::core::Abi for PALOBJ {
 }
 impl ::core::cmp::PartialEq for PALOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PALOBJ>()) == 0 }
+        self.ulReserved == other.ulReserved
     }
 }
 impl ::core::cmp::Eq for PALOBJ {}
@@ -9361,12 +9180,6 @@ impl ::core::clone::Clone for PANEL_BRIGHTNESS_SENSOR_DATA {
 unsafe impl ::windows::core::Abi for PANEL_BRIGHTNESS_SENSOR_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_BRIGHTNESS_SENSOR_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_BRIGHTNESS_SENSOR_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_BRIGHTNESS_SENSOR_DATA {}
 impl ::core::default::Default for PANEL_BRIGHTNESS_SENSOR_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9387,12 +9200,6 @@ impl ::core::clone::Clone for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
 unsafe impl ::windows::core::Abi for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_BRIGHTNESS_SENSOR_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_BRIGHTNESS_SENSOR_DATA_0 {}
 impl ::core::default::Default for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9419,7 +9226,7 @@ unsafe impl ::windows::core::Abi for PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {
 }
 impl ::core::cmp::PartialEq for PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_BRIGHTNESS_SENSOR_DATA_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {}
@@ -9451,7 +9258,7 @@ unsafe impl ::windows::core::Abi for PANEL_GET_BACKLIGHT_REDUCTION {
 }
 impl ::core::cmp::PartialEq for PANEL_GET_BACKLIGHT_REDUCTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_GET_BACKLIGHT_REDUCTION>()) == 0 }
+        self.BacklightUsersetting == other.BacklightUsersetting && self.BacklightEffective == other.BacklightEffective && self.GammaRamp == other.GammaRamp
     }
 }
 impl ::core::cmp::Eq for PANEL_GET_BACKLIGHT_REDUCTION {}
@@ -9475,12 +9282,6 @@ impl ::core::clone::Clone for PANEL_GET_BRIGHTNESS {
 unsafe impl ::windows::core::Abi for PANEL_GET_BRIGHTNESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_GET_BRIGHTNESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_GET_BRIGHTNESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_GET_BRIGHTNESS {}
 impl ::core::default::Default for PANEL_GET_BRIGHTNESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9501,12 +9302,6 @@ impl ::core::clone::Clone for PANEL_GET_BRIGHTNESS_0 {
 unsafe impl ::windows::core::Abi for PANEL_GET_BRIGHTNESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_GET_BRIGHTNESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_GET_BRIGHTNESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_GET_BRIGHTNESS_0 {}
 impl ::core::default::Default for PANEL_GET_BRIGHTNESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9534,7 +9329,7 @@ unsafe impl ::windows::core::Abi for PANEL_GET_BRIGHTNESS_0_0 {
 }
 impl ::core::cmp::PartialEq for PANEL_GET_BRIGHTNESS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_GET_BRIGHTNESS_0_0>()) == 0 }
+        self.CurrentInMillinits == other.CurrentInMillinits && self.TargetInMillinits == other.TargetInMillinits
     }
 }
 impl ::core::cmp::Eq for PANEL_GET_BRIGHTNESS_0_0 {}
@@ -9558,12 +9353,6 @@ impl ::core::clone::Clone for PANEL_QUERY_BRIGHTNESS_CAPS {
 unsafe impl ::windows::core::Abi for PANEL_QUERY_BRIGHTNESS_CAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_QUERY_BRIGHTNESS_CAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_QUERY_BRIGHTNESS_CAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_QUERY_BRIGHTNESS_CAPS {}
 impl ::core::default::Default for PANEL_QUERY_BRIGHTNESS_CAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9584,12 +9373,6 @@ impl ::core::clone::Clone for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
 unsafe impl ::windows::core::Abi for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_QUERY_BRIGHTNESS_CAPS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_QUERY_BRIGHTNESS_CAPS_0 {}
 impl ::core::default::Default for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9616,7 +9399,7 @@ unsafe impl ::windows::core::Abi for PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {
 }
 impl ::core::cmp::PartialEq for PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_QUERY_BRIGHTNESS_CAPS_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {}
@@ -9640,12 +9423,6 @@ impl ::core::clone::Clone for PANEL_QUERY_BRIGHTNESS_RANGES {
 unsafe impl ::windows::core::Abi for PANEL_QUERY_BRIGHTNESS_RANGES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_QUERY_BRIGHTNESS_RANGES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_QUERY_BRIGHTNESS_RANGES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_QUERY_BRIGHTNESS_RANGES {}
 impl ::core::default::Default for PANEL_QUERY_BRIGHTNESS_RANGES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9666,12 +9443,6 @@ impl ::core::clone::Clone for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
 unsafe impl ::windows::core::Abi for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_QUERY_BRIGHTNESS_RANGES_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_QUERY_BRIGHTNESS_RANGES_0 {}
 impl ::core::default::Default for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9698,7 +9469,7 @@ unsafe impl ::windows::core::Abi for PANEL_SET_BACKLIGHT_OPTIMIZATION {
 }
 impl ::core::cmp::PartialEq for PANEL_SET_BACKLIGHT_OPTIMIZATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BACKLIGHT_OPTIMIZATION>()) == 0 }
+        self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for PANEL_SET_BACKLIGHT_OPTIMIZATION {}
@@ -9722,12 +9493,6 @@ impl ::core::clone::Clone for PANEL_SET_BRIGHTNESS {
 unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS {}
 impl ::core::default::Default for PANEL_SET_BRIGHTNESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9748,12 +9513,6 @@ impl ::core::clone::Clone for PANEL_SET_BRIGHTNESS_0 {
 unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS_0 {}
 impl ::core::default::Default for PANEL_SET_BRIGHTNESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9775,12 +9534,6 @@ impl ::core::clone::Clone for PANEL_SET_BRIGHTNESS_0_0 {
 unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS_0_0 {}
 impl ::core::default::Default for PANEL_SET_BRIGHTNESS_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9800,12 +9553,6 @@ impl ::core::clone::Clone for PANEL_SET_BRIGHTNESS_STATE {
 unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS_STATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS_STATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS_STATE {}
 impl ::core::default::Default for PANEL_SET_BRIGHTNESS_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9826,12 +9573,6 @@ impl ::core::clone::Clone for PANEL_SET_BRIGHTNESS_STATE_0 {
 unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS_STATE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS_STATE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS_STATE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS_STATE_0 {}
 impl ::core::default::Default for PANEL_SET_BRIGHTNESS_STATE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9858,7 +9599,7 @@ unsafe impl ::windows::core::Abi for PANEL_SET_BRIGHTNESS_STATE_0_0 {
 }
 impl ::core::cmp::PartialEq for PANEL_SET_BRIGHTNESS_STATE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANEL_SET_BRIGHTNESS_STATE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PANEL_SET_BRIGHTNESS_STATE_0_0 {}
@@ -9890,7 +9631,7 @@ unsafe impl ::windows::core::Abi for PATHDATA {
 }
 impl ::core::cmp::PartialEq for PATHDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATHDATA>()) == 0 }
+        self.flags == other.flags && self.count == other.count && self.pptfx == other.pptfx
     }
 }
 impl ::core::cmp::Eq for PATHDATA {}
@@ -9921,7 +9662,7 @@ unsafe impl ::windows::core::Abi for PATHOBJ {
 }
 impl ::core::cmp::PartialEq for PATHOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATHOBJ>()) == 0 }
+        self.fl == other.fl && self.cCurves == other.cCurves
     }
 }
 impl ::core::cmp::Eq for PATHOBJ {}
@@ -9960,7 +9701,7 @@ unsafe impl ::windows::core::Abi for PERBANDINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERBANDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERBANDINFO>()) == 0 }
+        self.bRepeatThisBand == other.bRepeatThisBand && self.szlBand == other.szlBand && self.ulHorzRes == other.ulHorzRes && self.ulVertRes == other.ulVertRes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9990,14 +9731,6 @@ impl ::core::clone::Clone for PHYSICAL_MONITOR {
 unsafe impl ::windows::core::Abi for PHYSICAL_MONITOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PHYSICAL_MONITOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_MONITOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PHYSICAL_MONITOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PHYSICAL_MONITOR {
     fn default() -> Self {
@@ -10032,7 +9765,7 @@ unsafe impl ::windows::core::Abi for POINTE {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for POINTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTE>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -10071,7 +9804,7 @@ unsafe impl ::windows::core::Abi for POINTE {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for POINTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTE>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 #[cfg(target_arch = "x86")]
@@ -10104,7 +9837,7 @@ unsafe impl ::windows::core::Abi for POINTFIX {
 }
 impl ::core::cmp::PartialEq for POINTFIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTFIX>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTFIX {}
@@ -10135,7 +9868,7 @@ unsafe impl ::windows::core::Abi for POINTQF {
 }
 impl ::core::cmp::PartialEq for POINTQF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTQF>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTQF {}
@@ -10168,7 +9901,7 @@ unsafe impl ::windows::core::Abi for RECTFX {
 }
 impl ::core::cmp::PartialEq for RECTFX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECTFX>()) == 0 }
+        self.xLeft == other.xLeft && self.yTop == other.yTop && self.xRight == other.xRight && self.yBottom == other.yBottom
     }
 }
 impl ::core::cmp::Eq for RECTFX {}
@@ -10199,7 +9932,7 @@ unsafe impl ::windows::core::Abi for RUN {
 }
 impl ::core::cmp::PartialEq for RUN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RUN>()) == 0 }
+        self.iStart == other.iStart && self.iStop == other.iStop
     }
 }
 impl ::core::cmp::Eq for RUN {}
@@ -10229,7 +9962,7 @@ unsafe impl ::windows::core::Abi for SET_ACTIVE_COLOR_PROFILE_NAME {
 }
 impl ::core::cmp::PartialEq for SET_ACTIVE_COLOR_PROFILE_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_ACTIVE_COLOR_PROFILE_NAME>()) == 0 }
+        self.ColorProfileName == other.ColorProfileName
     }
 }
 impl ::core::cmp::Eq for SET_ACTIVE_COLOR_PROFILE_NAME {}
@@ -10270,7 +10003,7 @@ unsafe impl ::windows::core::Abi for STROBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STROBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STROBJ>()) == 0 }
+        self.cGlyphs == other.cGlyphs && self.flAccel == other.flAccel && self.ulCharInc == other.ulCharInc && self.rclBkGround == other.rclBkGround && self.pgp == other.pgp && self.pwszOrg == other.pwszOrg
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10320,7 +10053,7 @@ unsafe impl ::windows::core::Abi for SURFOBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SURFOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SURFOBJ>()) == 0 }
+        self.dhsurf == other.dhsurf && self.hsurf == other.hsurf && self.dhpdev == other.dhpdev && self.hdev == other.hdev && self.sizlBitmap == other.sizlBitmap && self.cjBits == other.cjBits && self.pvBits == other.pvBits && self.pvScan0 == other.pvScan0 && self.lDelta == other.lDelta && self.iUniq == other.iUniq && self.iBitmapFormat == other.iBitmapFormat && self.iType == other.iType && self.fjBitmap == other.fjBitmap
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10354,7 +10087,7 @@ unsafe impl ::windows::core::Abi for Sources {
 }
 impl ::core::cmp::PartialEq for Sources {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Sources>()) == 0 }
+        self.sourceId == other.sourceId && self.numTargets == other.numTargets && self.aTargets == other.aTargets
     }
 }
 impl ::core::cmp::Eq for Sources {}
@@ -10392,7 +10125,7 @@ unsafe impl ::windows::core::Abi for TYPE1_FONT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TYPE1_FONT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TYPE1_FONT>()) == 0 }
+        self.hPFM == other.hPFM && self.hPFB == other.hPFB && self.ulIdentifier == other.ulIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10431,7 +10164,7 @@ unsafe impl ::windows::core::Abi for VGA_CHAR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VGA_CHAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VGA_CHAR>()) == 0 }
+        self.Char == other.Char && self.Attributes == other.Attributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10509,7 +10242,29 @@ unsafe impl ::windows::core::Abi for VIDEOPARAMETERS {
 }
 impl ::core::cmp::PartialEq for VIDEOPARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOPARAMETERS>()) == 0 }
+        self.Guid == other.Guid
+            && self.dwOffset == other.dwOffset
+            && self.dwCommand == other.dwCommand
+            && self.dwFlags == other.dwFlags
+            && self.dwMode == other.dwMode
+            && self.dwTVStandard == other.dwTVStandard
+            && self.dwAvailableModes == other.dwAvailableModes
+            && self.dwAvailableTVStandard == other.dwAvailableTVStandard
+            && self.dwFlickerFilter == other.dwFlickerFilter
+            && self.dwOverScanX == other.dwOverScanX
+            && self.dwOverScanY == other.dwOverScanY
+            && self.dwMaxUnscaledX == other.dwMaxUnscaledX
+            && self.dwMaxUnscaledY == other.dwMaxUnscaledY
+            && self.dwPositionX == other.dwPositionX
+            && self.dwPositionY == other.dwPositionY
+            && self.dwBrightness == other.dwBrightness
+            && self.dwContrast == other.dwContrast
+            && self.dwCPType == other.dwCPType
+            && self.dwCPCommand == other.dwCPCommand
+            && self.dwCPStandard == other.dwCPStandard
+            && self.dwCPKey == other.dwCPKey
+            && self.bCP_APSTriggerBits == other.bCP_APSTriggerBits
+            && self.bOEMCopyProtection == other.bOEMCopyProtection
     }
 }
 impl ::core::cmp::Eq for VIDEOPARAMETERS {}
@@ -10565,7 +10320,7 @@ unsafe impl ::windows::core::Abi for VIDEO_BANK_SELECT {
 }
 impl ::core::cmp::PartialEq for VIDEO_BANK_SELECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_BANK_SELECT>()) == 0 }
+        self.Length == other.Length && self.Size == other.Size && self.BankingFlags == other.BankingFlags && self.BankingType == other.BankingType && self.PlanarHCBankingType == other.PlanarHCBankingType && self.BitmapWidthInBytes == other.BitmapWidthInBytes && self.BitmapSize == other.BitmapSize && self.Granularity == other.Granularity && self.PlanarHCGranularity == other.PlanarHCGranularity && self.CodeOffset == other.CodeOffset && self.PlanarHCBankCodeOffset == other.PlanarHCBankCodeOffset && self.PlanarHCEnableCodeOffset == other.PlanarHCEnableCodeOffset && self.PlanarHCDisableCodeOffset == other.PlanarHCDisableCodeOffset
     }
 }
 impl ::core::cmp::Eq for VIDEO_BANK_SELECT {}
@@ -10603,7 +10358,7 @@ unsafe impl ::windows::core::Abi for VIDEO_BRIGHTNESS_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VIDEO_BRIGHTNESS_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_BRIGHTNESS_POLICY>()) == 0 }
+        self.DefaultToBiosPolicy == other.DefaultToBiosPolicy && self.LevelCount == other.LevelCount && self.Level == other.Level
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10642,7 +10397,7 @@ unsafe impl ::windows::core::Abi for VIDEO_BRIGHTNESS_POLICY_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VIDEO_BRIGHTNESS_POLICY_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_BRIGHTNESS_POLICY_0>()) == 0 }
+        self.BatteryLevel == other.BatteryLevel && self.Brightness == other.Brightness
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10669,12 +10424,6 @@ impl ::core::clone::Clone for VIDEO_CLUT {
 unsafe impl ::windows::core::Abi for VIDEO_CLUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIDEO_CLUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_CLUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIDEO_CLUT {}
 impl ::core::default::Default for VIDEO_CLUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10695,12 +10444,6 @@ impl ::core::clone::Clone for VIDEO_CLUT_0 {
 unsafe impl ::windows::core::Abi for VIDEO_CLUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIDEO_CLUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_CLUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIDEO_CLUT_0 {}
 impl ::core::default::Default for VIDEO_CLUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10730,7 +10473,7 @@ unsafe impl ::windows::core::Abi for VIDEO_CLUTDATA {
 }
 impl ::core::cmp::PartialEq for VIDEO_CLUTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_CLUTDATA>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for VIDEO_CLUTDATA {}
@@ -10796,7 +10539,24 @@ unsafe impl ::windows::core::Abi for VIDEO_COLOR_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for VIDEO_COLOR_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_COLOR_CAPABILITIES>()) == 0 }
+        self.Length == other.Length
+            && self.AttributeFlags == other.AttributeFlags
+            && self.RedPhosphoreDecay == other.RedPhosphoreDecay
+            && self.GreenPhosphoreDecay == other.GreenPhosphoreDecay
+            && self.BluePhosphoreDecay == other.BluePhosphoreDecay
+            && self.WhiteChromaticity_x == other.WhiteChromaticity_x
+            && self.WhiteChromaticity_y == other.WhiteChromaticity_y
+            && self.WhiteChromaticity_Y == other.WhiteChromaticity_Y
+            && self.RedChromaticity_x == other.RedChromaticity_x
+            && self.RedChromaticity_y == other.RedChromaticity_y
+            && self.GreenChromaticity_x == other.GreenChromaticity_x
+            && self.GreenChromaticity_y == other.GreenChromaticity_y
+            && self.BlueChromaticity_x == other.BlueChromaticity_x
+            && self.BlueChromaticity_y == other.BlueChromaticity_y
+            && self.WhiteGamma == other.WhiteGamma
+            && self.RedGamma == other.RedGamma
+            && self.GreenGamma == other.GreenGamma
+            && self.BlueGamma == other.BlueGamma
     }
 }
 impl ::core::cmp::Eq for VIDEO_COLOR_CAPABILITIES {}
@@ -10828,7 +10588,7 @@ unsafe impl ::windows::core::Abi for VIDEO_COLOR_LUT_DATA {
 }
 impl ::core::cmp::PartialEq for VIDEO_COLOR_LUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_COLOR_LUT_DATA>()) == 0 }
+        self.Length == other.Length && self.LutDataFormat == other.LutDataFormat && self.LutData == other.LutData
     }
 }
 impl ::core::cmp::Eq for VIDEO_COLOR_LUT_DATA {}
@@ -10863,7 +10623,7 @@ unsafe impl ::windows::core::Abi for VIDEO_CURSOR_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for VIDEO_CURSOR_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_CURSOR_ATTRIBUTES>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Column == other.Column && self.Row == other.Row && self.Rate == other.Rate && self.Enable == other.Enable
     }
 }
 impl ::core::cmp::Eq for VIDEO_CURSOR_ATTRIBUTES {}
@@ -10894,7 +10654,7 @@ unsafe impl ::windows::core::Abi for VIDEO_CURSOR_POSITION {
 }
 impl ::core::cmp::PartialEq for VIDEO_CURSOR_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_CURSOR_POSITION>()) == 0 }
+        self.Column == other.Column && self.Row == other.Row
     }
 }
 impl ::core::cmp::Eq for VIDEO_CURSOR_POSITION {}
@@ -10925,7 +10685,7 @@ unsafe impl ::windows::core::Abi for VIDEO_DEVICE_SESSION_STATUS {
 }
 impl ::core::cmp::PartialEq for VIDEO_DEVICE_SESSION_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_DEVICE_SESSION_STATUS>()) == 0 }
+        self.bEnable == other.bEnable && self.bSuccess == other.bSuccess
     }
 }
 impl ::core::cmp::Eq for VIDEO_DEVICE_SESSION_STATUS {}
@@ -10956,7 +10716,7 @@ unsafe impl ::windows::core::Abi for VIDEO_HARDWARE_STATE {
 }
 impl ::core::cmp::PartialEq for VIDEO_HARDWARE_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_HARDWARE_STATE>()) == 0 }
+        self.StateHeader == other.StateHeader && self.StateLength == other.StateLength
     }
 }
 impl ::core::cmp::Eq for VIDEO_HARDWARE_STATE {}
@@ -11046,7 +10806,36 @@ unsafe impl ::windows::core::Abi for VIDEO_HARDWARE_STATE_HEADER {
 }
 impl ::core::cmp::PartialEq for VIDEO_HARDWARE_STATE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_HARDWARE_STATE_HEADER>()) == 0 }
+        self.Length == other.Length
+            && self.PortValue == other.PortValue
+            && self.AttribIndexDataState == other.AttribIndexDataState
+            && self.BasicSequencerOffset == other.BasicSequencerOffset
+            && self.BasicCrtContOffset == other.BasicCrtContOffset
+            && self.BasicGraphContOffset == other.BasicGraphContOffset
+            && self.BasicAttribContOffset == other.BasicAttribContOffset
+            && self.BasicDacOffset == other.BasicDacOffset
+            && self.BasicLatchesOffset == other.BasicLatchesOffset
+            && self.ExtendedSequencerOffset == other.ExtendedSequencerOffset
+            && self.ExtendedCrtContOffset == other.ExtendedCrtContOffset
+            && self.ExtendedGraphContOffset == other.ExtendedGraphContOffset
+            && self.ExtendedAttribContOffset == other.ExtendedAttribContOffset
+            && self.ExtendedDacOffset == other.ExtendedDacOffset
+            && self.ExtendedValidatorStateOffset == other.ExtendedValidatorStateOffset
+            && self.ExtendedMiscDataOffset == other.ExtendedMiscDataOffset
+            && self.PlaneLength == other.PlaneLength
+            && self.Plane1Offset == other.Plane1Offset
+            && self.Plane2Offset == other.Plane2Offset
+            && self.Plane3Offset == other.Plane3Offset
+            && self.Plane4Offset == other.Plane4Offset
+            && self.VGAStateFlags == other.VGAStateFlags
+            && self.DIBOffset == other.DIBOffset
+            && self.DIBBitsPerPixel == other.DIBBitsPerPixel
+            && self.DIBXResolution == other.DIBXResolution
+            && self.DIBYResolution == other.DIBYResolution
+            && self.DIBXlatOffset == other.DIBXlatOffset
+            && self.DIBXlatLength == other.DIBXlatLength
+            && self.VesaInfoOffset == other.VesaInfoOffset
+            && self.FrameBufferData == other.FrameBufferData
     }
 }
 impl ::core::cmp::Eq for VIDEO_HARDWARE_STATE_HEADER {}
@@ -11079,7 +10868,7 @@ unsafe impl ::windows::core::Abi for VIDEO_LOAD_FONT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VIDEO_LOAD_FONT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_LOAD_FONT_INFORMATION>()) == 0 }
+        self.WidthInPixels == other.WidthInPixels && self.HeightInPixels == other.HeightInPixels && self.FontSize == other.FontSize && self.Font == other.Font
     }
 }
 impl ::core::cmp::Eq for VIDEO_LOAD_FONT_INFORMATION {}
@@ -11111,7 +10900,7 @@ unsafe impl ::windows::core::Abi for VIDEO_LUT_RGB256WORDS {
 }
 impl ::core::cmp::PartialEq for VIDEO_LUT_RGB256WORDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_LUT_RGB256WORDS>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue
     }
 }
 impl ::core::cmp::Eq for VIDEO_LUT_RGB256WORDS {}
@@ -11141,7 +10930,7 @@ unsafe impl ::windows::core::Abi for VIDEO_MEMORY {
 }
 impl ::core::cmp::PartialEq for VIDEO_MEMORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_MEMORY>()) == 0 }
+        self.RequestedVirtualAddress == other.RequestedVirtualAddress
     }
 }
 impl ::core::cmp::Eq for VIDEO_MEMORY {}
@@ -11174,7 +10963,7 @@ unsafe impl ::windows::core::Abi for VIDEO_MEMORY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VIDEO_MEMORY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_MEMORY_INFORMATION>()) == 0 }
+        self.VideoRamBase == other.VideoRamBase && self.VideoRamLength == other.VideoRamLength && self.FrameBufferBase == other.FrameBufferBase && self.FrameBufferLength == other.FrameBufferLength
     }
 }
 impl ::core::cmp::Eq for VIDEO_MEMORY_INFORMATION {}
@@ -11204,7 +10993,7 @@ unsafe impl ::windows::core::Abi for VIDEO_MODE {
 }
 impl ::core::cmp::PartialEq for VIDEO_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_MODE>()) == 0 }
+        self.RequestedMode == other.RequestedMode
     }
 }
 impl ::core::cmp::Eq for VIDEO_MODE {}
@@ -11274,7 +11063,26 @@ unsafe impl ::windows::core::Abi for VIDEO_MODE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VIDEO_MODE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_MODE_INFORMATION>()) == 0 }
+        self.Length == other.Length
+            && self.ModeIndex == other.ModeIndex
+            && self.VisScreenWidth == other.VisScreenWidth
+            && self.VisScreenHeight == other.VisScreenHeight
+            && self.ScreenStride == other.ScreenStride
+            && self.NumberOfPlanes == other.NumberOfPlanes
+            && self.BitsPerPlane == other.BitsPerPlane
+            && self.Frequency == other.Frequency
+            && self.XMillimeter == other.XMillimeter
+            && self.YMillimeter == other.YMillimeter
+            && self.NumberRedBits == other.NumberRedBits
+            && self.NumberGreenBits == other.NumberGreenBits
+            && self.NumberBlueBits == other.NumberBlueBits
+            && self.RedMask == other.RedMask
+            && self.GreenMask == other.GreenMask
+            && self.BlueMask == other.BlueMask
+            && self.AttributeFlags == other.AttributeFlags
+            && self.VideoMemoryBitmapWidth == other.VideoMemoryBitmapWidth
+            && self.VideoMemoryBitmapHeight == other.VideoMemoryBitmapHeight
+            && self.DriverSpecificAttributeFlags == other.DriverSpecificAttributeFlags
     }
 }
 impl ::core::cmp::Eq for VIDEO_MODE_INFORMATION {}
@@ -11305,7 +11113,7 @@ unsafe impl ::windows::core::Abi for VIDEO_MONITOR_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for VIDEO_MONITOR_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_MONITOR_DESCRIPTOR>()) == 0 }
+        self.DescriptorSize == other.DescriptorSize && self.Descriptor == other.Descriptor
     }
 }
 impl ::core::cmp::Eq for VIDEO_MONITOR_DESCRIPTOR {}
@@ -11336,7 +11144,7 @@ unsafe impl ::windows::core::Abi for VIDEO_NUM_MODES {
 }
 impl ::core::cmp::PartialEq for VIDEO_NUM_MODES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_NUM_MODES>()) == 0 }
+        self.NumModes == other.NumModes && self.ModeInformationLength == other.ModeInformationLength
     }
 }
 impl ::core::cmp::Eq for VIDEO_NUM_MODES {}
@@ -11368,7 +11176,7 @@ unsafe impl ::windows::core::Abi for VIDEO_PALETTE_DATA {
 }
 impl ::core::cmp::PartialEq for VIDEO_PALETTE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_PALETTE_DATA>()) == 0 }
+        self.NumEntries == other.NumEntries && self.FirstEntry == other.FirstEntry && self.Colors == other.Colors
     }
 }
 impl ::core::cmp::Eq for VIDEO_PALETTE_DATA {}
@@ -11440,7 +11248,27 @@ unsafe impl ::windows::core::Abi for VIDEO_PERFORMANCE_COUNTER {
 }
 impl ::core::cmp::PartialEq for VIDEO_PERFORMANCE_COUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_PERFORMANCE_COUNTER>()) == 0 }
+        self.NbOfAllocationEvicted == other.NbOfAllocationEvicted
+            && self.NbOfAllocationMarked == other.NbOfAllocationMarked
+            && self.NbOfAllocationRestored == other.NbOfAllocationRestored
+            && self.KBytesEvicted == other.KBytesEvicted
+            && self.KBytesMarked == other.KBytesMarked
+            && self.KBytesRestored == other.KBytesRestored
+            && self.NbProcessCommited == other.NbProcessCommited
+            && self.NbAllocationCommited == other.NbAllocationCommited
+            && self.NbAllocationMarked == other.NbAllocationMarked
+            && self.KBytesAllocated == other.KBytesAllocated
+            && self.KBytesAvailable == other.KBytesAvailable
+            && self.KBytesCurMarked == other.KBytesCurMarked
+            && self.Reference == other.Reference
+            && self.Unreference == other.Unreference
+            && self.TrueReference == other.TrueReference
+            && self.NbOfPageIn == other.NbOfPageIn
+            && self.KBytesPageIn == other.KBytesPageIn
+            && self.NbOfPageOut == other.NbOfPageOut
+            && self.KBytesPageOut == other.KBytesPageOut
+            && self.NbOfRotateOut == other.NbOfRotateOut
+            && self.KBytesRotateOut == other.KBytesRotateOut
     }
 }
 impl ::core::cmp::Eq for VIDEO_PERFORMANCE_COUNTER {}
@@ -11477,7 +11305,7 @@ unsafe impl ::windows::core::Abi for VIDEO_POINTER_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for VIDEO_POINTER_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_POINTER_ATTRIBUTES>()) == 0 }
+        self.Flags == other.Flags && self.Width == other.Width && self.Height == other.Height && self.WidthInBytes == other.WidthInBytes && self.Enable == other.Enable && self.Column == other.Column && self.Row == other.Row && self.Pixels == other.Pixels
     }
 }
 impl ::core::cmp::Eq for VIDEO_POINTER_ATTRIBUTES {}
@@ -11511,7 +11339,7 @@ unsafe impl ::windows::core::Abi for VIDEO_POINTER_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for VIDEO_POINTER_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_POINTER_CAPABILITIES>()) == 0 }
+        self.Flags == other.Flags && self.MaxWidth == other.MaxWidth && self.MaxHeight == other.MaxHeight && self.HWPtrBitmapStart == other.HWPtrBitmapStart && self.HWPtrBitmapEnd == other.HWPtrBitmapEnd
     }
 }
 impl ::core::cmp::Eq for VIDEO_POINTER_CAPABILITIES {}
@@ -11542,7 +11370,7 @@ unsafe impl ::windows::core::Abi for VIDEO_POINTER_POSITION {
 }
 impl ::core::cmp::PartialEq for VIDEO_POINTER_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_POINTER_POSITION>()) == 0 }
+        self.Column == other.Column && self.Row == other.Row
     }
 }
 impl ::core::cmp::Eq for VIDEO_POINTER_POSITION {}
@@ -11574,7 +11402,7 @@ unsafe impl ::windows::core::Abi for VIDEO_POWER_MANAGEMENT {
 }
 impl ::core::cmp::PartialEq for VIDEO_POWER_MANAGEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_POWER_MANAGEMENT>()) == 0 }
+        self.Length == other.Length && self.DPMSVersion == other.DPMSVersion && self.PowerState == other.PowerState
     }
 }
 impl ::core::cmp::Eq for VIDEO_POWER_MANAGEMENT {}
@@ -11606,7 +11434,7 @@ unsafe impl ::windows::core::Abi for VIDEO_PUBLIC_ACCESS_RANGES {
 }
 impl ::core::cmp::PartialEq for VIDEO_PUBLIC_ACCESS_RANGES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_PUBLIC_ACCESS_RANGES>()) == 0 }
+        self.InIoSpace == other.InIoSpace && self.MappedInIoSpace == other.MappedInIoSpace && self.VirtualAddress == other.VirtualAddress
     }
 }
 impl ::core::cmp::Eq for VIDEO_PUBLIC_ACCESS_RANGES {}
@@ -11637,7 +11465,7 @@ unsafe impl ::windows::core::Abi for VIDEO_QUERY_PERFORMANCE_COUNTER {
 }
 impl ::core::cmp::PartialEq for VIDEO_QUERY_PERFORMANCE_COUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_QUERY_PERFORMANCE_COUNTER>()) == 0 }
+        self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for VIDEO_QUERY_PERFORMANCE_COUNTER {}
@@ -11667,7 +11495,7 @@ unsafe impl ::windows::core::Abi for VIDEO_REGISTER_VDM {
 }
 impl ::core::cmp::PartialEq for VIDEO_REGISTER_VDM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_REGISTER_VDM>()) == 0 }
+        self.MinimumStateSize == other.MinimumStateSize
     }
 }
 impl ::core::cmp::Eq for VIDEO_REGISTER_VDM {}
@@ -11706,7 +11534,7 @@ unsafe impl ::windows::core::Abi for VIDEO_SHARE_MEMORY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VIDEO_SHARE_MEMORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_SHARE_MEMORY>()) == 0 }
+        self.ProcessHandle == other.ProcessHandle && self.ViewOffset == other.ViewOffset && self.ViewSize == other.ViewSize && self.RequestedVirtualAddress == other.RequestedVirtualAddress
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11740,7 +11568,7 @@ unsafe impl ::windows::core::Abi for VIDEO_SHARE_MEMORY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VIDEO_SHARE_MEMORY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_SHARE_MEMORY_INFORMATION>()) == 0 }
+        self.SharedViewOffset == other.SharedViewOffset && self.SharedViewSize == other.SharedViewSize && self.VirtualAddress == other.VirtualAddress
     }
 }
 impl ::core::cmp::Eq for VIDEO_SHARE_MEMORY_INFORMATION {}
@@ -11776,7 +11604,7 @@ unsafe impl ::windows::core::Abi for VIDEO_VDM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VIDEO_VDM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_VDM>()) == 0 }
+        self.ProcessHandle == other.ProcessHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11808,21 +11636,13 @@ impl ::core::clone::Clone for VIDEO_WIN32K_CALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for VIDEO_WIN32K_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("VIDEO_WIN32K_CALLBACKS").field("PhysDisp", &self.PhysDisp).field("Callout", &self.Callout.map(|f| f as usize)).field("bACPI", &self.bACPI).field("pPhysDeviceObject", &self.pPhysDeviceObject).field("DualviewFlags", &self.DualviewFlags).finish()
+        f.debug_struct("VIDEO_WIN32K_CALLBACKS").field("PhysDisp", &self.PhysDisp).field("bACPI", &self.bACPI).field("pPhysDeviceObject", &self.pPhysDeviceObject).field("DualviewFlags", &self.DualviewFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for VIDEO_WIN32K_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDEO_WIN32K_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_WIN32K_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDEO_WIN32K_CALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDEO_WIN32K_CALLBACKS {
     fn default() -> Self {
@@ -11863,7 +11683,7 @@ unsafe impl ::windows::core::Abi for VIDEO_WIN32K_CALLBACKS_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VIDEO_WIN32K_CALLBACKS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEO_WIN32K_CALLBACKS_PARAMS>()) == 0 }
+        self.CalloutType == other.CalloutType && self.PhysDisp == other.PhysDisp && self.Param == other.Param && self.Status == other.Status && self.LockUserSession == other.LockUserSession && self.IsPostDevice == other.IsPostDevice && self.SurpriseRemoval == other.SurpriseRemoval && self.WaitForQueueReady == other.WaitForQueueReady
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11897,7 +11717,7 @@ unsafe impl ::windows::core::Abi for WCRUN {
 }
 impl ::core::cmp::PartialEq for WCRUN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCRUN>()) == 0 }
+        self.wcLow == other.wcLow && self.cGlyphs == other.cGlyphs && self.phg == other.phg
     }
 }
 impl ::core::cmp::Eq for WCRUN {}
@@ -11936,7 +11756,7 @@ unsafe impl ::windows::core::Abi for WNDOBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WNDOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNDOBJ>()) == 0 }
+        self.coClient == other.coClient && self.pvConsumer == other.pvConsumer && self.rclClient == other.rclClient && self.psoOwner == other.psoOwner
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11979,7 +11799,7 @@ unsafe impl ::windows::core::Abi for XFORML {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for XFORML {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XFORML>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22 && self.eDx == other.eDx && self.eDy == other.eDy
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -12022,7 +11842,7 @@ unsafe impl ::windows::core::Abi for XFORML {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for XFORML {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XFORML>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22 && self.eDx == other.eDx && self.eDy == other.eDy
     }
 }
 #[cfg(target_arch = "x86")]
@@ -12054,7 +11874,7 @@ unsafe impl ::windows::core::Abi for XFORMOBJ {
 }
 impl ::core::cmp::PartialEq for XFORMOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XFORMOBJ>()) == 0 }
+        self.ulReserved == other.ulReserved
     }
 }
 impl ::core::cmp::Eq for XFORMOBJ {}
@@ -12089,7 +11909,7 @@ unsafe impl ::windows::core::Abi for XLATEOBJ {
 }
 impl ::core::cmp::PartialEq for XLATEOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XLATEOBJ>()) == 0 }
+        self.iUniq == other.iUniq && self.flXlate == other.flXlate && self.iSrcType == other.iSrcType && self.iDstType == other.iDstType && self.cEntries == other.cEntries && self.pulXlate == other.pulXlate
     }
 }
 impl ::core::cmp::Eq for XLATEOBJ {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -1825,7 +1825,7 @@ unsafe impl ::windows::core::Abi for SW_DEVICE_CREATE_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for SW_DEVICE_CREATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SW_DEVICE_CREATE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pszInstanceId == other.pszInstanceId && self.pszzHardwareIds == other.pszzHardwareIds && self.pszzCompatibleIds == other.pszzCompatibleIds && self.pContainerId == other.pContainerId && self.CapabilityFlags == other.CapabilityFlags && self.pszDeviceDescription == other.pszDeviceDescription && self.pszDeviceLocation == other.pszDeviceLocation && self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
@@ -9708,7 +9708,7 @@ unsafe impl ::windows::core::Abi for FAX_CONFIGURATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_CONFIGURATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_CONFIGURATIONA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Retries == other.Retries && self.RetryDelay == other.RetryDelay && self.DirtyDays == other.DirtyDays && self.Branding == other.Branding && self.UseDeviceTsid == other.UseDeviceTsid && self.ServerCp == other.ServerCp && self.PauseServerQueue == other.PauseServerQueue && self.StartCheapTime == other.StartCheapTime && self.StopCheapTime == other.StopCheapTime && self.ArchiveOutgoingFaxes == other.ArchiveOutgoingFaxes && self.ArchiveDirectory == other.ArchiveDirectory && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9772,7 +9772,7 @@ unsafe impl ::windows::core::Abi for FAX_CONFIGURATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_CONFIGURATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_CONFIGURATIONW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Retries == other.Retries && self.RetryDelay == other.RetryDelay && self.DirtyDays == other.DirtyDays && self.Branding == other.Branding && self.UseDeviceTsid == other.UseDeviceTsid && self.ServerCp == other.ServerCp && self.PauseServerQueue == other.PauseServerQueue && self.StartCheapTime == other.StartCheapTime && self.StopCheapTime == other.StopCheapTime && self.ArchiveOutgoingFaxes == other.ArchiveOutgoingFaxes && self.ArchiveDirectory == other.ArchiveDirectory && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9812,7 +9812,7 @@ unsafe impl ::windows::core::Abi for FAX_CONTEXT_INFOA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for FAX_CONTEXT_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_CONTEXT_INFOA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.hDC == other.hDC && self.ServerName == other.ServerName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9852,7 +9852,7 @@ unsafe impl ::windows::core::Abi for FAX_CONTEXT_INFOW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for FAX_CONTEXT_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_CONTEXT_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.hDC == other.hDC && self.ServerName == other.ServerName
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -9948,7 +9948,35 @@ unsafe impl ::windows::core::Abi for FAX_COVERPAGE_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_COVERPAGE_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_COVERPAGE_INFOA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.CoverPageName == other.CoverPageName
+            && self.UseServerCoverPage == other.UseServerCoverPage
+            && self.RecName == other.RecName
+            && self.RecFaxNumber == other.RecFaxNumber
+            && self.RecCompany == other.RecCompany
+            && self.RecStreetAddress == other.RecStreetAddress
+            && self.RecCity == other.RecCity
+            && self.RecState == other.RecState
+            && self.RecZip == other.RecZip
+            && self.RecCountry == other.RecCountry
+            && self.RecTitle == other.RecTitle
+            && self.RecDepartment == other.RecDepartment
+            && self.RecOfficeLocation == other.RecOfficeLocation
+            && self.RecHomePhone == other.RecHomePhone
+            && self.RecOfficePhone == other.RecOfficePhone
+            && self.SdrName == other.SdrName
+            && self.SdrFaxNumber == other.SdrFaxNumber
+            && self.SdrCompany == other.SdrCompany
+            && self.SdrAddress == other.SdrAddress
+            && self.SdrTitle == other.SdrTitle
+            && self.SdrDepartment == other.SdrDepartment
+            && self.SdrOfficeLocation == other.SdrOfficeLocation
+            && self.SdrHomePhone == other.SdrHomePhone
+            && self.SdrOfficePhone == other.SdrOfficePhone
+            && self.Note == other.Note
+            && self.Subject == other.Subject
+            && self.TimeSent == other.TimeSent
+            && self.PageCount == other.PageCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10044,7 +10072,35 @@ unsafe impl ::windows::core::Abi for FAX_COVERPAGE_INFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_COVERPAGE_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_COVERPAGE_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.CoverPageName == other.CoverPageName
+            && self.UseServerCoverPage == other.UseServerCoverPage
+            && self.RecName == other.RecName
+            && self.RecFaxNumber == other.RecFaxNumber
+            && self.RecCompany == other.RecCompany
+            && self.RecStreetAddress == other.RecStreetAddress
+            && self.RecCity == other.RecCity
+            && self.RecState == other.RecState
+            && self.RecZip == other.RecZip
+            && self.RecCountry == other.RecCountry
+            && self.RecTitle == other.RecTitle
+            && self.RecDepartment == other.RecDepartment
+            && self.RecOfficeLocation == other.RecOfficeLocation
+            && self.RecHomePhone == other.RecHomePhone
+            && self.RecOfficePhone == other.RecOfficePhone
+            && self.SdrName == other.SdrName
+            && self.SdrFaxNumber == other.SdrFaxNumber
+            && self.SdrCompany == other.SdrCompany
+            && self.SdrAddress == other.SdrAddress
+            && self.SdrTitle == other.SdrTitle
+            && self.SdrDepartment == other.SdrDepartment
+            && self.SdrOfficeLocation == other.SdrOfficeLocation
+            && self.SdrHomePhone == other.SdrHomePhone
+            && self.SdrOfficePhone == other.SdrOfficePhone
+            && self.Note == other.Note
+            && self.Subject == other.Subject
+            && self.TimeSent == other.TimeSent
+            && self.PageCount == other.PageCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10122,7 +10178,7 @@ unsafe impl ::windows::core::Abi for FAX_DEVICE_STATUSA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_DEVICE_STATUSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_DEVICE_STATUSA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.CallerId == other.CallerId && self.Csid == other.Csid && self.CurrentPage == other.CurrentPage && self.DeviceId == other.DeviceId && self.DeviceName == other.DeviceName && self.DocumentName == other.DocumentName && self.JobType == other.JobType && self.PhoneNumber == other.PhoneNumber && self.RoutingString == other.RoutingString && self.SenderName == other.SenderName && self.RecipientName == other.RecipientName && self.Size == other.Size && self.StartTime == other.StartTime && self.Status == other.Status && self.StatusString == other.StatusString && self.SubmittedTime == other.SubmittedTime && self.TotalPages == other.TotalPages && self.Tsid == other.Tsid && self.UserName == other.UserName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10200,7 +10256,7 @@ unsafe impl ::windows::core::Abi for FAX_DEVICE_STATUSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_DEVICE_STATUSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_DEVICE_STATUSW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.CallerId == other.CallerId && self.Csid == other.Csid && self.CurrentPage == other.CurrentPage && self.DeviceId == other.DeviceId && self.DeviceName == other.DeviceName && self.DocumentName == other.DocumentName && self.JobType == other.JobType && self.PhoneNumber == other.PhoneNumber && self.RoutingString == other.RoutingString && self.SenderName == other.SenderName && self.RecipientName == other.RecipientName && self.Size == other.Size && self.StartTime == other.StartTime && self.Status == other.Status && self.StatusString == other.StatusString && self.SubmittedTime == other.SubmittedTime && self.TotalPages == other.TotalPages && self.Tsid == other.Tsid && self.UserName == other.UserName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10240,7 +10296,7 @@ unsafe impl ::windows::core::Abi for FAX_DEV_STATUS {
 }
 impl ::core::cmp::PartialEq for FAX_DEV_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_DEV_STATUS>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.StatusId == other.StatusId && self.StringId == other.StringId && self.PageCount == other.PageCount && self.CSI == other.CSI && self.CallerId == other.CallerId && self.RoutingInfo == other.RoutingInfo && self.ErrorCode == other.ErrorCode && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FAX_DEV_STATUS {}
@@ -10280,7 +10336,7 @@ unsafe impl ::windows::core::Abi for FAX_EVENTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_EVENTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_EVENTA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.TimeStamp == other.TimeStamp && self.DeviceId == other.DeviceId && self.EventId == other.EventId && self.JobId == other.JobId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10322,7 +10378,7 @@ unsafe impl ::windows::core::Abi for FAX_EVENTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_EVENTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_EVENTW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.TimeStamp == other.TimeStamp && self.DeviceId == other.DeviceId && self.EventId == other.EventId && self.JobId == other.JobId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10360,7 +10416,7 @@ unsafe impl ::windows::core::Abi for FAX_GLOBAL_ROUTING_INFOA {
 }
 impl ::core::cmp::PartialEq for FAX_GLOBAL_ROUTING_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_GLOBAL_ROUTING_INFOA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Priority == other.Priority && self.Guid == other.Guid && self.FriendlyName == other.FriendlyName && self.FunctionName == other.FunctionName && self.ExtensionImageName == other.ExtensionImageName && self.ExtensionFriendlyName == other.ExtensionFriendlyName
     }
 }
 impl ::core::cmp::Eq for FAX_GLOBAL_ROUTING_INFOA {}
@@ -10396,7 +10452,7 @@ unsafe impl ::windows::core::Abi for FAX_GLOBAL_ROUTING_INFOW {
 }
 impl ::core::cmp::PartialEq for FAX_GLOBAL_ROUTING_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_GLOBAL_ROUTING_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Priority == other.Priority && self.Guid == other.Guid && self.FriendlyName == other.FriendlyName && self.FunctionName == other.FunctionName && self.ExtensionImageName == other.ExtensionImageName && self.ExtensionFriendlyName == other.ExtensionFriendlyName
     }
 }
 impl ::core::cmp::Eq for FAX_GLOBAL_ROUTING_INFOW {}
@@ -10472,7 +10528,26 @@ unsafe impl ::windows::core::Abi for FAX_JOB_ENTRYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_JOB_ENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_JOB_ENTRYA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.JobId == other.JobId
+            && self.UserName == other.UserName
+            && self.JobType == other.JobType
+            && self.QueueStatus == other.QueueStatus
+            && self.Status == other.Status
+            && self.Size == other.Size
+            && self.PageCount == other.PageCount
+            && self.RecipientNumber == other.RecipientNumber
+            && self.RecipientName == other.RecipientName
+            && self.Tsid == other.Tsid
+            && self.SenderName == other.SenderName
+            && self.SenderCompany == other.SenderCompany
+            && self.SenderDept == other.SenderDept
+            && self.BillingCode == other.BillingCode
+            && self.ScheduleAction == other.ScheduleAction
+            && self.ScheduleTime == other.ScheduleTime
+            && self.DeliveryReportType == other.DeliveryReportType
+            && self.DeliveryReportAddress == other.DeliveryReportAddress
+            && self.DocumentName == other.DocumentName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10550,7 +10625,26 @@ unsafe impl ::windows::core::Abi for FAX_JOB_ENTRYW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_JOB_ENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_JOB_ENTRYW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.JobId == other.JobId
+            && self.UserName == other.UserName
+            && self.JobType == other.JobType
+            && self.QueueStatus == other.QueueStatus
+            && self.Status == other.Status
+            && self.Size == other.Size
+            && self.PageCount == other.PageCount
+            && self.RecipientNumber == other.RecipientNumber
+            && self.RecipientName == other.RecipientName
+            && self.Tsid == other.Tsid
+            && self.SenderName == other.SenderName
+            && self.SenderCompany == other.SenderCompany
+            && self.SenderDept == other.SenderDept
+            && self.BillingCode == other.BillingCode
+            && self.ScheduleAction == other.ScheduleAction
+            && self.ScheduleTime == other.ScheduleTime
+            && self.DeliveryReportType == other.DeliveryReportType
+            && self.DeliveryReportAddress == other.DeliveryReportAddress
+            && self.DocumentName == other.DocumentName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10618,7 +10712,7 @@ unsafe impl ::windows::core::Abi for FAX_JOB_PARAMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_JOB_PARAMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_JOB_PARAMA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.RecipientNumber == other.RecipientNumber && self.RecipientName == other.RecipientName && self.Tsid == other.Tsid && self.SenderName == other.SenderName && self.SenderCompany == other.SenderCompany && self.SenderDept == other.SenderDept && self.BillingCode == other.BillingCode && self.ScheduleAction == other.ScheduleAction && self.ScheduleTime == other.ScheduleTime && self.DeliveryReportType == other.DeliveryReportType && self.DeliveryReportAddress == other.DeliveryReportAddress && self.DocumentName == other.DocumentName && self.CallHandle == other.CallHandle && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10686,7 +10780,7 @@ unsafe impl ::windows::core::Abi for FAX_JOB_PARAMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_JOB_PARAMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_JOB_PARAMW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.RecipientNumber == other.RecipientNumber && self.RecipientName == other.RecipientName && self.Tsid == other.Tsid && self.SenderName == other.SenderName && self.SenderCompany == other.SenderCompany && self.SenderDept == other.SenderDept && self.BillingCode == other.BillingCode && self.ScheduleAction == other.ScheduleAction && self.ScheduleTime == other.ScheduleTime && self.DeliveryReportType == other.DeliveryReportType && self.DeliveryReportAddress == other.DeliveryReportAddress && self.DocumentName == other.DocumentName && self.CallHandle == other.CallHandle && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10720,7 +10814,7 @@ unsafe impl ::windows::core::Abi for FAX_LOG_CATEGORYA {
 }
 impl ::core::cmp::PartialEq for FAX_LOG_CATEGORYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_LOG_CATEGORYA>()) == 0 }
+        self.Name == other.Name && self.Category == other.Category && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for FAX_LOG_CATEGORYA {}
@@ -10752,7 +10846,7 @@ unsafe impl ::windows::core::Abi for FAX_LOG_CATEGORYW {
 }
 impl ::core::cmp::PartialEq for FAX_LOG_CATEGORYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_LOG_CATEGORYW>()) == 0 }
+        self.Name == other.Name && self.Category == other.Category && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for FAX_LOG_CATEGORYW {}
@@ -10790,7 +10884,7 @@ unsafe impl ::windows::core::Abi for FAX_PORT_INFOA {
 }
 impl ::core::cmp::PartialEq for FAX_PORT_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_PORT_INFOA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DeviceId == other.DeviceId && self.State == other.State && self.Flags == other.Flags && self.Rings == other.Rings && self.Priority == other.Priority && self.DeviceName == other.DeviceName && self.Tsid == other.Tsid && self.Csid == other.Csid
     }
 }
 impl ::core::cmp::Eq for FAX_PORT_INFOA {}
@@ -10828,7 +10922,7 @@ unsafe impl ::windows::core::Abi for FAX_PORT_INFOW {
 }
 impl ::core::cmp::PartialEq for FAX_PORT_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_PORT_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DeviceId == other.DeviceId && self.State == other.State && self.Flags == other.Flags && self.Rings == other.Rings && self.Priority == other.Priority && self.DeviceName == other.DeviceName && self.Tsid == other.Tsid && self.Csid == other.Csid
     }
 }
 impl ::core::cmp::Eq for FAX_PORT_INFOW {}
@@ -10880,7 +10974,7 @@ unsafe impl ::windows::core::Abi for FAX_PRINT_INFOA {
 }
 impl ::core::cmp::PartialEq for FAX_PRINT_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_PRINT_INFOA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DocName == other.DocName && self.RecipientName == other.RecipientName && self.RecipientNumber == other.RecipientNumber && self.SenderName == other.SenderName && self.SenderCompany == other.SenderCompany && self.SenderDept == other.SenderDept && self.SenderBillingCode == other.SenderBillingCode && self.Reserved == other.Reserved && self.DrEmailAddress == other.DrEmailAddress && self.OutputFileName == other.OutputFileName
     }
 }
 impl ::core::cmp::Eq for FAX_PRINT_INFOA {}
@@ -10932,7 +11026,7 @@ unsafe impl ::windows::core::Abi for FAX_PRINT_INFOW {
 }
 impl ::core::cmp::PartialEq for FAX_PRINT_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_PRINT_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DocName == other.DocName && self.RecipientName == other.RecipientName && self.RecipientNumber == other.RecipientNumber && self.SenderName == other.SenderName && self.SenderCompany == other.SenderCompany && self.SenderDept == other.SenderDept && self.SenderBillingCode == other.SenderBillingCode && self.Reserved == other.Reserved && self.DrEmailAddress == other.DrEmailAddress && self.OutputFileName == other.OutputFileName
     }
 }
 impl ::core::cmp::Eq for FAX_PRINT_INFOW {}
@@ -10966,7 +11060,7 @@ unsafe impl ::windows::core::Abi for FAX_RECEIVE {
 }
 impl ::core::cmp::PartialEq for FAX_RECEIVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_RECEIVE>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.FileName == other.FileName && self.ReceiverName == other.ReceiverName && self.ReceiverNumber == other.ReceiverNumber && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FAX_RECEIVE {}
@@ -11026,7 +11120,7 @@ unsafe impl ::windows::core::Abi for FAX_ROUTE {
 }
 impl ::core::cmp::PartialEq for FAX_ROUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_ROUTE>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.JobId == other.JobId && self.ElapsedTime == other.ElapsedTime && self.ReceiveTime == other.ReceiveTime && self.PageCount == other.PageCount && self.Csid == other.Csid && self.Tsid == other.Tsid && self.CallerId == other.CallerId && self.RoutingInfo == other.RoutingInfo && self.ReceiverName == other.ReceiverName && self.ReceiverNumber == other.ReceiverNumber && self.DeviceName == other.DeviceName && self.DeviceId == other.DeviceId && self.RoutingInfoData == other.RoutingInfoData && self.RoutingInfoDataSize == other.RoutingInfoDataSize
     }
 }
 impl ::core::cmp::Eq for FAX_ROUTE {}
@@ -11057,21 +11151,13 @@ impl ::core::clone::Clone for FAX_ROUTE_CALLBACKROUTINES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for FAX_ROUTE_CALLBACKROUTINES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("FAX_ROUTE_CALLBACKROUTINES").field("SizeOfStruct", &self.SizeOfStruct).field("FaxRouteAddFile", &self.FaxRouteAddFile.map(|f| f as usize)).field("FaxRouteDeleteFile", &self.FaxRouteDeleteFile.map(|f| f as usize)).field("FaxRouteGetFile", &self.FaxRouteGetFile.map(|f| f as usize)).field("FaxRouteEnumFiles", &self.FaxRouteEnumFiles.map(|f| f as usize)).field("FaxRouteModifyRoutingData", &self.FaxRouteModifyRoutingData.map(|f| f as usize)).finish()
+        f.debug_struct("FAX_ROUTE_CALLBACKROUTINES").field("SizeOfStruct", &self.SizeOfStruct).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for FAX_ROUTE_CALLBACKROUTINES {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FAX_ROUTE_CALLBACKROUTINES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_ROUTE_CALLBACKROUTINES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FAX_ROUTE_CALLBACKROUTINES {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FAX_ROUTE_CALLBACKROUTINES {
     fn default() -> Self {
@@ -11113,7 +11199,7 @@ unsafe impl ::windows::core::Abi for FAX_ROUTING_METHODA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_ROUTING_METHODA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_ROUTING_METHODA>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DeviceId == other.DeviceId && self.Enabled == other.Enabled && self.DeviceName == other.DeviceName && self.Guid == other.Guid && self.FriendlyName == other.FriendlyName && self.FunctionName == other.FunctionName && self.ExtensionImageName == other.ExtensionImageName && self.ExtensionFriendlyName == other.ExtensionFriendlyName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11159,7 +11245,7 @@ unsafe impl ::windows::core::Abi for FAX_ROUTING_METHODW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_ROUTING_METHODW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_ROUTING_METHODW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.DeviceId == other.DeviceId && self.Enabled == other.Enabled && self.DeviceName == other.DeviceName && self.Guid == other.Guid && self.FriendlyName == other.FriendlyName && self.FunctionName == other.FunctionName && self.ExtensionImageName == other.ExtensionImageName && self.ExtensionFriendlyName == other.ExtensionFriendlyName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11205,7 +11291,7 @@ unsafe impl ::windows::core::Abi for FAX_SEND {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FAX_SEND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_SEND>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.FileName == other.FileName && self.CallerName == other.CallerName && self.CallerNumber == other.CallerNumber && self.ReceiverName == other.ReceiverName && self.ReceiverNumber == other.ReceiverNumber && self.Branding == other.Branding && self.CallHandle == other.CallHandle && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11238,7 +11324,7 @@ unsafe impl ::windows::core::Abi for FAX_TIME {
 }
 impl ::core::cmp::PartialEq for FAX_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAX_TIME>()) == 0 }
+        self.Hour == other.Hour && self.Minute == other.Minute
     }
 }
 impl ::core::cmp::Eq for FAX_TIME {}
@@ -11270,7 +11356,7 @@ unsafe impl ::windows::core::Abi for STINOTIFY {
 }
 impl ::core::cmp::PartialEq for STINOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STINOTIFY>()) == 0 }
+        self.dwSize == other.dwSize && self.guidNotificationCode == other.guidNotificationCode && self.abNotificationData == other.abNotificationData
     }
 }
 impl ::core::cmp::Eq for STINOTIFY {}
@@ -11311,7 +11397,7 @@ unsafe impl ::windows::core::Abi for STISUBSCRIBE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STISUBSCRIBE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STISUBSCRIBE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwFilter == other.dwFilter && self.hWndNotify == other.hWndNotify && self.hEvent == other.hEvent && self.uiNotificationMessage == other.uiNotificationMessage
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11363,7 +11449,7 @@ unsafe impl ::windows::core::Abi for STI_DEVICE_INFORMATIONW {
 }
 impl ::core::cmp::PartialEq for STI_DEVICE_INFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_DEVICE_INFORMATIONW>()) == 0 }
+        self.dwSize == other.dwSize && self.DeviceType == other.DeviceType && self.szDeviceInternalName == other.szDeviceInternalName && self.DeviceCapabilitiesA == other.DeviceCapabilitiesA && self.dwHardwareConfiguration == other.dwHardwareConfiguration && self.pszVendorDescription == other.pszVendorDescription && self.pszDeviceDescription == other.pszDeviceDescription && self.pszPortName == other.pszPortName && self.pszPropProvider == other.pszPropProvider && self.pszLocalName == other.pszLocalName
     }
 }
 impl ::core::cmp::Eq for STI_DEVICE_INFORMATIONW {}
@@ -11398,7 +11484,7 @@ unsafe impl ::windows::core::Abi for STI_DEVICE_STATUS {
 }
 impl ::core::cmp::PartialEq for STI_DEVICE_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_DEVICE_STATUS>()) == 0 }
+        self.dwSize == other.dwSize && self.StatusMask == other.StatusMask && self.dwOnlineState == other.dwOnlineState && self.dwHardwareStatusCode == other.dwHardwareStatusCode && self.dwEventHandlingState == other.dwEventHandlingState && self.dwPollingInterval == other.dwPollingInterval
     }
 }
 impl ::core::cmp::Eq for STI_DEVICE_STATUS {}
@@ -11428,7 +11514,7 @@ unsafe impl ::windows::core::Abi for STI_DEV_CAPS {
 }
 impl ::core::cmp::PartialEq for STI_DEV_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_DEV_CAPS>()) == 0 }
+        self.dwGeneric == other.dwGeneric
     }
 }
 impl ::core::cmp::Eq for STI_DEV_CAPS {}
@@ -11462,7 +11548,7 @@ unsafe impl ::windows::core::Abi for STI_DIAG {
 }
 impl ::core::cmp::PartialEq for STI_DIAG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_DIAG>()) == 0 }
+        self.dwSize == other.dwSize && self.dwBasicDiagCode == other.dwBasicDiagCode && self.dwVendorDiagCode == other.dwVendorDiagCode && self.dwStatusMask == other.dwStatusMask && self.sErrorInfo == other.sErrorInfo
     }
 }
 impl ::core::cmp::Eq for STI_DIAG {}
@@ -11493,7 +11579,7 @@ unsafe impl ::windows::core::Abi for STI_USD_CAPS {
 }
 impl ::core::cmp::PartialEq for STI_USD_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_USD_CAPS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwGenericCaps == other.dwGenericCaps
     }
 }
 impl ::core::cmp::Eq for STI_USD_CAPS {}
@@ -11547,7 +11633,7 @@ unsafe impl ::windows::core::Abi for STI_WIA_DEVICE_INFORMATIONW {
 }
 impl ::core::cmp::PartialEq for STI_WIA_DEVICE_INFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STI_WIA_DEVICE_INFORMATIONW>()) == 0 }
+        self.dwSize == other.dwSize && self.DeviceType == other.DeviceType && self.szDeviceInternalName == other.szDeviceInternalName && self.DeviceCapabilitiesA == other.DeviceCapabilitiesA && self.dwHardwareConfiguration == other.dwHardwareConfiguration && self.pszVendorDescription == other.pszVendorDescription && self.pszDeviceDescription == other.pszDeviceDescription && self.pszPortName == other.pszPortName && self.pszPropProvider == other.pszPropProvider && self.pszLocalName == other.pszLocalName && self.pszUiDll == other.pszUiDll && self.pszServer == other.pszServer
     }
 }
 impl ::core::cmp::Eq for STI_WIA_DEVICE_INFORMATIONW {}
@@ -11580,7 +11666,7 @@ unsafe impl ::windows::core::Abi for _ERROR_INFOW {
 }
 impl ::core::cmp::PartialEq for _ERROR_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_ERROR_INFOW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwGenericError == other.dwGenericError && self.dwVendorError == other.dwVendorError && self.szExtendedErrorText == other.szExtendedErrorText
     }
 }
 impl ::core::cmp::Eq for _ERROR_INFOW {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
@@ -1498,14 +1498,6 @@ unsafe impl ::windows::core::Abi for GNSS_AGNSS_INJECT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_AGNSS_INJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_INJECT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_AGNSS_INJECT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_AGNSS_INJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1531,14 +1523,6 @@ impl ::core::clone::Clone for GNSS_AGNSS_INJECT_0 {
 unsafe impl ::windows::core::Abi for GNSS_AGNSS_INJECT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_AGNSS_INJECT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_INJECT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_AGNSS_INJECT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_AGNSS_INJECT_0 {
     fn default() -> Self {
@@ -1572,7 +1556,7 @@ unsafe impl ::windows::core::Abi for GNSS_AGNSS_INJECTBLOB {
 }
 impl ::core::cmp::PartialEq for GNSS_AGNSS_INJECTBLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_INJECTBLOB>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.BlobOui == other.BlobOui && self.BlobVersion == other.BlobVersion && self.AgnssFormat == other.AgnssFormat && self.BlobSize == other.BlobSize && self.BlobData == other.BlobData
     }
 }
 impl ::core::cmp::Eq for GNSS_AGNSS_INJECTBLOB {}
@@ -1606,7 +1590,7 @@ unsafe impl ::windows::core::Abi for GNSS_AGNSS_INJECTPOSITION {
 }
 impl ::core::cmp::PartialEq for GNSS_AGNSS_INJECTPOSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_INJECTPOSITION>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Age == other.Age && self.BasicData == other.BasicData && self.AccuracyData == other.AccuracyData
     }
 }
 impl ::core::cmp::Eq for GNSS_AGNSS_INJECTPOSITION {}
@@ -1645,7 +1629,7 @@ unsafe impl ::windows::core::Abi for GNSS_AGNSS_INJECTTIME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_AGNSS_INJECTTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_INJECTTIME>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.UtcTime == other.UtcTime && self.TimeUncertainty == other.TimeUncertainty
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1680,7 +1664,7 @@ unsafe impl ::windows::core::Abi for GNSS_AGNSS_REQUEST_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_AGNSS_REQUEST_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_AGNSS_REQUEST_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.RequestType == other.RequestType && self.BlobFormat == other.BlobFormat
     }
 }
 impl ::core::cmp::Eq for GNSS_AGNSS_REQUEST_PARAM {}
@@ -1712,7 +1696,7 @@ unsafe impl ::windows::core::Abi for GNSS_BREADCRUMBING_ALERT_DATA {
 }
 impl ::core::cmp::PartialEq for GNSS_BREADCRUMBING_ALERT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_BREADCRUMBING_ALERT_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_BREADCRUMBING_ALERT_DATA {}
@@ -1747,7 +1731,7 @@ unsafe impl ::windows::core::Abi for GNSS_BREADCRUMBING_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_BREADCRUMBING_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_BREADCRUMBING_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.MaximumHorizontalUncertainty == other.MaximumHorizontalUncertainty && self.MinDistanceBetweenFixes == other.MinDistanceBetweenFixes && self.MaximumErrorTimeoutMs == other.MaximumErrorTimeoutMs && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_BREADCRUMBING_PARAM {}
@@ -1778,14 +1762,6 @@ unsafe impl ::windows::core::Abi for GNSS_BREADCRUMB_LIST {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_BREADCRUMB_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_BREADCRUMB_LIST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_BREADCRUMB_LIST {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_BREADCRUMB_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1809,14 +1785,6 @@ impl ::core::clone::Clone for GNSS_BREADCRUMB_LIST_0 {
 unsafe impl ::windows::core::Abi for GNSS_BREADCRUMB_LIST_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_BREADCRUMB_LIST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_BREADCRUMB_LIST_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_BREADCRUMB_LIST_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_BREADCRUMB_LIST_0 {
     fn default() -> Self {
@@ -1872,7 +1840,7 @@ unsafe impl ::windows::core::Abi for GNSS_BREADCRUMB_V1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_BREADCRUMB_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_BREADCRUMB_V1>()) == 0 }
+        self.FixTimeStamp == other.FixTimeStamp && self.Latitude == other.Latitude && self.Longitude == other.Longitude && self.HorizontalAccuracy == other.HorizontalAccuracy && self.Speed == other.Speed && self.SpeedAccuracy == other.SpeedAccuracy && self.Altitude == other.Altitude && self.AltitudeAccuracy == other.AltitudeAccuracy && self.Heading == other.Heading && self.HeadingAccuracy == other.HeadingAccuracy && self.FixSuccess == other.FixSuccess
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1909,7 +1877,7 @@ unsafe impl ::windows::core::Abi for GNSS_CHIPSETINFO {
 }
 impl ::core::cmp::PartialEq for GNSS_CHIPSETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_CHIPSETINFO>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.ManufacturerID == other.ManufacturerID && self.HardwareID == other.HardwareID && self.FirmwareVersion == other.FirmwareVersion && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_CHIPSETINFO {}
@@ -1941,7 +1909,7 @@ unsafe impl ::windows::core::Abi for GNSS_CONTINUOUSTRACKING_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_CONTINUOUSTRACKING_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_CONTINUOUSTRACKING_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.PreferredInterval == other.PreferredInterval
     }
 }
 impl ::core::cmp::Eq for GNSS_CONTINUOUSTRACKING_PARAM {}
@@ -1974,7 +1942,7 @@ unsafe impl ::windows::core::Abi for GNSS_CP_NI_INFO {
 }
 impl ::core::cmp::PartialEq for GNSS_CP_NI_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_CP_NI_INFO>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.RequestorId == other.RequestorId && self.NotificationText == other.NotificationText
     }
 }
 impl ::core::cmp::Eq for GNSS_CP_NI_INFO {}
@@ -2015,7 +1983,7 @@ unsafe impl ::windows::core::Abi for GNSS_CWTESTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_CWTESTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_CWTESTDATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.TestResultStatus == other.TestResultStatus && self.SignalToNoiseRatio == other.SignalToNoiseRatio && self.Frequency == other.Frequency && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2107,7 +2075,33 @@ unsafe impl ::windows::core::Abi for GNSS_DEVICE_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_DEVICE_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_DEVICE_CAPABILITY>()) == 0 }
+        self.Size == other.Size
+            && self.Version == other.Version
+            && self.SupportMultipleFixSessions == other.SupportMultipleFixSessions
+            && self.SupportMultipleAppSessions == other.SupportMultipleAppSessions
+            && self.RequireAGnssInjection == other.RequireAGnssInjection
+            && self.AgnssFormatSupported == other.AgnssFormatSupported
+            && self.AgnssFormatPreferred == other.AgnssFormatPreferred
+            && self.SupportDistanceTracking == other.SupportDistanceTracking
+            && self.SupportContinuousTracking == other.SupportContinuousTracking
+            && self.Reserved1 == other.Reserved1
+            && self.Reserved2 == other.Reserved2
+            && self.Reserved3 == other.Reserved3
+            && self.Reserved4 == other.Reserved4
+            && self.Reserved5 == other.Reserved5
+            && self.GeofencingSupport == other.GeofencingSupport
+            && self.Reserved6 == other.Reserved6
+            && self.Reserved7 == other.Reserved7
+            && self.SupportCpLocation == other.SupportCpLocation
+            && self.SupportUplV2 == other.SupportUplV2
+            && self.SupportSuplV1 == other.SupportSuplV1
+            && self.SupportSuplV2 == other.SupportSuplV2
+            && self.SupportedSuplVersion == other.SupportedSuplVersion
+            && self.MaxGeofencesSupported == other.MaxGeofencesSupported
+            && self.SupportMultipleSuplRootCert == other.SupportMultipleSuplRootCert
+            && self.GnssBreadCrumbPayloadVersion == other.GnssBreadCrumbPayloadVersion
+            && self.MaxGnssBreadCrumbFixes == other.MaxGnssBreadCrumbFixes
+            && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2141,7 +2135,7 @@ unsafe impl ::windows::core::Abi for GNSS_DISTANCETRACKING_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_DISTANCETRACKING_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_DISTANCETRACKING_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.MovementThreshold == other.MovementThreshold
     }
 }
 impl ::core::cmp::Eq for GNSS_DISTANCETRACKING_PARAM {}
@@ -2177,7 +2171,7 @@ unsafe impl ::windows::core::Abi for GNSS_DRIVERCOMMAND_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_DRIVERCOMMAND_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_DRIVERCOMMAND_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.CommandType == other.CommandType && self.Reserved == other.Reserved && self.CommandDataSize == other.CommandDataSize && self.Unused == other.Unused && self.CommandData == other.CommandData
     }
 }
 impl ::core::cmp::Eq for GNSS_DRIVERCOMMAND_PARAM {}
@@ -2210,7 +2204,7 @@ unsafe impl ::windows::core::Abi for GNSS_DRIVER_REQUEST_DATA {
 }
 impl ::core::cmp::PartialEq for GNSS_DRIVER_REQUEST_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_DRIVER_REQUEST_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Request == other.Request && self.RequestFlag == other.RequestFlag
     }
 }
 impl ::core::cmp::Eq for GNSS_DRIVER_REQUEST_DATA {}
@@ -2251,7 +2245,7 @@ unsafe impl ::windows::core::Abi for GNSS_ERRORINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_ERRORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_ERRORINFO>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.ErrorCode == other.ErrorCode && self.IsRecoverable == other.IsRecoverable && self.ErrorDescription == other.ErrorDescription && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2286,14 +2280,6 @@ unsafe impl ::windows::core::Abi for GNSS_EVENT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_EVENT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_EVENT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_EVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2327,14 +2313,6 @@ unsafe impl ::windows::core::Abi for GNSS_EVENT_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_EVENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_EVENT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_EVENT_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_EVENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2363,14 +2341,6 @@ impl ::core::clone::Clone for GNSS_EVENT_2 {
 unsafe impl ::windows::core::Abi for GNSS_EVENT_2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_EVENT_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_EVENT_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_EVENT_2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_EVENT_2 {
     fn default() -> Self {
@@ -2405,14 +2375,6 @@ impl ::core::clone::Clone for GNSS_EVENT_2_0 {
 unsafe impl ::windows::core::Abi for GNSS_EVENT_2_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_EVENT_2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_EVENT_2_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_EVENT_2_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_EVENT_2_0 {
     fn default() -> Self {
@@ -2455,7 +2417,7 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_FIXDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.FixSessionID == other.FixSessionID && self.FixTimeStamp == other.FixTimeStamp && self.IsFinalFix == other.IsFinalFix && self.FixStatus == other.FixStatus && self.FixLevelOfDetails == other.FixLevelOfDetails && self.BasicData == other.BasicData && self.AccuracyData == other.AccuracyData && self.SatelliteData == other.SatelliteData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2502,7 +2464,7 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_2>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.FixSessionID == other.FixSessionID && self.FixTimeStamp == other.FixTimeStamp && self.IsFinalFix == other.IsFinalFix && self.FixStatus == other.FixStatus && self.FixLevelOfDetails == other.FixLevelOfDetails && self.BasicData == other.BasicData && self.AccuracyData == other.AccuracyData && self.SatelliteData == other.SatelliteData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2566,7 +2528,22 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_ACCURACY {
 }
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_ACCURACY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_ACCURACY>()) == 0 }
+        self.Size == other.Size
+            && self.Version == other.Version
+            && self.HorizontalAccuracy == other.HorizontalAccuracy
+            && self.HorizontalErrorMajorAxis == other.HorizontalErrorMajorAxis
+            && self.HorizontalErrorMinorAxis == other.HorizontalErrorMinorAxis
+            && self.HorizontalErrorAngle == other.HorizontalErrorAngle
+            && self.HeadingAccuracy == other.HeadingAccuracy
+            && self.AltitudeAccuracy == other.AltitudeAccuracy
+            && self.SpeedAccuracy == other.SpeedAccuracy
+            && self.HorizontalConfidence == other.HorizontalConfidence
+            && self.HeadingConfidence == other.HeadingConfidence
+            && self.AltitudeConfidence == other.AltitudeConfidence
+            && self.SpeedConfidence == other.SpeedConfidence
+            && self.PositionDilutionOfPrecision == other.PositionDilutionOfPrecision
+            && self.HorizontalDilutionOfPrecision == other.HorizontalDilutionOfPrecision
+            && self.VerticalDilutionOfPrecision == other.VerticalDilutionOfPrecision
     }
 }
 impl ::core::cmp::Eq for GNSS_FIXDATA_ACCURACY {}
@@ -2632,7 +2609,24 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_ACCURACY_2 {
 }
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_ACCURACY_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_ACCURACY_2>()) == 0 }
+        self.Size == other.Size
+            && self.Version == other.Version
+            && self.HorizontalAccuracy == other.HorizontalAccuracy
+            && self.HorizontalErrorMajorAxis == other.HorizontalErrorMajorAxis
+            && self.HorizontalErrorMinorAxis == other.HorizontalErrorMinorAxis
+            && self.HorizontalErrorAngle == other.HorizontalErrorAngle
+            && self.HeadingAccuracy == other.HeadingAccuracy
+            && self.AltitudeAccuracy == other.AltitudeAccuracy
+            && self.SpeedAccuracy == other.SpeedAccuracy
+            && self.HorizontalConfidence == other.HorizontalConfidence
+            && self.HeadingConfidence == other.HeadingConfidence
+            && self.AltitudeConfidence == other.AltitudeConfidence
+            && self.SpeedConfidence == other.SpeedConfidence
+            && self.PositionDilutionOfPrecision == other.PositionDilutionOfPrecision
+            && self.HorizontalDilutionOfPrecision == other.HorizontalDilutionOfPrecision
+            && self.VerticalDilutionOfPrecision == other.VerticalDilutionOfPrecision
+            && self.GeometricDilutionOfPrecision == other.GeometricDilutionOfPrecision
+            && self.TimeDilutionOfPrecision == other.TimeDilutionOfPrecision
     }
 }
 impl ::core::cmp::Eq for GNSS_FIXDATA_ACCURACY_2 {}
@@ -2668,7 +2662,7 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_BASIC {
 }
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_BASIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_BASIC>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Latitude == other.Latitude && self.Longitude == other.Longitude && self.Altitude == other.Altitude && self.Speed == other.Speed && self.Heading == other.Heading
     }
 }
 impl ::core::cmp::Eq for GNSS_FIXDATA_BASIC {}
@@ -2705,7 +2699,7 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_BASIC_2 {
 }
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_BASIC_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_BASIC_2>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Latitude == other.Latitude && self.Longitude == other.Longitude && self.Altitude == other.Altitude && self.Speed == other.Speed && self.Heading == other.Heading && self.AltitudeEllipsoid == other.AltitudeEllipsoid
     }
 }
 impl ::core::cmp::Eq for GNSS_FIXDATA_BASIC_2 {}
@@ -2744,7 +2738,7 @@ unsafe impl ::windows::core::Abi for GNSS_FIXDATA_SATELLITE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_FIXDATA_SATELLITE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXDATA_SATELLITE>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.SatelliteCount == other.SatelliteCount && self.SatelliteArray == other.SatelliteArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2778,12 +2772,6 @@ impl ::core::clone::Clone for GNSS_FIXSESSION_PARAM {
 unsafe impl ::windows::core::Abi for GNSS_FIXSESSION_PARAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GNSS_FIXSESSION_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXSESSION_PARAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GNSS_FIXSESSION_PARAM {}
 impl ::core::default::Default for GNSS_FIXSESSION_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2807,12 +2795,6 @@ impl ::core::clone::Clone for GNSS_FIXSESSION_PARAM_0 {
 unsafe impl ::windows::core::Abi for GNSS_FIXSESSION_PARAM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GNSS_FIXSESSION_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_FIXSESSION_PARAM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GNSS_FIXSESSION_PARAM_0 {}
 impl ::core::default::Default for GNSS_FIXSESSION_PARAM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2849,7 +2831,7 @@ unsafe impl ::windows::core::Abi for GNSS_GEOFENCES_TRACKINGSTATUS_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_GEOFENCES_TRACKINGSTATUS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOFENCES_TRACKINGSTATUS_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Status == other.Status && self.StatusTimeStamp == other.StatusTimeStamp && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2887,7 +2869,7 @@ unsafe impl ::windows::core::Abi for GNSS_GEOFENCE_ALERT_DATA {
 }
 impl ::core::cmp::PartialEq for GNSS_GEOFENCE_ALERT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOFENCE_ALERT_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.GeofenceID == other.GeofenceID && self.GeofenceState == other.GeofenceState && self.FixBasicData == other.FixBasicData && self.FixAccuracyData == other.FixAccuracyData && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_GEOFENCE_ALERT_DATA {}
@@ -2915,12 +2897,6 @@ impl ::core::clone::Clone for GNSS_GEOFENCE_CREATE_PARAM {
 unsafe impl ::windows::core::Abi for GNSS_GEOFENCE_CREATE_PARAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GNSS_GEOFENCE_CREATE_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOFENCE_CREATE_PARAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GNSS_GEOFENCE_CREATE_PARAM {}
 impl ::core::default::Default for GNSS_GEOFENCE_CREATE_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2957,7 +2933,7 @@ unsafe impl ::windows::core::Abi for GNSS_GEOFENCE_CREATE_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_GEOFENCE_CREATE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOFENCE_CREATE_RESPONSE>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.CreationStatus == other.CreationStatus && self.GeofenceID == other.GeofenceID && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2992,7 +2968,7 @@ unsafe impl ::windows::core::Abi for GNSS_GEOFENCE_DELETE_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_GEOFENCE_DELETE_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOFENCE_DELETE_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.GeofenceID == other.GeofenceID && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_GEOFENCE_DELETE_PARAM {}
@@ -3018,12 +2994,6 @@ impl ::core::clone::Clone for GNSS_GEOREGION {
 unsafe impl ::windows::core::Abi for GNSS_GEOREGION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GNSS_GEOREGION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOREGION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GNSS_GEOREGION {}
 impl ::core::default::Default for GNSS_GEOREGION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3044,12 +3014,6 @@ impl ::core::clone::Clone for GNSS_GEOREGION_0 {
 unsafe impl ::windows::core::Abi for GNSS_GEOREGION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GNSS_GEOREGION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOREGION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GNSS_GEOREGION_0 {}
 impl ::core::default::Default for GNSS_GEOREGION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3078,7 +3042,7 @@ unsafe impl ::windows::core::Abi for GNSS_GEOREGION_CIRCLE {
 }
 impl ::core::cmp::PartialEq for GNSS_GEOREGION_CIRCLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_GEOREGION_CIRCLE>()) == 0 }
+        self.Latitude == other.Latitude && self.Longitude == other.Longitude && self.RadiusInMeters == other.RadiusInMeters
     }
 }
 impl ::core::cmp::Eq for GNSS_GEOREGION_CIRCLE {}
@@ -3109,7 +3073,7 @@ unsafe impl ::windows::core::Abi for GNSS_LKGFIX_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_LKGFIX_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_LKGFIX_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for GNSS_LKGFIX_PARAM {}
@@ -3145,14 +3109,6 @@ unsafe impl ::windows::core::Abi for GNSS_NI_REQUEST_PARAM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_NI_REQUEST_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_NI_REQUEST_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_NI_REQUEST_PARAM {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_NI_REQUEST_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3178,14 +3134,6 @@ impl ::core::clone::Clone for GNSS_NI_REQUEST_PARAM_0 {
 unsafe impl ::windows::core::Abi for GNSS_NI_REQUEST_PARAM_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GNSS_NI_REQUEST_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_NI_REQUEST_PARAM_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GNSS_NI_REQUEST_PARAM_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GNSS_NI_REQUEST_PARAM_0 {
     fn default() -> Self {
@@ -3216,7 +3164,7 @@ unsafe impl ::windows::core::Abi for GNSS_NI_RESPONSE {
 }
 impl ::core::cmp::PartialEq for GNSS_NI_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_NI_RESPONSE>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.RequestId == other.RequestId && self.UserResponse == other.UserResponse
     }
 }
 impl ::core::cmp::Eq for GNSS_NI_RESPONSE {}
@@ -3254,7 +3202,7 @@ unsafe impl ::windows::core::Abi for GNSS_NMEA_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_NMEA_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_NMEA_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.NmeaSentences == other.NmeaSentences
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3296,7 +3244,7 @@ unsafe impl ::windows::core::Abi for GNSS_PLATFORM_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_PLATFORM_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_PLATFORM_CAPABILITY>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.SupportAgnssInjection == other.SupportAgnssInjection && self.AgnssFormatSupported == other.AgnssFormatSupported && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3338,7 +3286,7 @@ unsafe impl ::windows::core::Abi for GNSS_SATELLITEINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_SATELLITEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SATELLITEINFO>()) == 0 }
+        self.SatelliteId == other.SatelliteId && self.UsedInPositiong == other.UsedInPositiong && self.Elevation == other.Elevation && self.Azimuth == other.Azimuth && self.SignalToNoiseRatio == other.SignalToNoiseRatio
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3375,7 +3323,7 @@ unsafe impl ::windows::core::Abi for GNSS_SELFTESTCONFIG {
 }
 impl ::core::cmp::PartialEq for GNSS_SELFTESTCONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SELFTESTCONFIG>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.TestType == other.TestType && self.Unused == other.Unused && self.InBufLen == other.InBufLen && self.InBuffer == other.InBuffer
     }
 }
 impl ::core::cmp::Eq for GNSS_SELFTESTCONFIG {}
@@ -3418,7 +3366,7 @@ unsafe impl ::windows::core::Abi for GNSS_SELFTESTRESULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_SELFTESTRESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SELFTESTRESULT>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.TestResultStatus == other.TestResultStatus && self.Result == other.Result && self.PinFailedBitMask == other.PinFailedBitMask && self.Unused == other.Unused && self.OutBufLen == other.OutBufLen && self.OutBuffer == other.OutBuffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3452,7 +3400,7 @@ unsafe impl ::windows::core::Abi for GNSS_SINGLESHOT_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_SINGLESHOT_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SINGLESHOT_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.ResponseTime == other.ResponseTime
     }
 }
 impl ::core::cmp::Eq for GNSS_SINGLESHOT_PARAM {}
@@ -3485,7 +3433,7 @@ unsafe impl ::windows::core::Abi for GNSS_STOPFIXSESSION_PARAM {
 }
 impl ::core::cmp::PartialEq for GNSS_STOPFIXSESSION_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_STOPFIXSESSION_PARAM>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.FixSessionID == other.FixSessionID && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for GNSS_STOPFIXSESSION_PARAM {}
@@ -3527,7 +3475,7 @@ unsafe impl ::windows::core::Abi for GNSS_SUPL_CERT_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_SUPL_CERT_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SUPL_CERT_CONFIG>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.CertAction == other.CertAction && self.SuplCertName == other.SuplCertName && self.CertSize == other.CertSize && self.Unused == other.Unused && self.CertData == other.CertData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3570,7 +3518,7 @@ unsafe impl ::windows::core::Abi for GNSS_SUPL_HSLP_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_SUPL_HSLP_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SUPL_HSLP_CONFIG>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.SuplHslp == other.SuplHslp && self.SuplHslpFromImsi == other.SuplHslpFromImsi && self.Reserved == other.Reserved && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3612,7 +3560,7 @@ unsafe impl ::windows::core::Abi for GNSS_SUPL_NI_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_SUPL_NI_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SUPL_NI_INFO>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.RequestorId == other.RequestorId && self.ClientName == other.ClientName && self.SuplNiUrl == other.SuplNiUrl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3645,7 +3593,7 @@ unsafe impl ::windows::core::Abi for GNSS_SUPL_VERSION {
 }
 impl ::core::cmp::PartialEq for GNSS_SUPL_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SUPL_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for GNSS_SUPL_VERSION {}
@@ -3677,7 +3625,7 @@ unsafe impl ::windows::core::Abi for GNSS_SUPL_VERSION_2 {
 }
 impl ::core::cmp::PartialEq for GNSS_SUPL_VERSION_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_SUPL_VERSION_2>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.ServiceIndicator == other.ServiceIndicator
     }
 }
 impl ::core::cmp::Eq for GNSS_SUPL_VERSION_2 {}
@@ -3718,7 +3666,7 @@ unsafe impl ::windows::core::Abi for GNSS_V2UPL_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GNSS_V2UPL_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_V2UPL_CONFIG>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.MPC == other.MPC && self.PDE == other.PDE && self.ApplicationTypeIndicator_MR == other.ApplicationTypeIndicator_MR && self.Unused == other.Unused
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3752,7 +3700,7 @@ unsafe impl ::windows::core::Abi for GNSS_V2UPL_NI_INFO {
 }
 impl ::core::cmp::PartialEq for GNSS_V2UPL_NI_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GNSS_V2UPL_NI_INFO>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.RequestorId == other.RequestorId
     }
 }
 impl ::core::cmp::Eq for GNSS_V2UPL_NI_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -7839,7 +7839,7 @@ unsafe impl ::windows::core::Abi for CPOINT {
 }
 impl ::core::cmp::PartialEq for CPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPOINT>()) == 0 }
+        self.lP == other.lP && self.dwLog == other.dwLog
     }
 }
 impl ::core::cmp::Eq for CPOINT {}
@@ -7868,12 +7868,6 @@ impl ::core::clone::Clone for DIACTIONA {
 unsafe impl ::windows::core::Abi for DIACTIONA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DIACTIONA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DIACTIONA {}
 impl ::core::default::Default for DIACTIONA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7894,12 +7888,6 @@ impl ::core::clone::Clone for DIACTIONA_0 {
 unsafe impl ::windows::core::Abi for DIACTIONA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DIACTIONA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DIACTIONA_0 {}
 impl ::core::default::Default for DIACTIONA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7960,7 +7948,7 @@ unsafe impl ::windows::core::Abi for DIACTIONFORMATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIACTIONFORMATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONFORMATA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwActionSize == other.dwActionSize && self.dwDataSize == other.dwDataSize && self.dwNumActions == other.dwNumActions && self.rgoAction == other.rgoAction && self.guidActionMap == other.guidActionMap && self.dwGenre == other.dwGenre && self.dwBufferSize == other.dwBufferSize && self.lAxisMin == other.lAxisMin && self.lAxisMax == other.lAxisMax && self.hInstString == other.hInstString && self.ftTimeStamp == other.ftTimeStamp && self.dwCRC == other.dwCRC && self.tszActionMap == other.tszActionMap
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8026,7 +8014,7 @@ unsafe impl ::windows::core::Abi for DIACTIONFORMATW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIACTIONFORMATW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONFORMATW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwActionSize == other.dwActionSize && self.dwDataSize == other.dwDataSize && self.dwNumActions == other.dwNumActions && self.rgoAction == other.rgoAction && self.guidActionMap == other.guidActionMap && self.dwGenre == other.dwGenre && self.dwBufferSize == other.dwBufferSize && self.lAxisMin == other.lAxisMin && self.lAxisMax == other.lAxisMax && self.hInstString == other.hInstString && self.ftTimeStamp == other.ftTimeStamp && self.dwCRC == other.dwCRC && self.tszActionMap == other.tszActionMap
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8057,12 +8045,6 @@ impl ::core::clone::Clone for DIACTIONW {
 unsafe impl ::windows::core::Abi for DIACTIONW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DIACTIONW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DIACTIONW {}
 impl ::core::default::Default for DIACTIONW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8083,12 +8065,6 @@ impl ::core::clone::Clone for DIACTIONW_0 {
 unsafe impl ::windows::core::Abi for DIACTIONW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DIACTIONW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIACTIONW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DIACTIONW_0 {}
 impl ::core::default::Default for DIACTIONW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8123,7 +8099,7 @@ unsafe impl ::windows::core::Abi for DICOLORSET {
 }
 impl ::core::cmp::PartialEq for DICOLORSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DICOLORSET>()) == 0 }
+        self.dwSize == other.dwSize && self.cTextFore == other.cTextFore && self.cTextHighlight == other.cTextHighlight && self.cCalloutLine == other.cCalloutLine && self.cCalloutHighlight == other.cCalloutHighlight && self.cBorder == other.cBorder && self.cControlFill == other.cControlFill && self.cHighlightFill == other.cHighlightFill && self.cAreaFill == other.cAreaFill
     }
 }
 impl ::core::cmp::Eq for DICOLORSET {}
@@ -8158,7 +8134,7 @@ unsafe impl ::windows::core::Abi for DICONDITION {
 }
 impl ::core::cmp::PartialEq for DICONDITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DICONDITION>()) == 0 }
+        self.lOffset == other.lOffset && self.lPositiveCoefficient == other.lPositiveCoefficient && self.lNegativeCoefficient == other.lNegativeCoefficient && self.dwPositiveSaturation == other.dwPositiveSaturation && self.dwNegativeSaturation == other.dwNegativeSaturation && self.lDeadBand == other.lDeadBand
     }
 }
 impl ::core::cmp::Eq for DICONDITION {}
@@ -8292,7 +8268,7 @@ unsafe impl ::windows::core::Abi for DICONSTANTFORCE {
 }
 impl ::core::cmp::PartialEq for DICONSTANTFORCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DICONSTANTFORCE>()) == 0 }
+        self.lMagnitude == other.lMagnitude
     }
 }
 impl ::core::cmp::Eq for DICONSTANTFORCE {}
@@ -8325,7 +8301,7 @@ unsafe impl ::windows::core::Abi for DICUSTOMFORCE {
 }
 impl ::core::cmp::PartialEq for DICUSTOMFORCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DICUSTOMFORCE>()) == 0 }
+        self.cChannels == other.cChannels && self.dwSamplePeriod == other.dwSamplePeriod && self.cSamples == other.cSamples && self.rglForceData == other.rglForceData
     }
 }
 impl ::core::cmp::Eq for DICUSTOMFORCE {}
@@ -8360,7 +8336,7 @@ unsafe impl ::windows::core::Abi for DIDATAFORMAT {
 }
 impl ::core::cmp::PartialEq for DIDATAFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDATAFORMAT>()) == 0 }
+        self.dwSize == other.dwSize && self.dwObjSize == other.dwObjSize && self.dwFlags == other.dwFlags && self.dwDataSize == other.dwDataSize && self.dwNumObjs == other.dwNumObjs && self.rgodf == other.rgodf
     }
 }
 impl ::core::cmp::Eq for DIDATAFORMAT {}
@@ -8412,7 +8388,7 @@ unsafe impl ::windows::core::Abi for DIDEVCAPS {
 }
 impl ::core::cmp::PartialEq for DIDEVCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDevType == other.dwDevType && self.dwAxes == other.dwAxes && self.dwButtons == other.dwButtons && self.dwPOVs == other.dwPOVs && self.dwFFSamplePeriod == other.dwFFSamplePeriod && self.dwFFMinTimeResolution == other.dwFFMinTimeResolution && self.dwFirmwareRevision == other.dwFirmwareRevision && self.dwHardwareRevision == other.dwHardwareRevision && self.dwFFDriverVersion == other.dwFFDriverVersion
     }
 }
 impl ::core::cmp::Eq for DIDEVCAPS {}
@@ -8447,7 +8423,7 @@ unsafe impl ::windows::core::Abi for DIDEVCAPS_DX3 {
 }
 impl ::core::cmp::PartialEq for DIDEVCAPS_DX3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVCAPS_DX3>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDevType == other.dwDevType && self.dwAxes == other.dwAxes && self.dwButtons == other.dwButtons && self.dwPOVs == other.dwPOVs
     }
 }
 impl ::core::cmp::Eq for DIDEVCAPS_DX3 {}
@@ -8491,7 +8467,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEIMAGEINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEIMAGEINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEIMAGEINFOA>()) == 0 }
+        self.tszImagePath == other.tszImagePath && self.dwFlags == other.dwFlags && self.dwViewID == other.dwViewID && self.rcOverlay == other.rcOverlay && self.dwObjID == other.dwObjID && self.dwcValidPts == other.dwcValidPts && self.rgptCalloutLine == other.rgptCalloutLine && self.rcCalloutRect == other.rcCalloutRect && self.dwTextAlign == other.dwTextAlign
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8537,7 +8513,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEIMAGEINFOHEADERA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEIMAGEINFOHEADERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEIMAGEINFOHEADERA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwSizeImageInfo == other.dwSizeImageInfo && self.dwcViews == other.dwcViews && self.dwcButtons == other.dwcButtons && self.dwcAxes == other.dwcAxes && self.dwcPOVs == other.dwcPOVs && self.dwBufferSize == other.dwBufferSize && self.dwBufferUsed == other.dwBufferUsed && self.lprgImageInfoArray == other.lprgImageInfoArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8583,7 +8559,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEIMAGEINFOHEADERW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEIMAGEINFOHEADERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEIMAGEINFOHEADERW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwSizeImageInfo == other.dwSizeImageInfo && self.dwcViews == other.dwcViews && self.dwcButtons == other.dwcButtons && self.dwcAxes == other.dwcAxes && self.dwcPOVs == other.dwcPOVs && self.dwBufferSize == other.dwBufferSize && self.dwBufferUsed == other.dwBufferUsed && self.lprgImageInfoArray == other.lprgImageInfoArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8629,7 +8605,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEIMAGEINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEIMAGEINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEIMAGEINFOW>()) == 0 }
+        self.tszImagePath == other.tszImagePath && self.dwFlags == other.dwFlags && self.dwViewID == other.dwViewID && self.rcOverlay == other.rcOverlay && self.dwObjID == other.dwObjID && self.dwcValidPts == other.dwcValidPts && self.rgptCalloutLine == other.rgptCalloutLine && self.rcCalloutRect == other.rcCalloutRect && self.dwTextAlign == other.dwTextAlign
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8675,7 +8651,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEINSTANCEA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEINSTANCEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEINSTANCEA>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.guidProduct == other.guidProduct && self.dwDevType == other.dwDevType && self.tszInstanceName == other.tszInstanceName && self.tszProductName == other.tszProductName && self.guidFFDriver == other.guidFFDriver && self.wUsagePage == other.wUsagePage && self.wUsage == other.wUsage
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8715,7 +8691,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEINSTANCEW {
 }
 impl ::core::cmp::PartialEq for DIDEVICEINSTANCEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEINSTANCEW>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.guidProduct == other.guidProduct && self.dwDevType == other.dwDevType && self.tszInstanceName == other.tszInstanceName && self.tszProductName == other.tszProductName && self.guidFFDriver == other.guidFFDriver && self.wUsagePage == other.wUsagePage && self.wUsage == other.wUsage
     }
 }
 impl ::core::cmp::Eq for DIDEVICEINSTANCEW {}
@@ -8756,7 +8732,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEINSTANCE_DX3A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEINSTANCE_DX3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEINSTANCE_DX3A>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.guidProduct == other.guidProduct && self.dwDevType == other.dwDevType && self.tszInstanceName == other.tszInstanceName && self.tszProductName == other.tszProductName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8793,7 +8769,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEINSTANCE_DX3W {
 }
 impl ::core::cmp::PartialEq for DIDEVICEINSTANCE_DX3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEINSTANCE_DX3W>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.guidProduct == other.guidProduct && self.dwDevType == other.dwDevType && self.tszInstanceName == other.tszInstanceName && self.tszProductName == other.tszProductName
     }
 }
 impl ::core::cmp::Eq for DIDEVICEINSTANCE_DX3W {}
@@ -8827,7 +8803,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTDATA {
 }
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTDATA>()) == 0 }
+        self.dwOfs == other.dwOfs && self.dwData == other.dwData && self.dwTimeStamp == other.dwTimeStamp && self.dwSequence == other.dwSequence && self.uAppData == other.uAppData
     }
 }
 impl ::core::cmp::Eq for DIDEVICEOBJECTDATA {}
@@ -8860,7 +8836,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTDATA_DX3 {
 }
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTDATA_DX3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTDATA_DX3>()) == 0 }
+        self.dwOfs == other.dwOfs && self.dwData == other.dwData && self.dwTimeStamp == other.dwTimeStamp && self.dwSequence == other.dwSequence
     }
 }
 impl ::core::cmp::Eq for DIDEVICEOBJECTDATA_DX3 {}
@@ -8926,7 +8902,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTINSTANCEA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTINSTANCEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTINSTANCEA>()) == 0 }
+        self.dwSize == other.dwSize && self.guidType == other.guidType && self.dwOfs == other.dwOfs && self.dwType == other.dwType && self.dwFlags == other.dwFlags && self.tszName == other.tszName && self.dwFFMaxForce == other.dwFFMaxForce && self.dwFFForceResolution == other.dwFFForceResolution && self.wCollectionNumber == other.wCollectionNumber && self.wDesignatorIndex == other.wDesignatorIndex && self.wUsagePage == other.wUsagePage && self.wUsage == other.wUsage && self.dwDimension == other.dwDimension && self.wExponent == other.wExponent && self.wReportId == other.wReportId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8988,7 +8964,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTINSTANCEW {
 }
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTINSTANCEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTINSTANCEW>()) == 0 }
+        self.dwSize == other.dwSize && self.guidType == other.guidType && self.dwOfs == other.dwOfs && self.dwType == other.dwType && self.dwFlags == other.dwFlags && self.tszName == other.tszName && self.dwFFMaxForce == other.dwFFMaxForce && self.dwFFForceResolution == other.dwFFForceResolution && self.wCollectionNumber == other.wCollectionNumber && self.wDesignatorIndex == other.wDesignatorIndex && self.wUsagePage == other.wUsagePage && self.wUsage == other.wUsage && self.dwDimension == other.dwDimension && self.wExponent == other.wExponent && self.wReportId == other.wReportId
     }
 }
 impl ::core::cmp::Eq for DIDEVICEOBJECTINSTANCEW {}
@@ -9029,7 +9005,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTINSTANCE_DX3A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTINSTANCE_DX3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTINSTANCE_DX3A>()) == 0 }
+        self.dwSize == other.dwSize && self.guidType == other.guidType && self.dwOfs == other.dwOfs && self.dwType == other.dwType && self.dwFlags == other.dwFlags && self.tszName == other.tszName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9066,7 +9042,7 @@ unsafe impl ::windows::core::Abi for DIDEVICEOBJECTINSTANCE_DX3W {
 }
 impl ::core::cmp::PartialEq for DIDEVICEOBJECTINSTANCE_DX3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICEOBJECTINSTANCE_DX3W>()) == 0 }
+        self.dwSize == other.dwSize && self.guidType == other.guidType && self.dwOfs == other.dwOfs && self.dwType == other.dwType && self.dwFlags == other.dwFlags && self.tszName == other.tszName
     }
 }
 impl ::core::cmp::Eq for DIDEVICEOBJECTINSTANCE_DX3W {}
@@ -9098,7 +9074,7 @@ unsafe impl ::windows::core::Abi for DIDEVICESTATE {
 }
 impl ::core::cmp::PartialEq for DIDEVICESTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDEVICESTATE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwState == other.dwState && self.dwLoad == other.dwLoad
     }
 }
 impl ::core::cmp::Eq for DIDEVICESTATE {}
@@ -9131,7 +9107,7 @@ unsafe impl ::windows::core::Abi for DIDRIVERVERSIONS {
 }
 impl ::core::cmp::PartialEq for DIDRIVERVERSIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIDRIVERVERSIONS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFirmwareRevision == other.dwFirmwareRevision && self.dwHardwareRevision == other.dwHardwareRevision && self.dwFFDriverVersion == other.dwFFDriverVersion
     }
 }
 impl ::core::cmp::Eq for DIDRIVERVERSIONS {}
@@ -9189,7 +9165,7 @@ unsafe impl ::windows::core::Abi for DIEFFECT {
 }
 impl ::core::cmp::PartialEq for DIEFFECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFECT>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDuration == other.dwDuration && self.dwSamplePeriod == other.dwSamplePeriod && self.dwGain == other.dwGain && self.dwTriggerButton == other.dwTriggerButton && self.dwTriggerRepeatInterval == other.dwTriggerRepeatInterval && self.cAxes == other.cAxes && self.rgdwAxes == other.rgdwAxes && self.rglDirection == other.rglDirection && self.lpEnvelope == other.lpEnvelope && self.cbTypeSpecificParams == other.cbTypeSpecificParams && self.lpvTypeSpecificParams == other.lpvTypeSpecificParams && self.dwStartDelay == other.dwStartDelay
     }
 }
 impl ::core::cmp::Eq for DIEFFECT {}
@@ -9223,7 +9199,7 @@ unsafe impl ::windows::core::Abi for DIEFFECTATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DIEFFECTATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFECTATTRIBUTES>()) == 0 }
+        self.dwEffectId == other.dwEffectId && self.dwEffType == other.dwEffType && self.dwStaticParams == other.dwStaticParams && self.dwDynamicParams == other.dwDynamicParams && self.dwCoords == other.dwCoords
     }
 }
 impl ::core::cmp::Eq for DIEFFECTATTRIBUTES {}
@@ -9264,7 +9240,7 @@ unsafe impl ::windows::core::Abi for DIEFFECTINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIEFFECTINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFECTINFOA>()) == 0 }
+        self.dwSize == other.dwSize && self.guid == other.guid && self.dwEffType == other.dwEffType && self.dwStaticParams == other.dwStaticParams && self.dwDynamicParams == other.dwDynamicParams && self.tszName == other.tszName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9301,7 +9277,7 @@ unsafe impl ::windows::core::Abi for DIEFFECTINFOW {
 }
 impl ::core::cmp::PartialEq for DIEFFECTINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFECTINFOW>()) == 0 }
+        self.dwSize == other.dwSize && self.guid == other.guid && self.dwEffType == other.dwEffType && self.dwStaticParams == other.dwStaticParams && self.dwDynamicParams == other.dwDynamicParams && self.tszName == other.tszName
     }
 }
 impl ::core::cmp::Eq for DIEFFECTINFOW {}
@@ -9357,7 +9333,7 @@ unsafe impl ::windows::core::Abi for DIEFFECT_DX5 {
 }
 impl ::core::cmp::PartialEq for DIEFFECT_DX5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFECT_DX5>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDuration == other.dwDuration && self.dwSamplePeriod == other.dwSamplePeriod && self.dwGain == other.dwGain && self.dwTriggerButton == other.dwTriggerButton && self.dwTriggerRepeatInterval == other.dwTriggerRepeatInterval && self.cAxes == other.cAxes && self.rgdwAxes == other.rgdwAxes && self.rglDirection == other.rglDirection && self.lpEnvelope == other.lpEnvelope && self.cbTypeSpecificParams == other.cbTypeSpecificParams && self.lpvTypeSpecificParams == other.lpvTypeSpecificParams
     }
 }
 impl ::core::cmp::Eq for DIEFFECT_DX5 {}
@@ -9392,7 +9368,7 @@ unsafe impl ::windows::core::Abi for DIEFFESCAPE {
 }
 impl ::core::cmp::PartialEq for DIEFFESCAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIEFFESCAPE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCommand == other.dwCommand && self.lpvInBuffer == other.lpvInBuffer && self.cbInBuffer == other.cbInBuffer && self.lpvOutBuffer == other.lpvOutBuffer && self.cbOutBuffer == other.cbOutBuffer
     }
 }
 impl ::core::cmp::Eq for DIEFFESCAPE {}
@@ -9426,7 +9402,7 @@ unsafe impl ::windows::core::Abi for DIENVELOPE {
 }
 impl ::core::cmp::PartialEq for DIENVELOPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIENVELOPE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwAttackLevel == other.dwAttackLevel && self.dwAttackTime == other.dwAttackTime && self.dwFadeLevel == other.dwFadeLevel && self.dwFadeTime == other.dwFadeTime
     }
 }
 impl ::core::cmp::Eq for DIENVELOPE {}
@@ -9458,7 +9434,7 @@ unsafe impl ::windows::core::Abi for DIFFDEVICEATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DIFFDEVICEATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIFFDEVICEATTRIBUTES>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwFFSamplePeriod == other.dwFFSamplePeriod && self.dwFFMinTimeResolution == other.dwFFMinTimeResolution
     }
 }
 impl ::core::cmp::Eq for DIFFDEVICEATTRIBUTES {}
@@ -9489,7 +9465,7 @@ unsafe impl ::windows::core::Abi for DIFFOBJECTATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DIFFOBJECTATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIFFOBJECTATTRIBUTES>()) == 0 }
+        self.dwFFMaxForce == other.dwFFMaxForce && self.dwFFForceResolution == other.dwFFForceResolution
     }
 }
 impl ::core::cmp::Eq for DIFFOBJECTATTRIBUTES {}
@@ -9528,7 +9504,7 @@ unsafe impl ::windows::core::Abi for DIFILEEFFECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIFILEEFFECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIFILEEFFECT>()) == 0 }
+        self.dwSize == other.dwSize && self.GuidEffect == other.GuidEffect && self.lpDiEffect == other.lpDiEffect && self.szFriendlyName == other.szFriendlyName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9562,7 +9538,7 @@ unsafe impl ::windows::core::Abi for DIHIDFFINITINFO {
 }
 impl ::core::cmp::PartialEq for DIHIDFFINITINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIHIDFFINITINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pwszDeviceInterface == other.pwszDeviceInterface && self.GuidInstance == other.GuidInstance
     }
 }
 impl ::core::cmp::Eq for DIHIDFFINITINFO {}
@@ -9598,7 +9574,7 @@ unsafe impl ::windows::core::Abi for DIJOYCONFIG {
 }
 impl ::core::cmp::PartialEq for DIJOYCONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYCONFIG>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.hwc == other.hwc && self.dwGain == other.dwGain && self.wszType == other.wszType && self.wszCallout == other.wszCallout && self.guidGameport == other.guidGameport
     }
 }
 impl ::core::cmp::Eq for DIJOYCONFIG {}
@@ -9633,7 +9609,7 @@ unsafe impl ::windows::core::Abi for DIJOYCONFIG_DX5 {
 }
 impl ::core::cmp::PartialEq for DIJOYCONFIG_DX5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYCONFIG_DX5>()) == 0 }
+        self.dwSize == other.dwSize && self.guidInstance == other.guidInstance && self.hwc == other.hwc && self.dwGain == other.dwGain && self.wszType == other.wszType && self.wszCallout == other.wszCallout
     }
 }
 impl ::core::cmp::Eq for DIJOYCONFIG_DX5 {}
@@ -9671,7 +9647,7 @@ unsafe impl ::windows::core::Abi for DIJOYSTATE {
 }
 impl ::core::cmp::PartialEq for DIJOYSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYSTATE>()) == 0 }
+        self.lX == other.lX && self.lY == other.lY && self.lZ == other.lZ && self.lRx == other.lRx && self.lRy == other.lRy && self.lRz == other.lRz && self.rglSlider == other.rglSlider && self.rgdwPOV == other.rgdwPOV && self.rgbButtons == other.rgbButtons
     }
 }
 impl ::core::cmp::Eq for DIJOYSTATE {}
@@ -9761,7 +9737,36 @@ unsafe impl ::windows::core::Abi for DIJOYSTATE2 {
 }
 impl ::core::cmp::PartialEq for DIJOYSTATE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYSTATE2>()) == 0 }
+        self.lX == other.lX
+            && self.lY == other.lY
+            && self.lZ == other.lZ
+            && self.lRx == other.lRx
+            && self.lRy == other.lRy
+            && self.lRz == other.lRz
+            && self.rglSlider == other.rglSlider
+            && self.rgdwPOV == other.rgdwPOV
+            && self.rgbButtons == other.rgbButtons
+            && self.lVX == other.lVX
+            && self.lVY == other.lVY
+            && self.lVZ == other.lVZ
+            && self.lVRx == other.lVRx
+            && self.lVRy == other.lVRy
+            && self.lVRz == other.lVRz
+            && self.rglVSlider == other.rglVSlider
+            && self.lAX == other.lAX
+            && self.lAY == other.lAY
+            && self.lAZ == other.lAZ
+            && self.lARx == other.lARx
+            && self.lARy == other.lARy
+            && self.lARz == other.lARz
+            && self.rglASlider == other.rglASlider
+            && self.lFX == other.lFX
+            && self.lFY == other.lFY
+            && self.lFZ == other.lFZ
+            && self.lFRx == other.lFRx
+            && self.lFRy == other.lFRy
+            && self.lFRz == other.lFRz
+            && self.rglFSlider == other.rglFSlider
     }
 }
 impl ::core::cmp::Eq for DIJOYSTATE2 {}
@@ -9799,7 +9804,7 @@ unsafe impl ::windows::core::Abi for DIJOYTYPEINFO {
 }
 impl ::core::cmp::PartialEq for DIJOYTYPEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYTYPEINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.hws == other.hws && self.clsidConfig == other.clsidConfig && self.wszDisplayName == other.wszDisplayName && self.wszCallout == other.wszCallout && self.wszHardwareId == other.wszHardwareId && self.dwFlags1 == other.dwFlags1 && self.dwFlags2 == other.dwFlags2 && self.wszMapFile == other.wszMapFile
     }
 }
 impl ::core::cmp::Eq for DIJOYTYPEINFO {}
@@ -9833,7 +9838,7 @@ unsafe impl ::windows::core::Abi for DIJOYTYPEINFO_DX5 {
 }
 impl ::core::cmp::PartialEq for DIJOYTYPEINFO_DX5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYTYPEINFO_DX5>()) == 0 }
+        self.dwSize == other.dwSize && self.hws == other.hws && self.clsidConfig == other.clsidConfig && self.wszDisplayName == other.wszDisplayName && self.wszCallout == other.wszCallout
     }
 }
 impl ::core::cmp::Eq for DIJOYTYPEINFO_DX5 {}
@@ -9869,7 +9874,7 @@ unsafe impl ::windows::core::Abi for DIJOYTYPEINFO_DX6 {
 }
 impl ::core::cmp::PartialEq for DIJOYTYPEINFO_DX6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYTYPEINFO_DX6>()) == 0 }
+        self.dwSize == other.dwSize && self.hws == other.hws && self.clsidConfig == other.clsidConfig && self.wszDisplayName == other.wszDisplayName && self.wszCallout == other.wszCallout && self.wszHardwareId == other.wszHardwareId && self.dwFlags1 == other.dwFlags1
     }
 }
 impl ::core::cmp::Eq for DIJOYTYPEINFO_DX6 {}
@@ -9902,7 +9907,7 @@ unsafe impl ::windows::core::Abi for DIJOYUSERVALUES {
 }
 impl ::core::cmp::PartialEq for DIJOYUSERVALUES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIJOYUSERVALUES>()) == 0 }
+        self.dwSize == other.dwSize && self.ruv == other.ruv && self.wszGlobalDriver == other.wszGlobalDriver && self.wszGameportEmulator == other.wszGameportEmulator
     }
 }
 impl ::core::cmp::Eq for DIJOYUSERVALUES {}
@@ -9935,7 +9940,7 @@ unsafe impl ::windows::core::Abi for DIMOUSESTATE {
 }
 impl ::core::cmp::PartialEq for DIMOUSESTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIMOUSESTATE>()) == 0 }
+        self.lX == other.lX && self.lY == other.lY && self.lZ == other.lZ && self.rgbButtons == other.rgbButtons
     }
 }
 impl ::core::cmp::Eq for DIMOUSESTATE {}
@@ -9968,7 +9973,7 @@ unsafe impl ::windows::core::Abi for DIMOUSESTATE2 {
 }
 impl ::core::cmp::PartialEq for DIMOUSESTATE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIMOUSESTATE2>()) == 0 }
+        self.lX == other.lX && self.lY == other.lY && self.lZ == other.lZ && self.rgbButtons == other.rgbButtons
     }
 }
 impl ::core::cmp::Eq for DIMOUSESTATE2 {}
@@ -10000,7 +10005,7 @@ unsafe impl ::windows::core::Abi for DIOBJECTATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DIOBJECTATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIOBJECTATTRIBUTES>()) == 0 }
+        self.dwFlags == other.dwFlags && self.wUsagePage == other.wUsagePage && self.wUsage == other.wUsage
     }
 }
 impl ::core::cmp::Eq for DIOBJECTATTRIBUTES {}
@@ -10032,7 +10037,7 @@ unsafe impl ::windows::core::Abi for DIOBJECTCALIBRATION {
 }
 impl ::core::cmp::PartialEq for DIOBJECTCALIBRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIOBJECTCALIBRATION>()) == 0 }
+        self.lMin == other.lMin && self.lCenter == other.lCenter && self.lMax == other.lMax
     }
 }
 impl ::core::cmp::Eq for DIOBJECTCALIBRATION {}
@@ -10065,7 +10070,7 @@ unsafe impl ::windows::core::Abi for DIOBJECTDATAFORMAT {
 }
 impl ::core::cmp::PartialEq for DIOBJECTDATAFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIOBJECTDATAFORMAT>()) == 0 }
+        self.pguid == other.pguid && self.dwOfs == other.dwOfs && self.dwType == other.dwType && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DIOBJECTDATAFORMAT {}
@@ -10098,7 +10103,7 @@ unsafe impl ::windows::core::Abi for DIPERIODIC {
 }
 impl ::core::cmp::PartialEq for DIPERIODIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPERIODIC>()) == 0 }
+        self.dwMagnitude == other.dwMagnitude && self.lOffset == other.lOffset && self.dwPhase == other.dwPhase && self.dwPeriod == other.dwPeriod
     }
 }
 impl ::core::cmp::Eq for DIPERIODIC {}
@@ -10129,7 +10134,7 @@ unsafe impl ::windows::core::Abi for DIPOVCALIBRATION {
 }
 impl ::core::cmp::PartialEq for DIPOVCALIBRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPOVCALIBRATION>()) == 0 }
+        self.lMin == other.lMin && self.lMax == other.lMax
     }
 }
 impl ::core::cmp::Eq for DIPOVCALIBRATION {}
@@ -10162,7 +10167,7 @@ unsafe impl ::windows::core::Abi for DIPROPCAL {
 }
 impl ::core::cmp::PartialEq for DIPROPCAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPCAL>()) == 0 }
+        self.diph == other.diph && self.lMin == other.lMin && self.lCenter == other.lCenter && self.lMax == other.lMax
     }
 }
 impl ::core::cmp::Eq for DIPROPCAL {}
@@ -10194,7 +10199,7 @@ unsafe impl ::windows::core::Abi for DIPROPCALPOV {
 }
 impl ::core::cmp::PartialEq for DIPROPCALPOV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPCALPOV>()) == 0 }
+        self.diph == other.diph && self.lMin == other.lMin && self.lMax == other.lMax
     }
 }
 impl ::core::cmp::Eq for DIPROPCALPOV {}
@@ -10226,7 +10231,7 @@ unsafe impl ::windows::core::Abi for DIPROPCPOINTS {
 }
 impl ::core::cmp::PartialEq for DIPROPCPOINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPCPOINTS>()) == 0 }
+        self.diph == other.diph && self.dwCPointsNum == other.dwCPointsNum && self.cp == other.cp
     }
 }
 impl ::core::cmp::Eq for DIPROPCPOINTS {}
@@ -10257,7 +10262,7 @@ unsafe impl ::windows::core::Abi for DIPROPDWORD {
 }
 impl ::core::cmp::PartialEq for DIPROPDWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPDWORD>()) == 0 }
+        self.diph == other.diph && self.dwData == other.dwData
     }
 }
 impl ::core::cmp::Eq for DIPROPDWORD {}
@@ -10289,7 +10294,7 @@ unsafe impl ::windows::core::Abi for DIPROPGUIDANDPATH {
 }
 impl ::core::cmp::PartialEq for DIPROPGUIDANDPATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPGUIDANDPATH>()) == 0 }
+        self.diph == other.diph && self.guidClass == other.guidClass && self.wszPath == other.wszPath
     }
 }
 impl ::core::cmp::Eq for DIPROPGUIDANDPATH {}
@@ -10322,7 +10327,7 @@ unsafe impl ::windows::core::Abi for DIPROPHEADER {
 }
 impl ::core::cmp::PartialEq for DIPROPHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPHEADER>()) == 0 }
+        self.dwSize == other.dwSize && self.dwHeaderSize == other.dwHeaderSize && self.dwObj == other.dwObj && self.dwHow == other.dwHow
     }
 }
 impl ::core::cmp::Eq for DIPROPHEADER {}
@@ -10353,7 +10358,7 @@ unsafe impl ::windows::core::Abi for DIPROPPOINTER {
 }
 impl ::core::cmp::PartialEq for DIPROPPOINTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPPOINTER>()) == 0 }
+        self.diph == other.diph && self.uData == other.uData
     }
 }
 impl ::core::cmp::Eq for DIPROPPOINTER {}
@@ -10385,7 +10390,7 @@ unsafe impl ::windows::core::Abi for DIPROPRANGE {
 }
 impl ::core::cmp::PartialEq for DIPROPRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPRANGE>()) == 0 }
+        self.diph == other.diph && self.lMin == other.lMin && self.lMax == other.lMax
     }
 }
 impl ::core::cmp::Eq for DIPROPRANGE {}
@@ -10416,7 +10421,7 @@ unsafe impl ::windows::core::Abi for DIPROPSTRING {
 }
 impl ::core::cmp::PartialEq for DIPROPSTRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIPROPSTRING>()) == 0 }
+        self.diph == other.diph && self.wsz == other.wsz
     }
 }
 impl ::core::cmp::Eq for DIPROPSTRING {}
@@ -10447,7 +10452,7 @@ unsafe impl ::windows::core::Abi for DIRAMPFORCE {
 }
 impl ::core::cmp::PartialEq for DIRAMPFORCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIRAMPFORCE>()) == 0 }
+        self.lStart == other.lStart && self.lEnd == other.lEnd
     }
 }
 impl ::core::cmp::Eq for DIRAMPFORCE {}
@@ -10480,7 +10485,7 @@ unsafe impl ::windows::core::Abi for HIDD_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for HIDD_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDD_ATTRIBUTES>()) == 0 }
+        self.Size == other.Size && self.VendorID == other.VendorID && self.ProductID == other.ProductID && self.VersionNumber == other.VersionNumber
     }
 }
 impl ::core::cmp::Eq for HIDD_ATTRIBUTES {}
@@ -10505,12 +10510,6 @@ impl ::core::clone::Clone for HIDD_CONFIGURATION {
 unsafe impl ::windows::core::Abi for HIDD_CONFIGURATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HIDD_CONFIGURATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDD_CONFIGURATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HIDD_CONFIGURATION {}
 impl ::core::default::Default for HIDD_CONFIGURATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10544,7 +10543,7 @@ unsafe impl ::windows::core::Abi for HIDP_BUTTON_ARRAY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIDP_BUTTON_ARRAY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_BUTTON_ARRAY_DATA>()) == 0 }
+        self.ArrayIndex == other.ArrayIndex && self.On == other.On
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10588,14 +10587,6 @@ unsafe impl ::windows::core::Abi for HIDP_BUTTON_CAPS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_BUTTON_CAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_BUTTON_CAPS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_BUTTON_CAPS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_BUTTON_CAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10620,14 +10611,6 @@ impl ::core::clone::Clone for HIDP_BUTTON_CAPS_0 {
 unsafe impl ::windows::core::Abi for HIDP_BUTTON_CAPS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_BUTTON_CAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_BUTTON_CAPS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_BUTTON_CAPS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_BUTTON_CAPS_0 {
     fn default() -> Self {
@@ -10668,7 +10651,7 @@ unsafe impl ::windows::core::Abi for HIDP_BUTTON_CAPS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIDP_BUTTON_CAPS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_BUTTON_CAPS_0_0>()) == 0 }
+        self.Usage == other.Usage && self.Reserved1 == other.Reserved1 && self.StringIndex == other.StringIndex && self.Reserved2 == other.Reserved2 && self.DesignatorIndex == other.DesignatorIndex && self.Reserved3 == other.Reserved3 && self.DataIndex == other.DataIndex && self.Reserved4 == other.Reserved4
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10713,7 +10696,7 @@ unsafe impl ::windows::core::Abi for HIDP_BUTTON_CAPS_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIDP_BUTTON_CAPS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_BUTTON_CAPS_0_1>()) == 0 }
+        self.UsageMin == other.UsageMin && self.UsageMax == other.UsageMax && self.StringMin == other.StringMin && self.StringMax == other.StringMax && self.DesignatorMin == other.DesignatorMin && self.DesignatorMax == other.DesignatorMax && self.DataIndexMin == other.DataIndexMin && self.DataIndexMax == other.DataIndexMax
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10777,7 +10760,22 @@ unsafe impl ::windows::core::Abi for HIDP_CAPS {
 }
 impl ::core::cmp::PartialEq for HIDP_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_CAPS>()) == 0 }
+        self.Usage == other.Usage
+            && self.UsagePage == other.UsagePage
+            && self.InputReportByteLength == other.InputReportByteLength
+            && self.OutputReportByteLength == other.OutputReportByteLength
+            && self.FeatureReportByteLength == other.FeatureReportByteLength
+            && self.Reserved == other.Reserved
+            && self.NumberLinkCollectionNodes == other.NumberLinkCollectionNodes
+            && self.NumberInputButtonCaps == other.NumberInputButtonCaps
+            && self.NumberInputValueCaps == other.NumberInputValueCaps
+            && self.NumberInputDataIndices == other.NumberInputDataIndices
+            && self.NumberOutputButtonCaps == other.NumberOutputButtonCaps
+            && self.NumberOutputValueCaps == other.NumberOutputValueCaps
+            && self.NumberOutputDataIndices == other.NumberOutputDataIndices
+            && self.NumberFeatureButtonCaps == other.NumberFeatureButtonCaps
+            && self.NumberFeatureValueCaps == other.NumberFeatureValueCaps
+            && self.NumberFeatureDataIndices == other.NumberFeatureDataIndices
     }
 }
 impl ::core::cmp::Eq for HIDP_CAPS {}
@@ -10807,14 +10805,6 @@ unsafe impl ::windows::core::Abi for HIDP_DATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_DATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10840,14 +10830,6 @@ unsafe impl ::windows::core::Abi for HIDP_DATA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_DATA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10870,12 +10852,6 @@ impl ::core::clone::Clone for HIDP_EXTENDED_ATTRIBUTES {
 unsafe impl ::windows::core::Abi for HIDP_EXTENDED_ATTRIBUTES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HIDP_EXTENDED_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_EXTENDED_ATTRIBUTES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HIDP_EXTENDED_ATTRIBUTES {}
 impl ::core::default::Default for HIDP_EXTENDED_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10895,12 +10871,6 @@ impl ::core::clone::Clone for HIDP_KEYBOARD_MODIFIER_STATE {
 unsafe impl ::windows::core::Abi for HIDP_KEYBOARD_MODIFIER_STATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HIDP_KEYBOARD_MODIFIER_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_KEYBOARD_MODIFIER_STATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HIDP_KEYBOARD_MODIFIER_STATE {}
 impl ::core::default::Default for HIDP_KEYBOARD_MODIFIER_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10921,12 +10891,6 @@ impl ::core::clone::Clone for HIDP_KEYBOARD_MODIFIER_STATE_0 {
 unsafe impl ::windows::core::Abi for HIDP_KEYBOARD_MODIFIER_STATE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HIDP_KEYBOARD_MODIFIER_STATE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_KEYBOARD_MODIFIER_STATE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HIDP_KEYBOARD_MODIFIER_STATE_0 {}
 impl ::core::default::Default for HIDP_KEYBOARD_MODIFIER_STATE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10953,7 +10917,7 @@ unsafe impl ::windows::core::Abi for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
 }
 impl ::core::cmp::PartialEq for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_KEYBOARD_MODIFIER_STATE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {}
@@ -10983,12 +10947,6 @@ impl ::core::clone::Clone for HIDP_LINK_COLLECTION_NODE {
 unsafe impl ::windows::core::Abi for HIDP_LINK_COLLECTION_NODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HIDP_LINK_COLLECTION_NODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_LINK_COLLECTION_NODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HIDP_LINK_COLLECTION_NODE {}
 impl ::core::default::Default for HIDP_LINK_COLLECTION_NODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11017,7 +10975,7 @@ unsafe impl ::windows::core::Abi for HIDP_UNKNOWN_TOKEN {
 }
 impl ::core::cmp::PartialEq for HIDP_UNKNOWN_TOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_UNKNOWN_TOKEN>()) == 0 }
+        self.Token == other.Token && self.Reserved == other.Reserved && self.BitField == other.BitField
     }
 }
 impl ::core::cmp::Eq for HIDP_UNKNOWN_TOKEN {}
@@ -11067,14 +11025,6 @@ unsafe impl ::windows::core::Abi for HIDP_VALUE_CAPS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_VALUE_CAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_VALUE_CAPS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_VALUE_CAPS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_VALUE_CAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11099,14 +11049,6 @@ impl ::core::clone::Clone for HIDP_VALUE_CAPS_0 {
 unsafe impl ::windows::core::Abi for HIDP_VALUE_CAPS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HIDP_VALUE_CAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_VALUE_CAPS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HIDP_VALUE_CAPS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HIDP_VALUE_CAPS_0 {
     fn default() -> Self {
@@ -11147,7 +11089,7 @@ unsafe impl ::windows::core::Abi for HIDP_VALUE_CAPS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIDP_VALUE_CAPS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_VALUE_CAPS_0_0>()) == 0 }
+        self.Usage == other.Usage && self.Reserved1 == other.Reserved1 && self.StringIndex == other.StringIndex && self.Reserved2 == other.Reserved2 && self.DesignatorIndex == other.DesignatorIndex && self.Reserved3 == other.Reserved3 && self.DataIndex == other.DataIndex && self.Reserved4 == other.Reserved4
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11192,7 +11134,7 @@ unsafe impl ::windows::core::Abi for HIDP_VALUE_CAPS_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIDP_VALUE_CAPS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIDP_VALUE_CAPS_0_1>()) == 0 }
+        self.UsageMin == other.UsageMin && self.UsageMax == other.UsageMax && self.StringMin == other.StringMin && self.StringMax == other.StringMax && self.DesignatorMin == other.DesignatorMin && self.DesignatorMax == other.DesignatorMax && self.DataIndexMin == other.DataIndexMin && self.DataIndexMax == other.DataIndexMax
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11235,7 +11177,7 @@ unsafe impl ::windows::core::Abi for HID_COLLECTION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HID_COLLECTION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HID_COLLECTION_INFORMATION>()) == 0 }
+        self.DescriptorSize == other.DescriptorSize && self.Polled == other.Polled && self.Reserved1 == other.Reserved1 && self.VendorID == other.VendorID && self.ProductID == other.ProductID && self.VersionNumber == other.VersionNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11268,7 +11210,7 @@ unsafe impl ::windows::core::Abi for HID_DRIVER_CONFIG {
 }
 impl ::core::cmp::PartialEq for HID_DRIVER_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HID_DRIVER_CONFIG>()) == 0 }
+        self.Size == other.Size && self.RingBufferSize == other.RingBufferSize
     }
 }
 impl ::core::cmp::Eq for HID_DRIVER_CONFIG {}
@@ -11300,7 +11242,7 @@ unsafe impl ::windows::core::Abi for HID_XFER_PACKET {
 }
 impl ::core::cmp::PartialEq for HID_XFER_PACKET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HID_XFER_PACKET>()) == 0 }
+        self.reportBuffer == other.reportBuffer && self.reportBufferLen == other.reportBufferLen && self.reportId == other.reportId
     }
 }
 impl ::core::cmp::Eq for HID_XFER_PACKET {}
@@ -11331,7 +11273,7 @@ unsafe impl ::windows::core::Abi for INDICATOR_LIST {
 }
 impl ::core::cmp::PartialEq for INDICATOR_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INDICATOR_LIST>()) == 0 }
+        self.MakeCode == other.MakeCode && self.IndicatorFlags == other.IndicatorFlags
     }
 }
 impl ::core::cmp::Eq for INDICATOR_LIST {}
@@ -11368,7 +11310,7 @@ unsafe impl ::windows::core::Abi for INPUT_BUTTON_ENABLE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INPUT_BUTTON_ENABLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_BUTTON_ENABLE_INFO>()) == 0 }
+        self.ButtonType == other.ButtonType && self.Enabled == other.Enabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11405,7 +11347,7 @@ unsafe impl ::windows::core::Abi for JOYCALIBRATE {
 }
 impl ::core::cmp::PartialEq for JOYCALIBRATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYCALIBRATE>()) == 0 }
+        self.wXbase == other.wXbase && self.wXdelta == other.wXdelta && self.wYbase == other.wYbase && self.wYdelta == other.wYdelta && self.wZbase == other.wZbase && self.wZdelta == other.wZdelta
     }
 }
 impl ::core::cmp::Eq for JOYCALIBRATE {}
@@ -11440,7 +11382,7 @@ unsafe impl ::windows::core::Abi for JOYPOS {
 }
 impl ::core::cmp::PartialEq for JOYPOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYPOS>()) == 0 }
+        self.dwX == other.dwX && self.dwY == other.dwY && self.dwZ == other.dwZ && self.dwR == other.dwR && self.dwU == other.dwU && self.dwV == other.dwV
     }
 }
 impl ::core::cmp::Eq for JOYPOS {}
@@ -11472,7 +11414,7 @@ unsafe impl ::windows::core::Abi for JOYRANGE {
 }
 impl ::core::cmp::PartialEq for JOYRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYRANGE>()) == 0 }
+        self.jpMin == other.jpMin && self.jpMax == other.jpMax && self.jpCenter == other.jpCenter
     }
 }
 impl ::core::cmp::Eq for JOYRANGE {}
@@ -11506,7 +11448,7 @@ unsafe impl ::windows::core::Abi for JOYREGHWCONFIG {
 }
 impl ::core::cmp::PartialEq for JOYREGHWCONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYREGHWCONFIG>()) == 0 }
+        self.hws == other.hws && self.dwUsageSettings == other.dwUsageSettings && self.hwv == other.hwv && self.dwType == other.dwType && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for JOYREGHWCONFIG {}
@@ -11537,7 +11479,7 @@ unsafe impl ::windows::core::Abi for JOYREGHWSETTINGS {
 }
 impl ::core::cmp::PartialEq for JOYREGHWSETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYREGHWSETTINGS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwNumButtons == other.dwNumButtons
     }
 }
 impl ::core::cmp::Eq for JOYREGHWSETTINGS {}
@@ -11569,7 +11511,7 @@ unsafe impl ::windows::core::Abi for JOYREGHWVALUES {
 }
 impl ::core::cmp::PartialEq for JOYREGHWVALUES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYREGHWVALUES>()) == 0 }
+        self.jrvHardware == other.jrvHardware && self.dwPOVValues == other.dwPOVValues && self.dwCalFlags == other.dwCalFlags
     }
 }
 impl ::core::cmp::Eq for JOYREGHWVALUES {}
@@ -11601,7 +11543,7 @@ unsafe impl ::windows::core::Abi for JOYREGUSERVALUES {
 }
 impl ::core::cmp::PartialEq for JOYREGUSERVALUES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYREGUSERVALUES>()) == 0 }
+        self.dwTimeOut == other.dwTimeOut && self.jrvRanges == other.jrvRanges && self.jpDeadZone == other.jpDeadZone
     }
 }
 impl ::core::cmp::Eq for JOYREGUSERVALUES {}
@@ -11638,7 +11580,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_ATTRIBUTES>()) == 0 }
+        self.KeyboardIdentifier == other.KeyboardIdentifier && self.KeyboardMode == other.KeyboardMode && self.NumberOfFunctionKeys == other.NumberOfFunctionKeys && self.NumberOfIndicators == other.NumberOfIndicators && self.NumberOfKeysTotal == other.NumberOfKeysTotal && self.InputDataQueueLength == other.InputDataQueueLength && self.KeyRepeatMinimum == other.KeyRepeatMinimum && self.KeyRepeatMaximum == other.KeyRepeatMaximum
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_ATTRIBUTES {}
@@ -11674,7 +11616,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_EXTENDED_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_EXTENDED_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_EXTENDED_ATTRIBUTES>()) == 0 }
+        self.Version == other.Version && self.FormFactor == other.FormFactor && self.KeyType == other.KeyType && self.PhysicalLayout == other.PhysicalLayout && self.VendorSpecificPhysicalLayout == other.VendorSpecificPhysicalLayout && self.IETFLanguageTagIndex == other.IETFLanguageTagIndex && self.ImplementedInputAssistControls == other.ImplementedInputAssistControls
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_EXTENDED_ATTRIBUTES {}
@@ -11705,7 +11647,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_ID {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_ID>()) == 0 }
+        self.Type == other.Type && self.Subtype == other.Subtype
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_ID {}
@@ -11737,7 +11679,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_IME_STATUS {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_IME_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_IME_STATUS>()) == 0 }
+        self.UnitId == other.UnitId && self.ImeOpen == other.ImeOpen && self.ImeConvMode == other.ImeConvMode
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_IME_STATUS {}
@@ -11768,7 +11710,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_INDICATOR_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_INDICATOR_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_INDICATOR_PARAMETERS>()) == 0 }
+        self.UnitId == other.UnitId && self.LedFlags == other.LedFlags
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_INDICATOR_PARAMETERS {}
@@ -11799,7 +11741,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_INDICATOR_TRANSLATION {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_INDICATOR_TRANSLATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_INDICATOR_TRANSLATION>()) == 0 }
+        self.NumberOfIndicatorKeys == other.NumberOfIndicatorKeys && self.IndicatorList == other.IndicatorList
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_INDICATOR_TRANSLATION {}
@@ -11833,7 +11775,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_INPUT_DATA {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_INPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_INPUT_DATA>()) == 0 }
+        self.UnitId == other.UnitId && self.MakeCode == other.MakeCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.ExtraInformation == other.ExtraInformation
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_INPUT_DATA {}
@@ -11865,7 +11807,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_TYPEMATIC_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_TYPEMATIC_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_TYPEMATIC_PARAMETERS>()) == 0 }
+        self.UnitId == other.UnitId && self.Rate == other.Rate && self.Delay == other.Delay
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_TYPEMATIC_PARAMETERS {}
@@ -11895,7 +11837,7 @@ unsafe impl ::windows::core::Abi for KEYBOARD_UNIT_ID_PARAMETER {
 }
 impl ::core::cmp::PartialEq for KEYBOARD_UNIT_ID_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBOARD_UNIT_ID_PARAMETER>()) == 0 }
+        self.UnitId == other.UnitId
     }
 }
 impl ::core::cmp::Eq for KEYBOARD_UNIT_ID_PARAMETER {}
@@ -11928,7 +11870,7 @@ unsafe impl ::windows::core::Abi for MOUSE_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for MOUSE_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_ATTRIBUTES>()) == 0 }
+        self.MouseIdentifier == other.MouseIdentifier && self.NumberOfButtons == other.NumberOfButtons && self.SampleRate == other.SampleRate && self.InputDataQueueLength == other.InputDataQueueLength
     }
 }
 impl ::core::cmp::Eq for MOUSE_ATTRIBUTES {}
@@ -11957,12 +11899,6 @@ impl ::core::clone::Clone for MOUSE_INPUT_DATA {
 unsafe impl ::windows::core::Abi for MOUSE_INPUT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MOUSE_INPUT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_INPUT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MOUSE_INPUT_DATA {}
 impl ::core::default::Default for MOUSE_INPUT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11983,12 +11919,6 @@ impl ::core::clone::Clone for MOUSE_INPUT_DATA_0 {
 unsafe impl ::windows::core::Abi for MOUSE_INPUT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MOUSE_INPUT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_INPUT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MOUSE_INPUT_DATA_0 {}
 impl ::core::default::Default for MOUSE_INPUT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12016,7 +11946,7 @@ unsafe impl ::windows::core::Abi for MOUSE_INPUT_DATA_0_0 {
 }
 impl ::core::cmp::PartialEq for MOUSE_INPUT_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_INPUT_DATA_0_0>()) == 0 }
+        self.ButtonFlags == other.ButtonFlags && self.ButtonData == other.ButtonData
     }
 }
 impl ::core::cmp::Eq for MOUSE_INPUT_DATA_0_0 {}
@@ -12046,7 +11976,7 @@ unsafe impl ::windows::core::Abi for MOUSE_UNIT_ID_PARAMETER {
 }
 impl ::core::cmp::PartialEq for MOUSE_UNIT_ID_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_UNIT_ID_PARAMETER>()) == 0 }
+        self.UnitId == other.UnitId
     }
 }
 impl ::core::cmp::Eq for MOUSE_UNIT_ID_PARAMETER {}
@@ -12077,7 +12007,7 @@ unsafe impl ::windows::core::Abi for USAGE_AND_PAGE {
 }
 impl ::core::cmp::PartialEq for USAGE_AND_PAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USAGE_AND_PAGE>()) == 0 }
+        self.Usage == other.Usage && self.UsagePage == other.UsagePage
     }
 }
 impl ::core::cmp::Eq for USAGE_AND_PAGE {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -4827,7 +4827,7 @@ unsafe impl ::windows::core::Abi for RANGEVALUE {
 }
 impl ::core::cmp::PartialEq for RANGEVALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RANGEVALUE>()) == 0 }
+        self.lMin == other.lMin && self.lMax == other.lMax && self.lStep == other.lStep
     }
 }
 impl ::core::cmp::Eq for RANGEVALUE {}
@@ -4935,7 +4935,42 @@ unsafe impl ::windows::core::Abi for SCANINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCANINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCANINFO>()) == 0 }
+        self.ADF == other.ADF
+            && self.TPA == other.TPA
+            && self.Endorser == other.Endorser
+            && self.OpticalXResolution == other.OpticalXResolution
+            && self.OpticalYResolution == other.OpticalYResolution
+            && self.BedWidth == other.BedWidth
+            && self.BedHeight == other.BedHeight
+            && self.IntensityRange == other.IntensityRange
+            && self.ContrastRange == other.ContrastRange
+            && self.SupportedCompressionType == other.SupportedCompressionType
+            && self.SupportedDataTypes == other.SupportedDataTypes
+            && self.WidthPixels == other.WidthPixels
+            && self.WidthBytes == other.WidthBytes
+            && self.Lines == other.Lines
+            && self.DataType == other.DataType
+            && self.PixelBits == other.PixelBits
+            && self.Intensity == other.Intensity
+            && self.Contrast == other.Contrast
+            && self.Xresolution == other.Xresolution
+            && self.Yresolution == other.Yresolution
+            && self.Window == other.Window
+            && self.DitherPattern == other.DitherPattern
+            && self.Negative == other.Negative
+            && self.Mirror == other.Mirror
+            && self.AutoBack == other.AutoBack
+            && self.ColorDitherPattern == other.ColorDitherPattern
+            && self.ToneMap == other.ToneMap
+            && self.Compression == other.Compression
+            && self.RawDataFormat == other.RawDataFormat
+            && self.RawPixelOrder == other.RawPixelOrder
+            && self.bNeedDataAlignment == other.bNeedDataAlignment
+            && self.DelayBetweenRead == other.DelayBetweenRead
+            && self.MaxBufferSize == other.MaxBufferSize
+            && self.DeviceIOHandles == other.DeviceIOHandles
+            && self.lReserved == other.lReserved
+            && self.pMicroDriverContext == other.pMicroDriverContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4970,7 +5005,7 @@ unsafe impl ::windows::core::Abi for SCANWINDOW {
 }
 impl ::core::cmp::PartialEq for SCANWINDOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCANWINDOW>()) == 0 }
+        self.xPos == other.xPos && self.yPos == other.yPos && self.xExtent == other.xExtent && self.yExtent == other.yExtent
     }
 }
 impl ::core::cmp::Eq for SCANWINDOW {}
@@ -5007,7 +5042,7 @@ unsafe impl ::windows::core::Abi for TWAIN_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for TWAIN_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TWAIN_CAPABILITY>()) == 0 }
+        self.lSize == other.lSize && self.lMSG == other.lMSG && self.lCapID == other.lCapID && self.lConType == other.lConType && self.lRC == other.lRC && self.lCC == other.lCC && self.lDataSize == other.lDataSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for TWAIN_CAPABILITY {}
@@ -5051,7 +5086,7 @@ unsafe impl ::windows::core::Abi for VAL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VAL>()) == 0 }
+        self.lVal == other.lVal && self.dblVal == other.dblVal && self.pGuid == other.pGuid && self.pScanInfo == other.pScanInfo && self.handle == other.handle && self.ppButtonNames == other.ppButtonNames && self.pHandle == other.pHandle && self.lReserved == other.lReserved && self.szVal == other.szVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5082,14 +5117,6 @@ unsafe impl ::windows::core::Abi for WIAS_CHANGED_VALUE_INFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WIAS_CHANGED_VALUE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.bChanged == other.bChanged && self.vt == other.vt && self.Old == other.Old && self.Current == other.Current
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WIAS_CHANGED_VALUE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WIAS_CHANGED_VALUE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5115,14 +5142,6 @@ unsafe impl ::windows::core::Abi for WIAS_CHANGED_VALUE_INFO_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WIAS_CHANGED_VALUE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIAS_CHANGED_VALUE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WIAS_CHANGED_VALUE_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WIAS_CHANGED_VALUE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5147,14 +5166,6 @@ impl ::core::clone::Clone for WIAS_CHANGED_VALUE_INFO_1 {
 unsafe impl ::windows::core::Abi for WIAS_CHANGED_VALUE_INFO_1 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WIAS_CHANGED_VALUE_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIAS_CHANGED_VALUE_INFO_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WIAS_CHANGED_VALUE_INFO_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WIAS_CHANGED_VALUE_INFO_1 {
     fn default() -> Self {
@@ -5206,7 +5217,7 @@ unsafe impl ::windows::core::Abi for WIAS_DOWN_SAMPLE_INFO {
 }
 impl ::core::cmp::PartialEq for WIAS_DOWN_SAMPLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIAS_DOWN_SAMPLE_INFO>()) == 0 }
+        self.ulOriginalWidth == other.ulOriginalWidth && self.ulOriginalHeight == other.ulOriginalHeight && self.ulBitsPerPixel == other.ulBitsPerPixel && self.ulXRes == other.ulXRes && self.ulYRes == other.ulYRes && self.ulDownSampledWidth == other.ulDownSampledWidth && self.ulDownSampledHeight == other.ulDownSampledHeight && self.ulActualSize == other.ulActualSize && self.ulDestBufSize == other.ulDestBufSize && self.ulSrcBufSize == other.ulSrcBufSize && self.pSrcBuffer == other.pSrcBuffer && self.pDestBuffer == other.pDestBuffer
     }
 }
 impl ::core::cmp::Eq for WIAS_DOWN_SAMPLE_INFO {}
@@ -5238,7 +5249,7 @@ unsafe impl ::windows::core::Abi for WIAS_ENDORSER_INFO {
 }
 impl ::core::cmp::PartialEq for WIAS_ENDORSER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIAS_ENDORSER_INFO>()) == 0 }
+        self.ulPageCount == other.ulPageCount && self.ulNumEndorserValues == other.ulNumEndorserValues && self.pEndorserValues == other.pEndorserValues
     }
 }
 impl ::core::cmp::Eq for WIAS_ENDORSER_INFO {}
@@ -5269,7 +5280,7 @@ unsafe impl ::windows::core::Abi for WIAS_ENDORSER_VALUE {
 }
 impl ::core::cmp::PartialEq for WIAS_ENDORSER_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIAS_ENDORSER_VALUE>()) == 0 }
+        self.wszTokenName == other.wszTokenName && self.wszValue == other.wszValue
     }
 }
 impl ::core::cmp::Eq for WIAS_ENDORSER_VALUE {}
@@ -5303,7 +5314,7 @@ unsafe impl ::windows::core::Abi for WIA_BARCODES {
 }
 impl ::core::cmp::PartialEq for WIA_BARCODES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_BARCODES>()) == 0 }
+        self.Tag == other.Tag && self.Version == other.Version && self.Size == other.Size && self.Count == other.Count && self.Barcodes == other.Barcodes
     }
 }
 impl ::core::cmp::Eq for WIA_BARCODES {}
@@ -5341,7 +5352,7 @@ unsafe impl ::windows::core::Abi for WIA_BARCODE_INFO {
 }
 impl ::core::cmp::PartialEq for WIA_BARCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_BARCODE_INFO>()) == 0 }
+        self.Size == other.Size && self.Type == other.Type && self.Page == other.Page && self.Confidence == other.Confidence && self.XOffset == other.XOffset && self.YOffset == other.YOffset && self.Rotation == other.Rotation && self.Length == other.Length && self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for WIA_BARCODE_INFO {}
@@ -5374,7 +5385,7 @@ unsafe impl ::windows::core::Abi for WIA_DATA_CALLBACK_HEADER {
 }
 impl ::core::cmp::PartialEq for WIA_DATA_CALLBACK_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_DATA_CALLBACK_HEADER>()) == 0 }
+        self.lSize == other.lSize && self.guidFormatID == other.guidFormatID && self.lBufferSize == other.lBufferSize && self.lPageCount == other.lPageCount
     }
 }
 impl ::core::cmp::Eq for WIA_DATA_CALLBACK_HEADER {}
@@ -5416,7 +5427,7 @@ unsafe impl ::windows::core::Abi for WIA_DATA_TRANSFER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIA_DATA_TRANSFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_DATA_TRANSFER_INFO>()) == 0 }
+        self.ulSize == other.ulSize && self.ulSection == other.ulSection && self.ulBufferSize == other.ulBufferSize && self.bDoubleBuffer == other.bDoubleBuffer && self.ulReserved1 == other.ulReserved1 && self.ulReserved2 == other.ulReserved2 && self.ulReserved3 == other.ulReserved3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5493,7 +5504,7 @@ unsafe impl ::windows::core::Abi for WIA_DEV_CAP_DRV {
 }
 impl ::core::cmp::PartialEq for WIA_DEV_CAP_DRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_DEV_CAP_DRV>()) == 0 }
+        self.guid == other.guid && self.ulFlags == other.ulFlags && self.wszName == other.wszName && self.wszDescription == other.wszDescription && self.wszIcon == other.wszIcon
     }
 }
 impl ::core::cmp::Eq for WIA_DEV_CAP_DRV {}
@@ -5568,7 +5579,7 @@ unsafe impl ::windows::core::Abi for WIA_EXTENDED_TRANSFER_INFO {
 }
 impl ::core::cmp::PartialEq for WIA_EXTENDED_TRANSFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_EXTENDED_TRANSFER_INFO>()) == 0 }
+        self.ulSize == other.ulSize && self.ulMinBufferSize == other.ulMinBufferSize && self.ulOptimalBufferSize == other.ulOptimalBufferSize && self.ulMaxBufferSize == other.ulMaxBufferSize && self.ulNumBuffers == other.ulNumBuffers
     }
 }
 impl ::core::cmp::Eq for WIA_EXTENDED_TRANSFER_INFO {}
@@ -5599,7 +5610,7 @@ unsafe impl ::windows::core::Abi for WIA_FORMAT_INFO {
 }
 impl ::core::cmp::PartialEq for WIA_FORMAT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_FORMAT_INFO>()) == 0 }
+        self.guidFormatID == other.guidFormatID && self.lTymed == other.lTymed
     }
 }
 impl ::core::cmp::Eq for WIA_FORMAT_INFO {}
@@ -5635,7 +5646,7 @@ unsafe impl ::windows::core::Abi for WIA_MICR {
 }
 impl ::core::cmp::PartialEq for WIA_MICR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_MICR>()) == 0 }
+        self.Tag == other.Tag && self.Version == other.Version && self.Size == other.Size && self.Placeholder == other.Placeholder && self.Reserved == other.Reserved && self.Count == other.Count && self.Micr == other.Micr
     }
 }
 impl ::core::cmp::Eq for WIA_MICR {}
@@ -5668,7 +5679,7 @@ unsafe impl ::windows::core::Abi for WIA_MICR_INFO {
 }
 impl ::core::cmp::PartialEq for WIA_MICR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_MICR_INFO>()) == 0 }
+        self.Size == other.Size && self.Page == other.Page && self.Length == other.Length && self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for WIA_MICR_INFO {}
@@ -5702,7 +5713,7 @@ unsafe impl ::windows::core::Abi for WIA_PATCH_CODES {
 }
 impl ::core::cmp::PartialEq for WIA_PATCH_CODES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PATCH_CODES>()) == 0 }
+        self.Tag == other.Tag && self.Version == other.Version && self.Size == other.Size && self.Count == other.Count && self.PatchCodes == other.PatchCodes
     }
 }
 impl ::core::cmp::Eq for WIA_PATCH_CODES {}
@@ -5732,7 +5743,7 @@ unsafe impl ::windows::core::Abi for WIA_PATCH_CODE_INFO {
 }
 impl ::core::cmp::PartialEq for WIA_PATCH_CODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PATCH_CODE_INFO>()) == 0 }
+        self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for WIA_PATCH_CODE_INFO {}
@@ -5770,7 +5781,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_CONTEXT>()) == 0 }
+        self.cProps == other.cProps && self.pProps == other.pProps && self.pChanged == other.pChanged
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5800,14 +5811,6 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.lAccessFlags == other.lAccessFlags && self.vt == other.vt && self.ValidVal == other.ValidVal
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for WIA_PROPERTY_INFO {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for WIA_PROPERTY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5836,14 +5839,6 @@ impl ::core::clone::Clone for WIA_PROPERTY_INFO_0 {
 unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for WIA_PROPERTY_INFO_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for WIA_PROPERTY_INFO_0 {
     fn default() -> Self {
@@ -5878,7 +5873,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_0 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_0>()) == 0 }
+        self.Nom == other.Nom && self.ValidBits == other.ValidBits
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -5956,7 +5951,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_2 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_2>()) == 0 }
+        self.cNumList == other.cNumList && self.Nom == other.Nom && self.pList == other.pList
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -5996,7 +5991,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_3 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_3>()) == 0 }
+        self.cNumList == other.cNumList && self.Nom == other.Nom && self.pList == other.pList
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -6036,7 +6031,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_4 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_4>()) == 0 }
+        self.cNumList == other.cNumList && self.Nom == other.Nom && self.pList == other.pList
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -6074,7 +6069,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_5 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_5>()) == 0 }
+        self.Dummy == other.Dummy
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -6115,7 +6110,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_6 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_6>()) == 0 }
+        self.Min == other.Min && self.Nom == other.Nom && self.Max == other.Max && self.Inc == other.Inc
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -6156,7 +6151,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPERTY_INFO_0_7 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for WIA_PROPERTY_INFO_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPERTY_INFO_0_7>()) == 0 }
+        self.Min == other.Min && self.Nom == other.Nom && self.Max == other.Max && self.Inc == other.Inc
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -6189,7 +6184,7 @@ unsafe impl ::windows::core::Abi for WIA_PROPID_TO_NAME {
 }
 impl ::core::cmp::PartialEq for WIA_PROPID_TO_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_PROPID_TO_NAME>()) == 0 }
+        self.propid == other.propid && self.pszName == other.pszName
     }
 }
 impl ::core::cmp::Eq for WIA_PROPID_TO_NAME {}
@@ -6257,7 +6252,7 @@ unsafe impl ::windows::core::Abi for WIA_RAW_HEADER {
 }
 impl ::core::cmp::PartialEq for WIA_RAW_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIA_RAW_HEADER>()) == 0 }
+        self.Tag == other.Tag && self.Version == other.Version && self.HeaderSize == other.HeaderSize && self.XRes == other.XRes && self.YRes == other.YRes && self.XExtent == other.XExtent && self.YExtent == other.YExtent && self.BytesPerLine == other.BytesPerLine && self.BitsPerPixel == other.BitsPerPixel && self.ChannelsPerPixel == other.ChannelsPerPixel && self.DataType == other.DataType && self.BitsPerChannel == other.BitsPerChannel && self.Compression == other.Compression && self.PhotometricInterp == other.PhotometricInterp && self.LineOrder == other.LineOrder && self.RawDataOffset == other.RawDataOffset && self.RawDataSize == other.RawDataSize && self.PaletteOffset == other.PaletteOffset && self.PaletteSize == other.PaletteSize
     }
 }
 impl ::core::cmp::Eq for WIA_RAW_HEADER {}
@@ -6290,7 +6285,7 @@ unsafe impl ::windows::core::Abi for WiaTransferParams {
 }
 impl ::core::cmp::PartialEq for WiaTransferParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WiaTransferParams>()) == 0 }
+        self.lMessage == other.lMessage && self.lPercentComplete == other.lPercentComplete && self.ulTransferredBytes == other.ulTransferredBytes && self.hrErrorStatus == other.hrErrorStatus
     }
 }
 impl ::core::cmp::Eq for WiaTransferParams {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
@@ -6542,7 +6542,7 @@ unsafe impl ::windows::core::Abi for WPD_COMMAND_ACCESS_LOOKUP_ENTRY {
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ::core::cmp::PartialEq for WPD_COMMAND_ACCESS_LOOKUP_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WPD_COMMAND_ACCESS_LOOKUP_ENTRY>()) == 0 }
+        self.Command == other.Command && self.AccessType == other.AccessType && self.AccessProperty == other.AccessProperty
     }
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
@@ -504,7 +504,7 @@ unsafe impl ::windows::core::Abi for DEVPROPCOMPKEY {
 }
 impl ::core::cmp::PartialEq for DEVPROPCOMPKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPROPCOMPKEY>()) == 0 }
+        self.Key == other.Key && self.Store == other.Store && self.LocaleName == other.LocaleName
     }
 }
 impl ::core::cmp::Eq for DEVPROPCOMPKEY {}
@@ -537,7 +537,7 @@ unsafe impl ::windows::core::Abi for DEVPROPERTY {
 }
 impl ::core::cmp::PartialEq for DEVPROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPROPERTY>()) == 0 }
+        self.CompKey == other.CompKey && self.Type == other.Type && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for DEVPROPERTY {}
@@ -568,7 +568,7 @@ unsafe impl ::windows::core::Abi for DEVPROPKEY {
 }
 impl ::core::cmp::PartialEq for DEVPROPKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVPROPKEY>()) == 0 }
+        self.fmtid == other.fmtid && self.pid == other.pid
     }
 }
 impl ::core::cmp::Eq for DEVPROPKEY {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
@@ -89,7 +89,7 @@ unsafe impl ::windows::core::Abi for PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT {
 }
 impl ::core::cmp::PartialEq for PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT>()) == 0 }
+        self.ActualPeriod == other.ActualPeriod
     }
 }
 impl ::core::cmp::Eq for PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT {}
@@ -122,7 +122,7 @@ unsafe impl ::windows::core::Abi for PWM_CONTROLLER_INFO {
 }
 impl ::core::cmp::PartialEq for PWM_CONTROLLER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_CONTROLLER_INFO>()) == 0 }
+        self.Size == other.Size && self.PinCount == other.PinCount && self.MinimumPeriod == other.MinimumPeriod && self.MaximumPeriod == other.MaximumPeriod
     }
 }
 impl ::core::cmp::Eq for PWM_CONTROLLER_INFO {}
@@ -152,7 +152,7 @@ unsafe impl ::windows::core::Abi for PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {
 }
 impl ::core::cmp::PartialEq for PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT>()) == 0 }
+        self.DesiredPeriod == other.DesiredPeriod
     }
 }
 impl ::core::cmp::Eq for PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {}
@@ -182,7 +182,7 @@ unsafe impl ::windows::core::Abi for PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {
 }
 impl ::core::cmp::PartialEq for PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT>()) == 0 }
+        self.ActualPeriod == other.ActualPeriod
     }
 }
 impl ::core::cmp::Eq for PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {}
@@ -212,7 +212,7 @@ unsafe impl ::windows::core::Abi for PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OU
 }
 impl ::core::cmp::PartialEq for PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OUTPUT>()) == 0 }
+        self.Percentage == other.Percentage
     }
 }
 impl ::core::cmp::Eq for PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OUTPUT {}
@@ -242,7 +242,7 @@ unsafe impl ::windows::core::Abi for PWM_PIN_GET_POLARITY_OUTPUT {
 }
 impl ::core::cmp::PartialEq for PWM_PIN_GET_POLARITY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_PIN_GET_POLARITY_OUTPUT>()) == 0 }
+        self.Polarity == other.Polarity
     }
 }
 impl ::core::cmp::Eq for PWM_PIN_GET_POLARITY_OUTPUT {}
@@ -278,7 +278,7 @@ unsafe impl ::windows::core::Abi for PWM_PIN_IS_STARTED_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PWM_PIN_IS_STARTED_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_PIN_IS_STARTED_OUTPUT>()) == 0 }
+        self.IsStarted == other.IsStarted
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -310,7 +310,7 @@ unsafe impl ::windows::core::Abi for PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_IN
 }
 impl ::core::cmp::PartialEq for PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT>()) == 0 }
+        self.Percentage == other.Percentage
     }
 }
 impl ::core::cmp::Eq for PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT {}
@@ -340,7 +340,7 @@ unsafe impl ::windows::core::Abi for PWM_PIN_SET_POLARITY_INPUT {
 }
 impl ::core::cmp::PartialEq for PWM_PIN_SET_POLARITY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PWM_PIN_SET_POLARITY_INPUT>()) == 0 }
+        self.Polarity == other.Polarity
     }
 }
 impl ::core::cmp::Eq for PWM_PIN_SET_POLARITY_INPUT {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
@@ -1988,12 +1988,6 @@ impl ::core::clone::Clone for MATRIX3X3 {
 unsafe impl ::windows::core::Abi for MATRIX3X3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MATRIX3X3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MATRIX3X3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MATRIX3X3 {}
 impl ::core::default::Default for MATRIX3X3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2015,12 +2009,6 @@ impl ::core::clone::Clone for MATRIX3X3_0 {
 unsafe impl ::windows::core::Abi for MATRIX3X3_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MATRIX3X3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MATRIX3X3_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MATRIX3X3_0 {}
 impl ::core::default::Default for MATRIX3X3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2055,7 +2043,7 @@ unsafe impl ::windows::core::Abi for MATRIX3X3_0_0 {
 }
 impl ::core::cmp::PartialEq for MATRIX3X3_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MATRIX3X3_0_0>()) == 0 }
+        self.A11 == other.A11 && self.A12 == other.A12 && self.A13 == other.A13 && self.A21 == other.A21 && self.A22 == other.A22 && self.A23 == other.A23 && self.A31 == other.A31 && self.A32 == other.A32 && self.A33 == other.A33
     }
 }
 impl ::core::cmp::Eq for MATRIX3X3_0_0 {}
@@ -2087,7 +2075,7 @@ unsafe impl ::windows::core::Abi for MATRIX3X3_0_1 {
 }
 impl ::core::cmp::PartialEq for MATRIX3X3_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MATRIX3X3_0_1>()) == 0 }
+        self.V1 == other.V1 && self.V2 == other.V2 && self.V3 == other.V3
     }
 }
 impl ::core::cmp::Eq for MATRIX3X3_0_1 {}
@@ -2120,7 +2108,7 @@ unsafe impl ::windows::core::Abi for QUATERNION {
 }
 impl ::core::cmp::PartialEq for QUATERNION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUATERNION>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.W == other.W
     }
 }
 impl ::core::cmp::Eq for QUATERNION {}
@@ -2147,14 +2135,6 @@ impl ::core::clone::Clone for SENSOR_COLLECTION_LIST {
 unsafe impl ::windows::core::Abi for SENSOR_COLLECTION_LIST {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::PartialEq for SENSOR_COLLECTION_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        self.AllocatedSizeInBytes == other.AllocatedSizeInBytes && self.Count == other.Count && self.List == other.List
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::Eq for SENSOR_COLLECTION_LIST {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ::core::default::Default for SENSOR_COLLECTION_LIST {
     fn default() -> Self {
@@ -2190,7 +2170,7 @@ unsafe impl ::windows::core::Abi for SENSOR_PROPERTY_LIST {
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ::core::cmp::PartialEq for SENSOR_PROPERTY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENSOR_PROPERTY_LIST>()) == 0 }
+        self.AllocatedSizeInBytes == other.AllocatedSizeInBytes && self.Count == other.Count && self.List == other.List
     }
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -2218,14 +2198,6 @@ impl ::core::clone::Clone for SENSOR_VALUE_PAIR {
 unsafe impl ::windows::core::Abi for SENSOR_VALUE_PAIR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::PartialEq for SENSOR_VALUE_PAIR {
-    fn eq(&self, other: &Self) -> bool {
-        self.Key == other.Key && self.Value == other.Value
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::Eq for SENSOR_VALUE_PAIR {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ::core::default::Default for SENSOR_VALUE_PAIR {
     fn default() -> Self {
@@ -2255,7 +2227,7 @@ unsafe impl ::windows::core::Abi for VEC3D {
 }
 impl ::core::cmp::PartialEq for VEC3D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VEC3D>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z
     }
 }
 impl ::core::cmp::Eq for VEC3D {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -16009,7 +16009,7 @@ unsafe impl ::windows::core::Abi for ADDRALIAS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRALIAS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRALIAS>()) == 0 }
+        self.rgchName == other.rgchName && self.rgchEName == other.rgchEName && self.rgchSrvr == other.rgchSrvr && self.dibDetail == other.dibDetail && self.r#type == other.r#type
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16040,12 +16040,6 @@ impl ::core::clone::Clone for DTR {
 unsafe impl ::windows::core::Abi for DTR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DTR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DTR {}
 impl ::core::default::Default for DTR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16072,7 +16066,7 @@ unsafe impl ::windows::core::Abi for HDRVCALL__ {
 }
 impl ::core::cmp::PartialEq for HDRVCALL__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDRVCALL__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDRVCALL__ {}
@@ -16102,7 +16096,7 @@ unsafe impl ::windows::core::Abi for HDRVDIALOGINSTANCE__ {
 }
 impl ::core::cmp::PartialEq for HDRVDIALOGINSTANCE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDRVDIALOGINSTANCE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDRVDIALOGINSTANCE__ {}
@@ -16132,7 +16126,7 @@ unsafe impl ::windows::core::Abi for HDRVLINE__ {
 }
 impl ::core::cmp::PartialEq for HDRVLINE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDRVLINE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDRVLINE__ {}
@@ -16162,7 +16156,7 @@ unsafe impl ::windows::core::Abi for HDRVMSPLINE__ {
 }
 impl ::core::cmp::PartialEq for HDRVMSPLINE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDRVMSPLINE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDRVMSPLINE__ {}
@@ -16192,7 +16186,7 @@ unsafe impl ::windows::core::Abi for HDRVPHONE__ {
 }
 impl ::core::cmp::PartialEq for HDRVPHONE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDRVPHONE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HDRVPHONE__ {}
@@ -16222,7 +16216,7 @@ unsafe impl ::windows::core::Abi for HPROVIDER__ {
 }
 impl ::core::cmp::PartialEq for HPROVIDER__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HPROVIDER__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HPROVIDER__ {}
@@ -16252,7 +16246,7 @@ unsafe impl ::windows::core::Abi for HTAPICALL__ {
 }
 impl ::core::cmp::PartialEq for HTAPICALL__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTAPICALL__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HTAPICALL__ {}
@@ -16282,7 +16276,7 @@ unsafe impl ::windows::core::Abi for HTAPILINE__ {
 }
 impl ::core::cmp::PartialEq for HTAPILINE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTAPILINE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HTAPILINE__ {}
@@ -16312,7 +16306,7 @@ unsafe impl ::windows::core::Abi for HTAPIPHONE__ {
 }
 impl ::core::cmp::PartialEq for HTAPIPHONE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTAPIPHONE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HTAPIPHONE__ {}
@@ -16391,12 +16385,6 @@ impl ::core::clone::Clone for LINEADDRESSCAPS {
 unsafe impl ::windows::core::Abi for LINEADDRESSCAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEADDRESSCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEADDRESSCAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEADDRESSCAPS {}
 impl ::core::default::Default for LINEADDRESSCAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16431,12 +16419,6 @@ impl ::core::clone::Clone for LINEADDRESSSTATUS {
 unsafe impl ::windows::core::Abi for LINEADDRESSSTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEADDRESSSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEADDRESSSTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEADDRESSSTATUS {}
 impl ::core::default::Default for LINEADDRESSSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16458,12 +16440,6 @@ impl ::core::clone::Clone for LINEAGENTACTIVITYENTRY {
 unsafe impl ::windows::core::Abi for LINEAGENTACTIVITYENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTACTIVITYENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTACTIVITYENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTACTIVITYENTRY {}
 impl ::core::default::Default for LINEAGENTACTIVITYENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16488,12 +16464,6 @@ impl ::core::clone::Clone for LINEAGENTACTIVITYLIST {
 unsafe impl ::windows::core::Abi for LINEAGENTACTIVITYLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTACTIVITYLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTACTIVITYLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTACTIVITYLIST {}
 impl ::core::default::Default for LINEAGENTACTIVITYLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16527,12 +16497,6 @@ impl ::core::clone::Clone for LINEAGENTCAPS {
 unsafe impl ::windows::core::Abi for LINEAGENTCAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTCAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTCAPS {}
 impl ::core::default::Default for LINEAGENTCAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16558,12 +16522,6 @@ impl ::core::clone::Clone for LINEAGENTENTRY {
 unsafe impl ::windows::core::Abi for LINEAGENTENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTENTRY {}
 impl ::core::default::Default for LINEAGENTENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16585,12 +16543,6 @@ impl ::core::clone::Clone for LINEAGENTGROUPENTRY {
 unsafe impl ::windows::core::Abi for LINEAGENTGROUPENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTGROUPENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTGROUPENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTGROUPENTRY {}
 impl ::core::default::Default for LINEAGENTGROUPENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16613,12 +16565,6 @@ impl ::core::clone::Clone for LINEAGENTGROUPENTRY_0 {
 unsafe impl ::windows::core::Abi for LINEAGENTGROUPENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTGROUPENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTGROUPENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTGROUPENTRY_0 {}
 impl ::core::default::Default for LINEAGENTGROUPENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16643,12 +16589,6 @@ impl ::core::clone::Clone for LINEAGENTGROUPLIST {
 unsafe impl ::windows::core::Abi for LINEAGENTGROUPLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTGROUPLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTGROUPLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTGROUPLIST {}
 impl ::core::default::Default for LINEAGENTGROUPLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16685,14 +16625,6 @@ unsafe impl ::windows::core::Abi for LINEAGENTINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEAGENTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEAGENTINFO {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEAGENTINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16717,12 +16649,6 @@ impl ::core::clone::Clone for LINEAGENTLIST {
 unsafe impl ::windows::core::Abi for LINEAGENTLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTLIST {}
 impl ::core::default::Default for LINEAGENTLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16745,12 +16671,6 @@ impl ::core::clone::Clone for LINEAGENTSESSIONENTRY {
 unsafe impl ::windows::core::Abi for LINEAGENTSESSIONENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTSESSIONENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTSESSIONENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTSESSIONENTRY {}
 impl ::core::default::Default for LINEAGENTSESSIONENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16791,14 +16711,6 @@ unsafe impl ::windows::core::Abi for LINEAGENTSESSIONINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEAGENTSESSIONINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTSESSIONINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEAGENTSESSIONINFO {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEAGENTSESSIONINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16823,12 +16735,6 @@ impl ::core::clone::Clone for LINEAGENTSESSIONLIST {
 unsafe impl ::windows::core::Abi for LINEAGENTSESSIONLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTSESSIONLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTSESSIONLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTSESSIONLIST {}
 impl ::core::default::Default for LINEAGENTSESSIONLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16861,12 +16767,6 @@ impl ::core::clone::Clone for LINEAGENTSTATUS {
 unsafe impl ::windows::core::Abi for LINEAGENTSTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAGENTSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAGENTSTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAGENTSTATUS {}
 impl ::core::default::Default for LINEAGENTSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16895,12 +16795,6 @@ impl ::core::clone::Clone for LINEAPPINFO {
 unsafe impl ::windows::core::Abi for LINEAPPINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEAPPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEAPPINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEAPPINFO {}
 impl ::core::default::Default for LINEAPPINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16997,12 +16891,6 @@ impl ::core::clone::Clone for LINECALLINFO {
 unsafe impl ::windows::core::Abi for LINECALLINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECALLINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECALLINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECALLINFO {}
 impl ::core::default::Default for LINECALLINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17027,12 +16915,6 @@ impl ::core::clone::Clone for LINECALLLIST {
 unsafe impl ::windows::core::Abi for LINECALLLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECALLLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECALLLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECALLLIST {}
 impl ::core::default::Default for LINECALLLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17092,12 +16974,6 @@ impl ::core::clone::Clone for LINECALLPARAMS {
 unsafe impl ::windows::core::Abi for LINECALLPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECALLPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECALLPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECALLPARAMS {}
 impl ::core::default::Default for LINECALLPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17132,14 +17008,6 @@ unsafe impl ::windows::core::Abi for LINECALLSTATUS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LINECALLSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECALLSTATUS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LINECALLSTATUS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LINECALLSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17161,12 +17029,6 @@ impl ::core::clone::Clone for LINECALLTREATMENTENTRY {
 unsafe impl ::windows::core::Abi for LINECALLTREATMENTENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECALLTREATMENTENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECALLTREATMENTENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECALLTREATMENTENTRY {}
 impl ::core::default::Default for LINECALLTREATMENTENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17196,12 +17058,6 @@ impl ::core::clone::Clone for LINECARDENTRY {
 unsafe impl ::windows::core::Abi for LINECARDENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECARDENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECARDENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECARDENTRY {}
 impl ::core::default::Default for LINECARDENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17231,12 +17087,6 @@ impl ::core::clone::Clone for LINECOUNTRYENTRY {
 unsafe impl ::windows::core::Abi for LINECOUNTRYENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECOUNTRYENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECOUNTRYENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECOUNTRYENTRY {}
 impl ::core::default::Default for LINECOUNTRYENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17261,12 +17111,6 @@ impl ::core::clone::Clone for LINECOUNTRYLIST {
 unsafe impl ::windows::core::Abi for LINECOUNTRYLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINECOUNTRYLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINECOUNTRYLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINECOUNTRYLIST {}
 impl ::core::default::Default for LINECOUNTRYLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17340,12 +17184,6 @@ impl ::core::clone::Clone for LINEDEVCAPS {
 unsafe impl ::windows::core::Abi for LINEDEVCAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEDEVCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEDEVCAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEDEVCAPS {}
 impl ::core::default::Default for LINEDEVCAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17386,12 +17224,6 @@ impl ::core::clone::Clone for LINEDEVSTATUS {
 unsafe impl ::windows::core::Abi for LINEDEVSTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEDEVSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEDEVSTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEDEVSTATUS {}
 impl ::core::default::Default for LINEDEVSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17414,12 +17246,6 @@ impl ::core::clone::Clone for LINEDIALPARAMS {
 unsafe impl ::windows::core::Abi for LINEDIALPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEDIALPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEDIALPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEDIALPARAMS {}
 impl ::core::default::Default for LINEDIALPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17442,12 +17268,6 @@ impl ::core::clone::Clone for LINEEXTENSIONID {
 unsafe impl ::windows::core::Abi for LINEEXTENSIONID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEEXTENSIONID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEEXTENSIONID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEEXTENSIONID {}
 impl ::core::default::Default for LINEEXTENSIONID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17472,12 +17292,6 @@ impl ::core::clone::Clone for LINEFORWARD {
 unsafe impl ::windows::core::Abi for LINEFORWARD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEFORWARD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEFORWARD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEFORWARD {}
 impl ::core::default::Default for LINEFORWARD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17499,12 +17313,6 @@ impl ::core::clone::Clone for LINEFORWARDLIST {
 unsafe impl ::windows::core::Abi for LINEFORWARDLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEFORWARDLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEFORWARDLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEFORWARDLIST {}
 impl ::core::default::Default for LINEFORWARDLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17527,12 +17335,6 @@ impl ::core::clone::Clone for LINEGENERATETONE {
 unsafe impl ::windows::core::Abi for LINEGENERATETONE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEGENERATETONE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEGENERATETONE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEGENERATETONE {}
 impl ::core::default::Default for LINEGENERATETONE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17562,14 +17364,6 @@ unsafe impl ::windows::core::Abi for LINEINITIALIZEEXPARAMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LINEINITIALIZEEXPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEINITIALIZEEXPARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LINEINITIALIZEEXPARAMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LINEINITIALIZEEXPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17594,14 +17388,6 @@ impl ::core::clone::Clone for LINEINITIALIZEEXPARAMS_0 {
 unsafe impl ::windows::core::Abi for LINEINITIALIZEEXPARAMS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LINEINITIALIZEEXPARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEINITIALIZEEXPARAMS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LINEINITIALIZEEXPARAMS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LINEINITIALIZEEXPARAMS_0 {
     fn default() -> Self {
@@ -17638,12 +17424,6 @@ impl ::core::clone::Clone for LINELOCATIONENTRY {
 unsafe impl ::windows::core::Abi for LINELOCATIONENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINELOCATIONENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINELOCATIONENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINELOCATIONENTRY {}
 impl ::core::default::Default for LINELOCATIONENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17664,12 +17444,6 @@ impl ::core::clone::Clone for LINEMEDIACONTROLCALLSTATE {
 unsafe impl ::windows::core::Abi for LINEMEDIACONTROLCALLSTATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMEDIACONTROLCALLSTATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMEDIACONTROLCALLSTATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMEDIACONTROLCALLSTATE {}
 impl ::core::default::Default for LINEMEDIACONTROLCALLSTATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17691,12 +17465,6 @@ impl ::core::clone::Clone for LINEMEDIACONTROLDIGIT {
 unsafe impl ::windows::core::Abi for LINEMEDIACONTROLDIGIT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMEDIACONTROLDIGIT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMEDIACONTROLDIGIT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMEDIACONTROLDIGIT {}
 impl ::core::default::Default for LINEMEDIACONTROLDIGIT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17718,12 +17486,6 @@ impl ::core::clone::Clone for LINEMEDIACONTROLMEDIA {
 unsafe impl ::windows::core::Abi for LINEMEDIACONTROLMEDIA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMEDIACONTROLMEDIA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMEDIACONTROLMEDIA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMEDIACONTROLMEDIA {}
 impl ::core::default::Default for LINEMEDIACONTROLMEDIA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17748,12 +17510,6 @@ impl ::core::clone::Clone for LINEMEDIACONTROLTONE {
 unsafe impl ::windows::core::Abi for LINEMEDIACONTROLTONE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMEDIACONTROLTONE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMEDIACONTROLTONE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMEDIACONTROLTONE {}
 impl ::core::default::Default for LINEMEDIACONTROLTONE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17778,12 +17534,6 @@ impl ::core::clone::Clone for LINEMESSAGE {
 unsafe impl ::windows::core::Abi for LINEMESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMESSAGE {}
 impl ::core::default::Default for LINEMESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17807,12 +17557,6 @@ impl ::core::clone::Clone for LINEMONITORTONE {
 unsafe impl ::windows::core::Abi for LINEMONITORTONE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEMONITORTONE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEMONITORTONE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEMONITORTONE {}
 impl ::core::default::Default for LINEMONITORTONE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17834,12 +17578,6 @@ impl ::core::clone::Clone for LINEPROVIDERENTRY {
 unsafe impl ::windows::core::Abi for LINEPROVIDERENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEPROVIDERENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROVIDERENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEPROVIDERENTRY {}
 impl ::core::default::Default for LINEPROVIDERENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17864,12 +17602,6 @@ impl ::core::clone::Clone for LINEPROVIDERLIST {
 unsafe impl ::windows::core::Abi for LINEPROVIDERLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEPROVIDERLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROVIDERLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEPROVIDERLIST {}
 impl ::core::default::Default for LINEPROVIDERLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17900,14 +17632,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST {
     fn default() -> Self {
@@ -17952,14 +17676,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17986,14 +17702,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_0 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_0 {
     fn default() -> Self {
@@ -18024,14 +17732,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_1 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18060,14 +17760,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_2 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18092,14 +17784,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_3 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_3 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_3>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_3 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_3 {
     fn default() -> Self {
@@ -18126,14 +17810,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_4 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18158,14 +17834,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_5 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_5 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_5>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_5 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_5 {
     fn default() -> Self {
@@ -18192,14 +17860,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_6 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_6>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_6 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18224,14 +17884,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_7 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_7 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_7 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_7>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_7 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_7 {
     fn default() -> Self {
@@ -18258,14 +17910,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_8 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_8 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_8>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_8 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_8 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18291,14 +17935,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_9 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_9 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_9>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_9 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_9 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18322,14 +17958,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_10 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_10 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_10 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_10>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_10 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_10 {
     fn default() -> Self {
@@ -18356,14 +17984,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_11 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_11 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_11>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_11 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_11 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18388,14 +18008,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_12 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_12 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_12 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_12>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_12 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_12 {
     fn default() -> Self {
@@ -18422,14 +18034,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_13 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_13 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_13>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_13 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_13 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18455,14 +18059,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_14 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_14 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_14>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_14 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_14 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18487,14 +18083,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_15 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_15 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_15 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_15>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_15 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_15 {
     fn default() -> Self {
@@ -18522,14 +18110,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_16 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_16 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_16>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_16 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_16 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18555,14 +18135,6 @@ impl ::core::clone::Clone for LINEPROXYREQUEST_0_17 {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_17 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_17 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_17>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_17 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_17 {
     fn default() -> Self {
@@ -18590,14 +18162,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_18 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_18 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_18>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_18 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_18 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18623,14 +18187,6 @@ unsafe impl ::windows::core::Abi for LINEPROXYREQUEST_0_19 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for LINEPROXYREQUEST_0_19 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUEST_0_19>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for LINEPROXYREQUEST_0_19 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for LINEPROXYREQUEST_0_19 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18655,12 +18211,6 @@ impl ::core::clone::Clone for LINEPROXYREQUESTLIST {
 unsafe impl ::windows::core::Abi for LINEPROXYREQUESTLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEPROXYREQUESTLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEPROXYREQUESTLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEPROXYREQUESTLIST {}
 impl ::core::default::Default for LINEPROXYREQUESTLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18682,12 +18232,6 @@ impl ::core::clone::Clone for LINEQUEUEENTRY {
 unsafe impl ::windows::core::Abi for LINEQUEUEENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEQUEUEENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEQUEUEENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEQUEUEENTRY {}
 impl ::core::default::Default for LINEQUEUEENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18719,12 +18263,6 @@ impl ::core::clone::Clone for LINEQUEUEINFO {
 unsafe impl ::windows::core::Abi for LINEQUEUEINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEQUEUEINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEQUEUEINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEQUEUEINFO {}
 impl ::core::default::Default for LINEQUEUEINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18749,12 +18287,6 @@ impl ::core::clone::Clone for LINEQUEUELIST {
 unsafe impl ::windows::core::Abi for LINEQUEUELIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEQUEUELIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEQUEUELIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEQUEUELIST {}
 impl ::core::default::Default for LINEQUEUELIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18790,7 +18322,7 @@ unsafe impl ::windows::core::Abi for LINEREQMAKECALL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LINEREQMAKECALL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEREQMAKECALL>()) == 0 }
+        self.szDestAddress == other.szDestAddress && self.szAppName == other.szAppName && self.szCalledParty == other.szCalledParty && self.szComment == other.szComment
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18818,12 +18350,6 @@ impl ::core::clone::Clone for LINEREQMAKECALLW {
 unsafe impl ::windows::core::Abi for LINEREQMAKECALLW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINEREQMAKECALLW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEREQMAKECALLW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINEREQMAKECALLW {}
 impl ::core::default::Default for LINEREQMAKECALLW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18856,14 +18382,6 @@ impl ::core::clone::Clone for LINEREQMEDIACALL {
 unsafe impl ::windows::core::Abi for LINEREQMEDIACALL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LINEREQMEDIACALL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEREQMEDIACALL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LINEREQMEDIACALL {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LINEREQMEDIACALL {
     fn default() -> Self {
@@ -18898,14 +18416,6 @@ unsafe impl ::windows::core::Abi for LINEREQMEDIACALLW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LINEREQMEDIACALLW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINEREQMEDIACALLW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LINEREQMEDIACALLW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LINEREQMEDIACALLW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18927,12 +18437,6 @@ impl ::core::clone::Clone for LINETERMCAPS {
 unsafe impl ::windows::core::Abi for LINETERMCAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINETERMCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINETERMCAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINETERMCAPS {}
 impl ::core::default::Default for LINETERMCAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18962,12 +18466,6 @@ impl ::core::clone::Clone for LINETRANSLATECAPS {
 unsafe impl ::windows::core::Abi for LINETRANSLATECAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINETRANSLATECAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINETRANSLATECAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINETRANSLATECAPS {}
 impl ::core::default::Default for LINETRANSLATECAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18996,12 +18494,6 @@ impl ::core::clone::Clone for LINETRANSLATEOUTPUT {
 unsafe impl ::windows::core::Abi for LINETRANSLATEOUTPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LINETRANSLATEOUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINETRANSLATEOUTPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LINETRANSLATEOUTPUT {}
 impl ::core::default::Default for LINETRANSLATEOUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19026,14 +18518,6 @@ impl ::core::clone::Clone for MSP_EVENT_INFO {
 unsafe impl ::windows::core::Abi for MSP_EVENT_INFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for MSP_EVENT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwSize == other.dwSize && self.Event == other.Event && self.hCall == other.hCall && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for MSP_EVENT_INFO {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for MSP_EVENT_INFO {
     fn default() -> Self {
@@ -19063,14 +18547,6 @@ impl ::core::clone::Clone for MSP_EVENT_INFO_0 {
 unsafe impl ::windows::core::Abi for MSP_EVENT_INFO_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for MSP_EVENT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSP_EVENT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for MSP_EVENT_INFO_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for MSP_EVENT_INFO_0 {
     fn default() -> Self {
@@ -19339,7 +18815,7 @@ unsafe impl ::windows::core::Abi for MSP_EVENT_INFO_0_6 {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for MSP_EVENT_INFO_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSP_EVENT_INFO_0_6>()) == 0 }
+        self.dwBufferSize == other.dwBufferSize && self.pBuffer == other.pBuffer
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -19410,14 +18886,6 @@ unsafe impl ::windows::core::Abi for NSID {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NSID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NSID>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NSID {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NSID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19442,14 +18910,6 @@ impl ::core::clone::Clone for NSID_0 {
 unsafe impl ::windows::core::Abi for NSID_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NSID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NSID_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NSID_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NSID_0 {
     fn default() -> Self {
@@ -19479,12 +18939,6 @@ impl ::core::clone::Clone for PHONEBUTTONINFO {
 unsafe impl ::windows::core::Abi for PHONEBUTTONINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PHONEBUTTONINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONEBUTTONINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PHONEBUTTONINFO {}
 impl ::core::default::Default for PHONEBUTTONINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19549,12 +19003,6 @@ impl ::core::clone::Clone for PHONECAPS {
 unsafe impl ::windows::core::Abi for PHONECAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PHONECAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONECAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PHONECAPS {}
 impl ::core::default::Default for PHONECAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19577,12 +19025,6 @@ impl ::core::clone::Clone for PHONEEXTENSIONID {
 unsafe impl ::windows::core::Abi for PHONEEXTENSIONID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PHONEEXTENSIONID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONEEXTENSIONID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PHONEEXTENSIONID {}
 impl ::core::default::Default for PHONEEXTENSIONID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19612,14 +19054,6 @@ unsafe impl ::windows::core::Abi for PHONEINITIALIZEEXPARAMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PHONEINITIALIZEEXPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONEINITIALIZEEXPARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PHONEINITIALIZEEXPARAMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PHONEINITIALIZEEXPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19645,14 +19079,6 @@ unsafe impl ::windows::core::Abi for PHONEINITIALIZEEXPARAMS_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PHONEINITIALIZEEXPARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONEINITIALIZEEXPARAMS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PHONEINITIALIZEEXPARAMS_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PHONEINITIALIZEEXPARAMS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19677,12 +19103,6 @@ impl ::core::clone::Clone for PHONEMESSAGE {
 unsafe impl ::windows::core::Abi for PHONEMESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PHONEMESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONEMESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PHONEMESSAGE {}
 impl ::core::default::Default for PHONEMESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19727,12 +19147,6 @@ impl ::core::clone::Clone for PHONESTATUS {
 unsafe impl ::windows::core::Abi for PHONESTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PHONESTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHONESTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PHONESTATUS {}
 impl ::core::default::Default for PHONESTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19756,12 +19170,6 @@ impl ::core::clone::Clone for RENDDATA {
 unsafe impl ::windows::core::Abi for RENDDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RENDDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RENDDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RENDDATA {}
 impl ::core::default::Default for RENDDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19791,7 +19199,7 @@ unsafe impl ::windows::core::Abi for STnefProblem {
 }
 impl ::core::cmp::PartialEq for STnefProblem {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STnefProblem>()) == 0 }
+        self.ulComponent == other.ulComponent && self.ulAttribute == other.ulAttribute && self.ulPropTag == other.ulPropTag && self.scode == other.scode
     }
 }
 impl ::core::cmp::Eq for STnefProblem {}
@@ -19822,7 +19230,7 @@ unsafe impl ::windows::core::Abi for STnefProblemArray {
 }
 impl ::core::cmp::PartialEq for STnefProblemArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STnefProblemArray>()) == 0 }
+        self.cProblem == other.cProblem && self.aProblem == other.aProblem
     }
 }
 impl ::core::cmp::Eq for STnefProblemArray {}
@@ -19855,7 +19263,7 @@ unsafe impl ::windows::core::Abi for TAPI_CUSTOMTONE {
 }
 impl ::core::cmp::PartialEq for TAPI_CUSTOMTONE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPI_CUSTOMTONE>()) == 0 }
+        self.dwFrequency == other.dwFrequency && self.dwCadenceOn == other.dwCadenceOn && self.dwCadenceOff == other.dwCadenceOff && self.dwVolume == other.dwVolume
     }
 }
 impl ::core::cmp::Eq for TAPI_CUSTOMTONE {}
@@ -19889,7 +19297,7 @@ unsafe impl ::windows::core::Abi for TAPI_DETECTTONE {
 }
 impl ::core::cmp::PartialEq for TAPI_DETECTTONE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPI_DETECTTONE>()) == 0 }
+        self.dwAppSpecific == other.dwAppSpecific && self.dwDuration == other.dwDuration && self.dwFrequency1 == other.dwFrequency1 && self.dwFrequency2 == other.dwFrequency2 && self.dwFrequency3 == other.dwFrequency3
     }
 }
 impl ::core::cmp::Eq for TAPI_DETECTTONE {}
@@ -19922,7 +19330,7 @@ unsafe impl ::windows::core::Abi for TRP {
 }
 impl ::core::cmp::PartialEq for TRP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRP>()) == 0 }
+        self.trpid == other.trpid && self.cbgrtrp == other.cbgrtrp && self.cch == other.cch && self.cbRgb == other.cbRgb
     }
 }
 impl ::core::cmp::Eq for TRP {}
@@ -19957,7 +19365,7 @@ unsafe impl ::windows::core::Abi for TUISPICREATEDIALOGINSTANCEPARAMS {
 }
 impl ::core::cmp::PartialEq for TUISPICREATEDIALOGINSTANCEPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TUISPICREATEDIALOGINSTANCEPARAMS>()) == 0 }
+        self.dwRequestID == other.dwRequestID && self.hdDlgInst == other.hdDlgInst && self.htDlgInst == other.htDlgInst && self.lpszUIDLLName == other.lpszUIDLLName && self.lpParams == other.lpParams && self.dwSize == other.dwSize
     }
 }
 impl ::core::cmp::Eq for TUISPICREATEDIALOGINSTANCEPARAMS {}
@@ -19985,12 +19393,6 @@ impl ::core::clone::Clone for VARSTRING {
 unsafe impl ::windows::core::Abi for VARSTRING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VARSTRING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VARSTRING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VARSTRING {}
 impl ::core::default::Default for VARSTRING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
@@ -1894,7 +1894,7 @@ unsafe impl ::windows::core::Abi for ALTERNATE_INTERFACE {
 }
 impl ::core::cmp::PartialEq for ALTERNATE_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ALTERNATE_INTERFACE>()) == 0 }
+        self.InterfaceNumber == other.InterfaceNumber && self.AlternateInterfaceNumber == other.AlternateInterfaceNumber
     }
 }
 impl ::core::cmp::Eq for ALTERNATE_INTERFACE {}
@@ -1918,12 +1918,6 @@ impl ::core::clone::Clone for BM_REQUEST_TYPE {
 unsafe impl ::windows::core::Abi for BM_REQUEST_TYPE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BM_REQUEST_TYPE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BM_REQUEST_TYPE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BM_REQUEST_TYPE {}
 impl ::core::default::Default for BM_REQUEST_TYPE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1950,7 +1944,7 @@ unsafe impl ::windows::core::Abi for BM_REQUEST_TYPE_0 {
 }
 impl ::core::cmp::PartialEq for BM_REQUEST_TYPE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BM_REQUEST_TYPE_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for BM_REQUEST_TYPE_0 {}
@@ -1982,7 +1976,7 @@ unsafe impl ::windows::core::Abi for CHANNEL_INFO {
 }
 impl ::core::cmp::PartialEq for CHANNEL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANNEL_INFO>()) == 0 }
+        self.EventChannelSize == other.EventChannelSize && self.uReadDataAlignment == other.uReadDataAlignment && self.uWriteDataAlignment == other.uWriteDataAlignment
     }
 }
 impl ::core::cmp::Eq for CHANNEL_INFO {}
@@ -2015,7 +2009,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for DEVICE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DESCRIPTOR>()) == 0 }
+        self.usVendorId == other.usVendorId && self.usProductId == other.usProductId && self.usBcdDevice == other.usBcdDevice && self.usLanguageId == other.usLanguageId
     }
 }
 impl ::core::cmp::Eq for DEVICE_DESCRIPTOR {}
@@ -2047,7 +2041,7 @@ unsafe impl ::windows::core::Abi for DRV_VERSION {
 }
 impl ::core::cmp::PartialEq for DRV_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRV_VERSION>()) == 0 }
+        self.major == other.major && self.minor == other.minor && self.internal == other.internal
     }
 }
 impl ::core::cmp::Eq for DRV_VERSION {}
@@ -2080,7 +2074,7 @@ unsafe impl ::windows::core::Abi for IO_BLOCK {
 }
 impl ::core::cmp::PartialEq for IO_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_BLOCK>()) == 0 }
+        self.uOffset == other.uOffset && self.uLength == other.uLength && self.pbyData == other.pbyData && self.uIndex == other.uIndex
     }
 }
 impl ::core::cmp::Eq for IO_BLOCK {}
@@ -2116,7 +2110,7 @@ unsafe impl ::windows::core::Abi for IO_BLOCK_EX {
 }
 impl ::core::cmp::PartialEq for IO_BLOCK_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_BLOCK_EX>()) == 0 }
+        self.uOffset == other.uOffset && self.uLength == other.uLength && self.pbyData == other.pbyData && self.uIndex == other.uIndex && self.bRequest == other.bRequest && self.bmRequestType == other.bmRequestType && self.fTransferDirectionIn == other.fTransferDirectionIn
     }
 }
 impl ::core::cmp::Eq for IO_BLOCK_EX {}
@@ -2143,12 +2137,6 @@ impl ::core::clone::Clone for OS_STRING {
 unsafe impl ::windows::core::Abi for OS_STRING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OS_STRING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OS_STRING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OS_STRING {}
 impl ::core::default::Default for OS_STRING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2169,12 +2157,6 @@ impl ::core::clone::Clone for OS_STRING_0 {
 unsafe impl ::windows::core::Abi for OS_STRING_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OS_STRING_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OS_STRING_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OS_STRING_0 {}
 impl ::core::default::Default for OS_STRING_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2205,12 +2187,6 @@ impl ::core::clone::Clone for PACKET_PARAMETERS {
 unsafe impl ::windows::core::Abi for PACKET_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PACKET_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKET_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PACKET_PARAMETERS {}
 impl ::core::default::Default for PACKET_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2231,12 +2207,6 @@ impl ::core::clone::Clone for RAW_RESET_PORT_PARAMETERS {
 unsafe impl ::windows::core::Abi for RAW_RESET_PORT_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAW_RESET_PORT_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_RESET_PORT_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAW_RESET_PORT_PARAMETERS {}
 impl ::core::default::Default for RAW_RESET_PORT_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2258,12 +2228,6 @@ impl ::core::clone::Clone for RAW_ROOTPORT_FEATURE {
 unsafe impl ::windows::core::Abi for RAW_ROOTPORT_FEATURE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAW_ROOTPORT_FEATURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_ROOTPORT_FEATURE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAW_ROOTPORT_FEATURE {}
 impl ::core::default::Default for RAW_ROOTPORT_FEATURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2284,12 +2248,6 @@ impl ::core::clone::Clone for RAW_ROOTPORT_PARAMETERS {
 unsafe impl ::windows::core::Abi for RAW_ROOTPORT_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAW_ROOTPORT_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_ROOTPORT_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAW_ROOTPORT_PARAMETERS {}
 impl ::core::default::Default for RAW_ROOTPORT_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2309,12 +2267,6 @@ impl ::core::clone::Clone for URB {
 unsafe impl ::windows::core::Abi for URB {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for URB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URB>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for URB {}
 impl ::core::default::Default for URB {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2354,12 +2306,6 @@ impl ::core::clone::Clone for URB_0 {
 unsafe impl ::windows::core::Abi for URB_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for URB_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URB_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for URB_0 {}
 impl ::core::default::Default for URB_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2381,12 +2327,6 @@ impl ::core::clone::Clone for USBD_DEVICE_INFORMATION {
 unsafe impl ::windows::core::Abi for USBD_DEVICE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBD_DEVICE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_DEVICE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBD_DEVICE_INFORMATION {}
 impl ::core::default::Default for USBD_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2420,12 +2360,6 @@ impl ::core::clone::Clone for USBD_ENDPOINT_OFFLOAD_INFORMATION {
 unsafe impl ::windows::core::Abi for USBD_ENDPOINT_OFFLOAD_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBD_ENDPOINT_OFFLOAD_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_ENDPOINT_OFFLOAD_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBD_ENDPOINT_OFFLOAD_INFORMATION {}
 impl ::core::default::Default for USBD_ENDPOINT_OFFLOAD_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2461,7 +2395,7 @@ unsafe impl ::windows::core::Abi for USBD_INTERFACE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for USBD_INTERFACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_INTERFACE_INFORMATION>()) == 0 }
+        self.Length == other.Length && self.InterfaceNumber == other.InterfaceNumber && self.AlternateSetting == other.AlternateSetting && self.Class == other.Class && self.SubClass == other.SubClass && self.Protocol == other.Protocol && self.Reserved == other.Reserved && self.InterfaceHandle == other.InterfaceHandle && self.NumberOfPipes == other.NumberOfPipes && self.Pipes == other.Pipes
     }
 }
 impl ::core::cmp::Eq for USBD_INTERFACE_INFORMATION {}
@@ -2493,7 +2427,7 @@ unsafe impl ::windows::core::Abi for USBD_ISO_PACKET_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USBD_ISO_PACKET_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_ISO_PACKET_DESCRIPTOR>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for USBD_ISO_PACKET_DESCRIPTOR {}
@@ -2529,7 +2463,7 @@ unsafe impl ::windows::core::Abi for USBD_PIPE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for USBD_PIPE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_PIPE_INFORMATION>()) == 0 }
+        self.MaximumPacketSize == other.MaximumPacketSize && self.EndpointAddress == other.EndpointAddress && self.Interval == other.Interval && self.PipeType == other.PipeType && self.PipeHandle == other.PipeHandle && self.MaximumTransferSize == other.MaximumTransferSize && self.PipeFlags == other.PipeFlags
     }
 }
 impl ::core::cmp::Eq for USBD_PIPE_INFORMATION {}
@@ -2562,7 +2496,7 @@ unsafe impl ::windows::core::Abi for USBD_STREAM_INFORMATION {
 }
 impl ::core::cmp::PartialEq for USBD_STREAM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_STREAM_INFORMATION>()) == 0 }
+        self.PipeHandle == other.PipeHandle && self.StreamID == other.StreamID && self.MaximumTransferSize == other.MaximumTransferSize && self.PipeFlags == other.PipeFlags
     }
 }
 impl ::core::cmp::Eq for USBD_STREAM_INFORMATION {}
@@ -2593,7 +2527,7 @@ unsafe impl ::windows::core::Abi for USBD_VERSION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for USBD_VERSION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBD_VERSION_INFORMATION>()) == 0 }
+        self.USBDI_Version == other.USBDI_Version && self.Supported_USB_Version == other.Supported_USB_Version
     }
 }
 impl ::core::cmp::Eq for USBD_VERSION_INFORMATION {}
@@ -2631,7 +2565,7 @@ unsafe impl ::windows::core::Abi for USBFN_BUS_CONFIGURATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USBFN_BUS_CONFIGURATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_BUS_CONFIGURATION_INFO>()) == 0 }
+        self.ConfigurationName == other.ConfigurationName && self.IsCurrent == other.IsCurrent && self.IsActive == other.IsActive
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2666,14 +2600,6 @@ unsafe impl ::windows::core::Abi for USBFN_CLASS_INFORMATION_PACKET {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USBFN_CLASS_INFORMATION_PACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_CLASS_INFORMATION_PACKET>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USBFN_CLASS_INFORMATION_PACKET {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USBFN_CLASS_INFORMATION_PACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2703,14 +2629,6 @@ unsafe impl ::windows::core::Abi for USBFN_CLASS_INFORMATION_PACKET_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USBFN_CLASS_INFORMATION_PACKET_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_CLASS_INFORMATION_PACKET_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USBFN_CLASS_INFORMATION_PACKET_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USBFN_CLASS_INFORMATION_PACKET_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2732,12 +2650,6 @@ impl ::core::clone::Clone for USBFN_CLASS_INTERFACE {
 unsafe impl ::windows::core::Abi for USBFN_CLASS_INTERFACE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBFN_CLASS_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_CLASS_INTERFACE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBFN_CLASS_INTERFACE {}
 impl ::core::default::Default for USBFN_CLASS_INTERFACE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2760,12 +2672,6 @@ impl ::core::clone::Clone for USBFN_CLASS_INTERFACE_EX {
 unsafe impl ::windows::core::Abi for USBFN_CLASS_INTERFACE_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBFN_CLASS_INTERFACE_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_CLASS_INTERFACE_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBFN_CLASS_INTERFACE_EX {}
 impl ::core::default::Default for USBFN_CLASS_INTERFACE_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2795,7 +2701,7 @@ unsafe impl ::windows::core::Abi for USBFN_INTERFACE_INFO {
 }
 impl ::core::cmp::PartialEq for USBFN_INTERFACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_INTERFACE_INFO>()) == 0 }
+        self.InterfaceNumber == other.InterfaceNumber && self.Speed == other.Speed && self.Size == other.Size && self.InterfaceDescriptorSet == other.InterfaceDescriptorSet
     }
 }
 impl ::core::cmp::Eq for USBFN_INTERFACE_INFO {}
@@ -2819,12 +2725,6 @@ impl ::core::clone::Clone for USBFN_NOTIFICATION {
 unsafe impl ::windows::core::Abi for USBFN_NOTIFICATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBFN_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_NOTIFICATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBFN_NOTIFICATION {}
 impl ::core::default::Default for USBFN_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2848,12 +2748,6 @@ impl ::core::clone::Clone for USBFN_NOTIFICATION_0 {
 unsafe impl ::windows::core::Abi for USBFN_NOTIFICATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBFN_NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_NOTIFICATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBFN_NOTIFICATION_0 {}
 impl ::core::default::Default for USBFN_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2874,12 +2768,6 @@ impl ::core::clone::Clone for USBFN_PIPE_INFORMATION {
 unsafe impl ::windows::core::Abi for USBFN_PIPE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBFN_PIPE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_PIPE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBFN_PIPE_INFORMATION {}
 impl ::core::default::Default for USBFN_PIPE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2907,7 +2795,7 @@ unsafe impl ::windows::core::Abi for USBFN_USB_STRING {
 }
 impl ::core::cmp::PartialEq for USBFN_USB_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBFN_USB_STRING>()) == 0 }
+        self.StringIndex == other.StringIndex && self.UsbString == other.UsbString
     }
 }
 impl ::core::cmp::Eq for USBFN_USB_STRING {}
@@ -2939,7 +2827,7 @@ unsafe impl ::windows::core::Abi for USBSCAN_GET_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USBSCAN_GET_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBSCAN_GET_DESCRIPTOR>()) == 0 }
+        self.DescriptorType == other.DescriptorType && self.Index == other.Index && self.LanguageId == other.LanguageId
     }
 }
 impl ::core::cmp::Eq for USBSCAN_GET_DESCRIPTOR {}
@@ -2970,7 +2858,7 @@ unsafe impl ::windows::core::Abi for USBSCAN_PIPE_CONFIGURATION {
 }
 impl ::core::cmp::PartialEq for USBSCAN_PIPE_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBSCAN_PIPE_CONFIGURATION>()) == 0 }
+        self.NumberOfPipes == other.NumberOfPipes && self.PipeInfo == other.PipeInfo
     }
 }
 impl ::core::cmp::Eq for USBSCAN_PIPE_CONFIGURATION {}
@@ -3003,7 +2891,7 @@ unsafe impl ::windows::core::Abi for USBSCAN_PIPE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for USBSCAN_PIPE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBSCAN_PIPE_INFORMATION>()) == 0 }
+        self.MaximumPacketSize == other.MaximumPacketSize && self.EndpointAddress == other.EndpointAddress && self.Interval == other.Interval && self.PipeType == other.PipeType
     }
 }
 impl ::core::cmp::Eq for USBSCAN_PIPE_INFORMATION {}
@@ -3035,7 +2923,7 @@ unsafe impl ::windows::core::Abi for USBSCAN_TIMEOUT {
 }
 impl ::core::cmp::PartialEq for USBSCAN_TIMEOUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBSCAN_TIMEOUT>()) == 0 }
+        self.TimeoutRead == other.TimeoutRead && self.TimeoutWrite == other.TimeoutWrite && self.TimeoutEvent == other.TimeoutEvent
     }
 }
 impl ::core::cmp::Eq for USBSCAN_TIMEOUT {}
@@ -3059,12 +2947,6 @@ impl ::core::clone::Clone for USBUSER_BANDWIDTH_INFO_REQUEST {
 unsafe impl ::windows::core::Abi for USBUSER_BANDWIDTH_INFO_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_BANDWIDTH_INFO_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_BANDWIDTH_INFO_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_BANDWIDTH_INFO_REQUEST {}
 impl ::core::default::Default for USBUSER_BANDWIDTH_INFO_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3090,14 +2972,6 @@ unsafe impl ::windows::core::Abi for USBUSER_BUS_STATISTICS_0_REQUEST {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USBUSER_BUS_STATISTICS_0_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_BUS_STATISTICS_0_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USBUSER_BUS_STATISTICS_0_REQUEST {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USBUSER_BUS_STATISTICS_0_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3118,12 +2992,6 @@ impl ::core::clone::Clone for USBUSER_CLOSE_RAW_DEVICE {
 unsafe impl ::windows::core::Abi for USBUSER_CLOSE_RAW_DEVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_CLOSE_RAW_DEVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_CLOSE_RAW_DEVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_CLOSE_RAW_DEVICE {}
 impl ::core::default::Default for USBUSER_CLOSE_RAW_DEVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3144,12 +3012,6 @@ impl ::core::clone::Clone for USBUSER_CONTROLLER_INFO_0 {
 unsafe impl ::windows::core::Abi for USBUSER_CONTROLLER_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_CONTROLLER_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_CONTROLLER_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_CONTROLLER_INFO_0 {}
 impl ::core::default::Default for USBUSER_CONTROLLER_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3170,12 +3032,6 @@ impl ::core::clone::Clone for USBUSER_CONTROLLER_UNICODE_NAME {
 unsafe impl ::windows::core::Abi for USBUSER_CONTROLLER_UNICODE_NAME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_CONTROLLER_UNICODE_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_CONTROLLER_UNICODE_NAME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_CONTROLLER_UNICODE_NAME {}
 impl ::core::default::Default for USBUSER_CONTROLLER_UNICODE_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3201,14 +3057,6 @@ unsafe impl ::windows::core::Abi for USBUSER_GET_DRIVER_VERSION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USBUSER_GET_DRIVER_VERSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_GET_DRIVER_VERSION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USBUSER_GET_DRIVER_VERSION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USBUSER_GET_DRIVER_VERSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3229,12 +3077,6 @@ impl ::core::clone::Clone for USBUSER_GET_USB2HW_VERSION {
 unsafe impl ::windows::core::Abi for USBUSER_GET_USB2HW_VERSION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_GET_USB2HW_VERSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_GET_USB2HW_VERSION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_GET_USB2HW_VERSION {}
 impl ::core::default::Default for USBUSER_GET_USB2HW_VERSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3255,12 +3097,6 @@ impl ::core::clone::Clone for USBUSER_OPEN_RAW_DEVICE {
 unsafe impl ::windows::core::Abi for USBUSER_OPEN_RAW_DEVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_OPEN_RAW_DEVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_OPEN_RAW_DEVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_OPEN_RAW_DEVICE {}
 impl ::core::default::Default for USBUSER_OPEN_RAW_DEVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3281,12 +3117,6 @@ impl ::core::clone::Clone for USBUSER_PASS_THRU_REQUEST {
 unsafe impl ::windows::core::Abi for USBUSER_PASS_THRU_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_PASS_THRU_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_PASS_THRU_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_PASS_THRU_REQUEST {}
 impl ::core::default::Default for USBUSER_PASS_THRU_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3312,14 +3142,6 @@ unsafe impl ::windows::core::Abi for USBUSER_POWER_INFO_REQUEST {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USBUSER_POWER_INFO_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_POWER_INFO_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USBUSER_POWER_INFO_REQUEST {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USBUSER_POWER_INFO_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3340,12 +3162,6 @@ impl ::core::clone::Clone for USBUSER_RAW_RESET_ROOT_PORT {
 unsafe impl ::windows::core::Abi for USBUSER_RAW_RESET_ROOT_PORT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_RAW_RESET_ROOT_PORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_RAW_RESET_ROOT_PORT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_RAW_RESET_ROOT_PORT {}
 impl ::core::default::Default for USBUSER_RAW_RESET_ROOT_PORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3366,12 +3182,6 @@ impl ::core::clone::Clone for USBUSER_REFRESH_HCT_REG {
 unsafe impl ::windows::core::Abi for USBUSER_REFRESH_HCT_REG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_REFRESH_HCT_REG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_REFRESH_HCT_REG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_REFRESH_HCT_REG {}
 impl ::core::default::Default for USBUSER_REFRESH_HCT_REG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3394,12 +3204,6 @@ impl ::core::clone::Clone for USBUSER_REQUEST_HEADER {
 unsafe impl ::windows::core::Abi for USBUSER_REQUEST_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_REQUEST_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_REQUEST_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_REQUEST_HEADER {}
 impl ::core::default::Default for USBUSER_REQUEST_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3420,12 +3224,6 @@ impl ::core::clone::Clone for USBUSER_ROOTPORT_FEATURE_REQUEST {
 unsafe impl ::windows::core::Abi for USBUSER_ROOTPORT_FEATURE_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_ROOTPORT_FEATURE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_ROOTPORT_FEATURE_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_ROOTPORT_FEATURE_REQUEST {}
 impl ::core::default::Default for USBUSER_ROOTPORT_FEATURE_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3446,12 +3244,6 @@ impl ::core::clone::Clone for USBUSER_ROOTPORT_PARAMETERS {
 unsafe impl ::windows::core::Abi for USBUSER_ROOTPORT_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_ROOTPORT_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_ROOTPORT_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_ROOTPORT_PARAMETERS {}
 impl ::core::default::Default for USBUSER_ROOTPORT_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3472,12 +3264,6 @@ impl ::core::clone::Clone for USBUSER_SEND_ONE_PACKET {
 unsafe impl ::windows::core::Abi for USBUSER_SEND_ONE_PACKET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_SEND_ONE_PACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_SEND_ONE_PACKET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_SEND_ONE_PACKET {}
 impl ::core::default::Default for USBUSER_SEND_ONE_PACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3498,12 +3284,6 @@ impl ::core::clone::Clone for USBUSER_SEND_RAW_COMMAND {
 unsafe impl ::windows::core::Abi for USBUSER_SEND_RAW_COMMAND {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USBUSER_SEND_RAW_COMMAND {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USBUSER_SEND_RAW_COMMAND>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USBUSER_SEND_RAW_COMMAND {}
 impl ::core::default::Default for USBUSER_SEND_RAW_COMMAND {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3524,12 +3304,6 @@ impl ::core::clone::Clone for USB_20_PORT_CHANGE {
 unsafe impl ::windows::core::Abi for USB_20_PORT_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_20_PORT_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_20_PORT_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_20_PORT_CHANGE {}
 impl ::core::default::Default for USB_20_PORT_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3549,12 +3323,6 @@ impl ::core::clone::Clone for USB_20_PORT_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_20_PORT_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_20_PORT_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_20_PORT_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_20_PORT_CHANGE_0 {}
 impl ::core::default::Default for USB_20_PORT_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3575,12 +3343,6 @@ impl ::core::clone::Clone for USB_20_PORT_STATUS {
 unsafe impl ::windows::core::Abi for USB_20_PORT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_20_PORT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_20_PORT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_20_PORT_STATUS {}
 impl ::core::default::Default for USB_20_PORT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3600,12 +3362,6 @@ impl ::core::clone::Clone for USB_20_PORT_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_20_PORT_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_20_PORT_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_20_PORT_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_20_PORT_STATUS_0 {}
 impl ::core::default::Default for USB_20_PORT_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3633,12 +3389,6 @@ impl ::core::clone::Clone for USB_30_HUB_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_30_HUB_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_30_HUB_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_30_HUB_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_30_HUB_DESCRIPTOR {}
 impl ::core::default::Default for USB_30_HUB_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3659,12 +3409,6 @@ impl ::core::clone::Clone for USB_30_PORT_CHANGE {
 unsafe impl ::windows::core::Abi for USB_30_PORT_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_30_PORT_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_30_PORT_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_30_PORT_CHANGE {}
 impl ::core::default::Default for USB_30_PORT_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3684,12 +3428,6 @@ impl ::core::clone::Clone for USB_30_PORT_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_30_PORT_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_30_PORT_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_30_PORT_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_30_PORT_CHANGE_0 {}
 impl ::core::default::Default for USB_30_PORT_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3710,12 +3448,6 @@ impl ::core::clone::Clone for USB_30_PORT_STATUS {
 unsafe impl ::windows::core::Abi for USB_30_PORT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_30_PORT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_30_PORT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_30_PORT_STATUS {}
 impl ::core::default::Default for USB_30_PORT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3735,12 +3467,6 @@ impl ::core::clone::Clone for USB_30_PORT_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_30_PORT_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_30_PORT_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_30_PORT_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_30_PORT_STATUS_0 {}
 impl ::core::default::Default for USB_30_PORT_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3770,12 +3496,6 @@ impl ::core::clone::Clone for USB_BANDWIDTH_INFO {
 unsafe impl ::windows::core::Abi for USB_BANDWIDTH_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_BANDWIDTH_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_BANDWIDTH_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_BANDWIDTH_INFO {}
 impl ::core::default::Default for USB_BANDWIDTH_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3798,12 +3518,6 @@ impl ::core::clone::Clone for USB_BOS_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_BOS_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_BOS_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_BOS_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_BOS_DESCRIPTOR {}
 impl ::core::default::Default for USB_BOS_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3843,14 +3557,6 @@ unsafe impl ::windows::core::Abi for USB_BUS_STATISTICS_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_BUS_STATISTICS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_BUS_STATISTICS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_BUS_STATISTICS_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_BUS_STATISTICS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3870,12 +3576,6 @@ impl ::core::clone::Clone for USB_CLOSE_RAW_DEVICE_PARAMETERS {
 unsafe impl ::windows::core::Abi for USB_CLOSE_RAW_DEVICE_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_CLOSE_RAW_DEVICE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_CLOSE_RAW_DEVICE_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_CLOSE_RAW_DEVICE_PARAMETERS {}
 impl ::core::default::Default for USB_CLOSE_RAW_DEVICE_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3903,7 +3603,7 @@ unsafe impl ::windows::core::Abi for USB_COMMON_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USB_COMMON_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_COMMON_DESCRIPTOR>()) == 0 }
+        self.bLength == other.bLength && self.bDescriptorType == other.bDescriptorType
     }
 }
 impl ::core::cmp::Eq for USB_COMMON_DESCRIPTOR {}
@@ -3933,12 +3633,6 @@ impl ::core::clone::Clone for USB_CONFIGURATION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_CONFIGURATION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_CONFIGURATION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_CONFIGURATION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_CONFIGURATION_DESCRIPTOR {}
 impl ::core::default::Default for USB_CONFIGURATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3970,12 +3664,6 @@ impl ::core::clone::Clone for USB_CONFIGURATION_POWER_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_CONFIGURATION_POWER_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_CONFIGURATION_POWER_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_CONFIGURATION_POWER_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_CONFIGURATION_POWER_DESCRIPTOR {}
 impl ::core::default::Default for USB_CONFIGURATION_POWER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4000,12 +3688,6 @@ impl ::core::clone::Clone for USB_CONTROLLER_INFO_0 {
 unsafe impl ::windows::core::Abi for USB_CONTROLLER_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_CONTROLLER_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_CONTROLLER_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_CONTROLLER_INFO_0 {}
 impl ::core::default::Default for USB_CONTROLLER_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4029,12 +3711,6 @@ impl ::core::clone::Clone for USB_DEFAULT_PIPE_SETUP_PACKET {
 unsafe impl ::windows::core::Abi for USB_DEFAULT_PIPE_SETUP_PACKET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEFAULT_PIPE_SETUP_PACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEFAULT_PIPE_SETUP_PACKET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEFAULT_PIPE_SETUP_PACKET {}
 impl ::core::default::Default for USB_DEFAULT_PIPE_SETUP_PACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4055,12 +3731,6 @@ impl ::core::clone::Clone for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
 unsafe impl ::windows::core::Abi for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEFAULT_PIPE_SETUP_PACKET_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEFAULT_PIPE_SETUP_PACKET_0 {}
 impl ::core::default::Default for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4088,7 +3758,7 @@ unsafe impl ::windows::core::Abi for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
 }
 impl ::core::cmp::PartialEq for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEFAULT_PIPE_SETUP_PACKET_0_0>()) == 0 }
+        self.LowByte == other.LowByte && self.HiByte == other.HiByte
     }
 }
 impl ::core::cmp::Eq for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {}
@@ -4112,12 +3782,6 @@ impl ::core::clone::Clone for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
 unsafe impl ::windows::core::Abi for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEFAULT_PIPE_SETUP_PACKET_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEFAULT_PIPE_SETUP_PACKET_1 {}
 impl ::core::default::Default for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4145,7 +3809,7 @@ unsafe impl ::windows::core::Abi for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
 }
 impl ::core::cmp::PartialEq for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEFAULT_PIPE_SETUP_PACKET_1_0>()) == 0 }
+        self.LowByte == other.LowByte && self.HiByte == other.HiByte
     }
 }
 impl ::core::cmp::Eq for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {}
@@ -4177,12 +3841,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4204,12 +3862,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4230,12 +3882,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4255,12 +3901,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4291,7 +3931,7 @@ unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPT
 }
 impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPTOR>()) == 0 }
+        self.bLength == other.bLength && self.bDescriptorType == other.bDescriptorType && self.bDevCapabilityType == other.bDevCapabilityType && self.bReserved == other.bReserved && self.ContainerID == other.ContainerID
     }
 }
 impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPTOR {}
@@ -4323,7 +3963,7 @@ unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_DESCRIPTOR>()) == 0 }
+        self.bLength == other.bLength && self.bDescriptorType == other.bDescriptorType && self.bDevCapabilityType == other.bDevCapabilityType
     }
 }
 impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_DESCRIPTOR {}
@@ -4350,12 +3990,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4376,12 +4010,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4401,12 +4029,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4436,12 +4058,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR 
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4462,12 +4078,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4487,12 +4097,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4517,12 +4121,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4551,12 +4149,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4577,12 +4169,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4602,12 +4188,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4628,12 +4208,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4653,12 +4227,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4685,12 +4253,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTO
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4711,12 +4273,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTO
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4736,12 +4292,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTO
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4762,12 +4312,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTO
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4787,12 +4331,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTO
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4819,12 +4357,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4847,12 +4379,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4873,12 +4399,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4898,12 +4418,6 @@ impl ::core::clone::Clone for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0
 unsafe impl ::windows::core::Abi for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4936,12 +4450,6 @@ impl ::core::clone::Clone for USB_DEVICE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4969,12 +4477,6 @@ impl ::core::clone::Clone for USB_DEVICE_QUALIFIER_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_DEVICE_QUALIFIER_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_QUALIFIER_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_QUALIFIER_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_QUALIFIER_DESCRIPTOR {}
 impl ::core::default::Default for USB_DEVICE_QUALIFIER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4995,12 +4497,6 @@ impl ::core::clone::Clone for USB_DEVICE_STATUS {
 unsafe impl ::windows::core::Abi for USB_DEVICE_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_STATUS {}
 impl ::core::default::Default for USB_DEVICE_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5020,12 +4516,6 @@ impl ::core::clone::Clone for USB_DEVICE_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_DEVICE_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_DEVICE_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DEVICE_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_DEVICE_STATUS_0 {}
 impl ::core::default::Default for USB_DEVICE_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5055,14 +4545,6 @@ unsafe impl ::windows::core::Abi for USB_DRIVER_VERSION_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_DRIVER_VERSION_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_DRIVER_VERSION_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_DRIVER_VERSION_PARAMETERS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_DRIVER_VERSION_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5087,12 +4569,6 @@ impl ::core::clone::Clone for USB_ENDPOINT_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_ENDPOINT_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_ENDPOINT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_ENDPOINT_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_ENDPOINT_DESCRIPTOR {}
 impl ::core::default::Default for USB_ENDPOINT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5113,12 +4589,6 @@ impl ::core::clone::Clone for USB_ENDPOINT_STATUS {
 unsafe impl ::windows::core::Abi for USB_ENDPOINT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_ENDPOINT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_ENDPOINT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_ENDPOINT_STATUS {}
 impl ::core::default::Default for USB_ENDPOINT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5138,12 +4608,6 @@ impl ::core::clone::Clone for USB_ENDPOINT_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_ENDPOINT_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_ENDPOINT_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_ENDPOINT_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_ENDPOINT_STATUS_0 {}
 impl ::core::default::Default for USB_ENDPOINT_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5178,14 +4642,6 @@ unsafe impl ::windows::core::Abi for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFO
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5206,12 +4662,6 @@ impl ::core::clone::Clone for USB_FUNCTION_SUSPEND_OPTIONS {
 unsafe impl ::windows::core::Abi for USB_FUNCTION_SUSPEND_OPTIONS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_FUNCTION_SUSPEND_OPTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_FUNCTION_SUSPEND_OPTIONS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_FUNCTION_SUSPEND_OPTIONS {}
 impl ::core::default::Default for USB_FUNCTION_SUSPEND_OPTIONS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5238,7 +4688,7 @@ unsafe impl ::windows::core::Abi for USB_FUNCTION_SUSPEND_OPTIONS_0 {
 }
 impl ::core::cmp::PartialEq for USB_FUNCTION_SUSPEND_OPTIONS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_FUNCTION_SUSPEND_OPTIONS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for USB_FUNCTION_SUSPEND_OPTIONS_0 {}
@@ -5261,12 +4711,6 @@ impl ::core::clone::Clone for USB_HIGH_SPEED_MAXPACKET {
 unsafe impl ::windows::core::Abi for USB_HIGH_SPEED_MAXPACKET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HIGH_SPEED_MAXPACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HIGH_SPEED_MAXPACKET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HIGH_SPEED_MAXPACKET {}
 impl ::core::default::Default for USB_HIGH_SPEED_MAXPACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5286,12 +4730,6 @@ impl ::core::clone::Clone for USB_HIGH_SPEED_MAXPACKET_0 {
 unsafe impl ::windows::core::Abi for USB_HIGH_SPEED_MAXPACKET_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HIGH_SPEED_MAXPACKET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HIGH_SPEED_MAXPACKET_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HIGH_SPEED_MAXPACKET_0 {}
 impl ::core::default::Default for USB_HIGH_SPEED_MAXPACKET_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5312,12 +4750,6 @@ impl ::core::clone::Clone for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
 unsafe impl ::windows::core::Abi for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_30_PORT_REMOTE_WAKE_MASK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_30_PORT_REMOTE_WAKE_MASK {}
 impl ::core::default::Default for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5344,7 +4776,7 @@ unsafe impl ::windows::core::Abi for USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {
 }
 impl ::core::cmp::PartialEq for USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_30_PORT_REMOTE_WAKE_MASK_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {}
@@ -5368,12 +4800,6 @@ impl ::core::clone::Clone for USB_HUB_CHANGE {
 unsafe impl ::windows::core::Abi for USB_HUB_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_CHANGE {}
 impl ::core::default::Default for USB_HUB_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5393,12 +4819,6 @@ impl ::core::clone::Clone for USB_HUB_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_HUB_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_CHANGE_0 {}
 impl ::core::default::Default for USB_HUB_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5424,12 +4844,6 @@ impl ::core::clone::Clone for USB_HUB_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_HUB_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_DESCRIPTOR {}
 impl ::core::default::Default for USB_HUB_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5450,12 +4864,6 @@ impl ::core::clone::Clone for USB_HUB_STATUS {
 unsafe impl ::windows::core::Abi for USB_HUB_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_STATUS {}
 impl ::core::default::Default for USB_HUB_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5475,12 +4883,6 @@ impl ::core::clone::Clone for USB_HUB_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_HUB_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_STATUS_0 {}
 impl ::core::default::Default for USB_HUB_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5501,12 +4903,6 @@ impl ::core::clone::Clone for USB_HUB_STATUS_AND_CHANGE {
 unsafe impl ::windows::core::Abi for USB_HUB_STATUS_AND_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_STATUS_AND_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_STATUS_AND_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_STATUS_AND_CHANGE {}
 impl ::core::default::Default for USB_HUB_STATUS_AND_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5527,12 +4923,6 @@ impl ::core::clone::Clone for USB_HUB_STATUS_AND_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_HUB_STATUS_AND_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_HUB_STATUS_AND_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_HUB_STATUS_AND_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_HUB_STATUS_AND_CHANGE_0 {}
 impl ::core::default::Default for USB_HUB_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5552,18 +4942,12 @@ impl ::core::clone::Clone for USB_IDLE_CALLBACK_INFO {
 }
 impl ::core::fmt::Debug for USB_IDLE_CALLBACK_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("USB_IDLE_CALLBACK_INFO").field("IdleCallback", &self.IdleCallback.map(|f| f as usize)).field("IdleContext", &self.IdleContext).finish()
+        f.debug_struct("USB_IDLE_CALLBACK_INFO").field("IdleContext", &self.IdleContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for USB_IDLE_CALLBACK_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_IDLE_CALLBACK_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_IDLE_CALLBACK_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_IDLE_CALLBACK_INFO {}
 impl ::core::default::Default for USB_IDLE_CALLBACK_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5597,7 +4981,7 @@ unsafe impl ::windows::core::Abi for USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_INTERFACE_ASSOCIATION_DESCRIPTOR>()) == 0 }
+        self.bLength == other.bLength && self.bDescriptorType == other.bDescriptorType && self.bFirstInterface == other.bFirstInterface && self.bInterfaceCount == other.bInterfaceCount && self.bFunctionClass == other.bFunctionClass && self.bFunctionSubClass == other.bFunctionSubClass && self.bFunctionProtocol == other.bFunctionProtocol && self.iFunction == other.iFunction
     }
 }
 impl ::core::cmp::Eq for USB_INTERFACE_ASSOCIATION_DESCRIPTOR {}
@@ -5635,7 +5019,7 @@ unsafe impl ::windows::core::Abi for USB_INTERFACE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for USB_INTERFACE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_INTERFACE_DESCRIPTOR>()) == 0 }
+        self.bLength == other.bLength && self.bDescriptorType == other.bDescriptorType && self.bInterfaceNumber == other.bInterfaceNumber && self.bAlternateSetting == other.bAlternateSetting && self.bNumEndpoints == other.bNumEndpoints && self.bInterfaceClass == other.bInterfaceClass && self.bInterfaceSubClass == other.bInterfaceSubClass && self.bInterfaceProtocol == other.bInterfaceProtocol && self.iInterface == other.iInterface
     }
 }
 impl ::core::cmp::Eq for USB_INTERFACE_DESCRIPTOR {}
@@ -5669,12 +5053,6 @@ impl ::core::clone::Clone for USB_INTERFACE_POWER_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_INTERFACE_POWER_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_INTERFACE_POWER_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_INTERFACE_POWER_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_INTERFACE_POWER_DESCRIPTOR {}
 impl ::core::default::Default for USB_INTERFACE_POWER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5695,12 +5073,6 @@ impl ::core::clone::Clone for USB_INTERFACE_STATUS {
 unsafe impl ::windows::core::Abi for USB_INTERFACE_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_INTERFACE_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_INTERFACE_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_INTERFACE_STATUS {}
 impl ::core::default::Default for USB_INTERFACE_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5720,12 +5092,6 @@ impl ::core::clone::Clone for USB_INTERFACE_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_INTERFACE_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_INTERFACE_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_INTERFACE_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_INTERFACE_STATUS_0 {}
 impl ::core::default::Default for USB_INTERFACE_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5746,12 +5112,6 @@ impl ::core::clone::Clone for USB_OPEN_RAW_DEVICE_PARAMETERS {
 unsafe impl ::windows::core::Abi for USB_OPEN_RAW_DEVICE_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_OPEN_RAW_DEVICE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_OPEN_RAW_DEVICE_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_OPEN_RAW_DEVICE_PARAMETERS {}
 impl ::core::default::Default for USB_OPEN_RAW_DEVICE_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5773,12 +5133,6 @@ impl ::core::clone::Clone for USB_PASS_THRU_PARAMETERS {
 unsafe impl ::windows::core::Abi for USB_PASS_THRU_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PASS_THRU_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PASS_THRU_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PASS_THRU_PARAMETERS {}
 impl ::core::default::Default for USB_PASS_THRU_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5800,12 +5154,6 @@ impl ::core::clone::Clone for USB_PORT_CHANGE {
 unsafe impl ::windows::core::Abi for USB_PORT_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_CHANGE {}
 impl ::core::default::Default for USB_PORT_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5826,12 +5174,6 @@ impl ::core::clone::Clone for USB_PORT_EXT_STATUS {
 unsafe impl ::windows::core::Abi for USB_PORT_EXT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_EXT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_EXT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_EXT_STATUS {}
 impl ::core::default::Default for USB_PORT_EXT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5851,12 +5193,6 @@ impl ::core::clone::Clone for USB_PORT_EXT_STATUS_0 {
 unsafe impl ::windows::core::Abi for USB_PORT_EXT_STATUS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_EXT_STATUS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_EXT_STATUS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_EXT_STATUS_0 {}
 impl ::core::default::Default for USB_PORT_EXT_STATUS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5877,12 +5213,6 @@ impl ::core::clone::Clone for USB_PORT_EXT_STATUS_AND_CHANGE {
 unsafe impl ::windows::core::Abi for USB_PORT_EXT_STATUS_AND_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_EXT_STATUS_AND_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_EXT_STATUS_AND_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_EXT_STATUS_AND_CHANGE {}
 impl ::core::default::Default for USB_PORT_EXT_STATUS_AND_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5903,12 +5233,6 @@ impl ::core::clone::Clone for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_EXT_STATUS_AND_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_EXT_STATUS_AND_CHANGE_0 {}
 impl ::core::default::Default for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5930,12 +5254,6 @@ impl ::core::clone::Clone for USB_PORT_STATUS {
 unsafe impl ::windows::core::Abi for USB_PORT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_STATUS {}
 impl ::core::default::Default for USB_PORT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5956,12 +5274,6 @@ impl ::core::clone::Clone for USB_PORT_STATUS_AND_CHANGE {
 unsafe impl ::windows::core::Abi for USB_PORT_STATUS_AND_CHANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_STATUS_AND_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_STATUS_AND_CHANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_STATUS_AND_CHANGE {}
 impl ::core::default::Default for USB_PORT_STATUS_AND_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5982,12 +5294,6 @@ impl ::core::clone::Clone for USB_PORT_STATUS_AND_CHANGE_0 {
 unsafe impl ::windows::core::Abi for USB_PORT_STATUS_AND_CHANGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_PORT_STATUS_AND_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_PORT_STATUS_AND_CHANGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_PORT_STATUS_AND_CHANGE_0 {}
 impl ::core::default::Default for USB_PORT_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6021,14 +5327,6 @@ unsafe impl ::windows::core::Abi for USB_POWER_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_POWER_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_POWER_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_POWER_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_POWER_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6058,12 +5356,6 @@ impl ::core::clone::Clone for USB_SEND_RAW_COMMAND_PARAMETERS {
 unsafe impl ::windows::core::Abi for USB_SEND_RAW_COMMAND_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_SEND_RAW_COMMAND_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SEND_RAW_COMMAND_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_SEND_RAW_COMMAND_PARAMETERS {}
 impl ::core::default::Default for USB_SEND_RAW_COMMAND_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6089,14 +5381,6 @@ unsafe impl ::windows::core::Abi for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATIO
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6121,14 +5405,6 @@ unsafe impl ::windows::core::Abi for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6150,12 +5426,6 @@ impl ::core::clone::Clone for USB_STRING_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_STRING_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_STRING_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_STRING_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_STRING_DESCRIPTOR {}
 impl ::core::default::Default for USB_STRING_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6178,12 +5448,6 @@ impl ::core::clone::Clone for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRI
 unsafe impl ::windows::core::Abi for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {}
 impl ::core::default::Default for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6207,12 +5471,6 @@ impl ::core::clone::Clone for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {}
 impl ::core::default::Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6234,12 +5492,6 @@ impl ::core::clone::Clone for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {}
 impl ::core::default::Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6266,7 +5518,7 @@ unsafe impl ::windows::core::Abi for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTO
 }
 impl ::core::cmp::PartialEq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0 {}
@@ -6296,7 +5548,7 @@ unsafe impl ::windows::core::Abi for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTO
 }
 impl ::core::cmp::PartialEq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1 {}
@@ -6320,12 +5572,6 @@ impl ::core::clone::Clone for USB_UNICODE_NAME {
 unsafe impl ::windows::core::Abi for USB_UNICODE_NAME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_UNICODE_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_UNICODE_NAME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_UNICODE_NAME {}
 impl ::core::default::Default for USB_UNICODE_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6345,12 +5591,6 @@ impl ::core::clone::Clone for USB_USB2HW_VERSION_PARAMETERS {
 unsafe impl ::windows::core::Abi for USB_USB2HW_VERSION_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USB_USB2HW_VERSION_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USB_USB2HW_VERSION_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USB_USB2HW_VERSION_PARAMETERS {}
 impl ::core::default::Default for USB_USB2HW_VERSION_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6380,7 +5620,7 @@ unsafe impl ::windows::core::Abi for WINUSB_PIPE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WINUSB_PIPE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINUSB_PIPE_INFORMATION>()) == 0 }
+        self.PipeType == other.PipeType && self.PipeId == other.PipeId && self.MaximumPacketSize == other.MaximumPacketSize && self.Interval == other.Interval
     }
 }
 impl ::core::cmp::Eq for WINUSB_PIPE_INFORMATION {}
@@ -6414,7 +5654,7 @@ unsafe impl ::windows::core::Abi for WINUSB_PIPE_INFORMATION_EX {
 }
 impl ::core::cmp::PartialEq for WINUSB_PIPE_INFORMATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINUSB_PIPE_INFORMATION_EX>()) == 0 }
+        self.PipeType == other.PipeType && self.PipeId == other.PipeId && self.MaximumPacketSize == other.MaximumPacketSize && self.Interval == other.Interval && self.MaximumBytesPerInterval == other.MaximumBytesPerInterval
     }
 }
 impl ::core::cmp::Eq for WINUSB_PIPE_INFORMATION_EX {}
@@ -6441,12 +5681,6 @@ impl ::core::clone::Clone for WINUSB_SETUP_PACKET {
 unsafe impl ::windows::core::Abi for WINUSB_SETUP_PACKET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINUSB_SETUP_PACKET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINUSB_SETUP_PACKET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINUSB_SETUP_PACKET {}
 impl ::core::default::Default for WINUSB_SETUP_PACKET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6480,7 +5714,7 @@ unsafe impl ::windows::core::Abi for _URB_BULK_OR_INTERRUPT_TRANSFER {
 }
 impl ::core::cmp::PartialEq for _URB_BULK_OR_INTERRUPT_TRANSFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_BULK_OR_INTERRUPT_TRANSFER>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.TransferFlags == other.TransferFlags && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca
     }
 }
 impl ::core::cmp::Eq for _URB_BULK_OR_INTERRUPT_TRANSFER {}
@@ -6536,7 +5770,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_DESCRIPTOR_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_DESCRIPTOR_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_DESCRIPTOR_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved0 == other.Reserved0 && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.Reserved1 == other.Reserved1 && self.Index == other.Index && self.DescriptorType == other.DescriptorType && self.LanguageId == other.LanguageId && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_DESCRIPTOR_REQUEST {}
@@ -6577,7 +5811,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_FEATURE_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_FEATURE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_FEATURE_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4 && self.Reserved5 == other.Reserved5 && self.UrbLink == other.UrbLink && self.hca == other.hca && self.Reserved0 == other.Reserved0 && self.FeatureSelector == other.FeatureSelector && self.Index == other.Index && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_FEATURE_REQUEST {}
@@ -6615,7 +5849,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_GET_CONFIGURATION_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_GET_CONFIGURATION_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_GET_CONFIGURATION_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved0 == other.Reserved0 && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_GET_CONFIGURATION_REQUEST {}
@@ -6655,7 +5889,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_GET_INTERFACE_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_GET_INTERFACE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_GET_INTERFACE_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved0 == other.Reserved0 && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.Reserved1 == other.Reserved1 && self.Interface == other.Interface && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_GET_INTERFACE_REQUEST {}
@@ -6695,7 +5929,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_GET_STATUS_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_GET_STATUS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_GET_STATUS_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved0 == other.Reserved0 && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.Reserved1 == other.Reserved1 && self.Index == other.Index && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_GET_STATUS_REQUEST {}
@@ -6733,7 +5967,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_TRANSFER {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_TRANSFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_TRANSFER>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.TransferFlags == other.TransferFlags && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.SetupPacket == other.SetupPacket
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_TRANSFER {}
@@ -6771,7 +6005,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_TRANSFER_EX {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_TRANSFER_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_TRANSFER_EX>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.TransferFlags == other.TransferFlags && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.Timeout == other.Timeout && self.hca == other.hca && self.SetupPacket == other.SetupPacket
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_TRANSFER_EX {}
@@ -6827,7 +6061,7 @@ unsafe impl ::windows::core::Abi for _URB_CONTROL_VENDOR_OR_CLASS_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_CONTROL_VENDOR_OR_CLASS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_CONTROL_VENDOR_OR_CLASS_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.TransferFlags == other.TransferFlags && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.RequestTypeReservedBits == other.RequestTypeReservedBits && self.Request == other.Request && self.Value == other.Value && self.Index == other.Index && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for _URB_CONTROL_VENDOR_OR_CLASS_REQUEST {}
@@ -6857,7 +6091,7 @@ unsafe impl ::windows::core::Abi for _URB_FRAME_LENGTH_CONTROL {
 }
 impl ::core::cmp::PartialEq for _URB_FRAME_LENGTH_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_FRAME_LENGTH_CONTROL>()) == 0 }
+        self.Hdr == other.Hdr
     }
 }
 impl ::core::cmp::Eq for _URB_FRAME_LENGTH_CONTROL {}
@@ -6888,7 +6122,7 @@ unsafe impl ::windows::core::Abi for _URB_GET_CURRENT_FRAME_NUMBER {
 }
 impl ::core::cmp::PartialEq for _URB_GET_CURRENT_FRAME_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_GET_CURRENT_FRAME_NUMBER>()) == 0 }
+        self.Hdr == other.Hdr && self.FrameNumber == other.FrameNumber
     }
 }
 impl ::core::cmp::Eq for _URB_GET_CURRENT_FRAME_NUMBER {}
@@ -6920,7 +6154,7 @@ unsafe impl ::windows::core::Abi for _URB_GET_FRAME_LENGTH {
 }
 impl ::core::cmp::PartialEq for _URB_GET_FRAME_LENGTH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_GET_FRAME_LENGTH>()) == 0 }
+        self.Hdr == other.Hdr && self.FrameLength == other.FrameLength && self.FrameNumber == other.FrameNumber
     }
 }
 impl ::core::cmp::Eq for _URB_GET_FRAME_LENGTH {}
@@ -6953,7 +6187,7 @@ unsafe impl ::windows::core::Abi for _URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS {
 }
 impl ::core::cmp::PartialEq for _URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.MaximumSendPathDelayInMilliSeconds == other.MaximumSendPathDelayInMilliSeconds && self.MaximumCompletionPathDelayInMilliSeconds == other.MaximumCompletionPathDelayInMilliSeconds
     }
 }
 impl ::core::cmp::Eq for _URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS {}
@@ -6983,7 +6217,7 @@ unsafe impl ::windows::core::Abi for _URB_HCD_AREA {
 }
 impl ::core::cmp::PartialEq for _URB_HCD_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_HCD_AREA>()) == 0 }
+        self.Reserved8 == other.Reserved8
     }
 }
 impl ::core::cmp::Eq for _URB_HCD_AREA {}
@@ -7017,7 +6251,7 @@ unsafe impl ::windows::core::Abi for _URB_HEADER {
 }
 impl ::core::cmp::PartialEq for _URB_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_HEADER>()) == 0 }
+        self.Length == other.Length && self.Function == other.Function && self.Status == other.Status && self.UsbdDeviceHandle == other.UsbdDeviceHandle && self.UsbdFlags == other.UsbdFlags
     }
 }
 impl ::core::cmp::Eq for _URB_HEADER {}
@@ -7071,7 +6305,7 @@ unsafe impl ::windows::core::Abi for _URB_ISOCH_TRANSFER {
 }
 impl ::core::cmp::PartialEq for _URB_ISOCH_TRANSFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_ISOCH_TRANSFER>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.TransferFlags == other.TransferFlags && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self.StartFrame == other.StartFrame && self.NumberOfPackets == other.NumberOfPackets && self.ErrorCount == other.ErrorCount && self.IsoPacket == other.IsoPacket
     }
 }
 impl ::core::cmp::Eq for _URB_ISOCH_TRANSFER {}
@@ -7106,7 +6340,7 @@ unsafe impl ::windows::core::Abi for _URB_OPEN_STATIC_STREAMS {
 }
 impl ::core::cmp::PartialEq for _URB_OPEN_STATIC_STREAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_OPEN_STATIC_STREAMS>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.NumberOfStreams == other.NumberOfStreams && self.StreamInfoVersion == other.StreamInfoVersion && self.StreamInfoSize == other.StreamInfoSize && self.Streams == other.Streams
     }
 }
 impl ::core::cmp::Eq for _URB_OPEN_STATIC_STREAMS {}
@@ -7164,7 +6398,7 @@ unsafe impl ::windows::core::Abi for _URB_OS_FEATURE_DESCRIPTOR_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_OS_FEATURE_DESCRIPTOR_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_OS_FEATURE_DESCRIPTOR_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.Reserved == other.Reserved && self.Reserved0 == other.Reserved0 && self.TransferBufferLength == other.TransferBufferLength && self.TransferBuffer == other.TransferBuffer && self.TransferBufferMDL == other.TransferBufferMDL && self.UrbLink == other.UrbLink && self.hca == other.hca && self._bitfield == other._bitfield && self.Reserved2 == other.Reserved2 && self.InterfaceNumber == other.InterfaceNumber && self.MS_PageIndex == other.MS_PageIndex && self.MS_FeatureDescriptorIndex == other.MS_FeatureDescriptorIndex && self.Reserved3 == other.Reserved3
     }
 }
 impl ::core::cmp::Eq for _URB_OS_FEATURE_DESCRIPTOR_REQUEST {}
@@ -7196,7 +6430,7 @@ unsafe impl ::windows::core::Abi for _URB_PIPE_REQUEST {
 }
 impl ::core::cmp::PartialEq for _URB_PIPE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_PIPE_REQUEST>()) == 0 }
+        self.Hdr == other.Hdr && self.PipeHandle == other.PipeHandle && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for _URB_PIPE_REQUEST {}
@@ -7229,7 +6463,7 @@ unsafe impl ::windows::core::Abi for _URB_SELECT_CONFIGURATION {
 }
 impl ::core::cmp::PartialEq for _URB_SELECT_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_SELECT_CONFIGURATION>()) == 0 }
+        self.Hdr == other.Hdr && self.ConfigurationDescriptor == other.ConfigurationDescriptor && self.ConfigurationHandle == other.ConfigurationHandle && self.Interface == other.Interface
     }
 }
 impl ::core::cmp::Eq for _URB_SELECT_CONFIGURATION {}
@@ -7261,7 +6495,7 @@ unsafe impl ::windows::core::Abi for _URB_SELECT_INTERFACE {
 }
 impl ::core::cmp::PartialEq for _URB_SELECT_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_SELECT_INTERFACE>()) == 0 }
+        self.Hdr == other.Hdr && self.ConfigurationHandle == other.ConfigurationHandle && self.Interface == other.Interface
     }
 }
 impl ::core::cmp::Eq for _URB_SELECT_INTERFACE {}
@@ -7292,7 +6526,7 @@ unsafe impl ::windows::core::Abi for _URB_SET_FRAME_LENGTH {
 }
 impl ::core::cmp::PartialEq for _URB_SET_FRAME_LENGTH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_URB_SET_FRAME_LENGTH>()) == 0 }
+        self.Hdr == other.Hdr && self.FrameLengthDelta == other.FrameLengthDelta
     }
 }
 impl ::core::cmp::Eq for _URB_SET_FRAME_LENGTH {}

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
@@ -2926,7 +2926,7 @@ unsafe impl ::windows::core::Abi for REQUESTBODY_GetStatus {
 }
 impl ::core::cmp::PartialEq for REQUESTBODY_GetStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUESTBODY_GetStatus>()) == 0 }
+        self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for REQUESTBODY_GetStatus {}
@@ -2963,7 +2963,7 @@ unsafe impl ::windows::core::Abi for REQUESTBODY_Renew {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REQUESTBODY_Renew {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUESTBODY_Renew>()) == 0 }
+        self.Expires == other.Expires && self.Any == other.Any
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3005,7 +3005,7 @@ unsafe impl ::windows::core::Abi for REQUESTBODY_Subscribe {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REQUESTBODY_Subscribe {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUESTBODY_Subscribe>()) == 0 }
+        self.EndTo == other.EndTo && self.Delivery == other.Delivery && self.Expires == other.Expires && self.Filter == other.Filter && self.Any == other.Any
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3037,7 +3037,7 @@ unsafe impl ::windows::core::Abi for REQUESTBODY_Unsubscribe {
 }
 impl ::core::cmp::PartialEq for REQUESTBODY_Unsubscribe {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUESTBODY_Unsubscribe>()) == 0 }
+        self.any == other.any
     }
 }
 impl ::core::cmp::Eq for REQUESTBODY_Unsubscribe {}
@@ -3067,7 +3067,7 @@ unsafe impl ::windows::core::Abi for RESPONSEBODY_GetMetadata {
 }
 impl ::core::cmp::PartialEq for RESPONSEBODY_GetMetadata {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESPONSEBODY_GetMetadata>()) == 0 }
+        self.Metadata == other.Metadata
     }
 }
 impl ::core::cmp::Eq for RESPONSEBODY_GetMetadata {}
@@ -3104,7 +3104,7 @@ unsafe impl ::windows::core::Abi for RESPONSEBODY_GetStatus {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESPONSEBODY_GetStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESPONSEBODY_GetStatus>()) == 0 }
+        self.expires == other.expires && self.any == other.any
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3143,7 +3143,7 @@ unsafe impl ::windows::core::Abi for RESPONSEBODY_Renew {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESPONSEBODY_Renew {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESPONSEBODY_Renew>()) == 0 }
+        self.expires == other.expires && self.any == other.any
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3183,7 +3183,7 @@ unsafe impl ::windows::core::Abi for RESPONSEBODY_Subscribe {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESPONSEBODY_Subscribe {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESPONSEBODY_Subscribe>()) == 0 }
+        self.SubscriptionManager == other.SubscriptionManager && self.expires == other.expires && self.any == other.any
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3218,7 +3218,7 @@ unsafe impl ::windows::core::Abi for RESPONSEBODY_SubscriptionEnd {
 }
 impl ::core::cmp::PartialEq for RESPONSEBODY_SubscriptionEnd {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESPONSEBODY_SubscriptionEnd>()) == 0 }
+        self.SubscriptionManager == other.SubscriptionManager && self.Status == other.Status && self.Reason == other.Reason && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for RESPONSEBODY_SubscriptionEnd {}
@@ -3252,7 +3252,7 @@ unsafe impl ::windows::core::Abi for WSDUdpRetransmitParams {
 }
 impl ::core::cmp::PartialEq for WSDUdpRetransmitParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDUdpRetransmitParams>()) == 0 }
+        self.ulSendDelay == other.ulSendDelay && self.ulRepeat == other.ulRepeat && self.ulRepeatMinDelay == other.ulRepeatMinDelay && self.ulRepeatMaxDelay == other.ulRepeatMaxDelay && self.ulRepeatUpperDelay == other.ulRepeatUpperDelay
     }
 }
 impl ::core::cmp::Eq for WSDUdpRetransmitParams {}
@@ -3285,7 +3285,7 @@ unsafe impl ::windows::core::Abi for WSDXML_ATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for WSDXML_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_ATTRIBUTE>()) == 0 }
+        self.Element == other.Element && self.Next == other.Next && self.Name == other.Name && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for WSDXML_ATTRIBUTE {}
@@ -3319,7 +3319,7 @@ unsafe impl ::windows::core::Abi for WSDXML_ELEMENT {
 }
 impl ::core::cmp::PartialEq for WSDXML_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_ELEMENT>()) == 0 }
+        self.Node == other.Node && self.Name == other.Name && self.FirstAttribute == other.FirstAttribute && self.FirstChild == other.FirstChild && self.PrefixMappings == other.PrefixMappings
     }
 }
 impl ::core::cmp::Eq for WSDXML_ELEMENT {}
@@ -3350,7 +3350,7 @@ unsafe impl ::windows::core::Abi for WSDXML_ELEMENT_LIST {
 }
 impl ::core::cmp::PartialEq for WSDXML_ELEMENT_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_ELEMENT_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSDXML_ELEMENT_LIST {}
@@ -3381,7 +3381,7 @@ unsafe impl ::windows::core::Abi for WSDXML_NAME {
 }
 impl ::core::cmp::PartialEq for WSDXML_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_NAME>()) == 0 }
+        self.Space == other.Space && self.LocalName == other.LocalName
     }
 }
 impl ::core::cmp::Eq for WSDXML_NAME {}
@@ -3415,7 +3415,7 @@ unsafe impl ::windows::core::Abi for WSDXML_NAMESPACE {
 }
 impl ::core::cmp::PartialEq for WSDXML_NAMESPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_NAMESPACE>()) == 0 }
+        self.Uri == other.Uri && self.PreferredPrefix == other.PreferredPrefix && self.Names == other.Names && self.NamesCount == other.NamesCount && self.Encoding == other.Encoding
     }
 }
 impl ::core::cmp::Eq for WSDXML_NAMESPACE {}
@@ -3451,7 +3451,7 @@ unsafe impl ::windows::core::Abi for WSDXML_NODE {
 }
 impl ::core::cmp::PartialEq for WSDXML_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_NODE>()) == 0 }
+        self.Type == other.Type && self.Parent == other.Parent && self.Next == other.Next
     }
 }
 impl ::core::cmp::Eq for WSDXML_NODE {}
@@ -3484,7 +3484,7 @@ unsafe impl ::windows::core::Abi for WSDXML_PREFIX_MAPPING {
 }
 impl ::core::cmp::PartialEq for WSDXML_PREFIX_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_PREFIX_MAPPING>()) == 0 }
+        self.Refs == other.Refs && self.Next == other.Next && self.Space == other.Space && self.Prefix == other.Prefix
     }
 }
 impl ::core::cmp::Eq for WSDXML_PREFIX_MAPPING {}
@@ -3515,7 +3515,7 @@ unsafe impl ::windows::core::Abi for WSDXML_TEXT {
 }
 impl ::core::cmp::PartialEq for WSDXML_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_TEXT>()) == 0 }
+        self.Node == other.Node && self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for WSDXML_TEXT {}
@@ -3546,7 +3546,7 @@ unsafe impl ::windows::core::Abi for WSDXML_TYPE {
 }
 impl ::core::cmp::PartialEq for WSDXML_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSDXML_TYPE>()) == 0 }
+        self.Uri == other.Uri && self.Table == other.Table
     }
 }
 impl ::core::cmp::Eq for WSDXML_TYPE {}
@@ -3578,7 +3578,7 @@ unsafe impl ::windows::core::Abi for WSD_APP_SEQUENCE {
 }
 impl ::core::cmp::PartialEq for WSD_APP_SEQUENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_APP_SEQUENCE>()) == 0 }
+        self.InstanceId == other.InstanceId && self.SequenceId == other.SequenceId && self.MessageNumber == other.MessageNumber
     }
 }
 impl ::core::cmp::Eq for WSD_APP_SEQUENCE {}
@@ -3609,7 +3609,7 @@ unsafe impl ::windows::core::Abi for WSD_BYE {
 }
 impl ::core::cmp::PartialEq for WSD_BYE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_BYE>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_BYE {}
@@ -3640,7 +3640,7 @@ unsafe impl ::windows::core::Abi for WSD_CONFIG_ADDRESSES {
 }
 impl ::core::cmp::PartialEq for WSD_CONFIG_ADDRESSES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_CONFIG_ADDRESSES>()) == 0 }
+        self.addresses == other.addresses && self.dwAddressCount == other.dwAddressCount
     }
 }
 impl ::core::cmp::Eq for WSD_CONFIG_ADDRESSES {}
@@ -3672,7 +3672,7 @@ unsafe impl ::windows::core::Abi for WSD_CONFIG_PARAM {
 }
 impl ::core::cmp::PartialEq for WSD_CONFIG_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_CONFIG_PARAM>()) == 0 }
+        self.configParamType == other.configParamType && self.pConfigData == other.pConfigData && self.dwConfigDataSize == other.dwConfigDataSize
     }
 }
 impl ::core::cmp::Eq for WSD_CONFIG_PARAM {}
@@ -3719,7 +3719,7 @@ unsafe impl ::windows::core::Abi for WSD_DATETIME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSD_DATETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_DATETIME>()) == 0 }
+        self.isPositive == other.isPositive && self.year == other.year && self.month == other.month && self.day == other.day && self.hour == other.hour && self.minute == other.minute && self.second == other.second && self.millisecond == other.millisecond && self.TZIsLocal == other.TZIsLocal && self.TZIsPositive == other.TZIsPositive && self.TZHour == other.TZHour && self.TZMinute == other.TZMinute
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3764,7 +3764,7 @@ unsafe impl ::windows::core::Abi for WSD_DURATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSD_DURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_DURATION>()) == 0 }
+        self.isPositive == other.isPositive && self.year == other.year && self.month == other.month && self.day == other.day && self.hour == other.hour && self.minute == other.minute && self.second == other.second && self.millisecond == other.millisecond
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3801,7 +3801,7 @@ unsafe impl ::windows::core::Abi for WSD_ENDPOINT_REFERENCE {
 }
 impl ::core::cmp::PartialEq for WSD_ENDPOINT_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_ENDPOINT_REFERENCE>()) == 0 }
+        self.Address == other.Address && self.ReferenceProperties == other.ReferenceProperties && self.ReferenceParameters == other.ReferenceParameters && self.PortType == other.PortType && self.ServiceName == other.ServiceName && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_ENDPOINT_REFERENCE {}
@@ -3832,7 +3832,7 @@ unsafe impl ::windows::core::Abi for WSD_ENDPOINT_REFERENCE_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_ENDPOINT_REFERENCE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_ENDPOINT_REFERENCE_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_ENDPOINT_REFERENCE_LIST {}
@@ -3867,18 +3867,12 @@ impl ::core::clone::Clone for WSD_EVENT {
 }
 impl ::core::fmt::Debug for WSD_EVENT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSD_EVENT").field("Hr", &self.Hr).field("EventType", &self.EventType).field("DispatchTag", &self.DispatchTag).field("HandlerContext", &self.HandlerContext).field("Soap", &self.Soap).field("Operation", &self.Operation).field("MessageParameters", &self.MessageParameters).finish()
+        f.debug_struct("WSD_EVENT").field("Hr", &self.Hr).field("EventType", &self.EventType).field("DispatchTag", &self.DispatchTag).field("Soap", &self.Soap).field("Operation", &self.Operation).field("MessageParameters", &self.MessageParameters).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WSD_EVENT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for WSD_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        self.Hr == other.Hr && self.EventType == other.EventType && self.DispatchTag == other.DispatchTag && self.HandlerContext == other.HandlerContext && self.Soap == other.Soap && self.Operation == other.Operation && self.MessageParameters == other.MessageParameters
-    }
-}
-impl ::core::cmp::Eq for WSD_EVENT {}
 impl ::core::default::Default for WSD_EVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3907,7 +3901,7 @@ unsafe impl ::windows::core::Abi for WSD_EVENTING_DELIVERY_MODE {
 }
 impl ::core::cmp::PartialEq for WSD_EVENTING_DELIVERY_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_EVENTING_DELIVERY_MODE>()) == 0 }
+        self.Mode == other.Mode && self.Push == other.Push && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WSD_EVENTING_DELIVERY_MODE {}
@@ -3937,7 +3931,7 @@ unsafe impl ::windows::core::Abi for WSD_EVENTING_DELIVERY_MODE_PUSH {
 }
 impl ::core::cmp::PartialEq for WSD_EVENTING_DELIVERY_MODE_PUSH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_EVENTING_DELIVERY_MODE_PUSH>()) == 0 }
+        self.NotifyTo == other.NotifyTo
     }
 }
 impl ::core::cmp::Eq for WSD_EVENTING_DELIVERY_MODE_PUSH {}
@@ -3974,7 +3968,7 @@ unsafe impl ::windows::core::Abi for WSD_EVENTING_EXPIRES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSD_EVENTING_EXPIRES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_EVENTING_EXPIRES>()) == 0 }
+        self.Duration == other.Duration && self.DateTime == other.DateTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4008,7 +4002,7 @@ unsafe impl ::windows::core::Abi for WSD_EVENTING_FILTER {
 }
 impl ::core::cmp::PartialEq for WSD_EVENTING_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_EVENTING_FILTER>()) == 0 }
+        self.Dialect == other.Dialect && self.FilterAction == other.FilterAction && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WSD_EVENTING_FILTER {}
@@ -4038,7 +4032,7 @@ unsafe impl ::windows::core::Abi for WSD_EVENTING_FILTER_ACTION {
 }
 impl ::core::cmp::PartialEq for WSD_EVENTING_FILTER_ACTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_EVENTING_FILTER_ACTION>()) == 0 }
+        self.Actions == other.Actions
     }
 }
 impl ::core::cmp::Eq for WSD_EVENTING_FILTER_ACTION {}
@@ -4061,18 +4055,12 @@ impl ::core::clone::Clone for WSD_HANDLER_CONTEXT {
 }
 impl ::core::fmt::Debug for WSD_HANDLER_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSD_HANDLER_CONTEXT").field("Handler", &self.Handler.map(|f| f as usize)).field("PVoid", &self.PVoid).field("Unknown", &self.Unknown).finish()
+        f.debug_struct("WSD_HANDLER_CONTEXT").field("PVoid", &self.PVoid).field("Unknown", &self.Unknown).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WSD_HANDLER_CONTEXT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for WSD_HANDLER_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        self.Handler.map(|f| f as usize) == other.Handler.map(|f| f as usize) && self.PVoid == other.PVoid && self.Unknown == other.Unknown
-    }
-}
-impl ::core::cmp::Eq for WSD_HANDLER_CONTEXT {}
 impl ::core::default::Default for WSD_HANDLER_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4100,7 +4088,7 @@ unsafe impl ::windows::core::Abi for WSD_HEADER_RELATESTO {
 }
 impl ::core::cmp::PartialEq for WSD_HEADER_RELATESTO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_HEADER_RELATESTO>()) == 0 }
+        self.RelationshipType == other.RelationshipType && self.MessageID == other.MessageID
     }
 }
 impl ::core::cmp::Eq for WSD_HEADER_RELATESTO {}
@@ -4135,7 +4123,7 @@ unsafe impl ::windows::core::Abi for WSD_HELLO {
 }
 impl ::core::cmp::PartialEq for WSD_HELLO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_HELLO>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Types == other.Types && self.Scopes == other.Scopes && self.XAddrs == other.XAddrs && self.MetadataVersion == other.MetadataVersion && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_HELLO {}
@@ -4166,7 +4154,7 @@ unsafe impl ::windows::core::Abi for WSD_HOST_METADATA {
 }
 impl ::core::cmp::PartialEq for WSD_HOST_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_HOST_METADATA>()) == 0 }
+        self.Host == other.Host && self.Hosted == other.Hosted
     }
 }
 impl ::core::cmp::Eq for WSD_HOST_METADATA {}
@@ -4197,7 +4185,7 @@ unsafe impl ::windows::core::Abi for WSD_LOCALIZED_STRING {
 }
 impl ::core::cmp::PartialEq for WSD_LOCALIZED_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_LOCALIZED_STRING>()) == 0 }
+        self.lang == other.lang && self.String == other.String
     }
 }
 impl ::core::cmp::Eq for WSD_LOCALIZED_STRING {}
@@ -4228,7 +4216,7 @@ unsafe impl ::windows::core::Abi for WSD_LOCALIZED_STRING_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_LOCALIZED_STRING_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_LOCALIZED_STRING_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_LOCALIZED_STRING_LIST {}
@@ -4263,7 +4251,7 @@ unsafe impl ::windows::core::Abi for WSD_METADATA_SECTION {
 }
 impl ::core::cmp::PartialEq for WSD_METADATA_SECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_METADATA_SECTION>()) == 0 }
+        self.Dialect == other.Dialect && self.Identifier == other.Identifier && self.Data == other.Data && self.MetadataReference == other.MetadataReference && self.Location == other.Location && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_METADATA_SECTION {}
@@ -4294,7 +4282,7 @@ unsafe impl ::windows::core::Abi for WSD_METADATA_SECTION_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_METADATA_SECTION_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_METADATA_SECTION_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_METADATA_SECTION_LIST {}
@@ -4325,7 +4313,7 @@ unsafe impl ::windows::core::Abi for WSD_NAME_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_NAME_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_NAME_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_NAME_LIST {}
@@ -4349,18 +4337,12 @@ impl ::core::clone::Clone for WSD_OPERATION {
 }
 impl ::core::fmt::Debug for WSD_OPERATION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSD_OPERATION").field("RequestType", &self.RequestType).field("ResponseType", &self.ResponseType).field("RequestStubFunction", &self.RequestStubFunction.map(|f| f as usize)).finish()
+        f.debug_struct("WSD_OPERATION").field("RequestType", &self.RequestType).field("ResponseType", &self.ResponseType).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WSD_OPERATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSD_OPERATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_OPERATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSD_OPERATION {}
 impl ::core::default::Default for WSD_OPERATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4390,7 +4372,7 @@ unsafe impl ::windows::core::Abi for WSD_PORT_TYPE {
 }
 impl ::core::cmp::PartialEq for WSD_PORT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_PORT_TYPE>()) == 0 }
+        self.EncodedName == other.EncodedName && self.OperationCount == other.OperationCount && self.Operations == other.Operations && self.ProtocolType == other.ProtocolType
     }
 }
 impl ::core::cmp::Eq for WSD_PORT_TYPE {}
@@ -4422,7 +4404,7 @@ unsafe impl ::windows::core::Abi for WSD_PROBE {
 }
 impl ::core::cmp::PartialEq for WSD_PROBE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_PROBE>()) == 0 }
+        self.Types == other.Types && self.Scopes == other.Scopes && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_PROBE {}
@@ -4457,7 +4439,7 @@ unsafe impl ::windows::core::Abi for WSD_PROBE_MATCH {
 }
 impl ::core::cmp::PartialEq for WSD_PROBE_MATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_PROBE_MATCH>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Types == other.Types && self.Scopes == other.Scopes && self.XAddrs == other.XAddrs && self.MetadataVersion == other.MetadataVersion && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_PROBE_MATCH {}
@@ -4488,7 +4470,7 @@ unsafe impl ::windows::core::Abi for WSD_PROBE_MATCHES {
 }
 impl ::core::cmp::PartialEq for WSD_PROBE_MATCHES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_PROBE_MATCHES>()) == 0 }
+        self.ProbeMatch == other.ProbeMatch && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_PROBE_MATCHES {}
@@ -4519,7 +4501,7 @@ unsafe impl ::windows::core::Abi for WSD_PROBE_MATCH_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_PROBE_MATCH_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_PROBE_MATCH_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_PROBE_MATCH_LIST {}
@@ -4549,7 +4531,7 @@ unsafe impl ::windows::core::Abi for WSD_REFERENCE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for WSD_REFERENCE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_REFERENCE_PARAMETERS>()) == 0 }
+        self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_REFERENCE_PARAMETERS {}
@@ -4579,7 +4561,7 @@ unsafe impl ::windows::core::Abi for WSD_REFERENCE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WSD_REFERENCE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_REFERENCE_PROPERTIES>()) == 0 }
+        self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_REFERENCE_PROPERTIES {}
@@ -4611,7 +4593,7 @@ unsafe impl ::windows::core::Abi for WSD_RELATIONSHIP_METADATA {
 }
 impl ::core::cmp::PartialEq for WSD_RELATIONSHIP_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_RELATIONSHIP_METADATA>()) == 0 }
+        self.Type == other.Type && self.Data == other.Data && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_RELATIONSHIP_METADATA {}
@@ -4642,7 +4624,7 @@ unsafe impl ::windows::core::Abi for WSD_RESOLVE {
 }
 impl ::core::cmp::PartialEq for WSD_RESOLVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_RESOLVE>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_RESOLVE {}
@@ -4677,7 +4659,7 @@ unsafe impl ::windows::core::Abi for WSD_RESOLVE_MATCH {
 }
 impl ::core::cmp::PartialEq for WSD_RESOLVE_MATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_RESOLVE_MATCH>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Types == other.Types && self.Scopes == other.Scopes && self.XAddrs == other.XAddrs && self.MetadataVersion == other.MetadataVersion && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_RESOLVE_MATCH {}
@@ -4708,7 +4690,7 @@ unsafe impl ::windows::core::Abi for WSD_RESOLVE_MATCHES {
 }
 impl ::core::cmp::PartialEq for WSD_RESOLVE_MATCHES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_RESOLVE_MATCHES>()) == 0 }
+        self.ResolveMatch == other.ResolveMatch && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_RESOLVE_MATCHES {}
@@ -4739,7 +4721,7 @@ unsafe impl ::windows::core::Abi for WSD_SCOPES {
 }
 impl ::core::cmp::PartialEq for WSD_SCOPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SCOPES>()) == 0 }
+        self.MatchBy == other.MatchBy && self.Scopes == other.Scopes
     }
 }
 impl ::core::cmp::Eq for WSD_SCOPES {}
@@ -4782,7 +4764,7 @@ unsafe impl ::windows::core::Abi for WSD_SECURITY_CERT_VALIDATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for WSD_SECURITY_CERT_VALIDATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SECURITY_CERT_VALIDATION>()) == 0 }
+        self.certMatchArray == other.certMatchArray && self.dwCertMatchArrayCount == other.dwCertMatchArrayCount && self.hCertMatchStore == other.hCertMatchStore && self.hCertIssuerStore == other.hCertIssuerStore && self.dwCertCheckOptions == other.dwCertCheckOptions && self.pszCNGHashAlgId == other.pszCNGHashAlgId && self.pbCertHash == other.pbCertHash && self.dwCertHashSize == other.dwCertHashSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -4824,7 +4806,7 @@ unsafe impl ::windows::core::Abi for WSD_SECURITY_CERT_VALIDATION_V1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for WSD_SECURITY_CERT_VALIDATION_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SECURITY_CERT_VALIDATION_V1>()) == 0 }
+        self.certMatchArray == other.certMatchArray && self.dwCertMatchArrayCount == other.dwCertMatchArrayCount && self.hCertMatchStore == other.hCertMatchStore && self.hCertIssuerStore == other.hCertIssuerStore && self.dwCertCheckOptions == other.dwCertCheckOptions
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -4865,7 +4847,7 @@ unsafe impl ::windows::core::Abi for WSD_SECURITY_SIGNATURE_VALIDATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for WSD_SECURITY_SIGNATURE_VALIDATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SECURITY_SIGNATURE_VALIDATION>()) == 0 }
+        self.signingCertArray == other.signingCertArray && self.dwSigningCertArrayCount == other.dwSigningCertArrayCount && self.hSigningCertStore == other.hSigningCertStore && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -4900,7 +4882,7 @@ unsafe impl ::windows::core::Abi for WSD_SERVICE_METADATA {
 }
 impl ::core::cmp::PartialEq for WSD_SERVICE_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SERVICE_METADATA>()) == 0 }
+        self.EndpointReference == other.EndpointReference && self.Types == other.Types && self.ServiceId == other.ServiceId && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_SERVICE_METADATA {}
@@ -4931,7 +4913,7 @@ unsafe impl ::windows::core::Abi for WSD_SERVICE_METADATA_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_SERVICE_METADATA_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SERVICE_METADATA_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_SERVICE_METADATA_LIST {}
@@ -4965,7 +4947,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_FAULT {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_FAULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_FAULT>()) == 0 }
+        self.Code == other.Code && self.Reason == other.Reason && self.Node == other.Node && self.Role == other.Role && self.Detail == other.Detail
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_FAULT {}
@@ -4996,7 +4978,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_FAULT_CODE {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_FAULT_CODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_FAULT_CODE>()) == 0 }
+        self.Value == other.Value && self.Subcode == other.Subcode
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_FAULT_CODE {}
@@ -5026,7 +5008,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_FAULT_REASON {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_FAULT_REASON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_FAULT_REASON>()) == 0 }
+        self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_FAULT_REASON {}
@@ -5057,7 +5039,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_FAULT_SUBCODE {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_FAULT_SUBCODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_FAULT_SUBCODE>()) == 0 }
+        self.Value == other.Value && self.Subcode == other.Subcode
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_FAULT_SUBCODE {}
@@ -5095,7 +5077,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_HEADER {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_HEADER>()) == 0 }
+        self.To == other.To && self.Action == other.Action && self.MessageID == other.MessageID && self.RelatesTo == other.RelatesTo && self.ReplyTo == other.ReplyTo && self.From == other.From && self.FaultTo == other.FaultTo && self.AppSequence == other.AppSequence && self.AnyHeaders == other.AnyHeaders
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_HEADER {}
@@ -5127,7 +5109,7 @@ unsafe impl ::windows::core::Abi for WSD_SOAP_MESSAGE {
 }
 impl ::core::cmp::PartialEq for WSD_SOAP_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_SOAP_MESSAGE>()) == 0 }
+        self.Header == other.Header && self.Body == other.Body && self.BodyType == other.BodyType
     }
 }
 impl ::core::cmp::Eq for WSD_SOAP_MESSAGE {}
@@ -5199,7 +5181,7 @@ unsafe impl ::windows::core::Abi for WSD_THIS_DEVICE_METADATA {
 }
 impl ::core::cmp::PartialEq for WSD_THIS_DEVICE_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_THIS_DEVICE_METADATA>()) == 0 }
+        self.FriendlyName == other.FriendlyName && self.FirmwareVersion == other.FirmwareVersion && self.SerialNumber == other.SerialNumber && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_THIS_DEVICE_METADATA {}
@@ -5235,7 +5217,7 @@ unsafe impl ::windows::core::Abi for WSD_THIS_MODEL_METADATA {
 }
 impl ::core::cmp::PartialEq for WSD_THIS_MODEL_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_THIS_MODEL_METADATA>()) == 0 }
+        self.Manufacturer == other.Manufacturer && self.ManufacturerUrl == other.ManufacturerUrl && self.ModelName == other.ModelName && self.ModelNumber == other.ModelNumber && self.ModelUrl == other.ModelUrl && self.PresentationUrl == other.PresentationUrl && self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_THIS_MODEL_METADATA {}
@@ -5265,7 +5247,7 @@ unsafe impl ::windows::core::Abi for WSD_UNKNOWN_LOOKUP {
 }
 impl ::core::cmp::PartialEq for WSD_UNKNOWN_LOOKUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_UNKNOWN_LOOKUP>()) == 0 }
+        self.Any == other.Any
     }
 }
 impl ::core::cmp::Eq for WSD_UNKNOWN_LOOKUP {}
@@ -5296,7 +5278,7 @@ unsafe impl ::windows::core::Abi for WSD_URI_LIST {
 }
 impl ::core::cmp::PartialEq for WSD_URI_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSD_URI_LIST>()) == 0 }
+        self.Next == other.Next && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for WSD_URI_LIST {}

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -19934,7 +19934,7 @@ unsafe impl ::windows::core::Abi for APP_LOCAL_DEVICE_ID {
 }
 impl ::core::cmp::PartialEq for APP_LOCAL_DEVICE_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_LOCAL_DEVICE_ID>()) == 0 }
+        self.value == other.value
     }
 }
 impl ::core::cmp::Eq for APP_LOCAL_DEVICE_ID {}
@@ -20204,12 +20204,6 @@ impl ::core::clone::Clone for DECIMAL {
 unsafe impl ::windows::core::Abi for DECIMAL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DECIMAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECIMAL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DECIMAL {}
 impl ::core::default::Default for DECIMAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20230,12 +20224,6 @@ impl ::core::clone::Clone for DECIMAL_0 {
 unsafe impl ::windows::core::Abi for DECIMAL_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DECIMAL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECIMAL_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DECIMAL_0 {}
 impl ::core::default::Default for DECIMAL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20263,7 +20251,7 @@ unsafe impl ::windows::core::Abi for DECIMAL_0_0 {
 }
 impl ::core::cmp::PartialEq for DECIMAL_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECIMAL_0_0>()) == 0 }
+        self.scale == other.scale && self.sign == other.sign
     }
 }
 impl ::core::cmp::Eq for DECIMAL_0_0 {}
@@ -20287,12 +20275,6 @@ impl ::core::clone::Clone for DECIMAL_1 {
 unsafe impl ::windows::core::Abi for DECIMAL_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DECIMAL_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECIMAL_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DECIMAL_1 {}
 impl ::core::default::Default for DECIMAL_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20320,7 +20302,7 @@ unsafe impl ::windows::core::Abi for DECIMAL_1_0 {
 }
 impl ::core::cmp::PartialEq for DECIMAL_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECIMAL_1_0>()) == 0 }
+        self.Lo32 == other.Lo32 && self.Mid32 == other.Mid32
     }
 }
 impl ::core::cmp::Eq for DECIMAL_1_0 {}
@@ -20351,7 +20333,7 @@ unsafe impl ::windows::core::Abi for FILETIME {
 }
 impl ::core::cmp::PartialEq for FILETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILETIME>()) == 0 }
+        self.dwLowDateTime == other.dwLowDateTime && self.dwHighDateTime == other.dwHighDateTime
     }
 }
 impl ::core::cmp::Eq for FILETIME {}
@@ -20382,7 +20364,7 @@ unsafe impl ::windows::core::Abi for FLOAT128 {
 }
 impl ::core::cmp::PartialEq for FLOAT128 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOAT128>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for FLOAT128 {}
@@ -20503,7 +20485,7 @@ unsafe impl ::windows::core::Abi for HLSURF__ {
 }
 impl ::core::cmp::PartialEq for HLSURF__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HLSURF__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HLSURF__ {}
@@ -20565,7 +20547,7 @@ unsafe impl ::windows::core::Abi for HSPRITE__ {
 }
 impl ::core::cmp::PartialEq for HSPRITE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSPRITE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HSPRITE__ {}
@@ -20595,7 +20577,7 @@ unsafe impl ::windows::core::Abi for HSTR__ {
 }
 impl ::core::cmp::PartialEq for HSTR__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSTR__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HSTR__ {}
@@ -20625,7 +20607,7 @@ unsafe impl ::windows::core::Abi for HUMPD__ {
 }
 impl ::core::cmp::PartialEq for HUMPD__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HUMPD__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HUMPD__ {}
@@ -20737,7 +20719,7 @@ unsafe impl ::windows::core::Abi for LUID {
 }
 impl ::core::cmp::PartialEq for LUID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LUID>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for LUID {}
@@ -20827,7 +20809,7 @@ unsafe impl ::windows::core::Abi for POINT {
 }
 impl ::core::cmp::PartialEq for POINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINT>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINT {}
@@ -20858,7 +20840,7 @@ unsafe impl ::windows::core::Abi for POINTL {
 }
 impl ::core::cmp::PartialEq for POINTL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTL>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTL {}
@@ -20889,7 +20871,7 @@ unsafe impl ::windows::core::Abi for POINTS {
 }
 impl ::core::cmp::PartialEq for POINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTS>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTS {}
@@ -20954,7 +20936,7 @@ unsafe impl ::windows::core::Abi for RECT {
 }
 impl ::core::cmp::PartialEq for RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECT>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for RECT {}
@@ -20987,7 +20969,7 @@ unsafe impl ::windows::core::Abi for RECTL {
 }
 impl ::core::cmp::PartialEq for RECTL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECTL>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for RECTL {}
@@ -21045,7 +21027,7 @@ unsafe impl ::windows::core::Abi for SIZE {
 }
 impl ::core::cmp::PartialEq for SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIZE>()) == 0 }
+        self.cx == other.cx && self.cy == other.cy
     }
 }
 impl ::core::cmp::Eq for SIZE {}
@@ -21082,7 +21064,7 @@ unsafe impl ::windows::core::Abi for SYSTEMTIME {
 }
 impl ::core::cmp::PartialEq for SYSTEMTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEMTIME>()) == 0 }
+        self.wYear == other.wYear && self.wMonth == other.wMonth && self.wDayOfWeek == other.wDayOfWeek && self.wDay == other.wDay && self.wHour == other.wHour && self.wMinute == other.wMinute && self.wSecond == other.wSecond && self.wMilliseconds == other.wMilliseconds
     }
 }
 impl ::core::cmp::Eq for SYSTEMTIME {}
@@ -21114,7 +21096,7 @@ unsafe impl ::windows::core::Abi for UNICODE_STRING {
 }
 impl ::core::cmp::PartialEq for UNICODE_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNICODE_STRING>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for UNICODE_STRING {}

--- a/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
@@ -1038,7 +1038,7 @@ unsafe impl ::windows::core::Abi for GAMING_DEVICE_MODEL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for GAMING_DEVICE_MODEL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GAMING_DEVICE_MODEL_INFORMATION>()) == 0 }
+        self.vendorId == other.vendorId && self.deviceId == other.deviceId
     }
 }
 impl ::core::cmp::Eq for GAMING_DEVICE_MODEL_INFORMATION {}

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -20487,7 +20487,7 @@ unsafe impl ::windows::core::Abi for CHARSETINFO {
 }
 impl ::core::cmp::PartialEq for CHARSETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARSETINFO>()) == 0 }
+        self.ciCharset == other.ciCharset && self.ciACP == other.ciACP && self.fs == other.fs
     }
 }
 impl ::core::cmp::Eq for CHARSETINFO {}
@@ -20519,7 +20519,7 @@ unsafe impl ::windows::core::Abi for CPINFO {
 }
 impl ::core::cmp::PartialEq for CPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPINFO>()) == 0 }
+        self.MaxCharSize == other.MaxCharSize && self.DefaultChar == other.DefaultChar && self.LeadByte == other.LeadByte
     }
 }
 impl ::core::cmp::Eq for CPINFO {}
@@ -20560,7 +20560,7 @@ unsafe impl ::windows::core::Abi for CPINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CPINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPINFOEXA>()) == 0 }
+        self.MaxCharSize == other.MaxCharSize && self.DefaultChar == other.DefaultChar && self.LeadByte == other.LeadByte && self.UnicodeDefaultChar == other.UnicodeDefaultChar && self.CodePage == other.CodePage && self.CodePageName == other.CodePageName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20597,7 +20597,7 @@ unsafe impl ::windows::core::Abi for CPINFOEXW {
 }
 impl ::core::cmp::PartialEq for CPINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPINFOEXW>()) == 0 }
+        self.MaxCharSize == other.MaxCharSize && self.DefaultChar == other.DefaultChar && self.LeadByte == other.LeadByte && self.UnicodeDefaultChar == other.UnicodeDefaultChar && self.CodePage == other.CodePage && self.CodePageName == other.CodePageName
     }
 }
 impl ::core::cmp::Eq for CPINFOEXW {}
@@ -20634,7 +20634,7 @@ unsafe impl ::windows::core::Abi for CURRENCYFMTA {
 }
 impl ::core::cmp::PartialEq for CURRENCYFMTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CURRENCYFMTA>()) == 0 }
+        self.NumDigits == other.NumDigits && self.LeadingZero == other.LeadingZero && self.Grouping == other.Grouping && self.lpDecimalSep == other.lpDecimalSep && self.lpThousandSep == other.lpThousandSep && self.NegativeOrder == other.NegativeOrder && self.PositiveOrder == other.PositiveOrder && self.lpCurrencySymbol == other.lpCurrencySymbol
     }
 }
 impl ::core::cmp::Eq for CURRENCYFMTA {}
@@ -20671,7 +20671,7 @@ unsafe impl ::windows::core::Abi for CURRENCYFMTW {
 }
 impl ::core::cmp::PartialEq for CURRENCYFMTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CURRENCYFMTW>()) == 0 }
+        self.NumDigits == other.NumDigits && self.LeadingZero == other.LeadingZero && self.Grouping == other.Grouping && self.lpDecimalSep == other.lpDecimalSep && self.lpThousandSep == other.lpThousandSep && self.NegativeOrder == other.NegativeOrder && self.PositiveOrder == other.PositiveOrder && self.lpCurrencySymbol == other.lpCurrencySymbol
     }
 }
 impl ::core::cmp::Eq for CURRENCYFMTW {}
@@ -20704,7 +20704,7 @@ unsafe impl ::windows::core::Abi for DetectEncodingInfo {
 }
 impl ::core::cmp::PartialEq for DetectEncodingInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DetectEncodingInfo>()) == 0 }
+        self.nLangID == other.nLangID && self.nCodePage == other.nCodePage && self.nDocPercent == other.nDocPercent && self.nConfidence == other.nConfidence
     }
 }
 impl ::core::cmp::Eq for DetectEncodingInfo {}
@@ -20741,7 +20741,7 @@ unsafe impl ::windows::core::Abi for ENUMTEXTMETRICA {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ENUMTEXTMETRICA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMTEXTMETRICA>()) == 0 }
+        self.etmNewTextMetricEx == other.etmNewTextMetricEx && self.etmAxesList == other.etmAxesList
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -20780,7 +20780,7 @@ unsafe impl ::windows::core::Abi for ENUMTEXTMETRICW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ENUMTEXTMETRICW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMTEXTMETRICW>()) == 0 }
+        self.etmNewTextMetricEx == other.etmNewTextMetricEx && self.etmAxesList == other.etmAxesList
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -20838,7 +20838,7 @@ unsafe impl ::windows::core::Abi for FILEMUIINFO {
 }
 impl ::core::cmp::PartialEq for FILEMUIINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEMUIINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVersion == other.dwVersion && self.dwFileType == other.dwFileType && self.pChecksum == other.pChecksum && self.pServiceChecksum == other.pServiceChecksum && self.dwLanguageNameOffset == other.dwLanguageNameOffset && self.dwTypeIDMainSize == other.dwTypeIDMainSize && self.dwTypeIDMainOffset == other.dwTypeIDMainOffset && self.dwTypeNameMainOffset == other.dwTypeNameMainOffset && self.dwTypeIDMUISize == other.dwTypeIDMUISize && self.dwTypeIDMUIOffset == other.dwTypeIDMUIOffset && self.dwTypeNameMUIOffset == other.dwTypeNameMUIOffset && self.abBuffer == other.abBuffer
     }
 }
 impl ::core::cmp::Eq for FILEMUIINFO {}
@@ -20869,7 +20869,7 @@ unsafe impl ::windows::core::Abi for FONTSIGNATURE {
 }
 impl ::core::cmp::PartialEq for FONTSIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTSIGNATURE>()) == 0 }
+        self.fsUsb == other.fsUsb && self.fsCsb == other.fsCsb
     }
 }
 impl ::core::cmp::Eq for FONTSIGNATURE {}
@@ -20900,7 +20900,7 @@ unsafe impl ::windows::core::Abi for GOFFSET {
 }
 impl ::core::cmp::PartialEq for GOFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOFFSET>()) == 0 }
+        self.du == other.du && self.dv == other.dv
     }
 }
 impl ::core::cmp::Eq for GOFFSET {}
@@ -21028,7 +21028,7 @@ unsafe impl ::windows::core::Abi for LOCALESIGNATURE {
 }
 impl ::core::cmp::PartialEq for LOCALESIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALESIGNATURE>()) == 0 }
+        self.lsUsb == other.lsUsb && self.lsCsbDefault == other.lsCsbDefault && self.lsCsbSupported == other.lsCsbSupported
     }
 }
 impl ::core::cmp::Eq for LOCALESIGNATURE {}
@@ -21078,7 +21078,7 @@ unsafe impl ::windows::core::Abi for MAPPING_DATA_RANGE {
 }
 impl ::core::cmp::PartialEq for MAPPING_DATA_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPPING_DATA_RANGE>()) == 0 }
+        self.dwStartIndex == other.dwStartIndex && self.dwEndIndex == other.dwEndIndex && self.pszDescription == other.pszDescription && self.dwDescriptionLength == other.dwDescriptionLength && self.pData == other.pData && self.dwDataSize == other.dwDataSize && self.pszContentType == other.pszContentType && self.prgActionIds == other.prgActionIds && self.dwActionsCount == other.dwActionsCount && self.prgActionDisplayNames == other.prgActionDisplayNames
     }
 }
 impl ::core::cmp::Eq for MAPPING_DATA_RANGE {}
@@ -21128,7 +21128,7 @@ unsafe impl ::windows::core::Abi for MAPPING_ENUM_OPTIONS {
 }
 impl ::core::cmp::PartialEq for MAPPING_ENUM_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPPING_ENUM_OPTIONS>()) == 0 }
+        self.Size == other.Size && self.pszCategory == other.pszCategory && self.pszInputLanguage == other.pszInputLanguage && self.pszOutputLanguage == other.pszOutputLanguage && self.pszInputScript == other.pszInputScript && self.pszOutputScript == other.pszOutputScript && self.pszInputContentType == other.pszInputContentType && self.pszOutputContentType == other.pszOutputContentType && self.pGuid == other.pGuid && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MAPPING_ENUM_OPTIONS {}
@@ -21174,10 +21174,8 @@ impl ::core::fmt::Debug for MAPPING_OPTIONS {
             .field("pszInputContentType", &self.pszInputContentType)
             .field("pszOutputContentType", &self.pszOutputContentType)
             .field("pszUILanguage", &self.pszUILanguage)
-            .field("pfnRecognizeCallback", &self.pfnRecognizeCallback.map(|f| f as usize))
             .field("pRecognizeCallerData", &self.pRecognizeCallerData)
             .field("dwRecognizeCallerDataSize", &self.dwRecognizeCallerDataSize)
-            .field("pfnActionCallback", &self.pfnActionCallback.map(|f| f as usize))
             .field("pActionCallerData", &self.pActionCallerData)
             .field("dwActionCallerDataSize", &self.dwActionCallerDataSize)
             .field("dwServiceFlag", &self.dwServiceFlag)
@@ -21188,12 +21186,6 @@ impl ::core::fmt::Debug for MAPPING_OPTIONS {
 unsafe impl ::windows::core::Abi for MAPPING_OPTIONS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MAPPING_OPTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPPING_OPTIONS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MAPPING_OPTIONS {}
 impl ::core::default::Default for MAPPING_OPTIONS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21227,7 +21219,7 @@ unsafe impl ::windows::core::Abi for MAPPING_PROPERTY_BAG {
 }
 impl ::core::cmp::PartialEq for MAPPING_PROPERTY_BAG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPPING_PROPERTY_BAG>()) == 0 }
+        self.Size == other.Size && self.prgResultRanges == other.prgResultRanges && self.dwRangesCount == other.dwRangesCount && self.pServiceData == other.pServiceData && self.dwServiceDataSize == other.dwServiceDataSize && self.pCallerData == other.pCallerData && self.dwCallerDataSize == other.dwCallerDataSize && self.pContext == other.pContext
     }
 }
 impl ::core::cmp::Eq for MAPPING_PROPERTY_BAG {}
@@ -21307,7 +21299,31 @@ unsafe impl ::windows::core::Abi for MAPPING_SERVICE_INFO {
 }
 impl ::core::cmp::PartialEq for MAPPING_SERVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPPING_SERVICE_INFO>()) == 0 }
+        self.Size == other.Size
+            && self.pszCopyright == other.pszCopyright
+            && self.wMajorVersion == other.wMajorVersion
+            && self.wMinorVersion == other.wMinorVersion
+            && self.wBuildVersion == other.wBuildVersion
+            && self.wStepVersion == other.wStepVersion
+            && self.dwInputContentTypesCount == other.dwInputContentTypesCount
+            && self.prgInputContentTypes == other.prgInputContentTypes
+            && self.dwOutputContentTypesCount == other.dwOutputContentTypesCount
+            && self.prgOutputContentTypes == other.prgOutputContentTypes
+            && self.dwInputLanguagesCount == other.dwInputLanguagesCount
+            && self.prgInputLanguages == other.prgInputLanguages
+            && self.dwOutputLanguagesCount == other.dwOutputLanguagesCount
+            && self.prgOutputLanguages == other.prgOutputLanguages
+            && self.dwInputScriptsCount == other.dwInputScriptsCount
+            && self.prgInputScripts == other.prgInputScripts
+            && self.dwOutputScriptsCount == other.dwOutputScriptsCount
+            && self.prgOutputScripts == other.prgOutputScripts
+            && self.guid == other.guid
+            && self.pszCategory == other.pszCategory
+            && self.pszDescription == other.pszDescription
+            && self.dwPrivateDataSize == other.dwPrivateDataSize
+            && self.pPrivateData == other.pPrivateData
+            && self.pContext == other.pContext
+            && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MAPPING_SERVICE_INFO {}
@@ -21357,7 +21373,7 @@ unsafe impl ::windows::core::Abi for MIMECPINFO {
 }
 impl ::core::cmp::PartialEq for MIMECPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIMECPINFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.uiCodePage == other.uiCodePage && self.uiFamilyCodePage == other.uiFamilyCodePage && self.wszDescription == other.wszDescription && self.wszWebCharset == other.wszWebCharset && self.wszHeaderCharset == other.wszHeaderCharset && self.wszBodyCharset == other.wszBodyCharset && self.wszFixedWidthFont == other.wszFixedWidthFont && self.wszProportionalFont == other.wszProportionalFont && self.bGDICharset == other.bGDICharset
     }
 }
 impl ::core::cmp::Eq for MIMECPINFO {}
@@ -21389,7 +21405,7 @@ unsafe impl ::windows::core::Abi for MIMECSETINFO {
 }
 impl ::core::cmp::PartialEq for MIMECSETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIMECSETINFO>()) == 0 }
+        self.uiCodePage == other.uiCodePage && self.uiInternetEncoding == other.uiInternetEncoding && self.wszCharset == other.wszCharset
     }
 }
 impl ::core::cmp::Eq for MIMECSETINFO {}
@@ -21426,7 +21442,7 @@ unsafe impl ::windows::core::Abi for NEWTEXTMETRICEXA {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for NEWTEXTMETRICEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWTEXTMETRICEXA>()) == 0 }
+        self.ntmTm == other.ntmTm && self.ntmFontSig == other.ntmFontSig
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -21465,7 +21481,7 @@ unsafe impl ::windows::core::Abi for NEWTEXTMETRICEXW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for NEWTEXTMETRICEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWTEXTMETRICEXW>()) == 0 }
+        self.ntmTm == other.ntmTm && self.ntmFontSig == other.ntmFontSig
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -21501,7 +21517,7 @@ unsafe impl ::windows::core::Abi for NLSVERSIONINFO {
 }
 impl ::core::cmp::PartialEq for NLSVERSIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLSVERSIONINFO>()) == 0 }
+        self.dwNLSVersionInfoSize == other.dwNLSVersionInfoSize && self.dwNLSVersion == other.dwNLSVersion && self.dwDefinedVersion == other.dwDefinedVersion && self.dwEffectiveId == other.dwEffectiveId && self.guidCustomVersion == other.guidCustomVersion
     }
 }
 impl ::core::cmp::Eq for NLSVERSIONINFO {}
@@ -21535,7 +21551,7 @@ unsafe impl ::windows::core::Abi for NLSVERSIONINFOEX {
 }
 impl ::core::cmp::PartialEq for NLSVERSIONINFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLSVERSIONINFOEX>()) == 0 }
+        self.dwNLSVersionInfoSize == other.dwNLSVersionInfoSize && self.dwNLSVersion == other.dwNLSVersion && self.dwDefinedVersion == other.dwDefinedVersion && self.dwEffectiveId == other.dwEffectiveId && self.guidCustomVersion == other.guidCustomVersion
     }
 }
 impl ::core::cmp::Eq for NLSVERSIONINFOEX {}
@@ -21570,7 +21586,7 @@ unsafe impl ::windows::core::Abi for NUMBERFMTA {
 }
 impl ::core::cmp::PartialEq for NUMBERFMTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NUMBERFMTA>()) == 0 }
+        self.NumDigits == other.NumDigits && self.LeadingZero == other.LeadingZero && self.Grouping == other.Grouping && self.lpDecimalSep == other.lpDecimalSep && self.lpThousandSep == other.lpThousandSep && self.NegativeOrder == other.NegativeOrder
     }
 }
 impl ::core::cmp::Eq for NUMBERFMTA {}
@@ -21605,7 +21621,7 @@ unsafe impl ::windows::core::Abi for NUMBERFMTW {
 }
 impl ::core::cmp::PartialEq for NUMBERFMTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NUMBERFMTW>()) == 0 }
+        self.NumDigits == other.NumDigits && self.LeadingZero == other.LeadingZero && self.Grouping == other.Grouping && self.lpDecimalSep == other.lpDecimalSep && self.lpThousandSep == other.lpThousandSep && self.NegativeOrder == other.NegativeOrder
     }
 }
 impl ::core::cmp::Eq for NUMBERFMTW {}
@@ -21636,7 +21652,7 @@ unsafe impl ::windows::core::Abi for OPENTYPE_FEATURE_RECORD {
 }
 impl ::core::cmp::PartialEq for OPENTYPE_FEATURE_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENTYPE_FEATURE_RECORD>()) == 0 }
+        self.tagFeature == other.tagFeature && self.lParameter == other.lParameter
     }
 }
 impl ::core::cmp::Eq for OPENTYPE_FEATURE_RECORD {}
@@ -21668,7 +21684,7 @@ unsafe impl ::windows::core::Abi for RFC1766INFO {
 }
 impl ::core::cmp::PartialEq for RFC1766INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFC1766INFO>()) == 0 }
+        self.lcid == other.lcid && self.wszRfc1766 == other.wszRfc1766 && self.wszLocaleName == other.wszLocaleName
     }
 }
 impl ::core::cmp::Eq for RFC1766INFO {}
@@ -21699,7 +21715,7 @@ unsafe impl ::windows::core::Abi for SCRIPTFONTINFO {
 }
 impl ::core::cmp::PartialEq for SCRIPTFONTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPTFONTINFO>()) == 0 }
+        self.scripts == other.scripts && self.wszFont == other.wszFont
     }
 }
 impl ::core::cmp::Eq for SCRIPTFONTINFO {}
@@ -21733,7 +21749,7 @@ unsafe impl ::windows::core::Abi for SCRIPTINFO {
 }
 impl ::core::cmp::PartialEq for SCRIPTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPTINFO>()) == 0 }
+        self.ScriptId == other.ScriptId && self.uiCodePage == other.uiCodePage && self.wszDescription == other.wszDescription && self.wszFixedWidthFont == other.wszFixedWidthFont && self.wszProportionalFont == other.wszProportionalFont
     }
 }
 impl ::core::cmp::Eq for SCRIPTINFO {}
@@ -21764,7 +21780,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_ANALYSIS {
 }
 impl ::core::cmp::PartialEq for SCRIPT_ANALYSIS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_ANALYSIS>()) == 0 }
+        self._bitfield == other._bitfield && self.s == other.s
     }
 }
 impl ::core::cmp::Eq for SCRIPT_ANALYSIS {}
@@ -21794,7 +21810,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_CHARPROP {
 }
 impl ::core::cmp::PartialEq for SCRIPT_CHARPROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_CHARPROP>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCRIPT_CHARPROP {}
@@ -21824,7 +21840,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_CONTROL {
 }
 impl ::core::cmp::PartialEq for SCRIPT_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_CONTROL>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCRIPT_CONTROL {}
@@ -21856,7 +21872,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_DIGITSUBSTITUTE {
 }
 impl ::core::cmp::PartialEq for SCRIPT_DIGITSUBSTITUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_DIGITSUBSTITUTE>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2 && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for SCRIPT_DIGITSUBSTITUTE {}
@@ -21891,7 +21907,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_FONTPROPERTIES {
 }
 impl ::core::cmp::PartialEq for SCRIPT_FONTPROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_FONTPROPERTIES>()) == 0 }
+        self.cBytes == other.cBytes && self.wgBlank == other.wgBlank && self.wgDefault == other.wgDefault && self.wgInvalid == other.wgInvalid && self.wgKashida == other.wgKashida && self.iKashidaWidth == other.iKashidaWidth
     }
 }
 impl ::core::cmp::Eq for SCRIPT_FONTPROPERTIES {}
@@ -21922,7 +21938,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_GLYPHPROP {
 }
 impl ::core::cmp::PartialEq for SCRIPT_GLYPHPROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_GLYPHPROP>()) == 0 }
+        self.sva == other.sva && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for SCRIPT_GLYPHPROP {}
@@ -21953,7 +21969,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_ITEM {
 }
 impl ::core::cmp::PartialEq for SCRIPT_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_ITEM>()) == 0 }
+        self.iCharPos == other.iCharPos && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for SCRIPT_ITEM {}
@@ -21983,7 +21999,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_LOGATTR {
 }
 impl ::core::cmp::PartialEq for SCRIPT_LOGATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_LOGATTR>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCRIPT_LOGATTR {}
@@ -22014,7 +22030,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for SCRIPT_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_PROPERTIES>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2
     }
 }
 impl ::core::cmp::Eq for SCRIPT_PROPERTIES {}
@@ -22044,7 +22060,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_STATE {
 }
 impl ::core::cmp::PartialEq for SCRIPT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_STATE>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCRIPT_STATE {}
@@ -22077,7 +22093,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_TABDEF {
 }
 impl ::core::cmp::PartialEq for SCRIPT_TABDEF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_TABDEF>()) == 0 }
+        self.cTabStops == other.cTabStops && self.iScale == other.iScale && self.pTabStops == other.pTabStops && self.iTabOrigin == other.iTabOrigin
     }
 }
 impl ::core::cmp::Eq for SCRIPT_TABDEF {}
@@ -22107,7 +22123,7 @@ unsafe impl ::windows::core::Abi for SCRIPT_VISATTR {
 }
 impl ::core::cmp::PartialEq for SCRIPT_VISATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRIPT_VISATTR>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCRIPT_VISATTR {}
@@ -22138,7 +22154,7 @@ unsafe impl ::windows::core::Abi for TEXTRANGE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for TEXTRANGE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXTRANGE_PROPERTIES>()) == 0 }
+        self.potfRecords == other.potfRecords && self.cotfRecords == other.cotfRecords
     }
 }
 impl ::core::cmp::Eq for TEXTRANGE_PROPERTIES {}
@@ -22181,12 +22197,6 @@ impl ::core::clone::Clone for UCPTrie {
 unsafe impl ::windows::core::Abi for UCPTrie {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UCPTrie {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UCPTrie>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UCPTrie {}
 impl ::core::default::Default for UCPTrie {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22209,12 +22219,6 @@ impl ::core::clone::Clone for UCPTrieData {
 unsafe impl ::windows::core::Abi for UCPTrieData {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UCPTrieData {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UCPTrieData>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UCPTrieData {}
 impl ::core::default::Default for UCPTrieData {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22250,35 +22254,12 @@ impl ::core::clone::Clone for UCharIterator {
 }
 impl ::core::fmt::Debug for UCharIterator {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("UCharIterator")
-            .field("context", &self.context)
-            .field("length", &self.length)
-            .field("start", &self.start)
-            .field("index", &self.index)
-            .field("limit", &self.limit)
-            .field("reservedField", &self.reservedField)
-            .field("getIndex", &self.getIndex.map(|f| f as usize))
-            .field("move", &self.r#move.map(|f| f as usize))
-            .field("hasNext", &self.hasNext.map(|f| f as usize))
-            .field("hasPrevious", &self.hasPrevious.map(|f| f as usize))
-            .field("current", &self.current.map(|f| f as usize))
-            .field("next", &self.next.map(|f| f as usize))
-            .field("previous", &self.previous.map(|f| f as usize))
-            .field("reservedFn", &self.reservedFn.map(|f| f as usize))
-            .field("getState", &self.getState.map(|f| f as usize))
-            .field("setState", &self.setState.map(|f| f as usize))
-            .finish()
+        f.debug_struct("UCharIterator").field("context", &self.context).field("length", &self.length).field("start", &self.start).field("index", &self.index).field("limit", &self.limit).field("reservedField", &self.reservedField).finish()
     }
 }
 unsafe impl ::windows::core::Abi for UCharIterator {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UCharIterator {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UCharIterator>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UCharIterator {}
 impl ::core::default::Default for UCharIterator {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22324,7 +22305,7 @@ unsafe impl ::windows::core::Abi for UConverterFromUnicodeArgs {
 }
 impl ::core::cmp::PartialEq for UConverterFromUnicodeArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UConverterFromUnicodeArgs>()) == 0 }
+        self.size == other.size && self.flush == other.flush && self.converter == other.converter && self.source == other.source && self.sourceLimit == other.sourceLimit && self.target == other.target && self.targetLimit == other.targetLimit && self.offsets == other.offsets
     }
 }
 impl ::core::cmp::Eq for UConverterFromUnicodeArgs {}
@@ -22363,7 +22344,7 @@ unsafe impl ::windows::core::Abi for UConverterToUnicodeArgs {
 }
 impl ::core::cmp::PartialEq for UConverterToUnicodeArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UConverterToUnicodeArgs>()) == 0 }
+        self.size == other.size && self.flush == other.flush && self.converter == other.converter && self.source == other.source && self.sourceLimit == other.sourceLimit && self.target == other.target && self.targetLimit == other.targetLimit && self.offsets == other.offsets
     }
 }
 impl ::core::cmp::Eq for UConverterToUnicodeArgs {}
@@ -22401,7 +22382,7 @@ unsafe impl ::windows::core::Abi for UFieldPosition {
 }
 impl ::core::cmp::PartialEq for UFieldPosition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UFieldPosition>()) == 0 }
+        self.field == other.field && self.beginIndex == other.beginIndex && self.endIndex == other.endIndex
     }
 }
 impl ::core::cmp::Eq for UFieldPosition {}
@@ -22456,7 +22437,7 @@ unsafe impl ::windows::core::Abi for UIDNAInfo {
 }
 impl ::core::cmp::PartialEq for UIDNAInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UIDNAInfo>()) == 0 }
+        self.size == other.size && self.isTransitionalDifferent == other.isTransitionalDifferent && self.reservedB3 == other.reservedB3 && self.errors == other.errors && self.reservedI2 == other.reservedI2 && self.reservedI3 == other.reservedI3
     }
 }
 impl ::core::cmp::Eq for UIDNAInfo {}
@@ -22495,7 +22476,7 @@ unsafe impl ::windows::core::Abi for UNICODERANGE {
 }
 impl ::core::cmp::PartialEq for UNICODERANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNICODERANGE>()) == 0 }
+        self.wcFrom == other.wcFrom && self.wcTo == other.wcTo
     }
 }
 impl ::core::cmp::Eq for UNICODERANGE {}
@@ -22534,7 +22515,7 @@ unsafe impl ::windows::core::Abi for UParseError {
 }
 impl ::core::cmp::PartialEq for UParseError {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UParseError>()) == 0 }
+        self.line == other.line && self.offset == other.offset && self.preContext == other.preContext && self.postContext == other.postContext
     }
 }
 impl ::core::cmp::Eq for UParseError {}
@@ -22577,7 +22558,7 @@ unsafe impl ::windows::core::Abi for UReplaceableCallbacks {
 }
 impl ::core::cmp::PartialEq for UReplaceableCallbacks {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UReplaceableCallbacks>()) == 0 }
+        self.length == other.length && self.charAt == other.charAt && self.char32At == other.char32At && self.replace == other.replace && self.extract == other.extract && self.copy == other.copy
     }
 }
 impl ::core::cmp::Eq for UReplaceableCallbacks {}
@@ -22614,7 +22595,7 @@ unsafe impl ::windows::core::Abi for USerializedSet {
 }
 impl ::core::cmp::PartialEq for USerializedSet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USerializedSet>()) == 0 }
+        self.array == other.array && self.bmpLength == other.bmpLength && self.length == other.length && self.staticArray == other.staticArray
     }
 }
 impl ::core::cmp::Eq for USerializedSet {}
@@ -22702,7 +22683,30 @@ unsafe impl ::windows::core::Abi for UText {
 }
 impl ::core::cmp::PartialEq for UText {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UText>()) == 0 }
+        self.magic == other.magic
+            && self.flags == other.flags
+            && self.providerProperties == other.providerProperties
+            && self.sizeOfStruct == other.sizeOfStruct
+            && self.chunkNativeLimit == other.chunkNativeLimit
+            && self.extraSize == other.extraSize
+            && self.nativeIndexingLimit == other.nativeIndexingLimit
+            && self.chunkNativeStart == other.chunkNativeStart
+            && self.chunkOffset == other.chunkOffset
+            && self.chunkLength == other.chunkLength
+            && self.chunkContents == other.chunkContents
+            && self.pFuncs == other.pFuncs
+            && self.pExtra == other.pExtra
+            && self.context == other.context
+            && self.p == other.p
+            && self.q == other.q
+            && self.r == other.r
+            && self.privP == other.privP
+            && self.a == other.a
+            && self.b == other.b
+            && self.c == other.c
+            && self.privA == other.privA
+            && self.privB == other.privB
+            && self.privC == other.privC
     }
 }
 impl ::core::cmp::Eq for UText {}
@@ -22739,35 +22743,12 @@ impl ::core::clone::Clone for UTextFuncs {
 }
 impl ::core::fmt::Debug for UTextFuncs {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("UTextFuncs")
-            .field("tableSize", &self.tableSize)
-            .field("reserved1", &self.reserved1)
-            .field("reserved2", &self.reserved2)
-            .field("reserved3", &self.reserved3)
-            .field("clone", &self.clone.map(|f| f as usize))
-            .field("nativeLength", &self.nativeLength.map(|f| f as usize))
-            .field("access", &self.access.map(|f| f as usize))
-            .field("extract", &self.extract.map(|f| f as usize))
-            .field("replace", &self.replace.map(|f| f as usize))
-            .field("copy", &self.copy.map(|f| f as usize))
-            .field("mapOffsetToNative", &self.mapOffsetToNative.map(|f| f as usize))
-            .field("mapNativeIndexToUTF16", &self.mapNativeIndexToUTF16.map(|f| f as usize))
-            .field("close", &self.close.map(|f| f as usize))
-            .field("spare1", &self.spare1.map(|f| f as usize))
-            .field("spare2", &self.spare2.map(|f| f as usize))
-            .field("spare3", &self.spare3.map(|f| f as usize))
-            .finish()
+        f.debug_struct("UTextFuncs").field("tableSize", &self.tableSize).field("reserved1", &self.reserved1).field("reserved2", &self.reserved2).field("reserved3", &self.reserved3).finish()
     }
 }
 unsafe impl ::windows::core::Abi for UTextFuncs {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UTextFuncs {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UTextFuncs>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UTextFuncs {}
 impl ::core::default::Default for UTextFuncs {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22797,7 +22778,7 @@ unsafe impl ::windows::core::Abi for UTransPosition {
 }
 impl ::core::cmp::PartialEq for UTransPosition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UTransPosition>()) == 0 }
+        self.contextStart == other.contextStart && self.contextLimit == other.contextLimit && self.start == other.start && self.limit == other.limit
     }
 }
 impl ::core::cmp::Eq for UTransPosition {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -674,7 +674,7 @@ unsafe impl ::windows::core::Abi for CompositionFrameDisplayInstance {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for CompositionFrameDisplayInstance {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CompositionFrameDisplayInstance>()) == 0 }
+        self.displayAdapterLUID == other.displayAdapterLUID && self.displayVidPnSourceId == other.displayVidPnSourceId && self.displayUniqueId == other.displayUniqueId && self.renderAdapterLUID == other.renderAdapterLUID && self.instanceKind == other.instanceKind && self.finalTransform == other.finalTransform && self.requiredCrossAdapterCopy == other.requiredCrossAdapterCopy && self.colorSpace == other.colorSpace
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -711,7 +711,7 @@ unsafe impl ::windows::core::Abi for PresentationTransform {
 }
 impl ::core::cmp::PartialEq for PresentationTransform {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PresentationTransform>()) == 0 }
+        self.M11 == other.M11 && self.M12 == other.M12 && self.M21 == other.M21 && self.M22 == other.M22 && self.M31 == other.M31 && self.M32 == other.M32
     }
 }
 impl ::core::cmp::Eq for PresentationTransform {}
@@ -741,7 +741,7 @@ unsafe impl ::windows::core::Abi for SystemInterruptTime {
 }
 impl ::core::cmp::PartialEq for SystemInterruptTime {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SystemInterruptTime>()) == 0 }
+        self.value == other.value
     }
 }
 impl ::core::cmp::Eq for SystemInterruptTime {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -417,7 +417,7 @@ unsafe impl ::windows::core::Abi for DXCoreAdapterMemoryBudget {
 }
 impl ::core::cmp::PartialEq for DXCoreAdapterMemoryBudget {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXCoreAdapterMemoryBudget>()) == 0 }
+        self.budget == other.budget && self.currentUsage == other.currentUsage && self.availableForReservation == other.availableForReservation && self.currentReservation == other.currentReservation
     }
 }
 impl ::core::cmp::Eq for DXCoreAdapterMemoryBudget {}
@@ -448,7 +448,7 @@ unsafe impl ::windows::core::Abi for DXCoreAdapterMemoryBudgetNodeSegmentGroup {
 }
 impl ::core::cmp::PartialEq for DXCoreAdapterMemoryBudgetNodeSegmentGroup {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXCoreAdapterMemoryBudgetNodeSegmentGroup>()) == 0 }
+        self.nodeIndex == other.nodeIndex && self.segmentGroup == other.segmentGroup
     }
 }
 impl ::core::cmp::Eq for DXCoreAdapterMemoryBudgetNodeSegmentGroup {}
@@ -481,7 +481,7 @@ unsafe impl ::windows::core::Abi for DXCoreHardwareID {
 }
 impl ::core::cmp::PartialEq for DXCoreHardwareID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXCoreHardwareID>()) == 0 }
+        self.vendorID == other.vendorID && self.deviceID == other.deviceID && self.subSysID == other.subSysID && self.revision == other.revision
     }
 }
 impl ::core::cmp::Eq for DXCoreHardwareID {}
@@ -515,7 +515,7 @@ unsafe impl ::windows::core::Abi for DXCoreHardwareIDParts {
 }
 impl ::core::cmp::PartialEq for DXCoreHardwareIDParts {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXCoreHardwareIDParts>()) == 0 }
+        self.vendorID == other.vendorID && self.deviceID == other.deviceID && self.subSystemID == other.subSystemID && self.subVendorID == other.subVendorID && self.revisionID == other.revisionID
     }
 }
 impl ::core::cmp::Eq for DXCoreHardwareIDParts {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -515,7 +515,7 @@ unsafe impl ::windows::core::Abi for D2D1_BEZIER_SEGMENT {
 }
 impl ::core::cmp::PartialEq for D2D1_BEZIER_SEGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BEZIER_SEGMENT>()) == 0 }
+        self.point1 == other.point1 && self.point2 == other.point2 && self.point3 == other.point3
     }
 }
 impl ::core::cmp::Eq for D2D1_BEZIER_SEGMENT {}
@@ -548,7 +548,7 @@ unsafe impl ::windows::core::Abi for D2D1_COLOR_F {
 }
 impl ::core::cmp::PartialEq for D2D1_COLOR_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_COLOR_F>()) == 0 }
+        self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for D2D1_COLOR_F {}
@@ -585,7 +585,7 @@ unsafe impl ::windows::core::Abi for D2D1_PIXEL_FORMAT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D2D1_PIXEL_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_PIXEL_FORMAT>()) == 0 }
+        self.format == other.format && self.alphaMode == other.alphaMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -620,7 +620,7 @@ unsafe impl ::windows::core::Abi for D2D_COLOR_F {
 }
 impl ::core::cmp::PartialEq for D2D_COLOR_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_COLOR_F>()) == 0 }
+        self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for D2D_COLOR_F {}
@@ -643,12 +643,6 @@ impl ::core::clone::Clone for D2D_MATRIX_4X3_F {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_4X3_F {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_4X3_F {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X3_F>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_4X3_F {}
 impl ::core::default::Default for D2D_MATRIX_4X3_F {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -669,12 +663,6 @@ impl ::core::clone::Clone for D2D_MATRIX_4X3_F_0 {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_4X3_F_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_4X3_F_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X3_F_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_4X3_F_0 {}
 impl ::core::default::Default for D2D_MATRIX_4X3_F_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -712,7 +700,7 @@ unsafe impl ::windows::core::Abi for D2D_MATRIX_4X3_F_0_0 {
 }
 impl ::core::cmp::PartialEq for D2D_MATRIX_4X3_F_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X3_F_0_0>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._13 == other._13 && self._21 == other._21 && self._22 == other._22 && self._23 == other._23 && self._31 == other._31 && self._32 == other._32 && self._33 == other._33 && self._41 == other._41 && self._42 == other._42 && self._43 == other._43
     }
 }
 impl ::core::cmp::Eq for D2D_MATRIX_4X3_F_0_0 {}
@@ -735,12 +723,6 @@ impl ::core::clone::Clone for D2D_MATRIX_4X4_F {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_4X4_F {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_4X4_F {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X4_F>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_4X4_F {}
 impl ::core::default::Default for D2D_MATRIX_4X4_F {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -761,12 +743,6 @@ impl ::core::clone::Clone for D2D_MATRIX_4X4_F_0 {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_4X4_F_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_4X4_F_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X4_F_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_4X4_F_0 {}
 impl ::core::default::Default for D2D_MATRIX_4X4_F_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -808,7 +784,7 @@ unsafe impl ::windows::core::Abi for D2D_MATRIX_4X4_F_0_0 {
 }
 impl ::core::cmp::PartialEq for D2D_MATRIX_4X4_F_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_4X4_F_0_0>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._13 == other._13 && self._14 == other._14 && self._21 == other._21 && self._22 == other._22 && self._23 == other._23 && self._24 == other._24 && self._31 == other._31 && self._32 == other._32 && self._33 == other._33 && self._34 == other._34 && self._41 == other._41 && self._42 == other._42 && self._43 == other._43 && self._44 == other._44
     }
 }
 impl ::core::cmp::Eq for D2D_MATRIX_4X4_F_0_0 {}
@@ -831,12 +807,6 @@ impl ::core::clone::Clone for D2D_MATRIX_5X4_F {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_5X4_F {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_5X4_F {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_5X4_F>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_5X4_F {}
 impl ::core::default::Default for D2D_MATRIX_5X4_F {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -857,12 +827,6 @@ impl ::core::clone::Clone for D2D_MATRIX_5X4_F_0 {
 unsafe impl ::windows::core::Abi for D2D_MATRIX_5X4_F_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D_MATRIX_5X4_F_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_5X4_F_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D_MATRIX_5X4_F_0 {}
 impl ::core::default::Default for D2D_MATRIX_5X4_F_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -929,7 +893,7 @@ unsafe impl ::windows::core::Abi for D2D_MATRIX_5X4_F_0_0 {
 }
 impl ::core::cmp::PartialEq for D2D_MATRIX_5X4_F_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_MATRIX_5X4_F_0_0>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._13 == other._13 && self._14 == other._14 && self._21 == other._21 && self._22 == other._22 && self._23 == other._23 && self._24 == other._24 && self._31 == other._31 && self._32 == other._32 && self._33 == other._33 && self._34 == other._34 && self._41 == other._41 && self._42 == other._42 && self._43 == other._43 && self._44 == other._44 && self._51 == other._51 && self._52 == other._52 && self._53 == other._53 && self._54 == other._54
     }
 }
 impl ::core::cmp::Eq for D2D_MATRIX_5X4_F_0_0 {}
@@ -960,7 +924,7 @@ unsafe impl ::windows::core::Abi for D2D_POINT_2F {
 }
 impl ::core::cmp::PartialEq for D2D_POINT_2F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_POINT_2F>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for D2D_POINT_2F {}
@@ -991,7 +955,7 @@ unsafe impl ::windows::core::Abi for D2D_POINT_2U {
 }
 impl ::core::cmp::PartialEq for D2D_POINT_2U {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_POINT_2U>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for D2D_POINT_2U {}
@@ -1024,7 +988,7 @@ unsafe impl ::windows::core::Abi for D2D_RECT_F {
 }
 impl ::core::cmp::PartialEq for D2D_RECT_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_RECT_F>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for D2D_RECT_F {}
@@ -1057,7 +1021,7 @@ unsafe impl ::windows::core::Abi for D2D_RECT_U {
 }
 impl ::core::cmp::PartialEq for D2D_RECT_U {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_RECT_U>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for D2D_RECT_U {}
@@ -1088,7 +1052,7 @@ unsafe impl ::windows::core::Abi for D2D_SIZE_F {
 }
 impl ::core::cmp::PartialEq for D2D_SIZE_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_SIZE_F>()) == 0 }
+        self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for D2D_SIZE_F {}
@@ -1119,7 +1083,7 @@ unsafe impl ::windows::core::Abi for D2D_SIZE_U {
 }
 impl ::core::cmp::PartialEq for D2D_SIZE_U {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_SIZE_U>()) == 0 }
+        self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for D2D_SIZE_U {}
@@ -1150,7 +1114,7 @@ unsafe impl ::windows::core::Abi for D2D_VECTOR_2F {
 }
 impl ::core::cmp::PartialEq for D2D_VECTOR_2F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_VECTOR_2F>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for D2D_VECTOR_2F {}
@@ -1182,7 +1146,7 @@ unsafe impl ::windows::core::Abi for D2D_VECTOR_3F {
 }
 impl ::core::cmp::PartialEq for D2D_VECTOR_3F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_VECTOR_3F>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z
     }
 }
 impl ::core::cmp::Eq for D2D_VECTOR_3F {}
@@ -1215,7 +1179,7 @@ unsafe impl ::windows::core::Abi for D2D_VECTOR_4F {
 }
 impl ::core::cmp::PartialEq for D2D_VECTOR_4F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D_VECTOR_4F>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z && self.w == other.w
     }
 }
 impl ::core::cmp::Eq for D2D_VECTOR_4F {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -22972,7 +22972,7 @@ unsafe impl ::windows::core::Abi for D2D1_ARC_SEGMENT {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_ARC_SEGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_ARC_SEGMENT>()) == 0 }
+        self.point == other.point && self.size == other.size && self.rotationAngle == other.rotationAngle && self.sweepDirection == other.sweepDirection && self.arcSize == other.arcSize
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -23006,7 +23006,7 @@ unsafe impl ::windows::core::Abi for D2D1_BITMAP_BRUSH_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_BITMAP_BRUSH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BITMAP_BRUSH_PROPERTIES>()) == 0 }
+        self.extendModeX == other.extendModeX && self.extendModeY == other.extendModeY && self.interpolationMode == other.interpolationMode
     }
 }
 impl ::core::cmp::Eq for D2D1_BITMAP_BRUSH_PROPERTIES {}
@@ -23038,7 +23038,7 @@ unsafe impl ::windows::core::Abi for D2D1_BITMAP_BRUSH_PROPERTIES1 {
 }
 impl ::core::cmp::PartialEq for D2D1_BITMAP_BRUSH_PROPERTIES1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BITMAP_BRUSH_PROPERTIES1>()) == 0 }
+        self.extendModeX == other.extendModeX && self.extendModeY == other.extendModeY && self.interpolationMode == other.interpolationMode
     }
 }
 impl ::core::cmp::Eq for D2D1_BITMAP_BRUSH_PROPERTIES1 {}
@@ -23076,7 +23076,7 @@ unsafe impl ::windows::core::Abi for D2D1_BITMAP_PROPERTIES {
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D2D1_BITMAP_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BITMAP_PROPERTIES>()) == 0 }
+        self.pixelFormat == other.pixelFormat && self.dpiX == other.dpiX && self.dpiY == other.dpiY
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -23154,7 +23154,7 @@ unsafe impl ::windows::core::Abi for D2D1_BLEND_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for D2D1_BLEND_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BLEND_DESCRIPTION>()) == 0 }
+        self.sourceBlend == other.sourceBlend && self.destinationBlend == other.destinationBlend && self.blendOperation == other.blendOperation && self.sourceBlendAlpha == other.sourceBlendAlpha && self.destinationBlendAlpha == other.destinationBlendAlpha && self.blendOperationAlpha == other.blendOperationAlpha && self.blendFactor == other.blendFactor
     }
 }
 impl ::core::cmp::Eq for D2D1_BLEND_DESCRIPTION {}
@@ -23191,7 +23191,7 @@ unsafe impl ::windows::core::Abi for D2D1_BRUSH_PROPERTIES {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for D2D1_BRUSH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_BRUSH_PROPERTIES>()) == 0 }
+        self.opacity == other.opacity && self.transform == other.transform
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -23225,7 +23225,7 @@ unsafe impl ::windows::core::Abi for D2D1_CREATION_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_CREATION_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_CREATION_PROPERTIES>()) == 0 }
+        self.threadingMode == other.threadingMode && self.debugLevel == other.debugLevel && self.options == other.options
     }
 }
 impl ::core::cmp::Eq for D2D1_CREATION_PROPERTIES {}
@@ -23265,7 +23265,7 @@ unsafe impl ::windows::core::Abi for D2D1_CUSTOM_VERTEX_BUFFER_PROPERTIES {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D2D1_CUSTOM_VERTEX_BUFFER_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_CUSTOM_VERTEX_BUFFER_PROPERTIES>()) == 0 }
+        self.shaderBufferWithInputSignature == other.shaderBufferWithInputSignature && self.shaderBufferSize == other.shaderBufferSize && self.inputElements == other.inputElements && self.elementCount == other.elementCount && self.stride == other.stride
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -23307,7 +23307,7 @@ unsafe impl ::windows::core::Abi for D2D1_DRAWING_STATE_DESCRIPTION {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for D2D1_DRAWING_STATE_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_DRAWING_STATE_DESCRIPTION>()) == 0 }
+        self.antialiasMode == other.antialiasMode && self.textAntialiasMode == other.textAntialiasMode && self.tag1 == other.tag1 && self.tag2 == other.tag2 && self.transform == other.transform
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -23351,7 +23351,7 @@ unsafe impl ::windows::core::Abi for D2D1_DRAWING_STATE_DESCRIPTION1 {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for D2D1_DRAWING_STATE_DESCRIPTION1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_DRAWING_STATE_DESCRIPTION1>()) == 0 }
+        self.antialiasMode == other.antialiasMode && self.textAntialiasMode == other.textAntialiasMode && self.tag1 == other.tag1 && self.tag2 == other.tag2 && self.transform == other.transform && self.primitiveBlend == other.primitiveBlend && self.unitMode == other.unitMode
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -23429,7 +23429,7 @@ unsafe impl ::windows::core::Abi for D2D1_ELLIPSE {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_ELLIPSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_ELLIPSE>()) == 0 }
+        self.point == other.point && self.radiusX == other.radiusX && self.radiusY == other.radiusY
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -23461,7 +23461,7 @@ unsafe impl ::windows::core::Abi for D2D1_FACTORY_OPTIONS {
 }
 impl ::core::cmp::PartialEq for D2D1_FACTORY_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_FACTORY_OPTIONS>()) == 0 }
+        self.debugLevel == other.debugLevel
     }
 }
 impl ::core::cmp::Eq for D2D1_FACTORY_OPTIONS {}
@@ -23497,7 +23497,7 @@ unsafe impl ::windows::core::Abi for D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS 
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS>()) == 0 }
+        self.computeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == other.computeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23535,7 +23535,7 @@ unsafe impl ::windows::core::Abi for D2D1_FEATURE_DATA_DOUBLES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D2D1_FEATURE_DATA_DOUBLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_FEATURE_DATA_DOUBLES>()) == 0 }
+        self.doublePrecisionFloatShaderOps == other.doublePrecisionFloatShaderOps
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23621,7 +23621,30 @@ unsafe impl ::windows::core::Abi for D2D1_GRADIENT_MESH_PATCH {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_GRADIENT_MESH_PATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_GRADIENT_MESH_PATCH>()) == 0 }
+        self.point00 == other.point00
+            && self.point01 == other.point01
+            && self.point02 == other.point02
+            && self.point03 == other.point03
+            && self.point10 == other.point10
+            && self.point11 == other.point11
+            && self.point12 == other.point12
+            && self.point13 == other.point13
+            && self.point20 == other.point20
+            && self.point21 == other.point21
+            && self.point22 == other.point22
+            && self.point23 == other.point23
+            && self.point30 == other.point30
+            && self.point31 == other.point31
+            && self.point32 == other.point32
+            && self.point33 == other.point33
+            && self.color00 == other.color00
+            && self.color03 == other.color03
+            && self.color30 == other.color30
+            && self.color33 == other.color33
+            && self.topEdgeMode == other.topEdgeMode
+            && self.leftEdgeMode == other.leftEdgeMode
+            && self.bottomEdgeMode == other.bottomEdgeMode
+            && self.rightEdgeMode == other.rightEdgeMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -23660,7 +23683,7 @@ unsafe impl ::windows::core::Abi for D2D1_GRADIENT_STOP {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_GRADIENT_STOP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_GRADIENT_STOP>()) == 0 }
+        self.position == other.position && self.color == other.color
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -23700,7 +23723,7 @@ unsafe impl ::windows::core::Abi for D2D1_HWND_RENDER_TARGET_PROPERTIES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ::core::cmp::PartialEq for D2D1_HWND_RENDER_TARGET_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_HWND_RENDER_TARGET_PROPERTIES>()) == 0 }
+        self.hwnd == other.hwnd && self.pixelSize == other.pixelSize && self.presentOptions == other.presentOptions
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
@@ -23741,7 +23764,7 @@ unsafe impl ::windows::core::Abi for D2D1_IMAGE_BRUSH_PROPERTIES {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_IMAGE_BRUSH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_IMAGE_BRUSH_PROPERTIES>()) == 0 }
+        self.sourceRectangle == other.sourceRectangle && self.extendModeX == other.extendModeX && self.extendModeY == other.extendModeY && self.interpolationMode == other.interpolationMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -23775,7 +23798,7 @@ unsafe impl ::windows::core::Abi for D2D1_INK_BEZIER_SEGMENT {
 }
 impl ::core::cmp::PartialEq for D2D1_INK_BEZIER_SEGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_INK_BEZIER_SEGMENT>()) == 0 }
+        self.point1 == other.point1 && self.point2 == other.point2 && self.point3 == other.point3
     }
 }
 impl ::core::cmp::Eq for D2D1_INK_BEZIER_SEGMENT {}
@@ -23807,7 +23830,7 @@ unsafe impl ::windows::core::Abi for D2D1_INK_POINT {
 }
 impl ::core::cmp::PartialEq for D2D1_INK_POINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_INK_POINT>()) == 0 }
+        self.x == other.x && self.y == other.y && self.radius == other.radius
     }
 }
 impl ::core::cmp::Eq for D2D1_INK_POINT {}
@@ -23844,7 +23867,7 @@ unsafe impl ::windows::core::Abi for D2D1_INK_STYLE_PROPERTIES {
 #[cfg(feature = "Foundation_Numerics")]
 impl ::core::cmp::PartialEq for D2D1_INK_STYLE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_INK_STYLE_PROPERTIES>()) == 0 }
+        self.nibShape == other.nibShape && self.nibTransform == other.nibTransform
     }
 }
 #[cfg(feature = "Foundation_Numerics")]
@@ -23877,7 +23900,7 @@ unsafe impl ::windows::core::Abi for D2D1_INPUT_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for D2D1_INPUT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_INPUT_DESCRIPTION>()) == 0 }
+        self.filter == other.filter && self.levelOfDetailCount == other.levelOfDetailCount
     }
 }
 impl ::core::cmp::Eq for D2D1_INPUT_DESCRIPTION {}
@@ -23917,7 +23940,7 @@ unsafe impl ::windows::core::Abi for D2D1_INPUT_ELEMENT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D2D1_INPUT_ELEMENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_INPUT_ELEMENT_DESC>()) == 0 }
+        self.semanticName == other.semanticName && self.semanticIndex == other.semanticIndex && self.format == other.format && self.inputSlot == other.inputSlot && self.alignedByteOffset == other.alignedByteOffset
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24056,7 +24079,7 @@ unsafe impl ::windows::core::Abi for D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES>()) == 0 }
+        self.startPoint == other.startPoint && self.endPoint == other.endPoint
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24089,7 +24112,7 @@ unsafe impl ::windows::core::Abi for D2D1_MAPPED_RECT {
 }
 impl ::core::cmp::PartialEq for D2D1_MAPPED_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_MAPPED_RECT>()) == 0 }
+        self.pitch == other.pitch && self.bits == other.bits
     }
 }
 impl ::core::cmp::Eq for D2D1_MAPPED_RECT {}
@@ -24129,7 +24152,7 @@ unsafe impl ::windows::core::Abi for D2D1_POINT_DESCRIPTION {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_POINT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_POINT_DESCRIPTION>()) == 0 }
+        self.point == other.point && self.unitTangentVector == other.unitTangentVector && self.endSegment == other.endSegment && self.endFigure == other.endFigure && self.lengthToEndSegment == other.lengthToEndSegment
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24163,7 +24186,7 @@ unsafe impl ::windows::core::Abi for D2D1_PRINT_CONTROL_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_PRINT_CONTROL_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_PRINT_CONTROL_PROPERTIES>()) == 0 }
+        self.fontSubset == other.fontSubset && self.rasterDPI == other.rasterDPI && self.colorSpace == other.colorSpace
     }
 }
 impl ::core::cmp::Eq for D2D1_PRINT_CONTROL_PROPERTIES {}
@@ -24187,18 +24210,12 @@ impl ::core::clone::Clone for D2D1_PROPERTY_BINDING {
 }
 impl ::core::fmt::Debug for D2D1_PROPERTY_BINDING {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("D2D1_PROPERTY_BINDING").field("propertyName", &self.propertyName).field("setFunction", &self.setFunction.map(|f| f as usize)).field("getFunction", &self.getFunction.map(|f| f as usize)).finish()
+        f.debug_struct("D2D1_PROPERTY_BINDING").field("propertyName", &self.propertyName).finish()
     }
 }
 unsafe impl ::windows::core::Abi for D2D1_PROPERTY_BINDING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D2D1_PROPERTY_BINDING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_PROPERTY_BINDING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D2D1_PROPERTY_BINDING {}
 impl ::core::default::Default for D2D1_PROPERTY_BINDING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24232,7 +24249,7 @@ unsafe impl ::windows::core::Abi for D2D1_QUADRATIC_BEZIER_SEGMENT {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_QUADRATIC_BEZIER_SEGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_QUADRATIC_BEZIER_SEGMENT>()) == 0 }
+        self.point1 == other.point1 && self.point2 == other.point2
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24273,7 +24290,7 @@ unsafe impl ::windows::core::Abi for D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES>()) == 0 }
+        self.center == other.center && self.gradientOriginOffset == other.gradientOriginOffset && self.radiusX == other.radiusX && self.radiusY == other.radiusY
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24312,7 +24329,7 @@ unsafe impl ::windows::core::Abi for D2D1_RENDERING_CONTROLS {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_RENDERING_CONTROLS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_RENDERING_CONTROLS>()) == 0 }
+        self.bufferPrecision == other.bufferPrecision && self.tileSize == other.tileSize
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24355,7 +24372,7 @@ unsafe impl ::windows::core::Abi for D2D1_RENDER_TARGET_PROPERTIES {
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D2D1_RENDER_TARGET_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_RENDER_TARGET_PROPERTIES>()) == 0 }
+        self.r#type == other.r#type && self.pixelFormat == other.pixelFormat && self.dpiX == other.dpiX && self.dpiY == other.dpiY && self.usage == other.usage && self.minLevel == other.minLevel
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -24392,7 +24409,7 @@ unsafe impl ::windows::core::Abi for D2D1_RESOURCE_TEXTURE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_RESOURCE_TEXTURE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_RESOURCE_TEXTURE_PROPERTIES>()) == 0 }
+        self.extents == other.extents && self.dimensions == other.dimensions && self.bufferPrecision == other.bufferPrecision && self.channelDepth == other.channelDepth && self.filter == other.filter && self.extendModes == other.extendModes
     }
 }
 impl ::core::cmp::Eq for D2D1_RESOURCE_TEXTURE_PROPERTIES {}
@@ -24430,7 +24447,7 @@ unsafe impl ::windows::core::Abi for D2D1_ROUNDED_RECT {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_ROUNDED_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_ROUNDED_RECT>()) == 0 }
+        self.rect == other.rect && self.radiusX == other.radiusX && self.radiusY == other.radiusY
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24472,7 +24489,7 @@ unsafe impl ::windows::core::Abi for D2D1_SIMPLE_COLOR_PROFILE {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_SIMPLE_COLOR_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_SIMPLE_COLOR_PROFILE>()) == 0 }
+        self.redPrimary == other.redPrimary && self.greenPrimary == other.greenPrimary && self.bluePrimary == other.bluePrimary && self.whitePointXZ == other.whitePointXZ && self.gamma == other.gamma
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24510,7 +24527,7 @@ unsafe impl ::windows::core::Abi for D2D1_STROKE_STYLE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_STROKE_STYLE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_STROKE_STYLE_PROPERTIES>()) == 0 }
+        self.startCap == other.startCap && self.endCap == other.endCap && self.dashCap == other.dashCap && self.lineJoin == other.lineJoin && self.miterLimit == other.miterLimit && self.dashStyle == other.dashStyle && self.dashOffset == other.dashOffset
     }
 }
 impl ::core::cmp::Eq for D2D1_STROKE_STYLE_PROPERTIES {}
@@ -24547,7 +24564,7 @@ unsafe impl ::windows::core::Abi for D2D1_STROKE_STYLE_PROPERTIES1 {
 }
 impl ::core::cmp::PartialEq for D2D1_STROKE_STYLE_PROPERTIES1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_STROKE_STYLE_PROPERTIES1>()) == 0 }
+        self.startCap == other.startCap && self.endCap == other.endCap && self.dashCap == other.dashCap && self.lineJoin == other.lineJoin && self.miterLimit == other.miterLimit && self.dashStyle == other.dashStyle && self.dashOffset == other.dashOffset && self.transformType == other.transformType
     }
 }
 impl ::core::cmp::Eq for D2D1_STROKE_STYLE_PROPERTIES1 {}
@@ -24578,7 +24595,7 @@ unsafe impl ::windows::core::Abi for D2D1_SVG_LENGTH {
 }
 impl ::core::cmp::PartialEq for D2D1_SVG_LENGTH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_SVG_LENGTH>()) == 0 }
+        self.value == other.value && self.units == other.units
     }
 }
 impl ::core::cmp::Eq for D2D1_SVG_LENGTH {}
@@ -24616,7 +24633,7 @@ unsafe impl ::windows::core::Abi for D2D1_SVG_PRESERVE_ASPECT_RATIO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D2D1_SVG_PRESERVE_ASPECT_RATIO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_SVG_PRESERVE_ASPECT_RATIO>()) == 0 }
+        self.defer == other.defer && self.align == other.align && self.meetOrSlice == other.meetOrSlice
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24651,7 +24668,7 @@ unsafe impl ::windows::core::Abi for D2D1_SVG_VIEWBOX {
 }
 impl ::core::cmp::PartialEq for D2D1_SVG_VIEWBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_SVG_VIEWBOX>()) == 0 }
+        self.x == other.x && self.y == other.y && self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for D2D1_SVG_VIEWBOX {}
@@ -24685,7 +24702,7 @@ unsafe impl ::windows::core::Abi for D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES>()) == 0 }
+        self.orientation == other.orientation && self.scaleX == other.scaleX && self.scaleY == other.scaleY && self.interpolationMode == other.interpolationMode && self.options == other.options
     }
 }
 impl ::core::cmp::Eq for D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES {}
@@ -24723,7 +24740,7 @@ unsafe impl ::windows::core::Abi for D2D1_TRIANGLE {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::cmp::PartialEq for D2D1_TRIANGLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_TRIANGLE>()) == 0 }
+        self.point1 == other.point1 && self.point2 == other.point2 && self.point3 == other.point3
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -24758,7 +24775,7 @@ unsafe impl ::windows::core::Abi for D2D1_VERTEX_BUFFER_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D2D1_VERTEX_BUFFER_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_VERTEX_BUFFER_PROPERTIES>()) == 0 }
+        self.inputCount == other.inputCount && self.usage == other.usage && self.data == other.data && self.byteWidth == other.byteWidth
     }
 }
 impl ::core::cmp::Eq for D2D1_VERTEX_BUFFER_PROPERTIES {}
@@ -24789,7 +24806,7 @@ unsafe impl ::windows::core::Abi for D2D1_VERTEX_RANGE {
 }
 impl ::core::cmp::PartialEq for D2D1_VERTEX_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D2D1_VERTEX_RANGE>()) == 0 }
+        self.startVertex == other.startVertex && self.vertexCount == other.vertexCount
     }
 }
 impl ::core::cmp::Eq for D2D1_VERTEX_RANGE {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
@@ -1776,7 +1776,7 @@ unsafe impl ::windows::core::Abi for DxcArgPair {
 }
 impl ::core::cmp::PartialEq for DxcArgPair {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DxcArgPair>()) == 0 }
+        self.pName == other.pName && self.pValue == other.pValue
     }
 }
 impl ::core::cmp::Eq for DxcArgPair {}
@@ -1808,7 +1808,7 @@ unsafe impl ::windows::core::Abi for DxcBuffer {
 }
 impl ::core::cmp::PartialEq for DxcBuffer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DxcBuffer>()) == 0 }
+        self.Ptr == other.Ptr && self.Size == other.Size && self.Encoding == other.Encoding
     }
 }
 impl ::core::cmp::Eq for DxcBuffer {}
@@ -1839,7 +1839,7 @@ unsafe impl ::windows::core::Abi for DxcDefine {
 }
 impl ::core::cmp::PartialEq for DxcDefine {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DxcDefine>()) == 0 }
+        self.Name == other.Name && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DxcDefine {}
@@ -1870,7 +1870,7 @@ unsafe impl ::windows::core::Abi for DxcShaderHash {
 }
 impl ::core::cmp::PartialEq for DxcShaderHash {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DxcShaderHash>()) == 0 }
+        self.Flags == other.Flags && self.HashDigest == other.HashDigest
     }
 }
 impl ::core::cmp::Eq for DxcShaderHash {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Fxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Fxc/mod.rs
@@ -415,7 +415,7 @@ unsafe impl ::windows::core::Abi for D3D_SHADER_DATA {
 }
 impl ::core::cmp::PartialEq for D3D_SHADER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D_SHADER_DATA>()) == 0 }
+        self.pBytecode == other.pBytecode && self.BytecodeLength == other.BytecodeLength
     }
 }
 impl ::core::cmp::Eq for D3D_SHADER_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -1897,7 +1897,7 @@ unsafe impl ::windows::core::Abi for D3DVECTOR {
 }
 impl ::core::cmp::PartialEq for D3DVECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVECTOR>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z
     }
 }
 impl ::core::cmp::Eq for D3DVECTOR {}
@@ -1928,7 +1928,7 @@ unsafe impl ::windows::core::Abi for D3D_SHADER_MACRO {
 }
 impl ::core::cmp::PartialEq for D3D_SHADER_MACRO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D_SHADER_MACRO>()) == 0 }
+        self.Name == other.Name && self.Definition == other.Definition
     }
 }
 impl ::core::cmp::Eq for D3D_SHADER_MACRO {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -9293,7 +9293,7 @@ unsafe impl ::windows::core::Abi for D3D10_BLEND_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_BLEND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BLEND_DESC>()) == 0 }
+        self.AlphaToCoverageEnable == other.AlphaToCoverageEnable && self.BlendEnable == other.BlendEnable && self.SrcBlend == other.SrcBlend && self.DestBlend == other.DestBlend && self.BlendOp == other.BlendOp && self.SrcBlendAlpha == other.SrcBlendAlpha && self.DestBlendAlpha == other.DestBlendAlpha && self.BlendOpAlpha == other.BlendOpAlpha && self.RenderTargetWriteMask == other.RenderTargetWriteMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9333,7 +9333,7 @@ unsafe impl ::windows::core::Abi for D3D10_BLEND_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_BLEND_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BLEND_DESC1>()) == 0 }
+        self.AlphaToCoverageEnable == other.AlphaToCoverageEnable && self.IndependentBlendEnable == other.IndependentBlendEnable && self.RenderTarget == other.RenderTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9370,7 +9370,7 @@ unsafe impl ::windows::core::Abi for D3D10_BOX {
 }
 impl ::core::cmp::PartialEq for D3D10_BOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BOX>()) == 0 }
+        self.left == other.left && self.top == other.top && self.front == other.front && self.right == other.right && self.bottom == other.bottom && self.back == other.back
     }
 }
 impl ::core::cmp::Eq for D3D10_BOX {}
@@ -9404,7 +9404,7 @@ unsafe impl ::windows::core::Abi for D3D10_BUFFER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_DESC>()) == 0 }
+        self.ByteWidth == other.ByteWidth && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 impl ::core::cmp::Eq for D3D10_BUFFER_DESC {}
@@ -9428,12 +9428,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_RTV {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_RTV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_RTV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_RTV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_RTV {}
 impl ::core::default::Default for D3D10_BUFFER_RTV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9454,12 +9448,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_RTV_0 {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_RTV_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_RTV_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_RTV_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_RTV_0 {}
 impl ::core::default::Default for D3D10_BUFFER_RTV_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9480,12 +9468,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_RTV_1 {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_RTV_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_RTV_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_RTV_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_RTV_1 {}
 impl ::core::default::Default for D3D10_BUFFER_RTV_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9506,12 +9488,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_SRV {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_SRV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_SRV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_SRV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_SRV {}
 impl ::core::default::Default for D3D10_BUFFER_SRV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9532,12 +9508,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_SRV_0 {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_SRV_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_SRV_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_SRV_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_SRV_0 {}
 impl ::core::default::Default for D3D10_BUFFER_SRV_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9558,12 +9528,6 @@ impl ::core::clone::Clone for D3D10_BUFFER_SRV_1 {
 unsafe impl ::windows::core::Abi for D3D10_BUFFER_SRV_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D10_BUFFER_SRV_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_BUFFER_SRV_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D10_BUFFER_SRV_1 {}
 impl ::core::default::Default for D3D10_BUFFER_SRV_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9591,7 +9555,7 @@ unsafe impl ::windows::core::Abi for D3D10_COUNTER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_COUNTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_COUNTER_DESC>()) == 0 }
+        self.Counter == other.Counter && self.MiscFlags == other.MiscFlags
     }
 }
 impl ::core::cmp::Eq for D3D10_COUNTER_DESC {}
@@ -9623,7 +9587,7 @@ unsafe impl ::windows::core::Abi for D3D10_COUNTER_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_COUNTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_COUNTER_INFO>()) == 0 }
+        self.LastDeviceDependentCounter == other.LastDeviceDependentCounter && self.NumSimultaneousCounters == other.NumSimultaneousCounters && self.NumDetectableParallelUnits == other.NumDetectableParallelUnits
     }
 }
 impl ::core::cmp::Eq for D3D10_COUNTER_INFO {}
@@ -9656,7 +9620,7 @@ unsafe impl ::windows::core::Abi for D3D10_DEPTH_STENCILOP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_DEPTH_STENCILOP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_DEPTH_STENCILOP_DESC>()) == 0 }
+        self.StencilFailOp == other.StencilFailOp && self.StencilDepthFailOp == other.StencilDepthFailOp && self.StencilPassOp == other.StencilPassOp && self.StencilFunc == other.StencilFunc
     }
 }
 impl ::core::cmp::Eq for D3D10_DEPTH_STENCILOP_DESC {}
@@ -9699,7 +9663,7 @@ unsafe impl ::windows::core::Abi for D3D10_DEPTH_STENCIL_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_DEPTH_STENCIL_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_DEPTH_STENCIL_DESC>()) == 0 }
+        self.DepthEnable == other.DepthEnable && self.DepthWriteMask == other.DepthWriteMask && self.DepthFunc == other.DepthFunc && self.StencilEnable == other.StencilEnable && self.StencilReadMask == other.StencilReadMask && self.StencilWriteMask == other.StencilWriteMask && self.FrontFace == other.FrontFace && self.BackFace == other.BackFace
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9731,14 +9695,6 @@ unsafe impl ::windows::core::Abi for D3D10_DEPTH_STENCIL_VIEW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D10_DEPTH_STENCIL_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_DEPTH_STENCIL_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D10_DEPTH_STENCIL_VIEW_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D10_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9767,14 +9723,6 @@ impl ::core::clone::Clone for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_DEPTH_STENCIL_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
     fn default() -> Self {
@@ -9813,7 +9761,7 @@ unsafe impl ::windows::core::Abi for D3D10_EFFECT_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_EFFECT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_EFFECT_DESC>()) == 0 }
+        self.IsChildEffect == other.IsChildEffect && self.ConstantBuffers == other.ConstantBuffers && self.SharedConstantBuffers == other.SharedConstantBuffers && self.GlobalVariables == other.GlobalVariables && self.SharedGlobalVariables == other.SharedGlobalVariables && self.Techniques == other.Techniques
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9857,7 +9805,7 @@ unsafe impl ::windows::core::Abi for D3D10_EFFECT_SHADER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_EFFECT_SHADER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_EFFECT_SHADER_DESC>()) == 0 }
+        self.pInputSignature == other.pInputSignature && self.IsInline == other.IsInline && self.pBytecode == other.pBytecode && self.BytecodeLength == other.BytecodeLength && self.SODecl == other.SODecl && self.NumInputSignatureEntries == other.NumInputSignatureEntries && self.NumOutputSignatureEntries == other.NumOutputSignatureEntries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9904,7 +9852,7 @@ unsafe impl ::windows::core::Abi for D3D10_EFFECT_TYPE_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_EFFECT_TYPE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_EFFECT_TYPE_DESC>()) == 0 }
+        self.TypeName == other.TypeName && self.Class == other.Class && self.Type == other.Type && self.Elements == other.Elements && self.Members == other.Members && self.Rows == other.Rows && self.Columns == other.Columns && self.PackedSize == other.PackedSize && self.UnpackedSize == other.UnpackedSize && self.Stride == other.Stride
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -9941,7 +9889,7 @@ unsafe impl ::windows::core::Abi for D3D10_EFFECT_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_EFFECT_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_EFFECT_VARIABLE_DESC>()) == 0 }
+        self.Name == other.Name && self.Semantic == other.Semantic && self.Flags == other.Flags && self.Annotations == other.Annotations && self.BufferOffset == other.BufferOffset && self.ExplicitBindPoint == other.ExplicitBindPoint
     }
 }
 impl ::core::cmp::Eq for D3D10_EFFECT_VARIABLE_DESC {}
@@ -9972,7 +9920,7 @@ unsafe impl ::windows::core::Abi for D3D10_INFO_QUEUE_FILTER {
 }
 impl ::core::cmp::PartialEq for D3D10_INFO_QUEUE_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_INFO_QUEUE_FILTER>()) == 0 }
+        self.AllowList == other.AllowList && self.DenyList == other.DenyList
     }
 }
 impl ::core::cmp::Eq for D3D10_INFO_QUEUE_FILTER {}
@@ -10007,7 +9955,7 @@ unsafe impl ::windows::core::Abi for D3D10_INFO_QUEUE_FILTER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_INFO_QUEUE_FILTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_INFO_QUEUE_FILTER_DESC>()) == 0 }
+        self.NumCategories == other.NumCategories && self.pCategoryList == other.pCategoryList && self.NumSeverities == other.NumSeverities && self.pSeverityList == other.pSeverityList && self.NumIDs == other.NumIDs && self.pIDList == other.pIDList
     }
 }
 impl ::core::cmp::Eq for D3D10_INFO_QUEUE_FILTER_DESC {}
@@ -10049,7 +9997,7 @@ unsafe impl ::windows::core::Abi for D3D10_INPUT_ELEMENT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D10_INPUT_ELEMENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_INPUT_ELEMENT_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Format == other.Format && self.InputSlot == other.InputSlot && self.AlignedByteOffset == other.AlignedByteOffset && self.InputSlotClass == other.InputSlotClass && self.InstanceDataStepRate == other.InstanceDataStepRate
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -10082,7 +10030,7 @@ unsafe impl ::windows::core::Abi for D3D10_MAPPED_TEXTURE2D {
 }
 impl ::core::cmp::PartialEq for D3D10_MAPPED_TEXTURE2D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_MAPPED_TEXTURE2D>()) == 0 }
+        self.pData == other.pData && self.RowPitch == other.RowPitch
     }
 }
 impl ::core::cmp::Eq for D3D10_MAPPED_TEXTURE2D {}
@@ -10114,7 +10062,7 @@ unsafe impl ::windows::core::Abi for D3D10_MAPPED_TEXTURE3D {
 }
 impl ::core::cmp::PartialEq for D3D10_MAPPED_TEXTURE3D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_MAPPED_TEXTURE3D>()) == 0 }
+        self.pData == other.pData && self.RowPitch == other.RowPitch && self.DepthPitch == other.DepthPitch
     }
 }
 impl ::core::cmp::Eq for D3D10_MAPPED_TEXTURE3D {}
@@ -10148,7 +10096,7 @@ unsafe impl ::windows::core::Abi for D3D10_MESSAGE {
 }
 impl ::core::cmp::PartialEq for D3D10_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_MESSAGE>()) == 0 }
+        self.Category == other.Category && self.Severity == other.Severity && self.ID == other.ID && self.pDescription == other.pDescription && self.DescriptionByteLength == other.DescriptionByteLength
     }
 }
 impl ::core::cmp::Eq for D3D10_MESSAGE {}
@@ -10184,7 +10132,7 @@ unsafe impl ::windows::core::Abi for D3D10_PASS_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_PASS_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_PASS_DESC>()) == 0 }
+        self.Name == other.Name && self.Annotations == other.Annotations && self.pIAInputSignature == other.pIAInputSignature && self.IAInputSignatureSize == other.IAInputSignatureSize && self.StencilRef == other.StencilRef && self.SampleMask == other.SampleMask && self.BlendFactor == other.BlendFactor
     }
 }
 impl ::core::cmp::Eq for D3D10_PASS_DESC {}
@@ -10251,7 +10199,7 @@ unsafe impl ::windows::core::Abi for D3D10_QUERY_DATA_PIPELINE_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D10_QUERY_DATA_PIPELINE_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_QUERY_DATA_PIPELINE_STATISTICS>()) == 0 }
+        self.IAVertices == other.IAVertices && self.IAPrimitives == other.IAPrimitives && self.VSInvocations == other.VSInvocations && self.GSInvocations == other.GSInvocations && self.GSPrimitives == other.GSPrimitives && self.CInvocations == other.CInvocations && self.CPrimitives == other.CPrimitives && self.PSInvocations == other.PSInvocations
     }
 }
 impl ::core::cmp::Eq for D3D10_QUERY_DATA_PIPELINE_STATISTICS {}
@@ -10282,7 +10230,7 @@ unsafe impl ::windows::core::Abi for D3D10_QUERY_DATA_SO_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D10_QUERY_DATA_SO_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_QUERY_DATA_SO_STATISTICS>()) == 0 }
+        self.NumPrimitivesWritten == other.NumPrimitivesWritten && self.PrimitivesStorageNeeded == other.PrimitivesStorageNeeded
     }
 }
 impl ::core::cmp::Eq for D3D10_QUERY_DATA_SO_STATISTICS {}
@@ -10319,7 +10267,7 @@ unsafe impl ::windows::core::Abi for D3D10_QUERY_DATA_TIMESTAMP_DISJOINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_QUERY_DATA_TIMESTAMP_DISJOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_QUERY_DATA_TIMESTAMP_DISJOINT>()) == 0 }
+        self.Frequency == other.Frequency && self.Disjoint == other.Disjoint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10352,7 +10300,7 @@ unsafe impl ::windows::core::Abi for D3D10_QUERY_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_QUERY_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_QUERY_DESC>()) == 0 }
+        self.Query == other.Query && self.MiscFlags == other.MiscFlags
     }
 }
 impl ::core::cmp::Eq for D3D10_QUERY_DESC {}
@@ -10408,7 +10356,7 @@ unsafe impl ::windows::core::Abi for D3D10_RASTERIZER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_RASTERIZER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_RASTERIZER_DESC>()) == 0 }
+        self.FillMode == other.FillMode && self.CullMode == other.CullMode && self.FrontCounterClockwise == other.FrontCounterClockwise && self.DepthBias == other.DepthBias && self.DepthBiasClamp == other.DepthBiasClamp && self.SlopeScaledDepthBias == other.SlopeScaledDepthBias && self.DepthClipEnable == other.DepthClipEnable && self.ScissorEnable == other.ScissorEnable && self.MultisampleEnable == other.MultisampleEnable && self.AntialiasedLineEnable == other.AntialiasedLineEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10453,7 +10401,7 @@ unsafe impl ::windows::core::Abi for D3D10_RENDER_TARGET_BLEND_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_RENDER_TARGET_BLEND_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_RENDER_TARGET_BLEND_DESC1>()) == 0 }
+        self.BlendEnable == other.BlendEnable && self.SrcBlend == other.SrcBlend && self.DestBlend == other.DestBlend && self.BlendOp == other.BlendOp && self.SrcBlendAlpha == other.SrcBlendAlpha && self.DestBlendAlpha == other.DestBlendAlpha && self.BlendOpAlpha == other.BlendOpAlpha && self.RenderTargetWriteMask == other.RenderTargetWriteMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10485,14 +10433,6 @@ unsafe impl ::windows::core::Abi for D3D10_RENDER_TARGET_VIEW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D10_RENDER_TARGET_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_RENDER_TARGET_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D10_RENDER_TARGET_VIEW_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D10_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10523,14 +10463,6 @@ impl ::core::clone::Clone for D3D10_RENDER_TARGET_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D10_RENDER_TARGET_VIEW_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D10_RENDER_TARGET_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_RENDER_TARGET_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D10_RENDER_TARGET_VIEW_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D10_RENDER_TARGET_VIEW_DESC_0 {
     fn default() -> Self {
@@ -10567,7 +10499,7 @@ unsafe impl ::windows::core::Abi for D3D10_SAMPLER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_SAMPLER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SAMPLER_DESC>()) == 0 }
+        self.Filter == other.Filter && self.AddressU == other.AddressU && self.AddressV == other.AddressV && self.AddressW == other.AddressW && self.MipLODBias == other.MipLODBias && self.MaxAnisotropy == other.MaxAnisotropy && self.ComparisonFunc == other.ComparisonFunc && self.BorderColor == other.BorderColor && self.MinLOD == other.MinLOD && self.MaxLOD == other.MaxLOD
     }
 }
 impl ::core::cmp::Eq for D3D10_SAMPLER_DESC {}
@@ -10607,7 +10539,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_BUFFER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_BUFFER_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.Variables == other.Variables && self.Size == other.Size && self.uFlags == other.uFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10642,7 +10574,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_FILE_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_FILE_INFO>()) == 0 }
+        self.FileName == other.FileName && self.FileNameLen == other.FileNameLen && self.FileData == other.FileData && self.FileLen == other.FileLen
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_DEBUG_FILE_INFO {}
@@ -10714,7 +10646,27 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_INFO>()) == 0 }
+        self.Size == other.Size
+            && self.Creator == other.Creator
+            && self.EntrypointName == other.EntrypointName
+            && self.ShaderTarget == other.ShaderTarget
+            && self.CompileFlags == other.CompileFlags
+            && self.Files == other.Files
+            && self.FileInfo == other.FileInfo
+            && self.Instructions == other.Instructions
+            && self.InstructionInfo == other.InstructionInfo
+            && self.Variables == other.Variables
+            && self.VariableInfo == other.VariableInfo
+            && self.InputVariables == other.InputVariables
+            && self.InputVariableInfo == other.InputVariableInfo
+            && self.Tokens == other.Tokens
+            && self.TokenInfo == other.TokenInfo
+            && self.Scopes == other.Scopes
+            && self.ScopeInfo == other.ScopeInfo
+            && self.ScopeVariables == other.ScopeVariables
+            && self.ScopeVariableInfo == other.ScopeVariableInfo
+            && self.UintOffset == other.UintOffset
+            && self.StringOffset == other.StringOffset
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_DEBUG_INFO {}
@@ -10749,7 +10701,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_INPUT_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_INPUT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_INPUT_INFO>()) == 0 }
+        self.Var == other.Var && self.InitialRegisterSet == other.InitialRegisterSet && self.InitialBank == other.InitialBank && self.InitialRegister == other.InitialRegister && self.InitialComponent == other.InitialComponent && self.InitialValue == other.InitialValue
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_DEBUG_INPUT_INFO {}
@@ -10794,7 +10746,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_INST_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_INST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_INST_INFO>()) == 0 }
+        self.Id == other.Id && self.Opcode == other.Opcode && self.uOutputs == other.uOutputs && self.pOutputs == other.pOutputs && self.TokenId == other.TokenId && self.NestingLevel == other.NestingLevel && self.Scopes == other.Scopes && self.ScopeInfo == other.ScopeInfo && self.AccessedVars == other.AccessedVars && self.AccessedVarsInfo == other.AccessedVarsInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10838,7 +10790,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_OUTPUTREG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_OUTPUTREG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_OUTPUTREG_INFO>()) == 0 }
+        self.OutputRegisterSet == other.OutputRegisterSet && self.OutputReg == other.OutputReg && self.TempArrayReg == other.TempArrayReg && self.OutputComponents == other.OutputComponents && self.OutputVars == other.OutputVars && self.IndexReg == other.IndexReg && self.IndexComp == other.IndexComp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10884,7 +10836,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_OUTPUTVAR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_OUTPUTVAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_OUTPUTVAR>()) == 0 }
+        self.Var == other.Var && self.uValueMin == other.uValueMin && self.uValueMax == other.uValueMax && self.iValueMin == other.iValueMin && self.iValueMax == other.iValueMax && self.fValueMin == other.fValueMin && self.fValueMax == other.fValueMax && self.bNaNPossible == other.bNaNPossible && self.bInfPossible == other.bInfPossible
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10932,7 +10884,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_SCOPEVAR_INFO {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_SCOPEVAR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_SCOPEVAR_INFO>()) == 0 }
+        self.TokenId == other.TokenId && self.VarType == other.VarType && self.Class == other.Class && self.Rows == other.Rows && self.Columns == other.Columns && self.StructMemberScope == other.StructMemberScope && self.uArrayIndices == other.uArrayIndices && self.ArrayElements == other.ArrayElements && self.ArrayStrides == other.ArrayStrides && self.uVariables == other.uVariables && self.uFirstVariable == other.uFirstVariable
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10968,7 +10920,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_SCOPE_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_SCOPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_SCOPE_INFO>()) == 0 }
+        self.ScopeType == other.ScopeType && self.Name == other.Name && self.uNameLen == other.uNameLen && self.uVariables == other.uVariables && self.VariableData == other.VariableData
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_DEBUG_SCOPE_INFO {}
@@ -11002,7 +10954,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_TOKEN_INFO {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_TOKEN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_TOKEN_INFO>()) == 0 }
+        self.File == other.File && self.Line == other.Line && self.Column == other.Column && self.TokenLength == other.TokenLength && self.TokenId == other.TokenId
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_DEBUG_TOKEN_INFO {}
@@ -11043,7 +10995,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DEBUG_VAR_INFO {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DEBUG_VAR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DEBUG_VAR_INFO>()) == 0 }
+        self.TokenId == other.TokenId && self.Type == other.Type && self.Register == other.Register && self.Component == other.Component && self.ScopeVar == other.ScopeVar && self.ScopeVarOffset == other.ScopeVarOffset
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -11137,7 +11089,34 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_DESC>()) == 0 }
+        self.Version == other.Version
+            && self.Creator == other.Creator
+            && self.Flags == other.Flags
+            && self.ConstantBuffers == other.ConstantBuffers
+            && self.BoundResources == other.BoundResources
+            && self.InputParameters == other.InputParameters
+            && self.OutputParameters == other.OutputParameters
+            && self.InstructionCount == other.InstructionCount
+            && self.TempRegisterCount == other.TempRegisterCount
+            && self.TempArrayCount == other.TempArrayCount
+            && self.DefCount == other.DefCount
+            && self.DclCount == other.DclCount
+            && self.TextureNormalInstructions == other.TextureNormalInstructions
+            && self.TextureLoadInstructions == other.TextureLoadInstructions
+            && self.TextureCompInstructions == other.TextureCompInstructions
+            && self.TextureBiasInstructions == other.TextureBiasInstructions
+            && self.TextureGradientInstructions == other.TextureGradientInstructions
+            && self.FloatInstructionCount == other.FloatInstructionCount
+            && self.IntInstructionCount == other.IntInstructionCount
+            && self.UintInstructionCount == other.UintInstructionCount
+            && self.StaticFlowControlCount == other.StaticFlowControlCount
+            && self.DynamicFlowControlCount == other.DynamicFlowControlCount
+            && self.MacroInstructionCount == other.MacroInstructionCount
+            && self.ArrayInstructionCount == other.ArrayInstructionCount
+            && self.CutInstructionCount == other.CutInstructionCount
+            && self.EmitInstructionCount == other.EmitInstructionCount
+            && self.GSOutputTopology == other.GSOutputTopology
+            && self.GSMaxOutputVertexCount == other.GSMaxOutputVertexCount
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -11182,7 +11161,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_INPUT_BIND_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_INPUT_BIND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_INPUT_BIND_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.BindPoint == other.BindPoint && self.BindCount == other.BindCount && self.uFlags == other.uFlags && self.ReturnType == other.ReturnType && self.Dimension == other.Dimension && self.NumSamples == other.NumSamples
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -11213,14 +11192,6 @@ impl ::core::clone::Clone for D3D10_SHADER_RESOURCE_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D10_SHADER_RESOURCE_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D10_SHADER_RESOURCE_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_RESOURCE_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D10_SHADER_RESOURCE_VIEW_DESC {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D10_SHADER_RESOURCE_VIEW_DESC {
     fn default() -> Self {
@@ -11254,14 +11225,6 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_RESOURCE_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11287,14 +11250,6 @@ impl ::core::clone::Clone for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
 unsafe impl ::windows::core::Abi for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_RESOURCE_VIEW_DESC1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D10_SHADER_RESOURCE_VIEW_DESC1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
     fn default() -> Self {
@@ -11328,14 +11283,6 @@ impl ::core::clone::Clone for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
 unsafe impl ::windows::core::Abi for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_RESOURCE_VIEW_DESC1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
     fn default() -> Self {
@@ -11375,7 +11322,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_TYPE_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SHADER_TYPE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_TYPE_DESC>()) == 0 }
+        self.Class == other.Class && self.Type == other.Type && self.Rows == other.Rows && self.Columns == other.Columns && self.Elements == other.Elements && self.Members == other.Members && self.Offset == other.Offset
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -11411,7 +11358,7 @@ unsafe impl ::windows::core::Abi for D3D10_SHADER_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_SHADER_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SHADER_VARIABLE_DESC>()) == 0 }
+        self.Name == other.Name && self.StartOffset == other.StartOffset && self.Size == other.Size && self.uFlags == other.uFlags && self.DefaultValue == other.DefaultValue
     }
 }
 impl ::core::cmp::Eq for D3D10_SHADER_VARIABLE_DESC {}
@@ -11453,7 +11400,7 @@ unsafe impl ::windows::core::Abi for D3D10_SIGNATURE_PARAMETER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D10_SIGNATURE_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SIGNATURE_PARAMETER_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Register == other.Register && self.SystemValueType == other.SystemValueType && self.ComponentType == other.ComponentType && self.Mask == other.Mask && self.ReadWriteMask == other.ReadWriteMask
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -11489,7 +11436,7 @@ unsafe impl ::windows::core::Abi for D3D10_SO_DECLARATION_ENTRY {
 }
 impl ::core::cmp::PartialEq for D3D10_SO_DECLARATION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SO_DECLARATION_ENTRY>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.StartComponent == other.StartComponent && self.ComponentCount == other.ComponentCount && self.OutputSlot == other.OutputSlot
     }
 }
 impl ::core::cmp::Eq for D3D10_SO_DECLARATION_ENTRY {}
@@ -11567,7 +11514,30 @@ unsafe impl ::windows::core::Abi for D3D10_STATE_BLOCK_MASK {
 }
 impl ::core::cmp::PartialEq for D3D10_STATE_BLOCK_MASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_STATE_BLOCK_MASK>()) == 0 }
+        self.VS == other.VS
+            && self.VSSamplers == other.VSSamplers
+            && self.VSShaderResources == other.VSShaderResources
+            && self.VSConstantBuffers == other.VSConstantBuffers
+            && self.GS == other.GS
+            && self.GSSamplers == other.GSSamplers
+            && self.GSShaderResources == other.GSShaderResources
+            && self.GSConstantBuffers == other.GSConstantBuffers
+            && self.PS == other.PS
+            && self.PSSamplers == other.PSSamplers
+            && self.PSShaderResources == other.PSShaderResources
+            && self.PSConstantBuffers == other.PSConstantBuffers
+            && self.IAVertexBuffers == other.IAVertexBuffers
+            && self.IAIndexBuffer == other.IAIndexBuffer
+            && self.IAInputLayout == other.IAInputLayout
+            && self.IAPrimitiveTopology == other.IAPrimitiveTopology
+            && self.OMRenderTargets == other.OMRenderTargets
+            && self.OMDepthStencilState == other.OMDepthStencilState
+            && self.OMBlendState == other.OMBlendState
+            && self.RSViewports == other.RSViewports
+            && self.RSScissorRects == other.RSScissorRects
+            && self.RSRasterizerState == other.RSRasterizerState
+            && self.SOBuffers == other.SOBuffers
+            && self.Predication == other.Predication
     }
 }
 impl ::core::cmp::Eq for D3D10_STATE_BLOCK_MASK {}
@@ -11599,7 +11569,7 @@ unsafe impl ::windows::core::Abi for D3D10_SUBRESOURCE_DATA {
 }
 impl ::core::cmp::PartialEq for D3D10_SUBRESOURCE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_SUBRESOURCE_DATA>()) == 0 }
+        self.pSysMem == other.pSysMem && self.SysMemPitch == other.SysMemPitch && self.SysMemSlicePitch == other.SysMemSlicePitch
     }
 }
 impl ::core::cmp::Eq for D3D10_SUBRESOURCE_DATA {}
@@ -11631,7 +11601,7 @@ unsafe impl ::windows::core::Abi for D3D10_TECHNIQUE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D10_TECHNIQUE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TECHNIQUE_DESC>()) == 0 }
+        self.Name == other.Name && self.Passes == other.Passes && self.Annotations == other.Annotations
     }
 }
 impl ::core::cmp::Eq for D3D10_TECHNIQUE_DESC {}
@@ -11663,7 +11633,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_ARRAY_DSV {}
@@ -11695,7 +11665,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_ARRAY_RTV {}
@@ -11728,7 +11698,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_ARRAY_SRV {}
@@ -11758,7 +11728,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_DSV {}
@@ -11788,7 +11758,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_RTV {}
@@ -11819,7 +11789,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX1D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX1D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX1D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX1D_SRV {}
@@ -11850,7 +11820,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_ARRAY_DSV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_ARRAY_DSV {}
@@ -11881,7 +11851,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_ARRAY_RTV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_ARRAY_RTV {}
@@ -11912,7 +11882,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_ARRAY_SRV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_ARRAY_SRV {}
@@ -11942,7 +11912,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_DSV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_DSV {}
@@ -11972,7 +11942,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_RTV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_RTV {}
@@ -12002,7 +11972,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2DMS_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2DMS_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2DMS_SRV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2DMS_SRV {}
@@ -12034,7 +12004,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_ARRAY_DSV {}
@@ -12066,7 +12036,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_ARRAY_RTV {}
@@ -12099,7 +12069,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_ARRAY_SRV {}
@@ -12129,7 +12099,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_DSV {}
@@ -12159,7 +12129,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_RTV {}
@@ -12190,7 +12160,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX2D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX2D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX2D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX2D_SRV {}
@@ -12222,7 +12192,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX3D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX3D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX3D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstWSlice == other.FirstWSlice && self.WSize == other.WSize
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX3D_RTV {}
@@ -12253,7 +12223,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEX3D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEX3D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEX3D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D10_TEX3D_SRV {}
@@ -12286,7 +12256,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEXCUBE_ARRAY_SRV1 {
 }
 impl ::core::cmp::PartialEq for D3D10_TEXCUBE_ARRAY_SRV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEXCUBE_ARRAY_SRV1>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.First2DArrayFace == other.First2DArrayFace && self.NumCubes == other.NumCubes
     }
 }
 impl ::core::cmp::Eq for D3D10_TEXCUBE_ARRAY_SRV1 {}
@@ -12317,7 +12287,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEXCUBE_SRV {
 }
 impl ::core::cmp::PartialEq for D3D10_TEXCUBE_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEXCUBE_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D10_TEXCUBE_SRV {}
@@ -12360,7 +12330,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEXTURE1D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D10_TEXTURE1D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEXTURE1D_DESC>()) == 0 }
+        self.Width == other.Width && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.Format == other.Format && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -12407,7 +12377,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEXTURE2D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D10_TEXTURE2D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEXTURE2D_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.Format == other.Format && self.SampleDesc == other.SampleDesc && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -12453,7 +12423,7 @@ unsafe impl ::windows::core::Abi for D3D10_TEXTURE3D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D10_TEXTURE3D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_TEXTURE3D_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth && self.MipLevels == other.MipLevels && self.Format == other.Format && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -12490,7 +12460,7 @@ unsafe impl ::windows::core::Abi for D3D10_VIEWPORT {
 }
 impl ::core::cmp::PartialEq for D3D10_VIEWPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D10_VIEWPORT>()) == 0 }
+        self.TopLeftX == other.TopLeftX && self.TopLeftY == other.TopLeftY && self.Width == other.Width && self.Height == other.Height && self.MinDepth == other.MinDepth && self.MaxDepth == other.MaxDepth
     }
 }
 impl ::core::cmp::Eq for D3D10_VIEWPORT {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -21261,7 +21261,7 @@ unsafe impl ::windows::core::Abi for D3D11_AES_CTR_IV {
 }
 impl ::core::cmp::PartialEq for D3D11_AES_CTR_IV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AES_CTR_IV>()) == 0 }
+        self.IV == other.IV && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for D3D11_AES_CTR_IV {}
@@ -21298,7 +21298,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_EN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_ENCRYPTION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_ENCRYPTION_INPUT>()) == 0 }
+        self.Parameters == other.Parameters && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21339,7 +21339,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSIO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION_INPUT>()) == 0 }
+        self.Parameters == other.Parameters && self.DecoderHandle == other.DecoderHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21379,7 +21379,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_IN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT>()) == 0 }
+        self.Parameters == other.Parameters && self.StartSequenceQuery == other.StartSequenceQuery && self.StartSequenceConfigure == other.StartSequenceConfigure
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21420,7 +21420,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_INPUT>()) == 0 }
+        self.omac == other.omac && self.ConfigureType == other.ConfigureType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21462,7 +21462,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_OUTPUT>()) == 0 }
+        self.omac == other.omac && self.ConfigureType == other.ConfigureType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber && self.ReturnCode == other.ReturnCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21492,14 +21492,6 @@ impl ::core::clone::Clone for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
 unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
     fn default() -> Self {
@@ -21536,7 +21528,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOUR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE_INPUT>()) == 0 }
+        self.Parameters == other.Parameters && self.ProcessType == other.ProcessType && self.ProcessHandle == other.ProcessHandle && self.AllowAccess == other.AllowAccess
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21562,12 +21554,6 @@ impl ::core::clone::Clone for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
 unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_PROTECTION_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_AUTHENTICATED_PROTECTION_FLAGS {}
 impl ::core::default::Default for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21594,7 +21580,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
 }
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_PROTECTION_FLAGS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {}
@@ -21631,7 +21617,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENC
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.EncryptionGuidCount == other.EncryptionGuidCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21670,7 +21656,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENC
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT>()) == 0 }
+        self.Input == other.Input && self.EncryptionGuidIndex == other.EncryptionGuidIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21710,7 +21696,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENC
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.EncryptionGuidIndex == other.EncryptionGuidIndex && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21751,7 +21737,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUT
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.BusType == other.BusType && self.AccessibleInContiguousBlocks == other.AccessibleInContiguousBlocks && self.AccessibleInNonContiguousBlocks == other.AccessibleInNonContiguousBlocks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21790,7 +21776,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTP
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.ChannelType == other.ChannelType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21829,7 +21815,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_IN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_INPUT>()) == 0 }
+        self.Input == other.Input && self.DecoderHandle == other.DecoderHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21870,7 +21856,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_OU
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DecoderHandle == other.DecoderHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21909,7 +21895,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBI
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILITY_ENCRYPTION_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILITY_ENCRYPTION_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21948,7 +21934,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUT
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21988,7 +21974,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_INPUT>()) == 0 }
+        self.QueryType == other.QueryType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22030,7 +22016,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_OUTPUT>()) == 0 }
+        self.omac == other.omac && self.QueryType == other.QueryType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber && self.ReturnCode == other.ReturnCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22070,7 +22056,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_I
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_INPUT>()) == 0 }
+        self.Input == other.Input && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22111,7 +22097,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_O
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.OutputIDCount == other.OutputIDCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22152,7 +22138,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT>()) == 0 }
+        self.Input == other.Input && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.OutputIDIndex == other.OutputIDIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22194,7 +22180,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT 
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.OutputIDIndex == other.OutputIDIndex && self.OutputID == other.OutputID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22224,14 +22210,6 @@ impl ::core::clone::Clone for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
 unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
     fn default() -> Self {
@@ -22266,7 +22244,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.RestrictedSharedResourceProcessCount == other.RestrictedSharedResourceProcessCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22305,7 +22283,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT>()) == 0 }
+        self.Input == other.Input && self.ProcessIndex == other.ProcessIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22346,7 +22324,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.ProcessIndex == other.ProcessIndex && self.ProcessIdentifier == other.ProcessIdentifier && self.ProcessHandle == other.ProcessHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22385,7 +22363,7 @@ unsafe impl ::windows::core::Abi for D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROT
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.UnrestrictedProtectedSharedResourceCount == other.UnrestrictedProtectedSharedResourceCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22425,7 +22403,7 @@ unsafe impl ::windows::core::Abi for D3D11_BLEND_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_BLEND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BLEND_DESC>()) == 0 }
+        self.AlphaToCoverageEnable == other.AlphaToCoverageEnable && self.IndependentBlendEnable == other.IndependentBlendEnable && self.RenderTarget == other.RenderTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22465,7 +22443,7 @@ unsafe impl ::windows::core::Abi for D3D11_BLEND_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_BLEND_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BLEND_DESC1>()) == 0 }
+        self.AlphaToCoverageEnable == other.AlphaToCoverageEnable && self.IndependentBlendEnable == other.IndependentBlendEnable && self.RenderTarget == other.RenderTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22502,7 +22480,7 @@ unsafe impl ::windows::core::Abi for D3D11_BOX {
 }
 impl ::core::cmp::PartialEq for D3D11_BOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BOX>()) == 0 }
+        self.left == other.left && self.top == other.top && self.front == other.front && self.right == other.right && self.bottom == other.bottom && self.back == other.back
     }
 }
 impl ::core::cmp::Eq for D3D11_BOX {}
@@ -22534,7 +22512,7 @@ unsafe impl ::windows::core::Abi for D3D11_BUFFEREX_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_BUFFEREX_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFEREX_SRV>()) == 0 }
+        self.FirstElement == other.FirstElement && self.NumElements == other.NumElements && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D11_BUFFEREX_SRV {}
@@ -22569,7 +22547,7 @@ unsafe impl ::windows::core::Abi for D3D11_BUFFER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_DESC>()) == 0 }
+        self.ByteWidth == other.ByteWidth && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags && self.StructureByteStride == other.StructureByteStride
     }
 }
 impl ::core::cmp::Eq for D3D11_BUFFER_DESC {}
@@ -22593,12 +22571,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_RTV {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_RTV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_RTV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_RTV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_RTV {}
 impl ::core::default::Default for D3D11_BUFFER_RTV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22619,12 +22591,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_RTV_0 {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_RTV_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_RTV_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_RTV_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_RTV_0 {}
 impl ::core::default::Default for D3D11_BUFFER_RTV_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22645,12 +22611,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_RTV_1 {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_RTV_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_RTV_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_RTV_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_RTV_1 {}
 impl ::core::default::Default for D3D11_BUFFER_RTV_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22671,12 +22631,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_SRV {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_SRV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_SRV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_SRV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_SRV {}
 impl ::core::default::Default for D3D11_BUFFER_SRV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22697,12 +22651,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_SRV_0 {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_SRV_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_SRV_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_SRV_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_SRV_0 {}
 impl ::core::default::Default for D3D11_BUFFER_SRV_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22723,12 +22671,6 @@ impl ::core::clone::Clone for D3D11_BUFFER_SRV_1 {
 unsafe impl ::windows::core::Abi for D3D11_BUFFER_SRV_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_BUFFER_SRV_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_SRV_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_BUFFER_SRV_1 {}
 impl ::core::default::Default for D3D11_BUFFER_SRV_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22757,7 +22699,7 @@ unsafe impl ::windows::core::Abi for D3D11_BUFFER_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_BUFFER_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_BUFFER_UAV>()) == 0 }
+        self.FirstElement == other.FirstElement && self.NumElements == other.NumElements && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D11_BUFFER_UAV {}
@@ -22800,7 +22742,7 @@ unsafe impl ::windows::core::Abi for D3D11_CLASS_INSTANCE_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_CLASS_INSTANCE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_CLASS_INSTANCE_DESC>()) == 0 }
+        self.InstanceId == other.InstanceId && self.InstanceIndex == other.InstanceIndex && self.TypeId == other.TypeId && self.ConstantBuffer == other.ConstantBuffer && self.BaseConstantBufferOffset == other.BaseConstantBufferOffset && self.BaseTexture == other.BaseTexture && self.BaseSampler == other.BaseSampler && self.Created == other.Created
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22834,7 +22776,7 @@ unsafe impl ::windows::core::Abi for D3D11_COMPUTE_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_COMPUTE_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_COMPUTE_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation && self.ThreadIDInGroup == other.ThreadIDInGroup && self.ThreadGroupID == other.ThreadGroupID
     }
 }
 impl ::core::cmp::Eq for D3D11_COMPUTE_SHADER_TRACE_DESC {}
@@ -22865,7 +22807,7 @@ unsafe impl ::windows::core::Abi for D3D11_COUNTER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_COUNTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_COUNTER_DESC>()) == 0 }
+        self.Counter == other.Counter && self.MiscFlags == other.MiscFlags
     }
 }
 impl ::core::cmp::Eq for D3D11_COUNTER_DESC {}
@@ -22897,7 +22839,7 @@ unsafe impl ::windows::core::Abi for D3D11_COUNTER_INFO {
 }
 impl ::core::cmp::PartialEq for D3D11_COUNTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_COUNTER_INFO>()) == 0 }
+        self.LastDeviceDependentCounter == other.LastDeviceDependentCounter && self.NumSimultaneousCounters == other.NumSimultaneousCounters && self.NumDetectableParallelUnits == other.NumDetectableParallelUnits
     }
 }
 impl ::core::cmp::Eq for D3D11_COUNTER_INFO {}
@@ -22930,7 +22872,7 @@ unsafe impl ::windows::core::Abi for D3D11_DEPTH_STENCILOP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_DEPTH_STENCILOP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DEPTH_STENCILOP_DESC>()) == 0 }
+        self.StencilFailOp == other.StencilFailOp && self.StencilDepthFailOp == other.StencilDepthFailOp && self.StencilPassOp == other.StencilPassOp && self.StencilFunc == other.StencilFunc
     }
 }
 impl ::core::cmp::Eq for D3D11_DEPTH_STENCILOP_DESC {}
@@ -22973,7 +22915,7 @@ unsafe impl ::windows::core::Abi for D3D11_DEPTH_STENCIL_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_DEPTH_STENCIL_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DEPTH_STENCIL_DESC>()) == 0 }
+        self.DepthEnable == other.DepthEnable && self.DepthWriteMask == other.DepthWriteMask && self.DepthFunc == other.DepthFunc && self.StencilEnable == other.StencilEnable && self.StencilReadMask == other.StencilReadMask && self.StencilWriteMask == other.StencilWriteMask && self.FrontFace == other.FrontFace && self.BackFace == other.BackFace
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23006,14 +22948,6 @@ unsafe impl ::windows::core::Abi for D3D11_DEPTH_STENCIL_VIEW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_DEPTH_STENCIL_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DEPTH_STENCIL_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_DEPTH_STENCIL_VIEW_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -23043,14 +22977,6 @@ unsafe impl ::windows::core::Abi for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DEPTH_STENCIL_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -23077,7 +23003,7 @@ unsafe impl ::windows::core::Abi for D3D11_DOMAIN_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_DOMAIN_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DOMAIN_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation
     }
 }
 impl ::core::cmp::Eq for D3D11_DOMAIN_SHADER_TRACE_DESC {}
@@ -23111,7 +23037,7 @@ unsafe impl ::windows::core::Abi for D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS 
 }
 impl ::core::cmp::PartialEq for D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS>()) == 0 }
+        self.IndexCountPerInstance == other.IndexCountPerInstance && self.InstanceCount == other.InstanceCount && self.StartIndexLocation == other.StartIndexLocation && self.BaseVertexLocation == other.BaseVertexLocation && self.StartInstanceLocation == other.StartInstanceLocation
     }
 }
 impl ::core::cmp::Eq for D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS {}
@@ -23144,7 +23070,7 @@ unsafe impl ::windows::core::Abi for D3D11_DRAW_INSTANCED_INDIRECT_ARGS {
 }
 impl ::core::cmp::PartialEq for D3D11_DRAW_INSTANCED_INDIRECT_ARGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_DRAW_INSTANCED_INDIRECT_ARGS>()) == 0 }
+        self.VertexCountPerInstance == other.VertexCountPerInstance && self.InstanceCount == other.InstanceCount && self.StartVertexLocation == other.StartVertexLocation && self.StartInstanceLocation == other.StartInstanceLocation
     }
 }
 impl ::core::cmp::Eq for D3D11_DRAW_INSTANCED_INDIRECT_ARGS {}
@@ -23176,7 +23102,7 @@ unsafe impl ::windows::core::Abi for D3D11_ENCRYPTED_BLOCK_INFO {
 }
 impl ::core::cmp::PartialEq for D3D11_ENCRYPTED_BLOCK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_ENCRYPTED_BLOCK_INFO>()) == 0 }
+        self.NumEncryptedBytesAtBeginning == other.NumEncryptedBytesAtBeginning && self.NumBytesInSkipPattern == other.NumBytesInSkipPattern && self.NumBytesInEncryptPattern == other.NumBytesInEncryptPattern
     }
 }
 impl ::core::cmp::Eq for D3D11_ENCRYPTED_BLOCK_INFO {}
@@ -23212,7 +23138,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_ARCHITECTURE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_ARCHITECTURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_ARCHITECTURE_INFO>()) == 0 }
+        self.TileBasedDeferredRenderer == other.TileBasedDeferredRenderer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23250,7 +23176,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS>()) == 0 }
+        self.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == other.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23316,7 +23242,20 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS>()) == 0 }
+        self.OutputMergerLogicOp == other.OutputMergerLogicOp
+            && self.UAVOnlyRenderingForcedSampleCount == other.UAVOnlyRenderingForcedSampleCount
+            && self.DiscardAPIsSeenByDriver == other.DiscardAPIsSeenByDriver
+            && self.FlagsForUpdateAndCopySeenByDriver == other.FlagsForUpdateAndCopySeenByDriver
+            && self.ClearView == other.ClearView
+            && self.CopyWithOverlap == other.CopyWithOverlap
+            && self.ConstantBufferPartialUpdate == other.ConstantBufferPartialUpdate
+            && self.ConstantBufferOffsetting == other.ConstantBufferOffsetting
+            && self.MapNoOverwriteOnDynamicConstantBuffer == other.MapNoOverwriteOnDynamicConstantBuffer
+            && self.MapNoOverwriteOnDynamicBufferSRV == other.MapNoOverwriteOnDynamicBufferSRV
+            && self.MultisampleRTVWithForcedSampleCountOne == other.MultisampleRTVWithForcedSampleCountOne
+            && self.SAD4ShaderInstructions == other.SAD4ShaderInstructions
+            && self.ExtendedDoublesShaderInstructions == other.ExtendedDoublesShaderInstructions
+            && self.ExtendedResourceSharing == other.ExtendedResourceSharing
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23357,7 +23296,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS1>()) == 0 }
+        self.TiledResourcesTier == other.TiledResourcesTier && self.MinMaxFiltering == other.MinMaxFiltering && self.ClearViewAlsoSupportsDepthOnlyFormats == other.ClearViewAlsoSupportsDepthOnlyFormats && self.MapOnDefaultBuffers == other.MapOnDefaultBuffers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23411,7 +23350,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS2>()) == 0 }
+        self.PSSpecifiedStencilRefSupported == other.PSSpecifiedStencilRefSupported && self.TypedUAVLoadAdditionalFormats == other.TypedUAVLoadAdditionalFormats && self.ROVsSupported == other.ROVsSupported && self.ConservativeRasterizationTier == other.ConservativeRasterizationTier && self.TiledResourcesTier == other.TiledResourcesTier && self.MapOnDefaultTextures == other.MapOnDefaultTextures && self.StandardSwizzle == other.StandardSwizzle && self.UnifiedMemoryArchitecture == other.UnifiedMemoryArchitecture
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23449,7 +23388,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS3>()) == 0 }
+        self.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer == other.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23487,7 +23426,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS4>()) == 0 }
+        self.ExtendedNV12SharedTextureSupported == other.ExtendedNV12SharedTextureSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23519,7 +23458,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D11_OPTIONS5 {
 }
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D11_OPTIONS5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D11_OPTIONS5>()) == 0 }
+        self.SharedResourceTier == other.SharedResourceTier
     }
 }
 impl ::core::cmp::Eq for D3D11_FEATURE_DATA_D3D11_OPTIONS5 {}
@@ -23555,7 +23494,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D9_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D9_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D9_OPTIONS>()) == 0 }
+        self.FullNonPow2TextureSupport == other.FullNonPow2TextureSupport
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23596,7 +23535,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D9_OPTIONS1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D9_OPTIONS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D9_OPTIONS1>()) == 0 }
+        self.FullNonPow2TextureSupported == other.FullNonPow2TextureSupported && self.DepthAsTextureWithLessEqualComparisonFilterSupported == other.DepthAsTextureWithLessEqualComparisonFilterSupported && self.SimpleInstancingSupported == other.SimpleInstancingSupported && self.TextureCubeFaceRenderTargetWithNonCubeDepthStencilSupported == other.TextureCubeFaceRenderTargetWithNonCubeDepthStencilSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23634,7 +23573,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT>()) == 0 }
+        self.SupportsDepthAsTextureWithLessEqualComparisonFilter == other.SupportsDepthAsTextureWithLessEqualComparisonFilter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23672,7 +23611,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_S
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT>()) == 0 }
+        self.SimpleInstancingSupported == other.SimpleInstancingSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23711,7 +23650,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_DISPLAYABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_DISPLAYABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_DISPLAYABLE>()) == 0 }
+        self.DisplayableTexture == other.DisplayableTexture && self.SharedResourceTier == other.SharedResourceTier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23749,7 +23688,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_DOUBLES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_DOUBLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_DOUBLES>()) == 0 }
+        self.DoublePrecisionFloatShaderOps == other.DoublePrecisionFloatShaderOps
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23788,7 +23727,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_FORMAT_SUPPORT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_FORMAT_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_FORMAT_SUPPORT>()) == 0 }
+        self.InFormat == other.InFormat && self.OutFormatSupport == other.OutFormatSupport
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -23827,7 +23766,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_FORMAT_SUPPORT2 {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_FORMAT_SUPPORT2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_FORMAT_SUPPORT2>()) == 0 }
+        self.InFormat == other.InFormat && self.OutFormatSupport2 == other.OutFormatSupport2
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -23860,7 +23799,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPP
 }
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT>()) == 0 }
+        self.MaxGPUVirtualAddressBitsPerResource == other.MaxGPUVirtualAddressBitsPerResource && self.MaxGPUVirtualAddressBitsPerProcess == other.MaxGPUVirtualAddressBitsPerProcess
     }
 }
 impl ::core::cmp::Eq for D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {}
@@ -23896,7 +23835,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_MARKER_SUPPORT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_MARKER_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_MARKER_SUPPORT>()) == 0 }
+        self.Profile == other.Profile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23928,7 +23867,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_SHADER_CACHE {
 }
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_SHADER_CACHE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_SHADER_CACHE>()) == 0 }
+        self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for D3D11_FEATURE_DATA_SHADER_CACHE {}
@@ -23959,7 +23898,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUP
 }
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT>()) == 0 }
+        self.PixelShaderMinPrecision == other.PixelShaderMinPrecision && self.AllOtherShaderStagesMinPrecision == other.AllOtherShaderStagesMinPrecision
     }
 }
 impl ::core::cmp::Eq for D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT {}
@@ -23996,7 +23935,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_THREADING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_THREADING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_THREADING>()) == 0 }
+        self.DriverConcurrentCreates == other.DriverConcurrentCreates && self.DriverCommandLists == other.DriverCommandLists
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24037,7 +23976,7 @@ unsafe impl ::windows::core::Abi for D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAM 
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAM>()) == 0 }
+        self.DecoderDesc == other.DecoderDesc && self.Components == other.Components && self.BinCount == other.BinCount && self.CounterBitDepth == other.CounterBitDepth
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24141,7 +24080,39 @@ unsafe impl ::windows::core::Abi for D3D11_FUNCTION_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ::core::cmp::PartialEq for D3D11_FUNCTION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_FUNCTION_DESC>()) == 0 }
+        self.Version == other.Version
+            && self.Creator == other.Creator
+            && self.Flags == other.Flags
+            && self.ConstantBuffers == other.ConstantBuffers
+            && self.BoundResources == other.BoundResources
+            && self.InstructionCount == other.InstructionCount
+            && self.TempRegisterCount == other.TempRegisterCount
+            && self.TempArrayCount == other.TempArrayCount
+            && self.DefCount == other.DefCount
+            && self.DclCount == other.DclCount
+            && self.TextureNormalInstructions == other.TextureNormalInstructions
+            && self.TextureLoadInstructions == other.TextureLoadInstructions
+            && self.TextureCompInstructions == other.TextureCompInstructions
+            && self.TextureBiasInstructions == other.TextureBiasInstructions
+            && self.TextureGradientInstructions == other.TextureGradientInstructions
+            && self.FloatInstructionCount == other.FloatInstructionCount
+            && self.IntInstructionCount == other.IntInstructionCount
+            && self.UintInstructionCount == other.UintInstructionCount
+            && self.StaticFlowControlCount == other.StaticFlowControlCount
+            && self.DynamicFlowControlCount == other.DynamicFlowControlCount
+            && self.MacroInstructionCount == other.MacroInstructionCount
+            && self.ArrayInstructionCount == other.ArrayInstructionCount
+            && self.MovInstructionCount == other.MovInstructionCount
+            && self.MovcInstructionCount == other.MovcInstructionCount
+            && self.ConversionInstructionCount == other.ConversionInstructionCount
+            && self.BitwiseInstructionCount == other.BitwiseInstructionCount
+            && self.MinFeatureLevel == other.MinFeatureLevel
+            && self.RequiredFeatureFlags == other.RequiredFeatureFlags
+            && self.Name == other.Name
+            && self.FunctionParameterCount == other.FunctionParameterCount
+            && self.HasReturn == other.HasReturn
+            && self.Has10Level9VertexShader == other.Has10Level9VertexShader
+            && self.Has10Level9PixelShader == other.Has10Level9PixelShader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -24173,7 +24144,7 @@ unsafe impl ::windows::core::Abi for D3D11_GEOMETRY_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_GEOMETRY_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_GEOMETRY_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation
     }
 }
 impl ::core::cmp::Eq for D3D11_GEOMETRY_SHADER_TRACE_DESC {}
@@ -24203,7 +24174,7 @@ unsafe impl ::windows::core::Abi for D3D11_HULL_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_HULL_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_HULL_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation
     }
 }
 impl ::core::cmp::Eq for D3D11_HULL_SHADER_TRACE_DESC {}
@@ -24234,7 +24205,7 @@ unsafe impl ::windows::core::Abi for D3D11_INFO_QUEUE_FILTER {
 }
 impl ::core::cmp::PartialEq for D3D11_INFO_QUEUE_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_INFO_QUEUE_FILTER>()) == 0 }
+        self.AllowList == other.AllowList && self.DenyList == other.DenyList
     }
 }
 impl ::core::cmp::Eq for D3D11_INFO_QUEUE_FILTER {}
@@ -24269,7 +24240,7 @@ unsafe impl ::windows::core::Abi for D3D11_INFO_QUEUE_FILTER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_INFO_QUEUE_FILTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_INFO_QUEUE_FILTER_DESC>()) == 0 }
+        self.NumCategories == other.NumCategories && self.pCategoryList == other.pCategoryList && self.NumSeverities == other.NumSeverities && self.pSeverityList == other.pSeverityList && self.NumIDs == other.NumIDs && self.pIDList == other.pIDList
     }
 }
 impl ::core::cmp::Eq for D3D11_INFO_QUEUE_FILTER_DESC {}
@@ -24311,7 +24282,7 @@ unsafe impl ::windows::core::Abi for D3D11_INPUT_ELEMENT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_INPUT_ELEMENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_INPUT_ELEMENT_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Format == other.Format && self.InputSlot == other.InputSlot && self.AlignedByteOffset == other.AlignedByteOffset && self.InputSlotClass == other.InputSlotClass && self.InstanceDataStepRate == other.InstanceDataStepRate
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24346,7 +24317,7 @@ unsafe impl ::windows::core::Abi for D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {
 }
 impl ::core::cmp::PartialEq for D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA>()) == 0 }
+        self.HWProtectionFunctionID == other.HWProtectionFunctionID && self.pInputData == other.pInputData && self.pOutputData == other.pOutputData && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {}
@@ -24378,7 +24349,7 @@ unsafe impl ::windows::core::Abi for D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA
 }
 impl ::core::cmp::PartialEq for D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA>()) == 0 }
+        self.PrivateDataSize == other.PrivateDataSize && self.HWProtectionDataSize == other.HWProtectionDataSize && self.pbInput == other.pbInput
     }
 }
 impl ::core::cmp::Eq for D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA {}
@@ -24413,7 +24384,7 @@ unsafe impl ::windows::core::Abi for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DAT
 }
 impl ::core::cmp::PartialEq for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA>()) == 0 }
+        self.PrivateDataSize == other.PrivateDataSize && self.MaxHWProtectionDataSize == other.MaxHWProtectionDataSize && self.HWProtectionDataSize == other.HWProtectionDataSize && self.TransportTime == other.TransportTime && self.ExecutionTime == other.ExecutionTime && self.pbOutput == other.pbOutput
     }
 }
 impl ::core::cmp::Eq for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA {}
@@ -24445,7 +24416,7 @@ unsafe impl ::windows::core::Abi for D3D11_LIBRARY_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_LIBRARY_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_LIBRARY_DESC>()) == 0 }
+        self.Creator == other.Creator && self.Flags == other.Flags && self.FunctionCount == other.FunctionCount
     }
 }
 impl ::core::cmp::Eq for D3D11_LIBRARY_DESC {}
@@ -24477,7 +24448,7 @@ unsafe impl ::windows::core::Abi for D3D11_MAPPED_SUBRESOURCE {
 }
 impl ::core::cmp::PartialEq for D3D11_MAPPED_SUBRESOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_MAPPED_SUBRESOURCE>()) == 0 }
+        self.pData == other.pData && self.RowPitch == other.RowPitch && self.DepthPitch == other.DepthPitch
     }
 }
 impl ::core::cmp::Eq for D3D11_MAPPED_SUBRESOURCE {}
@@ -24511,7 +24482,7 @@ unsafe impl ::windows::core::Abi for D3D11_MESSAGE {
 }
 impl ::core::cmp::PartialEq for D3D11_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_MESSAGE>()) == 0 }
+        self.Category == other.Category && self.Severity == other.Severity && self.ID == other.ID && self.pDescription == other.pDescription && self.DescriptionByteLength == other.DescriptionByteLength
     }
 }
 impl ::core::cmp::Eq for D3D11_MESSAGE {}
@@ -24541,7 +24512,7 @@ unsafe impl ::windows::core::Abi for D3D11_OMAC {
 }
 impl ::core::cmp::PartialEq for D3D11_OMAC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_OMAC>()) == 0 }
+        self.Omac == other.Omac
     }
 }
 impl ::core::cmp::Eq for D3D11_OMAC {}
@@ -24574,7 +24545,7 @@ unsafe impl ::windows::core::Abi for D3D11_PACKED_MIP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_PACKED_MIP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_PACKED_MIP_DESC>()) == 0 }
+        self.NumStandardMips == other.NumStandardMips && self.NumPackedMips == other.NumPackedMips && self.NumTilesForPackedMips == other.NumTilesForPackedMips && self.StartTileIndexInOverallResource == other.StartTileIndexInOverallResource
     }
 }
 impl ::core::cmp::Eq for D3D11_PACKED_MIP_DESC {}
@@ -24634,7 +24605,7 @@ unsafe impl ::windows::core::Abi for D3D11_PARAMETER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_PARAMETER_DESC>()) == 0 }
+        self.Name == other.Name && self.SemanticName == other.SemanticName && self.Type == other.Type && self.Class == other.Class && self.Rows == other.Rows && self.Columns == other.Columns && self.InterpolationMode == other.InterpolationMode && self.Flags == other.Flags && self.FirstInRegister == other.FirstInRegister && self.FirstInComponent == other.FirstInComponent && self.FirstOutRegister == other.FirstOutRegister && self.FirstOutComponent == other.FirstOutComponent
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -24669,7 +24640,7 @@ unsafe impl ::windows::core::Abi for D3D11_PIXEL_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_PIXEL_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_PIXEL_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation && self.X == other.X && self.Y == other.Y && self.SampleMask == other.SampleMask
     }
 }
 impl ::core::cmp::Eq for D3D11_PIXEL_SHADER_TRACE_DESC {}
@@ -24721,7 +24692,7 @@ unsafe impl ::windows::core::Abi for D3D11_QUERY_DATA_PIPELINE_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D11_QUERY_DATA_PIPELINE_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_QUERY_DATA_PIPELINE_STATISTICS>()) == 0 }
+        self.IAVertices == other.IAVertices && self.IAPrimitives == other.IAPrimitives && self.VSInvocations == other.VSInvocations && self.GSInvocations == other.GSInvocations && self.GSPrimitives == other.GSPrimitives && self.CInvocations == other.CInvocations && self.CPrimitives == other.CPrimitives && self.PSInvocations == other.PSInvocations && self.HSInvocations == other.HSInvocations && self.DSInvocations == other.DSInvocations && self.CSInvocations == other.CSInvocations
     }
 }
 impl ::core::cmp::Eq for D3D11_QUERY_DATA_PIPELINE_STATISTICS {}
@@ -24752,7 +24723,7 @@ unsafe impl ::windows::core::Abi for D3D11_QUERY_DATA_SO_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D11_QUERY_DATA_SO_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_QUERY_DATA_SO_STATISTICS>()) == 0 }
+        self.NumPrimitivesWritten == other.NumPrimitivesWritten && self.PrimitivesStorageNeeded == other.PrimitivesStorageNeeded
     }
 }
 impl ::core::cmp::Eq for D3D11_QUERY_DATA_SO_STATISTICS {}
@@ -24789,7 +24760,7 @@ unsafe impl ::windows::core::Abi for D3D11_QUERY_DATA_TIMESTAMP_DISJOINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_QUERY_DATA_TIMESTAMP_DISJOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_QUERY_DATA_TIMESTAMP_DISJOINT>()) == 0 }
+        self.Frequency == other.Frequency && self.Disjoint == other.Disjoint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24822,7 +24793,7 @@ unsafe impl ::windows::core::Abi for D3D11_QUERY_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_QUERY_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_QUERY_DESC>()) == 0 }
+        self.Query == other.Query && self.MiscFlags == other.MiscFlags
     }
 }
 impl ::core::cmp::Eq for D3D11_QUERY_DESC {}
@@ -24854,7 +24825,7 @@ unsafe impl ::windows::core::Abi for D3D11_QUERY_DESC1 {
 }
 impl ::core::cmp::PartialEq for D3D11_QUERY_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_QUERY_DESC1>()) == 0 }
+        self.Query == other.Query && self.MiscFlags == other.MiscFlags && self.ContextType == other.ContextType
     }
 }
 impl ::core::cmp::Eq for D3D11_QUERY_DESC1 {}
@@ -24910,7 +24881,7 @@ unsafe impl ::windows::core::Abi for D3D11_RASTERIZER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_RASTERIZER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RASTERIZER_DESC>()) == 0 }
+        self.FillMode == other.FillMode && self.CullMode == other.CullMode && self.FrontCounterClockwise == other.FrontCounterClockwise && self.DepthBias == other.DepthBias && self.DepthBiasClamp == other.DepthBiasClamp && self.SlopeScaledDepthBias == other.SlopeScaledDepthBias && self.DepthClipEnable == other.DepthClipEnable && self.ScissorEnable == other.ScissorEnable && self.MultisampleEnable == other.MultisampleEnable && self.AntialiasedLineEnable == other.AntialiasedLineEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24970,7 +24941,7 @@ unsafe impl ::windows::core::Abi for D3D11_RASTERIZER_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_RASTERIZER_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RASTERIZER_DESC1>()) == 0 }
+        self.FillMode == other.FillMode && self.CullMode == other.CullMode && self.FrontCounterClockwise == other.FrontCounterClockwise && self.DepthBias == other.DepthBias && self.DepthBiasClamp == other.DepthBiasClamp && self.SlopeScaledDepthBias == other.SlopeScaledDepthBias && self.DepthClipEnable == other.DepthClipEnable && self.ScissorEnable == other.ScissorEnable && self.MultisampleEnable == other.MultisampleEnable && self.AntialiasedLineEnable == other.AntialiasedLineEnable && self.ForcedSampleCount == other.ForcedSampleCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25032,7 +25003,7 @@ unsafe impl ::windows::core::Abi for D3D11_RASTERIZER_DESC2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_RASTERIZER_DESC2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RASTERIZER_DESC2>()) == 0 }
+        self.FillMode == other.FillMode && self.CullMode == other.CullMode && self.FrontCounterClockwise == other.FrontCounterClockwise && self.DepthBias == other.DepthBias && self.DepthBiasClamp == other.DepthBiasClamp && self.SlopeScaledDepthBias == other.SlopeScaledDepthBias && self.DepthClipEnable == other.DepthClipEnable && self.ScissorEnable == other.ScissorEnable && self.MultisampleEnable == other.MultisampleEnable && self.AntialiasedLineEnable == other.AntialiasedLineEnable && self.ForcedSampleCount == other.ForcedSampleCount && self.ConservativeRaster == other.ConservativeRaster
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25077,7 +25048,7 @@ unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_BLEND_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_BLEND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_BLEND_DESC>()) == 0 }
+        self.BlendEnable == other.BlendEnable && self.SrcBlend == other.SrcBlend && self.DestBlend == other.DestBlend && self.BlendOp == other.BlendOp && self.SrcBlendAlpha == other.SrcBlendAlpha && self.DestBlendAlpha == other.DestBlendAlpha && self.BlendOpAlpha == other.BlendOpAlpha && self.RenderTargetWriteMask == other.RenderTargetWriteMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25124,7 +25095,7 @@ unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_BLEND_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_BLEND_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_BLEND_DESC1>()) == 0 }
+        self.BlendEnable == other.BlendEnable && self.LogicOpEnable == other.LogicOpEnable && self.SrcBlend == other.SrcBlend && self.DestBlend == other.DestBlend && self.BlendOp == other.BlendOp && self.SrcBlendAlpha == other.SrcBlendAlpha && self.DestBlendAlpha == other.DestBlendAlpha && self.BlendOpAlpha == other.BlendOpAlpha && self.LogicOp == other.LogicOp && self.RenderTargetWriteMask == other.RenderTargetWriteMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25155,14 +25126,6 @@ impl ::core::clone::Clone for D3D11_RENDER_TARGET_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_RENDER_TARGET_VIEW_DESC {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
@@ -25195,14 +25158,6 @@ unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_RENDER_TARGET_VIEW_DESC_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_RENDER_TARGET_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25228,14 +25183,6 @@ impl ::core::clone::Clone for D3D11_RENDER_TARGET_VIEW_DESC1 {
 unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_VIEW_DESC1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_VIEW_DESC1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_VIEW_DESC1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_RENDER_TARGET_VIEW_DESC1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_RENDER_TARGET_VIEW_DESC1 {
     fn default() -> Self {
@@ -25267,14 +25214,6 @@ impl ::core::clone::Clone for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
 unsafe impl ::windows::core::Abi for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RENDER_TARGET_VIEW_DESC1_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_RENDER_TARGET_VIEW_DESC1_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
     fn default() -> Self {
@@ -25311,7 +25250,7 @@ unsafe impl ::windows::core::Abi for D3D11_SAMPLER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_SAMPLER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SAMPLER_DESC>()) == 0 }
+        self.Filter == other.Filter && self.AddressU == other.AddressU && self.AddressV == other.AddressV && self.AddressW == other.AddressW && self.MipLODBias == other.MipLODBias && self.MaxAnisotropy == other.MaxAnisotropy && self.ComparisonFunc == other.ComparisonFunc && self.BorderColor == other.BorderColor && self.MinLOD == other.MinLOD && self.MaxLOD == other.MaxLOD
     }
 }
 impl ::core::cmp::Eq for D3D11_SAMPLER_DESC {}
@@ -25351,7 +25290,7 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_BUFFER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_SHADER_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_BUFFER_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.Variables == other.Variables && self.Size == other.Size && self.uFlags == other.uFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -25465,7 +25404,44 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_SHADER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_DESC>()) == 0 }
+        self.Version == other.Version
+            && self.Creator == other.Creator
+            && self.Flags == other.Flags
+            && self.ConstantBuffers == other.ConstantBuffers
+            && self.BoundResources == other.BoundResources
+            && self.InputParameters == other.InputParameters
+            && self.OutputParameters == other.OutputParameters
+            && self.InstructionCount == other.InstructionCount
+            && self.TempRegisterCount == other.TempRegisterCount
+            && self.TempArrayCount == other.TempArrayCount
+            && self.DefCount == other.DefCount
+            && self.DclCount == other.DclCount
+            && self.TextureNormalInstructions == other.TextureNormalInstructions
+            && self.TextureLoadInstructions == other.TextureLoadInstructions
+            && self.TextureCompInstructions == other.TextureCompInstructions
+            && self.TextureBiasInstructions == other.TextureBiasInstructions
+            && self.TextureGradientInstructions == other.TextureGradientInstructions
+            && self.FloatInstructionCount == other.FloatInstructionCount
+            && self.IntInstructionCount == other.IntInstructionCount
+            && self.UintInstructionCount == other.UintInstructionCount
+            && self.StaticFlowControlCount == other.StaticFlowControlCount
+            && self.DynamicFlowControlCount == other.DynamicFlowControlCount
+            && self.MacroInstructionCount == other.MacroInstructionCount
+            && self.ArrayInstructionCount == other.ArrayInstructionCount
+            && self.CutInstructionCount == other.CutInstructionCount
+            && self.EmitInstructionCount == other.EmitInstructionCount
+            && self.GSOutputTopology == other.GSOutputTopology
+            && self.GSMaxOutputVertexCount == other.GSMaxOutputVertexCount
+            && self.InputPrimitive == other.InputPrimitive
+            && self.PatchConstantParameters == other.PatchConstantParameters
+            && self.cGSInstanceCount == other.cGSInstanceCount
+            && self.cControlPoints == other.cControlPoints
+            && self.HSOutputPrimitive == other.HSOutputPrimitive
+            && self.HSPartitioning == other.HSPartitioning
+            && self.TessellatorDomain == other.TessellatorDomain
+            && self.cBarrierInstructions == other.cBarrierInstructions
+            && self.cInterlockedInstructions == other.cInterlockedInstructions
+            && self.cTextureStoreInstructions == other.cTextureStoreInstructions
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -25510,7 +25486,7 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_INPUT_BIND_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_SHADER_INPUT_BIND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_INPUT_BIND_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.BindPoint == other.BindPoint && self.BindCount == other.BindCount && self.uFlags == other.uFlags && self.ReturnType == other.ReturnType && self.Dimension == other.Dimension && self.NumSamples == other.NumSamples
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -25541,14 +25517,6 @@ impl ::core::clone::Clone for D3D11_SHADER_RESOURCE_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_SHADER_RESOURCE_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D11_SHADER_RESOURCE_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_RESOURCE_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D11_SHADER_RESOURCE_VIEW_DESC {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D11_SHADER_RESOURCE_VIEW_DESC {
     fn default() -> Self {
@@ -25584,14 +25552,6 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_RESOURCE_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25617,14 +25577,6 @@ impl ::core::clone::Clone for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
 unsafe impl ::windows::core::Abi for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_RESOURCE_VIEW_DESC1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D11_SHADER_RESOURCE_VIEW_DESC1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
     fn default() -> Self {
@@ -25660,14 +25612,6 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_RESOURCE_VIEW_DESC1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25689,12 +25633,6 @@ impl ::core::clone::Clone for D3D11_SHADER_TRACE_DESC {
 unsafe impl ::windows::core::Abi for D3D11_SHADER_TRACE_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_SHADER_TRACE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_TRACE_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_SHADER_TRACE_DESC {}
 impl ::core::default::Default for D3D11_SHADER_TRACE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25719,12 +25657,6 @@ impl ::core::clone::Clone for D3D11_SHADER_TRACE_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D11_SHADER_TRACE_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_SHADER_TRACE_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_TRACE_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_SHADER_TRACE_DESC_0 {}
 impl ::core::default::Default for D3D11_SHADER_TRACE_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25764,7 +25696,7 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_TYPE_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_SHADER_TYPE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_TYPE_DESC>()) == 0 }
+        self.Class == other.Class && self.Type == other.Type && self.Rows == other.Rows && self.Columns == other.Columns && self.Elements == other.Elements && self.Members == other.Members && self.Offset == other.Offset && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -25804,7 +25736,7 @@ unsafe impl ::windows::core::Abi for D3D11_SHADER_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_SHADER_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SHADER_VARIABLE_DESC>()) == 0 }
+        self.Name == other.Name && self.StartOffset == other.StartOffset && self.Size == other.Size && self.uFlags == other.uFlags && self.DefaultValue == other.DefaultValue && self.StartTexture == other.StartTexture && self.TextureSize == other.TextureSize && self.StartSampler == other.StartSampler && self.SamplerSize == other.SamplerSize
     }
 }
 impl ::core::cmp::Eq for D3D11_SHADER_VARIABLE_DESC {}
@@ -25848,7 +25780,7 @@ unsafe impl ::windows::core::Abi for D3D11_SIGNATURE_PARAMETER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D11_SIGNATURE_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SIGNATURE_PARAMETER_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Register == other.Register && self.SystemValueType == other.SystemValueType && self.ComponentType == other.ComponentType && self.Mask == other.Mask && self.ReadWriteMask == other.ReadWriteMask && self.Stream == other.Stream && self.MinPrecision == other.MinPrecision
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -25885,7 +25817,7 @@ unsafe impl ::windows::core::Abi for D3D11_SO_DECLARATION_ENTRY {
 }
 impl ::core::cmp::PartialEq for D3D11_SO_DECLARATION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SO_DECLARATION_ENTRY>()) == 0 }
+        self.Stream == other.Stream && self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.StartComponent == other.StartComponent && self.ComponentCount == other.ComponentCount && self.OutputSlot == other.OutputSlot
     }
 }
 impl ::core::cmp::Eq for D3D11_SO_DECLARATION_ENTRY {}
@@ -25917,7 +25849,7 @@ unsafe impl ::windows::core::Abi for D3D11_SUBRESOURCE_DATA {
 }
 impl ::core::cmp::PartialEq for D3D11_SUBRESOURCE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SUBRESOURCE_DATA>()) == 0 }
+        self.pSysMem == other.pSysMem && self.SysMemPitch == other.SysMemPitch && self.SysMemSlicePitch == other.SysMemSlicePitch
     }
 }
 impl ::core::cmp::Eq for D3D11_SUBRESOURCE_DATA {}
@@ -25950,7 +25882,7 @@ unsafe impl ::windows::core::Abi for D3D11_SUBRESOURCE_TILING {
 }
 impl ::core::cmp::PartialEq for D3D11_SUBRESOURCE_TILING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_SUBRESOURCE_TILING>()) == 0 }
+        self.WidthInTiles == other.WidthInTiles && self.HeightInTiles == other.HeightInTiles && self.DepthInTiles == other.DepthInTiles && self.StartTileIndexInOverallResource == other.StartTileIndexInOverallResource
     }
 }
 impl ::core::cmp::Eq for D3D11_SUBRESOURCE_TILING {}
@@ -25982,7 +25914,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_ARRAY_DSV {}
@@ -26014,7 +25946,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_ARRAY_RTV {}
@@ -26047,7 +25979,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_ARRAY_SRV {}
@@ -26079,7 +26011,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_ARRAY_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_ARRAY_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_ARRAY_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_ARRAY_UAV {}
@@ -26109,7 +26041,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_DSV {}
@@ -26139,7 +26071,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_RTV {}
@@ -26170,7 +26102,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_SRV {}
@@ -26200,7 +26132,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX1D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX1D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX1D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX1D_UAV {}
@@ -26231,7 +26163,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_ARRAY_DSV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_ARRAY_DSV {}
@@ -26262,7 +26194,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_ARRAY_RTV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_ARRAY_RTV {}
@@ -26293,7 +26225,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_ARRAY_SRV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_ARRAY_SRV {}
@@ -26323,7 +26255,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_DSV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_DSV {}
@@ -26353,7 +26285,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_RTV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_RTV {}
@@ -26383,7 +26315,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2DMS_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2DMS_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2DMS_SRV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2DMS_SRV {}
@@ -26415,7 +26347,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_DSV {}
@@ -26447,7 +26379,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_RTV {}
@@ -26480,7 +26412,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_RTV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_RTV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_RTV1>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_RTV1 {}
@@ -26513,7 +26445,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_SRV {}
@@ -26547,7 +26479,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_SRV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_SRV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_SRV1>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_SRV1 {}
@@ -26579,7 +26511,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_UAV {}
@@ -26612,7 +26544,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_UAV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_UAV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_UAV1>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_UAV1 {}
@@ -26644,7 +26576,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_ARRAY_VPOV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_ARRAY_VPOV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_ARRAY_VPOV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_ARRAY_VPOV {}
@@ -26674,7 +26606,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_DSV {}
@@ -26704,7 +26636,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_RTV {}
@@ -26735,7 +26667,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_RTV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_RTV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_RTV1>()) == 0 }
+        self.MipSlice == other.MipSlice && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_RTV1 {}
@@ -26766,7 +26698,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_SRV {}
@@ -26798,7 +26730,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_SRV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_SRV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_SRV1>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_SRV1 {}
@@ -26828,7 +26760,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_UAV {}
@@ -26859,7 +26791,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_UAV1 {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_UAV1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_UAV1>()) == 0 }
+        self.MipSlice == other.MipSlice && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_UAV1 {}
@@ -26889,7 +26821,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_VDOV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_VDOV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_VDOV>()) == 0 }
+        self.ArraySlice == other.ArraySlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_VDOV {}
@@ -26920,7 +26852,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_VPIV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_VPIV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_VPIV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.ArraySlice == other.ArraySlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_VPIV {}
@@ -26950,7 +26882,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX2D_VPOV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX2D_VPOV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX2D_VPOV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX2D_VPOV {}
@@ -26982,7 +26914,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX3D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX3D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX3D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstWSlice == other.FirstWSlice && self.WSize == other.WSize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX3D_RTV {}
@@ -27013,7 +26945,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX3D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX3D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX3D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX3D_SRV {}
@@ -27045,7 +26977,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEX3D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEX3D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEX3D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstWSlice == other.FirstWSlice && self.WSize == other.WSize
     }
 }
 impl ::core::cmp::Eq for D3D11_TEX3D_UAV {}
@@ -27078,7 +27010,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXCUBE_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEXCUBE_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXCUBE_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.First2DArrayFace == other.First2DArrayFace && self.NumCubes == other.NumCubes
     }
 }
 impl ::core::cmp::Eq for D3D11_TEXCUBE_ARRAY_SRV {}
@@ -27109,7 +27041,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXCUBE_SRV {
 }
 impl ::core::cmp::PartialEq for D3D11_TEXCUBE_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXCUBE_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels
     }
 }
 impl ::core::cmp::Eq for D3D11_TEXCUBE_SRV {}
@@ -27152,7 +27084,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXTURE1D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_TEXTURE1D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXTURE1D_DESC>()) == 0 }
+        self.Width == other.Width && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.Format == other.Format && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27199,7 +27131,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXTURE2D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_TEXTURE2D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXTURE2D_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.Format == other.Format && self.SampleDesc == other.SampleDesc && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27247,7 +27179,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXTURE2D_DESC1 {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_TEXTURE2D_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXTURE2D_DESC1>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.Format == other.Format && self.SampleDesc == other.SampleDesc && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags && self.TextureLayout == other.TextureLayout
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27293,7 +27225,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXTURE3D_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_TEXTURE3D_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXTURE3D_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth && self.MipLevels == other.MipLevels && self.Format == other.Format && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27340,7 +27272,7 @@ unsafe impl ::windows::core::Abi for D3D11_TEXTURE3D_DESC1 {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_TEXTURE3D_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TEXTURE3D_DESC1>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth && self.MipLevels == other.MipLevels && self.Format == other.Format && self.Usage == other.Usage && self.BindFlags == other.BindFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.MiscFlags == other.MiscFlags && self.TextureLayout == other.TextureLayout
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27375,7 +27307,7 @@ unsafe impl ::windows::core::Abi for D3D11_TILED_RESOURCE_COORDINATE {
 }
 impl ::core::cmp::PartialEq for D3D11_TILED_RESOURCE_COORDINATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TILED_RESOURCE_COORDINATE>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.Subresource == other.Subresource
     }
 }
 impl ::core::cmp::Eq for D3D11_TILED_RESOURCE_COORDINATE {}
@@ -27415,7 +27347,7 @@ unsafe impl ::windows::core::Abi for D3D11_TILE_REGION_SIZE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_TILE_REGION_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TILE_REGION_SIZE>()) == 0 }
+        self.NumTiles == other.NumTiles && self.bUseBox == other.bUseBox && self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27449,7 +27381,7 @@ unsafe impl ::windows::core::Abi for D3D11_TILE_SHAPE {
 }
 impl ::core::cmp::PartialEq for D3D11_TILE_SHAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TILE_SHAPE>()) == 0 }
+        self.WidthInTexels == other.WidthInTexels && self.HeightInTexels == other.HeightInTexels && self.DepthInTexels == other.DepthInTexels
     }
 }
 impl ::core::cmp::Eq for D3D11_TILE_SHAPE {}
@@ -27475,12 +27407,6 @@ impl ::core::clone::Clone for D3D11_TRACE_REGISTER {
 unsafe impl ::windows::core::Abi for D3D11_TRACE_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_TRACE_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TRACE_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_TRACE_REGISTER {}
 impl ::core::default::Default for D3D11_TRACE_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27501,12 +27427,6 @@ impl ::core::clone::Clone for D3D11_TRACE_REGISTER_0 {
 unsafe impl ::windows::core::Abi for D3D11_TRACE_REGISTER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_TRACE_REGISTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TRACE_REGISTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_TRACE_REGISTER_0 {}
 impl ::core::default::Default for D3D11_TRACE_REGISTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27553,14 +27473,6 @@ unsafe impl ::windows::core::Abi for D3D11_TRACE_STATS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D11_TRACE_STATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TRACE_STATS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D11_TRACE_STATS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D11_TRACE_STATS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27599,7 +27511,7 @@ unsafe impl ::windows::core::Abi for D3D11_TRACE_STEP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_TRACE_STEP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TRACE_STEP>()) == 0 }
+        self.ID == other.ID && self.InstructionActive == other.InstructionActive && self.NumRegistersWritten == other.NumRegistersWritten && self.NumRegistersRead == other.NumRegistersRead && self.MiscOperations == other.MiscOperations && self.OpcodeType == other.OpcodeType && self.CurrentGlobalCycle == other.CurrentGlobalCycle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27632,7 +27544,7 @@ unsafe impl ::windows::core::Abi for D3D11_TRACE_VALUE {
 }
 impl ::core::cmp::PartialEq for D3D11_TRACE_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_TRACE_VALUE>()) == 0 }
+        self.Bits == other.Bits && self.ValidMask == other.ValidMask
     }
 }
 impl ::core::cmp::Eq for D3D11_TRACE_VALUE {}
@@ -27661,14 +27573,6 @@ impl ::core::clone::Clone for D3D11_UNORDERED_ACCESS_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_UNORDERED_ACCESS_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_UNORDERED_ACCESS_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_UNORDERED_ACCESS_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_UNORDERED_ACCESS_VIEW_DESC {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_UNORDERED_ACCESS_VIEW_DESC {
     fn default() -> Self {
@@ -27699,14 +27603,6 @@ unsafe impl ::windows::core::Abi for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_UNORDERED_ACCESS_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27732,14 +27628,6 @@ impl ::core::clone::Clone for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
 unsafe impl ::windows::core::Abi for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_UNORDERED_ACCESS_VIEW_DESC1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
     fn default() -> Self {
@@ -27770,14 +27658,6 @@ unsafe impl ::windows::core::Abi for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_UNORDERED_ACCESS_VIEW_DESC1_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27804,7 +27684,7 @@ unsafe impl ::windows::core::Abi for D3D11_VERTEX_SHADER_TRACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D11_VERTEX_SHADER_TRACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VERTEX_SHADER_TRACE_DESC>()) == 0 }
+        self.Invocation == other.Invocation
     }
 }
 impl ::core::cmp::Eq for D3D11_VERTEX_SHADER_TRACE_DESC {}
@@ -27827,12 +27707,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_COLOR {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_COLOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_COLOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_COLOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_COLOR {}
 impl ::core::default::Default for D3D11_VIDEO_COLOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27853,12 +27727,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_COLOR_0 {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_COLOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_COLOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_COLOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_COLOR_0 {}
 impl ::core::default::Default for D3D11_VIDEO_COLOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27888,7 +27756,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_COLOR_RGBA {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_COLOR_RGBA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_COLOR_RGBA>()) == 0 }
+        self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_COLOR_RGBA {}
@@ -27921,7 +27789,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_COLOR_YCbCrA {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_COLOR_YCbCrA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_COLOR_YCbCrA>()) == 0 }
+        self.Y == other.Y && self.Cb == other.Cb && self.Cr == other.Cr && self.A == other.A
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_COLOR_YCbCrA {}
@@ -27954,7 +27822,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_CONTENT_PROTECTION_CAPS {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_CONTENT_PROTECTION_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_CONTENT_PROTECTION_CAPS>()) == 0 }
+        self.Caps == other.Caps && self.KeyExchangeTypeCount == other.KeyExchangeTypeCount && self.BlockAlignmentSize == other.BlockAlignmentSize && self.ProtectedMemorySize == other.ProtectedMemorySize
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_CONTENT_PROTECTION_CAPS {}
@@ -28059,7 +27927,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_BUFFER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_BUFFER_DESC>()) == 0 }
+        self.BufferType == other.BufferType && self.BufferIndex == other.BufferIndex && self.DataOffset == other.DataOffset && self.DataSize == other.DataSize && self.FirstMBaddress == other.FirstMBaddress && self.NumMBsInBuffer == other.NumMBsInBuffer && self.Width == other.Width && self.Height == other.Height && self.Stride == other.Stride && self.ReservedBits == other.ReservedBits && self.pIV == other.pIV && self.IVSize == other.IVSize && self.PartialEncryption == other.PartialEncryption && self.EncryptedBlockInfo == other.EncryptedBlockInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28097,7 +27965,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_BUFFER_DESC1 {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_BUFFER_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_BUFFER_DESC1>()) == 0 }
+        self.BufferType == other.BufferType && self.DataOffset == other.DataOffset && self.DataSize == other.DataSize && self.pIV == other.pIV && self.IVSize == other.IVSize && self.pSubSampleMappingBlock == other.pSubSampleMappingBlock && self.SubSampleMappingCount == other.SubSampleMappingCount
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_BUFFER_DESC1 {}
@@ -28135,7 +28003,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_BUFFER_DESC2 {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_BUFFER_DESC2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_BUFFER_DESC2>()) == 0 }
+        self.BufferType == other.BufferType && self.DataOffset == other.DataOffset && self.DataSize == other.DataSize && self.pIV == other.pIV && self.IVSize == other.IVSize && self.pSubSampleMappingBlock == other.pSubSampleMappingBlock && self.SubSampleMappingCount == other.SubSampleMappingCount && self.cBlocksStripeEncrypted == other.cBlocksStripeEncrypted && self.cBlocksStripeClear == other.cBlocksStripeClear
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_BUFFER_DESC2 {}
@@ -28199,7 +28067,23 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_CONFIG {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_CONFIG>()) == 0 }
+        self.guidConfigBitstreamEncryption == other.guidConfigBitstreamEncryption
+            && self.guidConfigMBcontrolEncryption == other.guidConfigMBcontrolEncryption
+            && self.guidConfigResidDiffEncryption == other.guidConfigResidDiffEncryption
+            && self.ConfigBitstreamRaw == other.ConfigBitstreamRaw
+            && self.ConfigMBcontrolRasterOrder == other.ConfigMBcontrolRasterOrder
+            && self.ConfigResidDiffHost == other.ConfigResidDiffHost
+            && self.ConfigSpatialResid8 == other.ConfigSpatialResid8
+            && self.ConfigResid8Subtraction == other.ConfigResid8Subtraction
+            && self.ConfigSpatialHost8or9Clipping == other.ConfigSpatialHost8or9Clipping
+            && self.ConfigSpatialResidInterleaved == other.ConfigSpatialResidInterleaved
+            && self.ConfigIntraResidUnsigned == other.ConfigIntraResidUnsigned
+            && self.ConfigResidDiffAccelerator == other.ConfigResidDiffAccelerator
+            && self.ConfigHostInverseScan == other.ConfigHostInverseScan
+            && self.ConfigSpecificIDCT == other.ConfigSpecificIDCT
+            && self.Config4GroupedCoefs == other.Config4GroupedCoefs
+            && self.ConfigMinRenderTargetBuffCount == other.ConfigMinRenderTargetBuffCount
+            && self.ConfigDecoderSpecific == other.ConfigDecoderSpecific
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_CONFIG {}
@@ -28238,7 +28122,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_DESC>()) == 0 }
+        self.Guid == other.Guid && self.SampleWidth == other.SampleWidth && self.SampleHeight == other.SampleHeight && self.OutputFormat == other.OutputFormat
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -28276,7 +28160,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_EXTENSION {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_EXTENSION>()) == 0 }
+        self.Function == other.Function && self.pPrivateInputData == other.pPrivateInputData && self.PrivateInputDataSize == other.PrivateInputDataSize && self.pPrivateOutputData == other.pPrivateOutputData && self.PrivateOutputDataSize == other.PrivateOutputDataSize && self.ResourceCount == other.ResourceCount && self.ppResourceList == other.ppResourceList
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_EXTENSION {}
@@ -28301,12 +28185,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {}
 impl ::core::default::Default for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28326,12 +28204,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {}
 impl ::core::default::Default for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28359,7 +28231,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOC
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCK>()) == 0 }
+        self.ClearSize == other.ClearSize && self.EncryptedSize == other.EncryptedSize
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCK {}
@@ -28397,7 +28269,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_CAPS {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_CAPS>()) == 0 }
+        self.DeviceCaps == other.DeviceCaps && self.FeatureCaps == other.FeatureCaps && self.FilterCaps == other.FilterCaps && self.InputFormatCaps == other.InputFormatCaps && self.AutoStreamCaps == other.AutoStreamCaps && self.StereoCaps == other.StereoCaps && self.RateConversionCapsCount == other.RateConversionCapsCount && self.MaxInputStreams == other.MaxInputStreams && self.MaxStreamStates == other.MaxStreamStates
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_CAPS {}
@@ -28427,7 +28299,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_COLOR_SPACE {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_COLOR_SPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_COLOR_SPACE>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_COLOR_SPACE {}
@@ -28470,7 +28342,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_CONTENT_DESC>()) == 0 }
+        self.InputFrameFormat == other.InputFrameFormat && self.InputFrameRate == other.InputFrameRate && self.InputWidth == other.InputWidth && self.InputHeight == other.InputHeight && self.OutputFrameRate == other.OutputFrameRate && self.OutputWidth == other.OutputWidth && self.OutputHeight == other.OutputHeight && self.Usage == other.Usage
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -28511,7 +28383,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_CUSTOM_RATE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_CUSTOM_RATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_CUSTOM_RATE>()) == 0 }
+        self.CustomRate == other.CustomRate && self.OutputFrames == other.OutputFrames && self.InputInterlaced == other.InputInterlaced && self.InputFramesOrFields == other.InputFramesOrFields
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -28546,7 +28418,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_FILTER_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_FILTER_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_FILTER_RANGE>()) == 0 }
+        self.Minimum == other.Minimum && self.Maximum == other.Maximum && self.Default == other.Default && self.Multiplier == other.Multiplier
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_FILTER_RANGE {}
@@ -28571,12 +28443,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {}
 impl ::core::default::Default for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28596,12 +28462,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {}
 impl ::core::default::Default for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28622,12 +28482,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {}
 impl ::core::default::Default for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28648,12 +28502,6 @@ impl ::core::clone::Clone for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {}
 impl ::core::default::Default for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28684,7 +28532,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS 
 }
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS>()) == 0 }
+        self.PastFrames == other.PastFrames && self.FutureFrames == other.FutureFrames && self.ProcessorCaps == other.ProcessorCaps && self.ITelecineCaps == other.ITelecineCaps && self.CustomRateCount == other.CustomRateCount
     }
 }
 impl ::core::cmp::Eq for D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS {}
@@ -28793,7 +28641,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT 
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT>()) == 0 }
+        self.Enable == other.Enable && self.Width == other.Width && self.Height == other.Height && self.Format == other.Format
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -28834,7 +28682,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_SAMPLE_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D11_VIDEO_SAMPLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIDEO_SAMPLE_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format && self.ColorSpace == other.ColorSpace
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -28871,7 +28719,7 @@ unsafe impl ::windows::core::Abi for D3D11_VIEWPORT {
 }
 impl ::core::cmp::PartialEq for D3D11_VIEWPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_VIEWPORT>()) == 0 }
+        self.TopLeftX == other.TopLeftX && self.TopLeftY == other.TopLeftY && self.Width == other.Width && self.Height == other.Height && self.MinDepth == other.MinDepth && self.MaxDepth == other.MaxDepth
     }
 }
 impl ::core::cmp::Eq for D3D11_VIEWPORT {}
@@ -28904,7 +28752,7 @@ unsafe impl ::windows::core::Abi for D3DX11_FFT_BUFFER_INFO {
 }
 impl ::core::cmp::PartialEq for D3DX11_FFT_BUFFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DX11_FFT_BUFFER_INFO>()) == 0 }
+        self.NumTempBufferSizes == other.NumTempBufferSizes && self.TempBufferFloatSizes == other.TempBufferFloatSizes && self.NumPrecomputeBufferSizes == other.NumPrecomputeBufferSizes && self.PrecomputeBufferFloatSizes == other.PrecomputeBufferFloatSizes
     }
 }
 impl ::core::cmp::Eq for D3DX11_FFT_BUFFER_INFO {}
@@ -28937,7 +28785,7 @@ unsafe impl ::windows::core::Abi for D3DX11_FFT_DESC {
 }
 impl ::core::cmp::PartialEq for D3DX11_FFT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DX11_FFT_DESC>()) == 0 }
+        self.NumDimensions == other.NumDimensions && self.ElementLengths == other.ElementLengths && self.DimensionMask == other.DimensionMask && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for D3DX11_FFT_DESC {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -260,7 +260,7 @@ unsafe impl ::windows::core::Abi for D3D11_RESOURCE_FLAGS {
 }
 impl ::core::cmp::PartialEq for D3D11_RESOURCE_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D11_RESOURCE_FLAGS>()) == 0 }
+        self.BindFlags == other.BindFlags && self.MiscFlags == other.MiscFlags && self.CPUAccessFlags == other.CPUAccessFlags && self.StructureByteStride == other.StructureByteStride
     }
 }
 impl ::core::cmp::Eq for D3D11_RESOURCE_FLAGS {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -20425,7 +20425,7 @@ unsafe impl ::windows::core::Abi for D3D12_BLEND_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_BLEND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BLEND_DESC>()) == 0 }
+        self.AlphaToCoverageEnable == other.AlphaToCoverageEnable && self.IndependentBlendEnable == other.IndependentBlendEnable && self.RenderTarget == other.RenderTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20462,7 +20462,7 @@ unsafe impl ::windows::core::Abi for D3D12_BOX {
 }
 impl ::core::cmp::PartialEq for D3D12_BOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BOX>()) == 0 }
+        self.left == other.left && self.top == other.top && self.front == other.front && self.right == other.right && self.bottom == other.bottom && self.back == other.back
     }
 }
 impl ::core::cmp::Eq for D3D12_BOX {}
@@ -20493,7 +20493,7 @@ unsafe impl ::windows::core::Abi for D3D12_BUFFER_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_BUFFER_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUFFER_RTV>()) == 0 }
+        self.FirstElement == other.FirstElement && self.NumElements == other.NumElements
     }
 }
 impl ::core::cmp::Eq for D3D12_BUFFER_RTV {}
@@ -20526,7 +20526,7 @@ unsafe impl ::windows::core::Abi for D3D12_BUFFER_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_BUFFER_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUFFER_SRV>()) == 0 }
+        self.FirstElement == other.FirstElement && self.NumElements == other.NumElements && self.StructureByteStride == other.StructureByteStride && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_BUFFER_SRV {}
@@ -20560,7 +20560,7 @@ unsafe impl ::windows::core::Abi for D3D12_BUFFER_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_BUFFER_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUFFER_UAV>()) == 0 }
+        self.FirstElement == other.FirstElement && self.NumElements == other.NumElements && self.StructureByteStride == other.StructureByteStride && self.CounterOffsetInBytes == other.CounterOffsetInBytes && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_BUFFER_UAV {}
@@ -20591,14 +20591,6 @@ unsafe impl ::windows::core::Abi for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTU
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20627,14 +20619,6 @@ unsafe impl ::windows::core::Abi for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTU
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20660,14 +20644,6 @@ impl ::core::clone::Clone for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPU
 unsafe impl ::windows::core::Abi for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
     fn default() -> Self {
@@ -20696,7 +20672,7 @@ unsafe impl ::windows::core::Abi for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTU
 }
 impl ::core::cmp::PartialEq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER>()) == 0 }
+        self.Type == other.Type && self.NumDescs == other.NumDescs
     }
 }
 impl ::core::cmp::Eq for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER {}
@@ -20727,7 +20703,7 @@ unsafe impl ::windows::core::Abi for D3D12_CACHED_PIPELINE_STATE {
 }
 impl ::core::cmp::PartialEq for D3D12_CACHED_PIPELINE_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_CACHED_PIPELINE_STATE>()) == 0 }
+        self.pCachedBlob == other.pCachedBlob && self.CachedBlobSizeInBytes == other.CachedBlobSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_CACHED_PIPELINE_STATE {}
@@ -20756,14 +20732,6 @@ unsafe impl ::windows::core::Abi for D3D12_CLEAR_VALUE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_CLEAR_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_CLEAR_VALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_CLEAR_VALUE {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_CLEAR_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20788,14 +20756,6 @@ impl ::core::clone::Clone for D3D12_CLEAR_VALUE_0 {
 unsafe impl ::windows::core::Abi for D3D12_CLEAR_VALUE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_CLEAR_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_CLEAR_VALUE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_CLEAR_VALUE_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_CLEAR_VALUE_0 {
     fn default() -> Self {
@@ -20826,7 +20786,7 @@ unsafe impl ::windows::core::Abi for D3D12_COMMAND_QUEUE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_COMMAND_QUEUE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_COMMAND_QUEUE_DESC>()) == 0 }
+        self.Type == other.Type && self.Priority == other.Priority && self.Flags == other.Flags && self.NodeMask == other.NodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_COMMAND_QUEUE_DESC {}
@@ -20859,7 +20819,7 @@ unsafe impl ::windows::core::Abi for D3D12_COMMAND_SIGNATURE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_COMMAND_SIGNATURE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_COMMAND_SIGNATURE_DESC>()) == 0 }
+        self.ByteStride == other.ByteStride && self.NumArgumentDescs == other.NumArgumentDescs && self.pArgumentDescs == other.pArgumentDescs && self.NodeMask == other.NodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_COMMAND_SIGNATURE_DESC {}
@@ -20923,7 +20883,7 @@ unsafe impl ::windows::core::Abi for D3D12_CONSTANT_BUFFER_VIEW_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_CONSTANT_BUFFER_VIEW_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_CONSTANT_BUFFER_VIEW_DESC>()) == 0 }
+        self.BufferLocation == other.BufferLocation && self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_CONSTANT_BUFFER_VIEW_DESC {}
@@ -20953,7 +20913,7 @@ unsafe impl ::windows::core::Abi for D3D12_CPU_DESCRIPTOR_HANDLE {
 }
 impl ::core::cmp::PartialEq for D3D12_CPU_DESCRIPTOR_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_CPU_DESCRIPTOR_HANDLE>()) == 0 }
+        self.ptr == other.ptr
     }
 }
 impl ::core::cmp::Eq for D3D12_CPU_DESCRIPTOR_HANDLE {}
@@ -20983,7 +20943,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATI
 }
 impl ::core::cmp::PartialEq for D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS>()) == 0 }
+        self.ShaderPatchMode == other.ShaderPatchMode
     }
 }
 impl ::core::cmp::Eq for D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS {}
@@ -21015,7 +20975,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SET
 }
 impl ::core::cmp::PartialEq for D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS>()) == 0 }
+        self.MaxMessagesPerCommandList == other.MaxMessagesPerCommandList && self.DefaultShaderPatchMode == other.DefaultShaderPatchMode && self.PipelineStateCreateFlags == other.PipelineStateCreateFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS {}
@@ -21045,7 +21005,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE
 }
 impl ::core::cmp::PartialEq for D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR>()) == 0 }
+        self.SlowdownFactor == other.SlowdownFactor
     }
 }
 impl ::core::cmp::Eq for D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR {}
@@ -21078,7 +21038,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCILOP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCILOP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCILOP_DESC>()) == 0 }
+        self.StencilFailOp == other.StencilFailOp && self.StencilDepthFailOp == other.StencilDepthFailOp && self.StencilPassOp == other.StencilPassOp && self.StencilFunc == other.StencilFunc
     }
 }
 impl ::core::cmp::Eq for D3D12_DEPTH_STENCILOP_DESC {}
@@ -21121,7 +21081,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCIL_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCIL_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCIL_DESC>()) == 0 }
+        self.DepthEnable == other.DepthEnable && self.DepthWriteMask == other.DepthWriteMask && self.DepthFunc == other.DepthFunc && self.StencilEnable == other.StencilEnable && self.StencilReadMask == other.StencilReadMask && self.StencilWriteMask == other.StencilWriteMask && self.FrontFace == other.FrontFace && self.BackFace == other.BackFace
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21167,7 +21127,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCIL_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCIL_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCIL_DESC1>()) == 0 }
+        self.DepthEnable == other.DepthEnable && self.DepthWriteMask == other.DepthWriteMask && self.DepthFunc == other.DepthFunc && self.StencilEnable == other.StencilEnable && self.StencilReadMask == other.StencilReadMask && self.StencilWriteMask == other.StencilWriteMask && self.FrontFace == other.FrontFace && self.BackFace == other.BackFace && self.DepthBoundsTestEnable == other.DepthBoundsTestEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21200,7 +21160,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCIL_VALUE {
 }
 impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCIL_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCIL_VALUE>()) == 0 }
+        self.Depth == other.Depth && self.Stencil == other.Stencil
     }
 }
 impl ::core::cmp::Eq for D3D12_DEPTH_STENCIL_VALUE {}
@@ -21231,14 +21191,6 @@ unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCIL_VIEW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCIL_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCIL_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_DEPTH_STENCIL_VIEW_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21267,14 +21219,6 @@ impl ::core::clone::Clone for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEPTH_STENCIL_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
     fn default() -> Self {
@@ -21305,7 +21249,7 @@ unsafe impl ::windows::core::Abi for D3D12_DESCRIPTOR_HEAP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_DESCRIPTOR_HEAP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DESCRIPTOR_HEAP_DESC>()) == 0 }
+        self.Type == other.Type && self.NumDescriptors == other.NumDescriptors && self.Flags == other.Flags && self.NodeMask == other.NodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_DESCRIPTOR_HEAP_DESC {}
@@ -21339,7 +21283,7 @@ unsafe impl ::windows::core::Abi for D3D12_DESCRIPTOR_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D12_DESCRIPTOR_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DESCRIPTOR_RANGE>()) == 0 }
+        self.RangeType == other.RangeType && self.NumDescriptors == other.NumDescriptors && self.BaseShaderRegister == other.BaseShaderRegister && self.RegisterSpace == other.RegisterSpace && self.OffsetInDescriptorsFromTableStart == other.OffsetInDescriptorsFromTableStart
     }
 }
 impl ::core::cmp::Eq for D3D12_DESCRIPTOR_RANGE {}
@@ -21374,7 +21318,7 @@ unsafe impl ::windows::core::Abi for D3D12_DESCRIPTOR_RANGE1 {
 }
 impl ::core::cmp::PartialEq for D3D12_DESCRIPTOR_RANGE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DESCRIPTOR_RANGE1>()) == 0 }
+        self.RangeType == other.RangeType && self.NumDescriptors == other.NumDescriptors && self.BaseShaderRegister == other.BaseShaderRegister && self.RegisterSpace == other.RegisterSpace && self.Flags == other.Flags && self.OffsetInDescriptorsFromTableStart == other.OffsetInDescriptorsFromTableStart
     }
 }
 impl ::core::cmp::Eq for D3D12_DESCRIPTOR_RANGE1 {}
@@ -21405,7 +21349,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEVICE_REMOVED_EXTENDED_DATA {
 }
 impl ::core::cmp::PartialEq for D3D12_DEVICE_REMOVED_EXTENDED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEVICE_REMOVED_EXTENDED_DATA>()) == 0 }
+        self.Flags == other.Flags && self.pHeadAutoBreadcrumbNode == other.pHeadAutoBreadcrumbNode
     }
 }
 impl ::core::cmp::Eq for D3D12_DEVICE_REMOVED_EXTENDED_DATA {}
@@ -21437,7 +21381,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {
 }
 impl ::core::cmp::PartialEq for D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEVICE_REMOVED_EXTENDED_DATA1>()) == 0 }
+        self.DeviceRemovedReason == other.DeviceRemovedReason && self.AutoBreadcrumbsOutput == other.AutoBreadcrumbsOutput && self.PageFaultOutput == other.PageFaultOutput
     }
 }
 impl ::core::cmp::Eq for D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {}
@@ -21469,7 +21413,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {
 }
 impl ::core::cmp::PartialEq for D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEVICE_REMOVED_EXTENDED_DATA2>()) == 0 }
+        self.DeviceRemovedReason == other.DeviceRemovedReason && self.AutoBreadcrumbsOutput == other.AutoBreadcrumbsOutput && self.PageFaultOutput == other.PageFaultOutput
     }
 }
 impl ::core::cmp::Eq for D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {}
@@ -21502,7 +21446,7 @@ unsafe impl ::windows::core::Abi for D3D12_DEVICE_REMOVED_EXTENDED_DATA3 {
 }
 impl ::core::cmp::PartialEq for D3D12_DEVICE_REMOVED_EXTENDED_DATA3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DEVICE_REMOVED_EXTENDED_DATA3>()) == 0 }
+        self.DeviceRemovedReason == other.DeviceRemovedReason && self.AutoBreadcrumbsOutput == other.AutoBreadcrumbsOutput && self.PageFaultOutput == other.PageFaultOutput && self.DeviceState == other.DeviceState
     }
 }
 impl ::core::cmp::Eq for D3D12_DEVICE_REMOVED_EXTENDED_DATA3 {}
@@ -21541,7 +21485,7 @@ unsafe impl ::windows::core::Abi for D3D12_DISCARD_REGION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_DISCARD_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DISCARD_REGION>()) == 0 }
+        self.NumRects == other.NumRects && self.pRects == other.pRects && self.FirstSubresource == other.FirstSubresource && self.NumSubresources == other.NumSubresources
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21575,7 +21519,7 @@ unsafe impl ::windows::core::Abi for D3D12_DISPATCH_ARGUMENTS {
 }
 impl ::core::cmp::PartialEq for D3D12_DISPATCH_ARGUMENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DISPATCH_ARGUMENTS>()) == 0 }
+        self.ThreadGroupCountX == other.ThreadGroupCountX && self.ThreadGroupCountY == other.ThreadGroupCountY && self.ThreadGroupCountZ == other.ThreadGroupCountZ
     }
 }
 impl ::core::cmp::Eq for D3D12_DISPATCH_ARGUMENTS {}
@@ -21607,7 +21551,7 @@ unsafe impl ::windows::core::Abi for D3D12_DISPATCH_MESH_ARGUMENTS {
 }
 impl ::core::cmp::PartialEq for D3D12_DISPATCH_MESH_ARGUMENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DISPATCH_MESH_ARGUMENTS>()) == 0 }
+        self.ThreadGroupCountX == other.ThreadGroupCountX && self.ThreadGroupCountY == other.ThreadGroupCountY && self.ThreadGroupCountZ == other.ThreadGroupCountZ
     }
 }
 impl ::core::cmp::Eq for D3D12_DISPATCH_MESH_ARGUMENTS {}
@@ -21643,7 +21587,7 @@ unsafe impl ::windows::core::Abi for D3D12_DISPATCH_RAYS_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_DISPATCH_RAYS_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DISPATCH_RAYS_DESC>()) == 0 }
+        self.RayGenerationShaderRecord == other.RayGenerationShaderRecord && self.MissShaderTable == other.MissShaderTable && self.HitGroupTable == other.HitGroupTable && self.CallableShaderTable == other.CallableShaderTable && self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth
     }
 }
 impl ::core::cmp::Eq for D3D12_DISPATCH_RAYS_DESC {}
@@ -21676,7 +21620,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRAW_ARGUMENTS {
 }
 impl ::core::cmp::PartialEq for D3D12_DRAW_ARGUMENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRAW_ARGUMENTS>()) == 0 }
+        self.VertexCountPerInstance == other.VertexCountPerInstance && self.InstanceCount == other.InstanceCount && self.StartVertexLocation == other.StartVertexLocation && self.StartInstanceLocation == other.StartInstanceLocation
     }
 }
 impl ::core::cmp::Eq for D3D12_DRAW_ARGUMENTS {}
@@ -21710,7 +21654,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRAW_INDEXED_ARGUMENTS {
 }
 impl ::core::cmp::PartialEq for D3D12_DRAW_INDEXED_ARGUMENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRAW_INDEXED_ARGUMENTS>()) == 0 }
+        self.IndexCountPerInstance == other.IndexCountPerInstance && self.InstanceCount == other.InstanceCount && self.StartIndexLocation == other.StartIndexLocation && self.BaseVertexLocation == other.BaseVertexLocation && self.StartInstanceLocation == other.StartInstanceLocation
     }
 }
 impl ::core::cmp::Eq for D3D12_DRAW_INDEXED_ARGUMENTS {}
@@ -21743,7 +21687,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_ALLOCATION_NODE {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_ALLOCATION_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_ALLOCATION_NODE>()) == 0 }
+        self.ObjectNameA == other.ObjectNameA && self.ObjectNameW == other.ObjectNameW && self.AllocationType == other.AllocationType && self.pNext == other.pNext
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_ALLOCATION_NODE {}
@@ -21812,7 +21756,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>()) == 0 }
+        self.pHeadAutoBreadcrumbNode == other.pHeadAutoBreadcrumbNode
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT {}
@@ -21842,7 +21786,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>()) == 0 }
+        self.pHeadAutoBreadcrumbNode == other.pHeadAutoBreadcrumbNode
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {}
@@ -21873,7 +21817,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_BREADCRUMB_CONTEXT {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_BREADCRUMB_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_BREADCRUMB_CONTEXT>()) == 0 }
+        self.BreadcrumbIndex == other.BreadcrumbIndex && self.pContextString == other.pContextString
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_BREADCRUMB_CONTEXT {}
@@ -21905,7 +21849,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_PAGE_FAULT_OUTPUT {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_PAGE_FAULT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_PAGE_FAULT_OUTPUT>()) == 0 }
+        self.PageFaultVA == other.PageFaultVA && self.pHeadExistingAllocationNode == other.pHeadExistingAllocationNode && self.pHeadRecentFreedAllocationNode == other.pHeadRecentFreedAllocationNode
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_PAGE_FAULT_OUTPUT {}
@@ -21937,7 +21881,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_PAGE_FAULT_OUTPUT1 {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_PAGE_FAULT_OUTPUT1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_PAGE_FAULT_OUTPUT1>()) == 0 }
+        self.PageFaultVA == other.PageFaultVA && self.pHeadExistingAllocationNode == other.pHeadExistingAllocationNode && self.pHeadRecentFreedAllocationNode == other.pHeadRecentFreedAllocationNode
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_PAGE_FAULT_OUTPUT1 {}
@@ -21970,7 +21914,7 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_PAGE_FAULT_OUTPUT2 {
 }
 impl ::core::cmp::PartialEq for D3D12_DRED_PAGE_FAULT_OUTPUT2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DRED_PAGE_FAULT_OUTPUT2>()) == 0 }
+        self.PageFaultVA == other.PageFaultVA && self.pHeadExistingAllocationNode == other.pHeadExistingAllocationNode && self.pHeadRecentFreedAllocationNode == other.pHeadRecentFreedAllocationNode && self.PageFaultFlags == other.PageFaultFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_DRED_PAGE_FAULT_OUTPUT2 {}
@@ -22002,7 +21946,7 @@ unsafe impl ::windows::core::Abi for D3D12_DXIL_LIBRARY_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_DXIL_LIBRARY_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DXIL_LIBRARY_DESC>()) == 0 }
+        self.DXILLibrary == other.DXILLibrary && self.NumExports == other.NumExports && self.pExports == other.pExports
     }
 }
 impl ::core::cmp::Eq for D3D12_DXIL_LIBRARY_DESC {}
@@ -22034,7 +21978,7 @@ unsafe impl ::windows::core::Abi for D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION
 }
 impl ::core::cmp::PartialEq for D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION>()) == 0 }
+        self.SubobjectToAssociate == other.SubobjectToAssociate && self.NumExports == other.NumExports && self.pExports == other.pExports
     }
 }
 impl ::core::cmp::Eq for D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION {}
@@ -22097,7 +22041,7 @@ unsafe impl ::windows::core::Abi for D3D12_EXPORT_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_EXPORT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_EXPORT_DESC>()) == 0 }
+        self.Name == other.Name && self.ExportToRename == other.ExportToRename && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_EXPORT_DESC {}
@@ -22136,7 +22080,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_ARCHITECTURE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_ARCHITECTURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_ARCHITECTURE>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.TileBasedRenderer == other.TileBasedRenderer && self.UMA == other.UMA && self.CacheCoherentUMA == other.CacheCoherentUMA
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22178,7 +22122,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_ARCHITECTURE1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_ARCHITECTURE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_ARCHITECTURE1>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.TileBasedRenderer == other.TileBasedRenderer && self.UMA == other.UMA && self.CacheCoherentUMA == other.CacheCoherentUMA && self.IsolatedMMU == other.IsolatedMMU
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22218,7 +22162,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY>()) == 0 }
+        self.CommandListType == other.CommandListType && self.Priority == other.Priority && self.PriorityForTypeIsSupported == other.PriorityForTypeIsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22257,7 +22201,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_CROSS_NODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_CROSS_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_CROSS_NODE>()) == 0 }
+        self.SharingTier == other.SharingTier && self.AtomicShaderInstructions == other.AtomicShaderInstructions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22325,7 +22269,21 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS>()) == 0 }
+        self.DoublePrecisionFloatShaderOps == other.DoublePrecisionFloatShaderOps
+            && self.OutputMergerLogicOp == other.OutputMergerLogicOp
+            && self.MinPrecisionSupport == other.MinPrecisionSupport
+            && self.TiledResourcesTier == other.TiledResourcesTier
+            && self.ResourceBindingTier == other.ResourceBindingTier
+            && self.PSSpecifiedStencilRefSupported == other.PSSpecifiedStencilRefSupported
+            && self.TypedUAVLoadAdditionalFormats == other.TypedUAVLoadAdditionalFormats
+            && self.ROVsSupported == other.ROVsSupported
+            && self.ConservativeRasterizationTier == other.ConservativeRasterizationTier
+            && self.MaxGPUVirtualAddressBitsPerResource == other.MaxGPUVirtualAddressBitsPerResource
+            && self.StandardSwizzle64KBSupported == other.StandardSwizzle64KBSupported
+            && self.CrossNodeSharingTier == other.CrossNodeSharingTier
+            && self.CrossAdapterRowMajorTextureSupported == other.CrossAdapterRowMajorTextureSupported
+            && self.VPAndRTArrayIndexFromAnyShaderFeedingRasterizerSupportedWithoutGSEmulation == other.VPAndRTArrayIndexFromAnyShaderFeedingRasterizerSupportedWithoutGSEmulation
+            && self.ResourceHeapTier == other.ResourceHeapTier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22368,7 +22326,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS1>()) == 0 }
+        self.WaveOps == other.WaveOps && self.WaveLaneCountMin == other.WaveLaneCountMin && self.WaveLaneCountMax == other.WaveLaneCountMax && self.TotalLaneCount == other.TotalLaneCount && self.ExpandedComputeResourceStates == other.ExpandedComputeResourceStates && self.Int64ShaderOps == other.Int64ShaderOps
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22407,7 +22365,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS10 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS10>()) == 0 }
+        self.VariableRateShadingSumCombinerSupported == other.VariableRateShadingSumCombinerSupported && self.MeshShaderPerPrimitiveShadingRateSupported == other.MeshShaderPerPrimitiveShadingRateSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22445,7 +22403,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS11>()) == 0 }
+        self.AtomicInt64OnDescriptorHeapResourceSupported == other.AtomicInt64OnDescriptorHeapResourceSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22484,7 +22442,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS2>()) == 0 }
+        self.DepthBoundsTestSupported == other.DepthBoundsTestSupported && self.ProgrammableSamplePositionsTier == other.ProgrammableSamplePositionsTier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22526,7 +22484,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS3>()) == 0 }
+        self.CopyQueueTimestampQueriesSupported == other.CopyQueueTimestampQueriesSupported && self.CastingFullyTypedFormatSupported == other.CastingFullyTypedFormatSupported && self.WriteBufferImmediateSupportFlags == other.WriteBufferImmediateSupportFlags && self.ViewInstancingTier == other.ViewInstancingTier && self.BarycentricsSupported == other.BarycentricsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22566,7 +22524,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS4>()) == 0 }
+        self.MSAA64KBAlignedTextureSupported == other.MSAA64KBAlignedTextureSupported && self.SharedResourceCompatibilityTier == other.SharedResourceCompatibilityTier && self.Native16BitShaderOpsSupported == other.Native16BitShaderOpsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22606,7 +22564,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS5 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS5>()) == 0 }
+        self.SRVOnlyTiledResourceTier3 == other.SRVOnlyTiledResourceTier3 && self.RenderPassesTier == other.RenderPassesTier && self.RaytracingTier == other.RaytracingTier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22648,7 +22606,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS6>()) == 0 }
+        self.AdditionalShadingRatesSupported == other.AdditionalShadingRatesSupported && self.PerPrimitiveShadingRateSupportedWithViewportIndexing == other.PerPrimitiveShadingRateSupportedWithViewportIndexing && self.VariableShadingRateTier == other.VariableShadingRateTier && self.ShadingRateImageTileSize == other.ShadingRateImageTileSize && self.BackgroundProcessingSupported == other.BackgroundProcessingSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22681,7 +22639,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS7 {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS7>()) == 0 }
+        self.MeshShaderTier == other.MeshShaderTier && self.SamplerFeedbackTier == other.SamplerFeedbackTier
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_D3D12_OPTIONS7 {}
@@ -22717,7 +22675,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS8 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS8>()) == 0 }
+        self.UnalignedBlockTexturesSupported == other.UnalignedBlockTexturesSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22767,7 +22725,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_D3D12_OPTIONS9 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_D3D12_OPTIONS9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_D3D12_OPTIONS9>()) == 0 }
+        self.MeshShaderPipelineStatsSupported == other.MeshShaderPipelineStatsSupported && self.MeshShaderSupportsFullRangeRenderTargetArrayIndex == other.MeshShaderSupportsFullRangeRenderTargetArrayIndex && self.AtomicInt64OnTypedResourceSupported == other.AtomicInt64OnTypedResourceSupported && self.AtomicInt64OnGroupSharedSupported == other.AtomicInt64OnGroupSharedSupported && self.DerivativesInMeshAndAmplificationShadersSupported == other.DerivativesInMeshAndAmplificationShadersSupported && self.WaveMMATier == other.WaveMMATier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22806,7 +22764,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_DISPLAYABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_DISPLAYABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_DISPLAYABLE>()) == 0 }
+        self.DisplayableTexture == other.DisplayableTexture && self.SharedResourceCompatibilityTier == other.SharedResourceCompatibilityTier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22844,7 +22802,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_EXISTING_HEAPS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_EXISTING_HEAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_EXISTING_HEAPS>()) == 0 }
+        self.Supported == other.Supported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22884,7 +22842,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_FEATURE_LEVELS {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_FEATURE_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_FEATURE_LEVELS>()) == 0 }
+        self.NumFeatureLevels == other.NumFeatureLevels && self.pFeatureLevelsRequested == other.pFeatureLevelsRequested && self.MaxSupportedFeatureLevel == other.MaxSupportedFeatureLevel
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -22923,7 +22881,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_FORMAT_INFO {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_FORMAT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_FORMAT_INFO>()) == 0 }
+        self.Format == other.Format && self.PlaneCount == other.PlaneCount
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -22963,7 +22921,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_FORMAT_SUPPORT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_FORMAT_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_FORMAT_SUPPORT>()) == 0 }
+        self.Format == other.Format && self.Support1 == other.Support1 && self.Support2 == other.Support2
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -22996,7 +22954,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPP
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT>()) == 0 }
+        self.MaxGPUVirtualAddressBitsPerResource == other.MaxGPUVirtualAddressBitsPerResource && self.MaxGPUVirtualAddressBitsPerProcess == other.MaxGPUVirtualAddressBitsPerProcess
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {}
@@ -23035,7 +22993,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVE
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS>()) == 0 }
+        self.Format == other.Format && self.SampleCount == other.SampleCount && self.Flags == other.Flags && self.NumQualityLevels == other.NumQualityLevels
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -23068,7 +23026,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSI
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Support == other.Support
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT {}
@@ -23100,7 +23058,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSI
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Count == other.Count && self.pTypes == other.pTypes
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES {}
@@ -23131,7 +23089,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSI
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT {}
@@ -23166,7 +23124,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_QUERY_META_COMMAND {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_QUERY_META_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_QUERY_META_COMMAND>()) == 0 }
+        self.CommandId == other.CommandId && self.NodeMask == other.NodeMask && self.pQueryInputData == other.pQueryInputData && self.QueryInputDataSizeInBytes == other.QueryInputDataSizeInBytes && self.pQueryOutputData == other.pQueryOutputData && self.QueryOutputDataSizeInBytes == other.QueryOutputDataSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_QUERY_META_COMMAND {}
@@ -23196,7 +23154,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_ROOT_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_ROOT_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_ROOT_SIGNATURE>()) == 0 }
+        self.HighestVersion == other.HighestVersion
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_ROOT_SIGNATURE {}
@@ -23227,7 +23185,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_SERIALIZATION {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_SERIALIZATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_SERIALIZATION>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.HeapSerializationTier == other.HeapSerializationTier
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_SERIALIZATION {}
@@ -23257,7 +23215,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_SHADER_CACHE {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_SHADER_CACHE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_SHADER_CACHE>()) == 0 }
+        self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_SHADER_CACHE {}
@@ -23287,7 +23245,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_SHADER_MODEL {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_SHADER_MODEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_SHADER_MODEL>()) == 0 }
+        self.HighestShaderModel == other.HighestShaderModel
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_SHADER_MODEL {}
@@ -23389,7 +23347,39 @@ unsafe impl ::windows::core::Abi for D3D12_FUNCTION_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ::core::cmp::PartialEq for D3D12_FUNCTION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FUNCTION_DESC>()) == 0 }
+        self.Version == other.Version
+            && self.Creator == other.Creator
+            && self.Flags == other.Flags
+            && self.ConstantBuffers == other.ConstantBuffers
+            && self.BoundResources == other.BoundResources
+            && self.InstructionCount == other.InstructionCount
+            && self.TempRegisterCount == other.TempRegisterCount
+            && self.TempArrayCount == other.TempArrayCount
+            && self.DefCount == other.DefCount
+            && self.DclCount == other.DclCount
+            && self.TextureNormalInstructions == other.TextureNormalInstructions
+            && self.TextureLoadInstructions == other.TextureLoadInstructions
+            && self.TextureCompInstructions == other.TextureCompInstructions
+            && self.TextureBiasInstructions == other.TextureBiasInstructions
+            && self.TextureGradientInstructions == other.TextureGradientInstructions
+            && self.FloatInstructionCount == other.FloatInstructionCount
+            && self.IntInstructionCount == other.IntInstructionCount
+            && self.UintInstructionCount == other.UintInstructionCount
+            && self.StaticFlowControlCount == other.StaticFlowControlCount
+            && self.DynamicFlowControlCount == other.DynamicFlowControlCount
+            && self.MacroInstructionCount == other.MacroInstructionCount
+            && self.ArrayInstructionCount == other.ArrayInstructionCount
+            && self.MovInstructionCount == other.MovInstructionCount
+            && self.MovcInstructionCount == other.MovcInstructionCount
+            && self.ConversionInstructionCount == other.ConversionInstructionCount
+            && self.BitwiseInstructionCount == other.BitwiseInstructionCount
+            && self.MinFeatureLevel == other.MinFeatureLevel
+            && self.RequiredFeatureFlags == other.RequiredFeatureFlags
+            && self.Name == other.Name
+            && self.FunctionParameterCount == other.FunctionParameterCount
+            && self.HasReturn == other.HasReturn
+            && self.Has10Level9VertexShader == other.Has10Level9VertexShader
+            && self.Has10Level9PixelShader == other.Has10Level9PixelShader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -23450,7 +23440,7 @@ unsafe impl ::windows::core::Abi for D3D12_GPU_DESCRIPTOR_HANDLE {
 }
 impl ::core::cmp::PartialEq for D3D12_GPU_DESCRIPTOR_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_GPU_DESCRIPTOR_HANDLE>()) == 0 }
+        self.ptr == other.ptr
     }
 }
 impl ::core::cmp::Eq for D3D12_GPU_DESCRIPTOR_HANDLE {}
@@ -23481,7 +23471,7 @@ unsafe impl ::windows::core::Abi for D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {
 }
 impl ::core::cmp::PartialEq for D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.StrideInBytes == other.StrideInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {}
@@ -23512,7 +23502,7 @@ unsafe impl ::windows::core::Abi for D3D12_GPU_VIRTUAL_ADDRESS_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D12_GPU_VIRTUAL_ADDRESS_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_GPU_VIRTUAL_ADDRESS_RANGE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_GPU_VIRTUAL_ADDRESS_RANGE {}
@@ -23544,7 +23534,7 @@ unsafe impl ::windows::core::Abi for D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE 
 }
 impl ::core::cmp::PartialEq for D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.SizeInBytes == other.SizeInBytes && self.StrideInBytes == other.StrideInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE {}
@@ -23697,7 +23687,7 @@ unsafe impl ::windows::core::Abi for D3D12_HEAP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_HEAP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_HEAP_DESC>()) == 0 }
+        self.SizeInBytes == other.SizeInBytes && self.Properties == other.Properties && self.Alignment == other.Alignment && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_HEAP_DESC {}
@@ -23731,7 +23721,7 @@ unsafe impl ::windows::core::Abi for D3D12_HEAP_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for D3D12_HEAP_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_HEAP_PROPERTIES>()) == 0 }
+        self.Type == other.Type && self.CPUPageProperty == other.CPUPageProperty && self.MemoryPoolPreference == other.MemoryPoolPreference && self.CreationNodeMask == other.CreationNodeMask && self.VisibleNodeMask == other.VisibleNodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_HEAP_PROPERTIES {}
@@ -23765,7 +23755,7 @@ unsafe impl ::windows::core::Abi for D3D12_HIT_GROUP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_HIT_GROUP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_HIT_GROUP_DESC>()) == 0 }
+        self.HitGroupExport == other.HitGroupExport && self.Type == other.Type && self.AnyHitShaderImport == other.AnyHitShaderImport && self.ClosestHitShaderImport == other.ClosestHitShaderImport && self.IntersectionShaderImport == other.IntersectionShaderImport
     }
 }
 impl ::core::cmp::Eq for D3D12_HIT_GROUP_DESC {}
@@ -23803,7 +23793,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDEX_BUFFER_VIEW {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_INDEX_BUFFER_VIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDEX_BUFFER_VIEW>()) == 0 }
+        self.BufferLocation == other.BufferLocation && self.SizeInBytes == other.SizeInBytes && self.Format == other.Format
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -23829,12 +23819,6 @@ impl ::core::clone::Clone for D3D12_INDIRECT_ARGUMENT_DESC {
 unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC {}
 impl ::core::default::Default for D3D12_INDIRECT_ARGUMENT_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -23858,12 +23842,6 @@ impl ::core::clone::Clone for D3D12_INDIRECT_ARGUMENT_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0 {}
 impl ::core::default::Default for D3D12_INDIRECT_ARGUMENT_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -23890,7 +23868,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
 }
 impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0_0>()) == 0 }
+        self.RootParameterIndex == other.RootParameterIndex
     }
 }
 impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {}
@@ -23922,7 +23900,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
 }
 impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0_1>()) == 0 }
+        self.RootParameterIndex == other.RootParameterIndex && self.DestOffsetIn32BitValues == other.DestOffsetIn32BitValues && self.Num32BitValuesToSet == other.Num32BitValuesToSet
     }
 }
 impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {}
@@ -23952,7 +23930,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
 }
 impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0_2>()) == 0 }
+        self.RootParameterIndex == other.RootParameterIndex
     }
 }
 impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {}
@@ -23982,7 +23960,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0_3 {
 }
 impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0_3>()) == 0 }
+        self.RootParameterIndex == other.RootParameterIndex
     }
 }
 impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0_3 {}
@@ -24012,7 +23990,7 @@ unsafe impl ::windows::core::Abi for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {
 }
 impl ::core::cmp::PartialEq for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INDIRECT_ARGUMENT_DESC_0_4>()) == 0 }
+        self.Slot == other.Slot
     }
 }
 impl ::core::cmp::Eq for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {}
@@ -24043,7 +24021,7 @@ unsafe impl ::windows::core::Abi for D3D12_INFO_QUEUE_FILTER {
 }
 impl ::core::cmp::PartialEq for D3D12_INFO_QUEUE_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INFO_QUEUE_FILTER>()) == 0 }
+        self.AllowList == other.AllowList && self.DenyList == other.DenyList
     }
 }
 impl ::core::cmp::Eq for D3D12_INFO_QUEUE_FILTER {}
@@ -24078,7 +24056,7 @@ unsafe impl ::windows::core::Abi for D3D12_INFO_QUEUE_FILTER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_INFO_QUEUE_FILTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INFO_QUEUE_FILTER_DESC>()) == 0 }
+        self.NumCategories == other.NumCategories && self.pCategoryList == other.pCategoryList && self.NumSeverities == other.NumSeverities && self.pSeverityList == other.pSeverityList && self.NumIDs == other.NumIDs && self.pIDList == other.pIDList
     }
 }
 impl ::core::cmp::Eq for D3D12_INFO_QUEUE_FILTER_DESC {}
@@ -24120,7 +24098,7 @@ unsafe impl ::windows::core::Abi for D3D12_INPUT_ELEMENT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_INPUT_ELEMENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INPUT_ELEMENT_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Format == other.Format && self.InputSlot == other.InputSlot && self.AlignedByteOffset == other.AlignedByteOffset && self.InputSlotClass == other.InputSlotClass && self.InstanceDataStepRate == other.InstanceDataStepRate
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24159,7 +24137,7 @@ unsafe impl ::windows::core::Abi for D3D12_INPUT_LAYOUT_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_INPUT_LAYOUT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_INPUT_LAYOUT_DESC>()) == 0 }
+        self.pInputElementDescs == other.pInputElementDescs && self.NumElements == other.NumElements
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24193,7 +24171,7 @@ unsafe impl ::windows::core::Abi for D3D12_LIBRARY_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_LIBRARY_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_LIBRARY_DESC>()) == 0 }
+        self.Creator == other.Creator && self.Flags == other.Flags && self.FunctionCount == other.FunctionCount
     }
 }
 impl ::core::cmp::Eq for D3D12_LIBRARY_DESC {}
@@ -24254,7 +24232,7 @@ unsafe impl ::windows::core::Abi for D3D12_MEMCPY_DEST {
 }
 impl ::core::cmp::PartialEq for D3D12_MEMCPY_DEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_MEMCPY_DEST>()) == 0 }
+        self.pData == other.pData && self.RowPitch == other.RowPitch && self.SlicePitch == other.SlicePitch
     }
 }
 impl ::core::cmp::Eq for D3D12_MEMCPY_DEST {}
@@ -24288,7 +24266,7 @@ unsafe impl ::windows::core::Abi for D3D12_MESSAGE {
 }
 impl ::core::cmp::PartialEq for D3D12_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_MESSAGE>()) == 0 }
+        self.Category == other.Category && self.Severity == other.Severity && self.ID == other.ID && self.pDescription == other.pDescription && self.DescriptionByteLength == other.DescriptionByteLength
     }
 }
 impl ::core::cmp::Eq for D3D12_MESSAGE {}
@@ -24321,7 +24299,7 @@ unsafe impl ::windows::core::Abi for D3D12_META_COMMAND_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_META_COMMAND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_META_COMMAND_DESC>()) == 0 }
+        self.Id == other.Id && self.Name == other.Name && self.InitializationDirtyState == other.InitializationDirtyState && self.ExecutionDirtyState == other.ExecutionDirtyState
     }
 }
 impl ::core::cmp::Eq for D3D12_META_COMMAND_DESC {}
@@ -24355,7 +24333,7 @@ unsafe impl ::windows::core::Abi for D3D12_META_COMMAND_PARAMETER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_META_COMMAND_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_META_COMMAND_PARAMETER_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.Flags == other.Flags && self.RequiredResourceState == other.RequiredResourceState && self.StructureOffset == other.StructureOffset
     }
 }
 impl ::core::cmp::Eq for D3D12_META_COMMAND_PARAMETER_DESC {}
@@ -24387,7 +24365,7 @@ unsafe impl ::windows::core::Abi for D3D12_MIP_REGION {
 }
 impl ::core::cmp::PartialEq for D3D12_MIP_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_MIP_REGION>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth
     }
 }
 impl ::core::cmp::Eq for D3D12_MIP_REGION {}
@@ -24417,7 +24395,7 @@ unsafe impl ::windows::core::Abi for D3D12_NODE_MASK {
 }
 impl ::core::cmp::PartialEq for D3D12_NODE_MASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_NODE_MASK>()) == 0 }
+        self.NodeMask == other.NodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_NODE_MASK {}
@@ -24450,7 +24428,7 @@ unsafe impl ::windows::core::Abi for D3D12_PACKED_MIP_INFO {
 }
 impl ::core::cmp::PartialEq for D3D12_PACKED_MIP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PACKED_MIP_INFO>()) == 0 }
+        self.NumStandardMips == other.NumStandardMips && self.NumPackedMips == other.NumPackedMips && self.NumTilesForPackedMips == other.NumTilesForPackedMips && self.StartTileIndexInOverallResource == other.StartTileIndexInOverallResource
     }
 }
 impl ::core::cmp::Eq for D3D12_PACKED_MIP_INFO {}
@@ -24510,7 +24488,7 @@ unsafe impl ::windows::core::Abi for D3D12_PARAMETER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PARAMETER_DESC>()) == 0 }
+        self.Name == other.Name && self.SemanticName == other.SemanticName && self.Type == other.Type && self.Class == other.Class && self.Rows == other.Rows && self.Columns == other.Columns && self.InterpolationMode == other.InterpolationMode && self.Flags == other.Flags && self.FirstInRegister == other.FirstInRegister && self.FirstInComponent == other.FirstInComponent && self.FirstOutRegister == other.FirstOutRegister && self.FirstOutComponent == other.FirstOutComponent
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -24543,7 +24521,7 @@ unsafe impl ::windows::core::Abi for D3D12_PIPELINE_STATE_STREAM_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_PIPELINE_STATE_STREAM_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PIPELINE_STATE_STREAM_DESC>()) == 0 }
+        self.SizeInBytes == other.SizeInBytes && self.pPipelineStateSubobjectStream == other.pPipelineStateSubobjectStream
     }
 }
 impl ::core::cmp::Eq for D3D12_PIPELINE_STATE_STREAM_DESC {}
@@ -24580,7 +24558,7 @@ unsafe impl ::windows::core::Abi for D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>()) == 0 }
+        self.Offset == other.Offset && self.Footprint == other.Footprint
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -24613,7 +24591,7 @@ unsafe impl ::windows::core::Abi for D3D12_PROTECTED_RESOURCE_SESSION_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_PROTECTED_RESOURCE_SESSION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PROTECTED_RESOURCE_SESSION_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_PROTECTED_RESOURCE_SESSION_DESC {}
@@ -24645,7 +24623,7 @@ unsafe impl ::windows::core::Abi for D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
 }
 impl ::core::cmp::PartialEq for D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_PROTECTED_RESOURCE_SESSION_DESC1>()) == 0 }
+        self.NodeMask == other.NodeMask && self.Flags == other.Flags && self.ProtectionType == other.ProtectionType
     }
 }
 impl ::core::cmp::Eq for D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {}
@@ -24697,7 +24675,7 @@ unsafe impl ::windows::core::Abi for D3D12_QUERY_DATA_PIPELINE_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D12_QUERY_DATA_PIPELINE_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_QUERY_DATA_PIPELINE_STATISTICS>()) == 0 }
+        self.IAVertices == other.IAVertices && self.IAPrimitives == other.IAPrimitives && self.VSInvocations == other.VSInvocations && self.GSInvocations == other.GSInvocations && self.GSPrimitives == other.GSPrimitives && self.CInvocations == other.CInvocations && self.CPrimitives == other.CPrimitives && self.PSInvocations == other.PSInvocations && self.HSInvocations == other.HSInvocations && self.DSInvocations == other.DSInvocations && self.CSInvocations == other.CSInvocations
     }
 }
 impl ::core::cmp::Eq for D3D12_QUERY_DATA_PIPELINE_STATISTICS {}
@@ -24755,7 +24733,7 @@ unsafe impl ::windows::core::Abi for D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_QUERY_DATA_PIPELINE_STATISTICS1>()) == 0 }
+        self.IAVertices == other.IAVertices && self.IAPrimitives == other.IAPrimitives && self.VSInvocations == other.VSInvocations && self.GSInvocations == other.GSInvocations && self.GSPrimitives == other.GSPrimitives && self.CInvocations == other.CInvocations && self.CPrimitives == other.CPrimitives && self.PSInvocations == other.PSInvocations && self.HSInvocations == other.HSInvocations && self.DSInvocations == other.DSInvocations && self.CSInvocations == other.CSInvocations && self.ASInvocations == other.ASInvocations && self.MSInvocations == other.MSInvocations && self.MSPrimitives == other.MSPrimitives
     }
 }
 impl ::core::cmp::Eq for D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {}
@@ -24786,7 +24764,7 @@ unsafe impl ::windows::core::Abi for D3D12_QUERY_DATA_SO_STATISTICS {
 }
 impl ::core::cmp::PartialEq for D3D12_QUERY_DATA_SO_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_QUERY_DATA_SO_STATISTICS>()) == 0 }
+        self.NumPrimitivesWritten == other.NumPrimitivesWritten && self.PrimitivesStorageNeeded == other.PrimitivesStorageNeeded
     }
 }
 impl ::core::cmp::Eq for D3D12_QUERY_DATA_SO_STATISTICS {}
@@ -24818,7 +24796,7 @@ unsafe impl ::windows::core::Abi for D3D12_QUERY_HEAP_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_QUERY_HEAP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_QUERY_HEAP_DESC>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.NodeMask == other.NodeMask
     }
 }
 impl ::core::cmp::Eq for D3D12_QUERY_HEAP_DESC {}
@@ -24849,7 +24827,7 @@ unsafe impl ::windows::core::Abi for D3D12_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D12_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RANGE>()) == 0 }
+        self.Begin == other.Begin && self.End == other.End
     }
 }
 impl ::core::cmp::Eq for D3D12_RANGE {}
@@ -24880,7 +24858,7 @@ unsafe impl ::windows::core::Abi for D3D12_RANGE_UINT64 {
 }
 impl ::core::cmp::PartialEq for D3D12_RANGE_UINT64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RANGE_UINT64>()) == 0 }
+        self.Begin == other.Begin && self.End == other.End
     }
 }
 impl ::core::cmp::Eq for D3D12_RANGE_UINT64 {}
@@ -24938,7 +24916,7 @@ unsafe impl ::windows::core::Abi for D3D12_RASTERIZER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_RASTERIZER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RASTERIZER_DESC>()) == 0 }
+        self.FillMode == other.FillMode && self.CullMode == other.CullMode && self.FrontCounterClockwise == other.FrontCounterClockwise && self.DepthBias == other.DepthBias && self.DepthBiasClamp == other.DepthBiasClamp && self.SlopeScaledDepthBias == other.SlopeScaledDepthBias && self.DepthClipEnable == other.DepthClipEnable && self.MultisampleEnable == other.MultisampleEnable && self.AntialiasedLineEnable == other.AntialiasedLineEnable && self.ForcedSampleCount == other.ForcedSampleCount && self.ConservativeRaster == other.ConservativeRaster
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24975,7 +24953,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_AABB {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_AABB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_AABB>()) == 0 }
+        self.MinX == other.MinX && self.MinY == other.MinY && self.MinZ == other.MinZ && self.MaxX == other.MaxX && self.MaxY == other.MaxY && self.MaxZ == other.MaxZ
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_AABB {}
@@ -25005,7 +24983,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POS
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC>()) == 0 }
+        self.CompactedSizeInBytes == other.CompactedSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC {}
@@ -25035,7 +25013,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POS
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC>()) == 0 }
+        self.CurrentSizeInBytes == other.CurrentSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC {}
@@ -25066,7 +25044,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POS
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC>()) == 0 }
+        self.DestBuffer == other.DestBuffer && self.InfoType == other.InfoType
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC {}
@@ -25097,7 +25075,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POS
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC>()) == 0 }
+        self.SerializedSizeInBytes == other.SerializedSizeInBytes && self.NumBottomLevelAccelerationStructurePointers == other.NumBottomLevelAccelerationStructurePointers
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC {}
@@ -25127,7 +25105,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POS
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC>()) == 0 }
+        self.DecodedSizeInBytes == other.DecodedSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC {}
@@ -25159,7 +25137,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PRE
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO>()) == 0 }
+        self.ResultDataMaxSizeInBytes == other.ResultDataMaxSizeInBytes && self.ScratchDataSizeInBytes == other.ScratchDataSizeInBytes && self.UpdateScratchDataSizeInBytes == other.UpdateScratchDataSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {}
@@ -25189,7 +25167,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV>()) == 0 }
+        self.Location == other.Location
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV {}
@@ -25220,7 +25198,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_GEOMETRY_AABBS_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_GEOMETRY_AABBS_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_GEOMETRY_AABBS_DESC>()) == 0 }
+        self.AABBCount == other.AABBCount && self.AABBs == other.AABBs
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_GEOMETRY_AABBS_DESC {}
@@ -25250,14 +25228,6 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_GEOMETRY_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RAYTRACING_GEOMETRY_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_GEOMETRY_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RAYTRACING_GEOMETRY_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RAYTRACING_GEOMETRY_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25282,14 +25252,6 @@ impl ::core::clone::Clone for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_GEOMETRY_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RAYTRACING_GEOMETRY_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
     fn default() -> Self {
@@ -25329,7 +25291,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC>()) == 0 }
+        self.Transform3x4 == other.Transform3x4 && self.IndexFormat == other.IndexFormat && self.VertexFormat == other.VertexFormat && self.IndexCount == other.IndexCount && self.VertexCount == other.VertexCount && self.IndexBuffer == other.IndexBuffer && self.VertexBuffer == other.VertexBuffer
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -25364,7 +25326,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_INSTANCE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_INSTANCE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_INSTANCE_DESC>()) == 0 }
+        self.Transform == other.Transform && self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2 && self.AccelerationStructure == other.AccelerationStructure
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_INSTANCE_DESC {}
@@ -25394,7 +25356,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_PIPELINE_CONFIG {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_PIPELINE_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_PIPELINE_CONFIG>()) == 0 }
+        self.MaxTraceRecursionDepth == other.MaxTraceRecursionDepth
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_PIPELINE_CONFIG {}
@@ -25425,7 +25387,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_PIPELINE_CONFIG1 {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_PIPELINE_CONFIG1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_PIPELINE_CONFIG1>()) == 0 }
+        self.MaxTraceRecursionDepth == other.MaxTraceRecursionDepth && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_PIPELINE_CONFIG1 {}
@@ -25456,7 +25418,7 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_SHADER_CONFIG {
 }
 impl ::core::cmp::PartialEq for D3D12_RAYTRACING_SHADER_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RAYTRACING_SHADER_CONFIG>()) == 0 }
+        self.MaxPayloadSizeInBytes == other.MaxPayloadSizeInBytes && self.MaxAttributeSizeInBytes == other.MaxAttributeSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RAYTRACING_SHADER_CONFIG {}
@@ -25485,14 +25447,6 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_BEGINNING_ACCESS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_BEGINNING_ACCESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_PASS_BEGINNING_ACCESS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_BEGINNING_ACCESS {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RENDER_PASS_BEGINNING_ACCESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25517,14 +25471,6 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_PASS_BEGINNING_ACCESS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25548,14 +25494,6 @@ impl ::core::clone::Clone for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETER
 unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
     fn default() -> Self {
@@ -25589,14 +25527,6 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        self.cpuDescriptor == other.cpuDescriptor && self.DepthBeginningAccess == other.DepthBeginningAccess && self.StencilBeginningAccess == other.StencilBeginningAccess && self.DepthEndingAccess == other.DepthEndingAccess && self.StencilEndingAccess == other.StencilEndingAccess
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25620,14 +25550,6 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_ENDING_ACCESS {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_ENDING_ACCESS {
-    fn eq(&self, other: &Self) -> bool {
-        self.Type == other.Type && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_ENDING_ACCESS {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_RENDER_PASS_ENDING_ACCESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25649,14 +25571,6 @@ impl ::core::clone::Clone for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
 unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_PASS_ENDING_ACCESS_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_ENDING_ACCESS_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
     fn default() -> Self {
@@ -25744,7 +25658,7 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUB
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS>()) == 0 }
+        self.SrcSubresource == other.SrcSubresource && self.DstSubresource == other.DstSubresource && self.DstX == other.DstX && self.DstY == other.DstY && self.SrcRect == other.SrcRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25773,14 +25687,6 @@ impl ::core::clone::Clone for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
 unsafe impl ::windows::core::Abi for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        self.cpuDescriptor == other.cpuDescriptor && self.BeginningAccess == other.BeginningAccess && self.EndingAccess == other.EndingAccess
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_RENDER_PASS_RENDER_TARGET_DESC {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
     fn default() -> Self {
@@ -25823,7 +25729,7 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_TARGET_BLEND_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_RENDER_TARGET_BLEND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_TARGET_BLEND_DESC>()) == 0 }
+        self.BlendEnable == other.BlendEnable && self.LogicOpEnable == other.LogicOpEnable && self.SrcBlend == other.SrcBlend && self.DestBlend == other.DestBlend && self.BlendOp == other.BlendOp && self.SrcBlendAlpha == other.SrcBlendAlpha && self.DestBlendAlpha == other.DestBlendAlpha && self.BlendOpAlpha == other.BlendOpAlpha && self.LogicOp == other.LogicOp && self.RenderTargetWriteMask == other.RenderTargetWriteMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25855,14 +25761,6 @@ unsafe impl ::windows::core::Abi for D3D12_RENDER_TARGET_VIEW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RENDER_TARGET_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_TARGET_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RENDER_TARGET_VIEW_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25893,14 +25791,6 @@ impl ::core::clone::Clone for D3D12_RENDER_TARGET_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_RENDER_TARGET_VIEW_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_RENDER_TARGET_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RENDER_TARGET_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_RENDER_TARGET_VIEW_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_RENDER_TARGET_VIEW_DESC_0 {
     fn default() -> Self {
@@ -25959,7 +25849,7 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_ALLOCATION_INFO {
 }
 impl ::core::cmp::PartialEq for D3D12_RESOURCE_ALLOCATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_ALLOCATION_INFO>()) == 0 }
+        self.SizeInBytes == other.SizeInBytes && self.Alignment == other.Alignment
     }
 }
 impl ::core::cmp::Eq for D3D12_RESOURCE_ALLOCATION_INFO {}
@@ -25991,7 +25881,7 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_ALLOCATION_INFO1 {
 }
 impl ::core::cmp::PartialEq for D3D12_RESOURCE_ALLOCATION_INFO1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_ALLOCATION_INFO1>()) == 0 }
+        self.Offset == other.Offset && self.Alignment == other.Alignment && self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_RESOURCE_ALLOCATION_INFO1 {}
@@ -26015,12 +25905,6 @@ impl ::core::clone::Clone for D3D12_RESOURCE_BARRIER {
 unsafe impl ::windows::core::Abi for D3D12_RESOURCE_BARRIER {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for D3D12_RESOURCE_BARRIER {
-    fn eq(&self, other: &Self) -> bool {
-        self.Type == other.Type && self.Flags == other.Flags && self.Anonymous == other.Anonymous
-    }
-}
-impl ::core::cmp::Eq for D3D12_RESOURCE_BARRIER {}
 impl ::core::default::Default for D3D12_RESOURCE_BARRIER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26041,12 +25925,6 @@ impl ::core::clone::Clone for D3D12_RESOURCE_BARRIER_0 {
 unsafe impl ::windows::core::Abi for D3D12_RESOURCE_BARRIER_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for D3D12_RESOURCE_BARRIER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_BARRIER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_RESOURCE_BARRIER_0 {}
 impl ::core::default::Default for D3D12_RESOURCE_BARRIER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26088,7 +25966,7 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_RESOURCE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_DESC>()) == 0 }
+        self.Dimension == other.Dimension && self.Alignment == other.Alignment && self.Width == other.Width && self.Height == other.Height && self.DepthOrArraySize == other.DepthOrArraySize && self.MipLevels == other.MipLevels && self.Format == other.Format && self.SampleDesc == other.SampleDesc && self.Layout == other.Layout && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -26136,7 +26014,7 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_DESC1 {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_RESOURCE_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_DESC1>()) == 0 }
+        self.Dimension == other.Dimension && self.Alignment == other.Alignment && self.Width == other.Width && self.Height == other.Height && self.DepthOrArraySize == other.DepthOrArraySize && self.MipLevels == other.MipLevels && self.Format == other.Format && self.SampleDesc == other.SampleDesc && self.Layout == other.Layout && self.Flags == other.Flags && self.SamplerFeedbackMipRegion == other.SamplerFeedbackMipRegion
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -26231,7 +26109,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_CONSTANTS {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_CONSTANTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_CONSTANTS>()) == 0 }
+        self.ShaderRegister == other.ShaderRegister && self.RegisterSpace == other.RegisterSpace && self.Num32BitValues == other.Num32BitValues
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_CONSTANTS {}
@@ -26262,7 +26140,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_DESCRIPTOR>()) == 0 }
+        self.ShaderRegister == other.ShaderRegister && self.RegisterSpace == other.RegisterSpace
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_DESCRIPTOR {}
@@ -26294,7 +26172,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_DESCRIPTOR1 {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_DESCRIPTOR1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_DESCRIPTOR1>()) == 0 }
+        self.ShaderRegister == other.ShaderRegister && self.RegisterSpace == other.RegisterSpace && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_DESCRIPTOR1 {}
@@ -26325,7 +26203,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_DESCRIPTOR_TABLE {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_DESCRIPTOR_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_DESCRIPTOR_TABLE>()) == 0 }
+        self.NumDescriptorRanges == other.NumDescriptorRanges && self.pDescriptorRanges == other.pDescriptorRanges
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_DESCRIPTOR_TABLE {}
@@ -26356,7 +26234,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_DESCRIPTOR_TABLE1 {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_DESCRIPTOR_TABLE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_DESCRIPTOR_TABLE1>()) == 0 }
+        self.NumDescriptorRanges == other.NumDescriptorRanges && self.pDescriptorRanges == other.pDescriptorRanges
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_DESCRIPTOR_TABLE1 {}
@@ -26381,12 +26259,6 @@ impl ::core::clone::Clone for D3D12_ROOT_PARAMETER {
 unsafe impl ::windows::core::Abi for D3D12_ROOT_PARAMETER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_ROOT_PARAMETER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_PARAMETER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_ROOT_PARAMETER {}
 impl ::core::default::Default for D3D12_ROOT_PARAMETER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26408,12 +26280,6 @@ impl ::core::clone::Clone for D3D12_ROOT_PARAMETER_0 {
 unsafe impl ::windows::core::Abi for D3D12_ROOT_PARAMETER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_ROOT_PARAMETER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_PARAMETER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_ROOT_PARAMETER_0 {}
 impl ::core::default::Default for D3D12_ROOT_PARAMETER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26435,12 +26301,6 @@ impl ::core::clone::Clone for D3D12_ROOT_PARAMETER1 {
 unsafe impl ::windows::core::Abi for D3D12_ROOT_PARAMETER1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_ROOT_PARAMETER1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_PARAMETER1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_ROOT_PARAMETER1 {}
 impl ::core::default::Default for D3D12_ROOT_PARAMETER1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26462,12 +26322,6 @@ impl ::core::clone::Clone for D3D12_ROOT_PARAMETER1_0 {
 unsafe impl ::windows::core::Abi for D3D12_ROOT_PARAMETER1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_ROOT_PARAMETER1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_PARAMETER1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_ROOT_PARAMETER1_0 {}
 impl ::core::default::Default for D3D12_ROOT_PARAMETER1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26498,7 +26352,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_SIGNATURE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_SIGNATURE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_SIGNATURE_DESC>()) == 0 }
+        self.NumParameters == other.NumParameters && self.pParameters == other.pParameters && self.NumStaticSamplers == other.NumStaticSamplers && self.pStaticSamplers == other.pStaticSamplers && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_SIGNATURE_DESC {}
@@ -26532,7 +26386,7 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_SIGNATURE_DESC1 {
 }
 impl ::core::cmp::PartialEq for D3D12_ROOT_SIGNATURE_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_ROOT_SIGNATURE_DESC1>()) == 0 }
+        self.NumParameters == other.NumParameters && self.pParameters == other.pParameters && self.NumStaticSamplers == other.NumStaticSamplers && self.pStaticSamplers == other.pStaticSamplers && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_ROOT_SIGNATURE_DESC1 {}
@@ -26569,7 +26423,7 @@ unsafe impl ::windows::core::Abi for D3D12_RT_FORMAT_ARRAY {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_RT_FORMAT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RT_FORMAT_ARRAY>()) == 0 }
+        self.RTFormats == other.RTFormats && self.NumRenderTargets == other.NumRenderTargets
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -26610,7 +26464,7 @@ unsafe impl ::windows::core::Abi for D3D12_SAMPLER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_SAMPLER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SAMPLER_DESC>()) == 0 }
+        self.Filter == other.Filter && self.AddressU == other.AddressU && self.AddressV == other.AddressV && self.AddressW == other.AddressW && self.MipLODBias == other.MipLODBias && self.MaxAnisotropy == other.MaxAnisotropy && self.ComparisonFunc == other.ComparisonFunc && self.BorderColor == other.BorderColor && self.MinLOD == other.MinLOD && self.MaxLOD == other.MaxLOD
     }
 }
 impl ::core::cmp::Eq for D3D12_SAMPLER_DESC {}
@@ -26641,7 +26495,7 @@ unsafe impl ::windows::core::Abi for D3D12_SAMPLE_POSITION {
 }
 impl ::core::cmp::PartialEq for D3D12_SAMPLE_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SAMPLE_POSITION>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for D3D12_SAMPLE_POSITION {}
@@ -26672,7 +26526,7 @@ unsafe impl ::windows::core::Abi for D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENT
 }
 impl ::core::cmp::PartialEq for D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER>()) == 0 }
+        self.DriverOpaqueGUID == other.DriverOpaqueGUID && self.DriverOpaqueVersioningData == other.DriverOpaqueVersioningData
     }
 }
 impl ::core::cmp::Eq for D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER {}
@@ -26705,7 +26559,7 @@ unsafe impl ::windows::core::Abi for D3D12_SERIALIZED_RAYTRACING_ACCELERATION_ST
 }
 impl ::core::cmp::PartialEq for D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER>()) == 0 }
+        self.DriverMatchingIdentifier == other.DriverMatchingIdentifier && self.SerializedSizeInBytesIncludingHeader == other.SerializedSizeInBytesIncludingHeader && self.DeserializedSizeInBytes == other.DeserializedSizeInBytes && self.NumBottomLevelAccelerationStructurePointersAfterHeader == other.NumBottomLevelAccelerationStructurePointersAfterHeader
     }
 }
 impl ::core::cmp::Eq for D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER {}
@@ -26745,7 +26599,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_BUFFER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_SHADER_BUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_BUFFER_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.Variables == other.Variables && self.Size == other.Size && self.uFlags == other.uFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -26778,7 +26632,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_BYTECODE {
 }
 impl ::core::cmp::PartialEq for D3D12_SHADER_BYTECODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_BYTECODE>()) == 0 }
+        self.pShaderBytecode == other.pShaderBytecode && self.BytecodeLength == other.BytecodeLength
     }
 }
 impl ::core::cmp::Eq for D3D12_SHADER_BYTECODE {}
@@ -26814,7 +26668,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_CACHE_SESSION_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_SHADER_CACHE_SESSION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_CACHE_SESSION_DESC>()) == 0 }
+        self.Identifier == other.Identifier && self.Mode == other.Mode && self.Flags == other.Flags && self.MaximumInMemoryCacheSizeBytes == other.MaximumInMemoryCacheSizeBytes && self.MaximumInMemoryCacheEntries == other.MaximumInMemoryCacheEntries && self.MaximumValueFileSizeBytes == other.MaximumValueFileSizeBytes && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for D3D12_SHADER_CACHE_SESSION_DESC {}
@@ -26926,7 +26780,44 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_SHADER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_DESC>()) == 0 }
+        self.Version == other.Version
+            && self.Creator == other.Creator
+            && self.Flags == other.Flags
+            && self.ConstantBuffers == other.ConstantBuffers
+            && self.BoundResources == other.BoundResources
+            && self.InputParameters == other.InputParameters
+            && self.OutputParameters == other.OutputParameters
+            && self.InstructionCount == other.InstructionCount
+            && self.TempRegisterCount == other.TempRegisterCount
+            && self.TempArrayCount == other.TempArrayCount
+            && self.DefCount == other.DefCount
+            && self.DclCount == other.DclCount
+            && self.TextureNormalInstructions == other.TextureNormalInstructions
+            && self.TextureLoadInstructions == other.TextureLoadInstructions
+            && self.TextureCompInstructions == other.TextureCompInstructions
+            && self.TextureBiasInstructions == other.TextureBiasInstructions
+            && self.TextureGradientInstructions == other.TextureGradientInstructions
+            && self.FloatInstructionCount == other.FloatInstructionCount
+            && self.IntInstructionCount == other.IntInstructionCount
+            && self.UintInstructionCount == other.UintInstructionCount
+            && self.StaticFlowControlCount == other.StaticFlowControlCount
+            && self.DynamicFlowControlCount == other.DynamicFlowControlCount
+            && self.MacroInstructionCount == other.MacroInstructionCount
+            && self.ArrayInstructionCount == other.ArrayInstructionCount
+            && self.CutInstructionCount == other.CutInstructionCount
+            && self.EmitInstructionCount == other.EmitInstructionCount
+            && self.GSOutputTopology == other.GSOutputTopology
+            && self.GSMaxOutputVertexCount == other.GSMaxOutputVertexCount
+            && self.InputPrimitive == other.InputPrimitive
+            && self.PatchConstantParameters == other.PatchConstantParameters
+            && self.cGSInstanceCount == other.cGSInstanceCount
+            && self.cControlPoints == other.cControlPoints
+            && self.HSOutputPrimitive == other.HSOutputPrimitive
+            && self.HSPartitioning == other.HSPartitioning
+            && self.TessellatorDomain == other.TessellatorDomain
+            && self.cBarrierInstructions == other.cBarrierInstructions
+            && self.cInterlockedInstructions == other.cInterlockedInstructions
+            && self.cTextureStoreInstructions == other.cTextureStoreInstructions
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -26973,7 +26864,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_INPUT_BIND_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_SHADER_INPUT_BIND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_INPUT_BIND_DESC>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.BindPoint == other.BindPoint && self.BindCount == other.BindCount && self.uFlags == other.uFlags && self.ReturnType == other.ReturnType && self.Dimension == other.Dimension && self.NumSamples == other.NumSamples && self.Space == other.Space && self.uID == other.uID
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -27005,14 +26896,6 @@ impl ::core::clone::Clone for D3D12_SHADER_RESOURCE_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D12_SHADER_RESOURCE_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_SHADER_RESOURCE_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_RESOURCE_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_SHADER_RESOURCE_VIEW_DESC {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_SHADER_RESOURCE_VIEW_DESC {
     fn default() -> Self {
@@ -27047,14 +26930,6 @@ impl ::core::clone::Clone for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_RESOURCE_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
     fn default() -> Self {
@@ -27095,7 +26970,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_TYPE_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_SHADER_TYPE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_TYPE_DESC>()) == 0 }
+        self.Class == other.Class && self.Type == other.Type && self.Rows == other.Rows && self.Columns == other.Columns && self.Elements == other.Elements && self.Members == other.Members && self.Offset == other.Offset && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -27135,7 +27010,7 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_VARIABLE_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_SHADER_VARIABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SHADER_VARIABLE_DESC>()) == 0 }
+        self.Name == other.Name && self.StartOffset == other.StartOffset && self.Size == other.Size && self.uFlags == other.uFlags && self.DefaultValue == other.DefaultValue && self.StartTexture == other.StartTexture && self.TextureSize == other.TextureSize && self.StartSampler == other.StartSampler && self.SamplerSize == other.SamplerSize
     }
 }
 impl ::core::cmp::Eq for D3D12_SHADER_VARIABLE_DESC {}
@@ -27179,7 +27054,7 @@ unsafe impl ::windows::core::Abi for D3D12_SIGNATURE_PARAMETER_DESC {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3D12_SIGNATURE_PARAMETER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SIGNATURE_PARAMETER_DESC>()) == 0 }
+        self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.Register == other.Register && self.SystemValueType == other.SystemValueType && self.ComponentType == other.ComponentType && self.Mask == other.Mask && self.ReadWriteMask == other.ReadWriteMask && self.Stream == other.Stream && self.MinPrecision == other.MinPrecision
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -27216,7 +27091,7 @@ unsafe impl ::windows::core::Abi for D3D12_SO_DECLARATION_ENTRY {
 }
 impl ::core::cmp::PartialEq for D3D12_SO_DECLARATION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SO_DECLARATION_ENTRY>()) == 0 }
+        self.Stream == other.Stream && self.SemanticName == other.SemanticName && self.SemanticIndex == other.SemanticIndex && self.StartComponent == other.StartComponent && self.ComponentCount == other.ComponentCount && self.OutputSlot == other.OutputSlot
     }
 }
 impl ::core::cmp::Eq for D3D12_SO_DECLARATION_ENTRY {}
@@ -27246,7 +27121,7 @@ unsafe impl ::windows::core::Abi for D3D12_STATE_OBJECT_CONFIG {
 }
 impl ::core::cmp::PartialEq for D3D12_STATE_OBJECT_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STATE_OBJECT_CONFIG>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_STATE_OBJECT_CONFIG {}
@@ -27278,7 +27153,7 @@ unsafe impl ::windows::core::Abi for D3D12_STATE_OBJECT_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_STATE_OBJECT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STATE_OBJECT_DESC>()) == 0 }
+        self.Type == other.Type && self.NumSubobjects == other.NumSubobjects && self.pSubobjects == other.pSubobjects
     }
 }
 impl ::core::cmp::Eq for D3D12_STATE_OBJECT_DESC {}
@@ -27309,7 +27184,7 @@ unsafe impl ::windows::core::Abi for D3D12_STATE_SUBOBJECT {
 }
 impl ::core::cmp::PartialEq for D3D12_STATE_SUBOBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STATE_SUBOBJECT>()) == 0 }
+        self.Type == other.Type && self.pDesc == other.pDesc
     }
 }
 impl ::core::cmp::Eq for D3D12_STATE_SUBOBJECT {}
@@ -27365,7 +27240,7 @@ unsafe impl ::windows::core::Abi for D3D12_STATIC_SAMPLER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_STATIC_SAMPLER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STATIC_SAMPLER_DESC>()) == 0 }
+        self.Filter == other.Filter && self.AddressU == other.AddressU && self.AddressV == other.AddressV && self.AddressW == other.AddressW && self.MipLODBias == other.MipLODBias && self.MaxAnisotropy == other.MaxAnisotropy && self.ComparisonFunc == other.ComparisonFunc && self.BorderColor == other.BorderColor && self.MinLOD == other.MinLOD && self.MaxLOD == other.MaxLOD && self.ShaderRegister == other.ShaderRegister && self.RegisterSpace == other.RegisterSpace && self.ShaderVisibility == other.ShaderVisibility
     }
 }
 impl ::core::cmp::Eq for D3D12_STATIC_SAMPLER_DESC {}
@@ -27397,7 +27272,7 @@ unsafe impl ::windows::core::Abi for D3D12_STREAM_OUTPUT_BUFFER_VIEW {
 }
 impl ::core::cmp::PartialEq for D3D12_STREAM_OUTPUT_BUFFER_VIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STREAM_OUTPUT_BUFFER_VIEW>()) == 0 }
+        self.BufferLocation == other.BufferLocation && self.SizeInBytes == other.SizeInBytes && self.BufferFilledSizeLocation == other.BufferFilledSizeLocation
     }
 }
 impl ::core::cmp::Eq for D3D12_STREAM_OUTPUT_BUFFER_VIEW {}
@@ -27431,7 +27306,7 @@ unsafe impl ::windows::core::Abi for D3D12_STREAM_OUTPUT_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_STREAM_OUTPUT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_STREAM_OUTPUT_DESC>()) == 0 }
+        self.pSODeclaration == other.pSODeclaration && self.NumEntries == other.NumEntries && self.pBufferStrides == other.pBufferStrides && self.NumStrides == other.NumStrides && self.RasterizedStream == other.RasterizedStream
     }
 }
 impl ::core::cmp::Eq for D3D12_STREAM_OUTPUT_DESC {}
@@ -27463,7 +27338,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
 }
 impl ::core::cmp::PartialEq for D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION>()) == 0 }
+        self.pSubobjectToAssociate == other.pSubobjectToAssociate && self.NumExports == other.NumExports && self.pExports == other.pExports
     }
 }
 impl ::core::cmp::Eq for D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {}
@@ -27495,7 +27370,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBRESOURCE_DATA {
 }
 impl ::core::cmp::PartialEq for D3D12_SUBRESOURCE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBRESOURCE_DATA>()) == 0 }
+        self.pData == other.pData && self.RowPitch == other.RowPitch && self.SlicePitch == other.SlicePitch
     }
 }
 impl ::core::cmp::Eq for D3D12_SUBRESOURCE_DATA {}
@@ -27535,7 +27410,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBRESOURCE_FOOTPRINT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_SUBRESOURCE_FOOTPRINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBRESOURCE_FOOTPRINT>()) == 0 }
+        self.Format == other.Format && self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth && self.RowPitch == other.RowPitch
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -27569,7 +27444,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBRESOURCE_INFO {
 }
 impl ::core::cmp::PartialEq for D3D12_SUBRESOURCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBRESOURCE_INFO>()) == 0 }
+        self.Offset == other.Offset && self.RowPitch == other.RowPitch && self.DepthPitch == other.DepthPitch
     }
 }
 impl ::core::cmp::Eq for D3D12_SUBRESOURCE_INFO {}
@@ -27600,7 +27475,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBRESOURCE_RANGE_UINT64 {
 }
 impl ::core::cmp::PartialEq for D3D12_SUBRESOURCE_RANGE_UINT64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBRESOURCE_RANGE_UINT64>()) == 0 }
+        self.Subresource == other.Subresource && self.Range == other.Range
     }
 }
 impl ::core::cmp::Eq for D3D12_SUBRESOURCE_RANGE_UINT64 {}
@@ -27633,7 +27508,7 @@ unsafe impl ::windows::core::Abi for D3D12_SUBRESOURCE_TILING {
 }
 impl ::core::cmp::PartialEq for D3D12_SUBRESOURCE_TILING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_SUBRESOURCE_TILING>()) == 0 }
+        self.WidthInTiles == other.WidthInTiles && self.HeightInTiles == other.HeightInTiles && self.DepthInTiles == other.DepthInTiles && self.StartTileIndexInOverallResource == other.StartTileIndexInOverallResource
     }
 }
 impl ::core::cmp::Eq for D3D12_SUBRESOURCE_TILING {}
@@ -27665,7 +27540,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_ARRAY_DSV {}
@@ -27697,7 +27572,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_ARRAY_RTV {}
@@ -27731,7 +27606,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_ARRAY_SRV {}
@@ -27763,7 +27638,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_ARRAY_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_ARRAY_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_ARRAY_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_ARRAY_UAV {}
@@ -27793,7 +27668,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_DSV {}
@@ -27823,7 +27698,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_RTV {}
@@ -27855,7 +27730,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_SRV {}
@@ -27885,7 +27760,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX1D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX1D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX1D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX1D_UAV {}
@@ -27916,7 +27791,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_ARRAY_DSV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_ARRAY_DSV {}
@@ -27947,7 +27822,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_ARRAY_RTV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_ARRAY_RTV {}
@@ -27978,7 +27853,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_ARRAY_SRV>()) == 0 }
+        self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_ARRAY_SRV {}
@@ -28008,7 +27883,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_DSV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_DSV {}
@@ -28038,7 +27913,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_RTV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_RTV {}
@@ -28068,7 +27943,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2DMS_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2DMS_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2DMS_SRV>()) == 0 }
+        self.UnusedField_NothingToDefine == other.UnusedField_NothingToDefine
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2DMS_SRV {}
@@ -28100,7 +27975,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_ARRAY_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_ARRAY_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_ARRAY_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_ARRAY_DSV {}
@@ -28133,7 +28008,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_ARRAY_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_ARRAY_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_ARRAY_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_ARRAY_RTV {}
@@ -28168,7 +28043,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_ARRAY_SRV {}
@@ -28201,7 +28076,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_ARRAY_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_ARRAY_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_ARRAY_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstArraySlice == other.FirstArraySlice && self.ArraySize == other.ArraySize && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_ARRAY_UAV {}
@@ -28231,7 +28106,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_DSV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_DSV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_DSV>()) == 0 }
+        self.MipSlice == other.MipSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_DSV {}
@@ -28262,7 +28137,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_RTV {}
@@ -28295,7 +28170,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.PlaneSlice == other.PlaneSlice && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_SRV {}
@@ -28326,7 +28201,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX2D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX2D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX2D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.PlaneSlice == other.PlaneSlice
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX2D_UAV {}
@@ -28358,7 +28233,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX3D_RTV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX3D_RTV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX3D_RTV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstWSlice == other.FirstWSlice && self.WSize == other.WSize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX3D_RTV {}
@@ -28390,7 +28265,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX3D_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX3D_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX3D_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX3D_SRV {}
@@ -28422,7 +28297,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEX3D_UAV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEX3D_UAV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEX3D_UAV>()) == 0 }
+        self.MipSlice == other.MipSlice && self.FirstWSlice == other.FirstWSlice && self.WSize == other.WSize
     }
 }
 impl ::core::cmp::Eq for D3D12_TEX3D_UAV {}
@@ -28456,7 +28331,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEXCUBE_ARRAY_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEXCUBE_ARRAY_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEXCUBE_ARRAY_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.First2DArrayFace == other.First2DArrayFace && self.NumCubes == other.NumCubes && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEXCUBE_ARRAY_SRV {}
@@ -28488,7 +28363,7 @@ unsafe impl ::windows::core::Abi for D3D12_TEXCUBE_SRV {
 }
 impl ::core::cmp::PartialEq for D3D12_TEXCUBE_SRV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEXCUBE_SRV>()) == 0 }
+        self.MostDetailedMip == other.MostDetailedMip && self.MipLevels == other.MipLevels && self.ResourceMinLODClamp == other.ResourceMinLODClamp
     }
 }
 impl ::core::cmp::Eq for D3D12_TEXCUBE_SRV {}
@@ -28516,14 +28391,6 @@ unsafe impl ::windows::core::Abi for D3D12_TEXTURE_COPY_LOCATION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_TEXTURE_COPY_LOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        self.pResource == other.pResource && self.Type == other.Type && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_TEXTURE_COPY_LOCATION {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_TEXTURE_COPY_LOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28548,14 +28415,6 @@ impl ::core::clone::Clone for D3D12_TEXTURE_COPY_LOCATION_0 {
 unsafe impl ::windows::core::Abi for D3D12_TEXTURE_COPY_LOCATION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_TEXTURE_COPY_LOCATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TEXTURE_COPY_LOCATION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_TEXTURE_COPY_LOCATION_0 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_TEXTURE_COPY_LOCATION_0 {
     fn default() -> Self {
@@ -28586,7 +28445,7 @@ unsafe impl ::windows::core::Abi for D3D12_TILED_RESOURCE_COORDINATE {
 }
 impl ::core::cmp::PartialEq for D3D12_TILED_RESOURCE_COORDINATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TILED_RESOURCE_COORDINATE>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.Subresource == other.Subresource
     }
 }
 impl ::core::cmp::Eq for D3D12_TILED_RESOURCE_COORDINATE {}
@@ -28626,7 +28485,7 @@ unsafe impl ::windows::core::Abi for D3D12_TILE_REGION_SIZE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_TILE_REGION_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TILE_REGION_SIZE>()) == 0 }
+        self.NumTiles == other.NumTiles && self.UseBox == other.UseBox && self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28660,7 +28519,7 @@ unsafe impl ::windows::core::Abi for D3D12_TILE_SHAPE {
 }
 impl ::core::cmp::PartialEq for D3D12_TILE_SHAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_TILE_SHAPE>()) == 0 }
+        self.WidthInTexels == other.WidthInTexels && self.HeightInTexels == other.HeightInTexels && self.DepthInTexels == other.DepthInTexels
     }
 }
 impl ::core::cmp::Eq for D3D12_TILE_SHAPE {}
@@ -28689,14 +28548,6 @@ impl ::core::clone::Clone for D3D12_UNORDERED_ACCESS_VIEW_DESC {
 unsafe impl ::windows::core::Abi for D3D12_UNORDERED_ACCESS_VIEW_DESC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_UNORDERED_ACCESS_VIEW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_UNORDERED_ACCESS_VIEW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_UNORDERED_ACCESS_VIEW_DESC {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_UNORDERED_ACCESS_VIEW_DESC {
     fn default() -> Self {
@@ -28727,14 +28578,6 @@ unsafe impl ::windows::core::Abi for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_UNORDERED_ACCESS_VIEW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28755,12 +28598,6 @@ impl ::core::clone::Clone for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
 unsafe impl ::windows::core::Abi for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {}
 impl ::core::default::Default for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28783,12 +28620,6 @@ impl ::core::clone::Clone for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
 unsafe impl ::windows::core::Abi for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {}
 impl ::core::default::Default for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28809,12 +28640,6 @@ impl ::core::clone::Clone for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
 unsafe impl ::windows::core::Abi for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VERSIONED_ROOT_SIGNATURE_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {}
 impl ::core::default::Default for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28835,12 +28660,6 @@ impl ::core::clone::Clone for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {}
 impl ::core::default::Default for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28869,7 +28688,7 @@ unsafe impl ::windows::core::Abi for D3D12_VERTEX_BUFFER_VIEW {
 }
 impl ::core::cmp::PartialEq for D3D12_VERTEX_BUFFER_VIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VERTEX_BUFFER_VIEW>()) == 0 }
+        self.BufferLocation == other.BufferLocation && self.SizeInBytes == other.SizeInBytes && self.StrideInBytes == other.StrideInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_VERTEX_BUFFER_VIEW {}
@@ -28904,7 +28723,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIEWPORT {
 }
 impl ::core::cmp::PartialEq for D3D12_VIEWPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIEWPORT>()) == 0 }
+        self.TopLeftX == other.TopLeftX && self.TopLeftY == other.TopLeftY && self.Width == other.Width && self.Height == other.Height && self.MinDepth == other.MinDepth && self.MaxDepth == other.MaxDepth
     }
 }
 impl ::core::cmp::Eq for D3D12_VIEWPORT {}
@@ -28935,7 +28754,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIEW_INSTANCE_LOCATION {
 }
 impl ::core::cmp::PartialEq for D3D12_VIEW_INSTANCE_LOCATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIEW_INSTANCE_LOCATION>()) == 0 }
+        self.ViewportArrayIndex == other.ViewportArrayIndex && self.RenderTargetArrayIndex == other.RenderTargetArrayIndex
     }
 }
 impl ::core::cmp::Eq for D3D12_VIEW_INSTANCE_LOCATION {}
@@ -28967,7 +28786,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIEW_INSTANCING_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_VIEW_INSTANCING_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIEW_INSTANCING_DESC>()) == 0 }
+        self.ViewInstanceCount == other.ViewInstanceCount && self.pViewInstanceLocations == other.pViewInstanceLocations && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_VIEW_INSTANCING_DESC {}
@@ -28998,7 +28817,7 @@ unsafe impl ::windows::core::Abi for D3D12_WRITEBUFFERIMMEDIATE_PARAMETER {
 }
 impl ::core::cmp::PartialEq for D3D12_WRITEBUFFERIMMEDIATE_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_WRITEBUFFERIMMEDIATE_PARAMETER>()) == 0 }
+        self.Dest == other.Dest && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for D3D12_WRITEBUFFERIMMEDIATE_PARAMETER {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -6082,16 +6082,6 @@ unsafe impl ::windows::core::Abi for D3DADAPTER_IDENTIFIER9 {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DADAPTER_IDENTIFIER9 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DADAPTER_IDENTIFIER9>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DADAPTER_IDENTIFIER9 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DADAPTER_IDENTIFIER9 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6130,16 +6120,6 @@ unsafe impl ::windows::core::Abi for D3DADAPTER_IDENTIFIER9 {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DADAPTER_IDENTIFIER9 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DADAPTER_IDENTIFIER9>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DADAPTER_IDENTIFIER9 {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DADAPTER_IDENTIFIER9 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6165,14 +6145,6 @@ unsafe impl ::windows::core::Abi for D3DAES_CTR_IV {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for D3DAES_CTR_IV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAES_CTR_IV>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for D3DAES_CTR_IV {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for D3DAES_CTR_IV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6197,14 +6169,6 @@ impl ::core::clone::Clone for D3DAES_CTR_IV {
 unsafe impl ::windows::core::Abi for D3DAES_CTR_IV {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for D3DAES_CTR_IV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAES_CTR_IV>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for D3DAES_CTR_IV {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for D3DAES_CTR_IV {
     fn default() -> Self {
@@ -6241,7 +6205,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGURECRYPTOSESS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGURECRYPTOSESSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGURECRYPTOSESSION>()) == 0 }
+        self.Parameters == other.Parameters && self.DXVA2DecodeHandle == other.DXVA2DecodeHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6281,7 +6245,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE>()) == 0 }
+        self.Parameters == other.Parameters && self.StartSequenceQuery == other.StartSequenceQuery && self.StartSequenceConfigure == other.StartSequenceConfigure
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6311,14 +6275,6 @@ impl ::core::clone::Clone for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
 unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
     fn default() -> Self {
@@ -6355,7 +6311,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGURESHAREDRESO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGURESHAREDRESOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGURESHAREDRESOURCE>()) == 0 }
+        self.Parameters == other.Parameters && self.ProcessIdentiferType == other.ProcessIdentiferType && self.ProcessHandle == other.ProcessHandle && self.AllowAccess == other.AllowAccess
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6394,7 +6350,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESSEDENCRYPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESSEDENCRYPTION>()) == 0 }
+        self.Parameters == other.Parameters && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6435,7 +6391,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGURE_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGURE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGURE_INPUT>()) == 0 }
+        self.omac == other.omac && self.ConfigureType == other.ConfigureType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6477,7 +6433,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT>()) == 0 }
+        self.omac == other.omac && self.ConfigureType == other.ConfigureType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber && self.ReturnCode == other.ReturnCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6502,12 +6458,6 @@ impl ::core::clone::Clone for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
 unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {}
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6528,12 +6478,6 @@ impl ::core::clone::Clone for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
 unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {}
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6560,7 +6504,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_
 }
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0 {}
@@ -6597,7 +6541,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYCHANNELTYPE_OU
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYCHANNELTYPE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYCHANNELTYPE_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.ChannelType == other.ChannelType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6636,7 +6580,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_INPUT>()) == 0 }
+        self.Input == other.Input && self.DXVA2DecodeHandle == other.DXVA2DecodeHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6677,7 +6621,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DXVA2DecodeHandle == other.DXVA2DecodeHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6716,7 +6660,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_O
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DeviceHandle == other.DeviceHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6755,7 +6699,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYP
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUIDCOUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUIDCOUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.NumEncryptionGuids == other.NumEncryptionGuids
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6794,7 +6738,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYP
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_INPUT>()) == 0 }
+        self.Input == other.Input && self.EncryptionGuidIndex == other.EncryptionGuidIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6834,7 +6778,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYP
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.EncryptionGuidIndex == other.EncryptionGuidIndex && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6875,7 +6819,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYINFOBUSTYPE_OU
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYINFOBUSTYPE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYINFOBUSTYPE_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.BusType == other.BusType && self.bAccessibleInContiguousBlocks == other.bAccessibleInContiguousBlocks && self.bAccessibleInNonContiguousBlocks == other.bAccessibleInNonContiguousBlocks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6915,7 +6859,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_INPUT>()) == 0 }
+        self.Input == other.Input && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6956,7 +6900,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.NumOutputIDs == other.NumOutputIDs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6997,7 +6941,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT>()) == 0 }
+        self.Input == other.Input && self.DeviceHandle == other.DeviceHandle && self.CryptoSessionHandle == other.CryptoSessionHandle && self.OutputIDIndex == other.OutputIDIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7036,16 +6980,6 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPU
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7079,16 +7013,6 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPU
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7113,14 +7037,6 @@ impl ::core::clone::Clone for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
 unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
     fn default() -> Self {
@@ -7155,7 +7071,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESSCOUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESSCOUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.NumRestrictedSharedResourceProcesses == other.NumRestrictedSharedResourceProcesses
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7194,7 +7110,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_INPUT>()) == 0 }
+        self.Input == other.Input && self.ProcessIndex == other.ProcessIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7235,7 +7151,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.ProcessIndex == other.ProcessIndex && self.ProcessIdentifer == other.ProcessIdentifer && self.ProcessHandle == other.ProcessHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7274,7 +7190,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDEN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDENCRYPTIONLEVEL_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDENCRYPTIONLEVEL_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.EncryptionGuid == other.EncryptionGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7313,7 +7229,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERYUNRESTRICTEDPR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERYUNRESTRICTEDPROTECTEDSHAREDRESOURCECOUNT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERYUNRESTRICTEDPROTECTEDSHAREDRESOURCECOUNT_OUTPUT>()) == 0 }
+        self.Output == other.Output && self.NumUnrestrictedProtectedSharedResources == other.NumUnrestrictedProtectedSharedResources
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7353,7 +7269,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERY_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERY_INPUT>()) == 0 }
+        self.QueryType == other.QueryType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7395,7 +7311,7 @@ unsafe impl ::windows::core::Abi for D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT>()) == 0 }
+        self.omac == other.omac && self.QueryType == other.QueryType && self.hChannel == other.hChannel && self.SequenceNumber == other.SequenceNumber && self.ReturnCode == other.ReturnCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7432,7 +7348,7 @@ unsafe impl ::windows::core::Abi for D3DBOX {
 }
 impl ::core::cmp::PartialEq for D3DBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DBOX>()) == 0 }
+        self.Left == other.Left && self.Top == other.Top && self.Right == other.Right && self.Bottom == other.Bottom && self.Front == other.Front && self.Back == other.Back
     }
 }
 impl ::core::cmp::Eq for D3DBOX {}
@@ -7600,7 +7516,75 @@ unsafe impl ::windows::core::Abi for D3DCAPS9 {
 }
 impl ::core::cmp::PartialEq for D3DCAPS9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCAPS9>()) == 0 }
+        self.DeviceType == other.DeviceType
+            && self.AdapterOrdinal == other.AdapterOrdinal
+            && self.Caps == other.Caps
+            && self.Caps2 == other.Caps2
+            && self.Caps3 == other.Caps3
+            && self.PresentationIntervals == other.PresentationIntervals
+            && self.CursorCaps == other.CursorCaps
+            && self.DevCaps == other.DevCaps
+            && self.PrimitiveMiscCaps == other.PrimitiveMiscCaps
+            && self.RasterCaps == other.RasterCaps
+            && self.ZCmpCaps == other.ZCmpCaps
+            && self.SrcBlendCaps == other.SrcBlendCaps
+            && self.DestBlendCaps == other.DestBlendCaps
+            && self.AlphaCmpCaps == other.AlphaCmpCaps
+            && self.ShadeCaps == other.ShadeCaps
+            && self.TextureCaps == other.TextureCaps
+            && self.TextureFilterCaps == other.TextureFilterCaps
+            && self.CubeTextureFilterCaps == other.CubeTextureFilterCaps
+            && self.VolumeTextureFilterCaps == other.VolumeTextureFilterCaps
+            && self.TextureAddressCaps == other.TextureAddressCaps
+            && self.VolumeTextureAddressCaps == other.VolumeTextureAddressCaps
+            && self.LineCaps == other.LineCaps
+            && self.MaxTextureWidth == other.MaxTextureWidth
+            && self.MaxTextureHeight == other.MaxTextureHeight
+            && self.MaxVolumeExtent == other.MaxVolumeExtent
+            && self.MaxTextureRepeat == other.MaxTextureRepeat
+            && self.MaxTextureAspectRatio == other.MaxTextureAspectRatio
+            && self.MaxAnisotropy == other.MaxAnisotropy
+            && self.MaxVertexW == other.MaxVertexW
+            && self.GuardBandLeft == other.GuardBandLeft
+            && self.GuardBandTop == other.GuardBandTop
+            && self.GuardBandRight == other.GuardBandRight
+            && self.GuardBandBottom == other.GuardBandBottom
+            && self.ExtentsAdjust == other.ExtentsAdjust
+            && self.StencilCaps == other.StencilCaps
+            && self.FVFCaps == other.FVFCaps
+            && self.TextureOpCaps == other.TextureOpCaps
+            && self.MaxTextureBlendStages == other.MaxTextureBlendStages
+            && self.MaxSimultaneousTextures == other.MaxSimultaneousTextures
+            && self.VertexProcessingCaps == other.VertexProcessingCaps
+            && self.MaxActiveLights == other.MaxActiveLights
+            && self.MaxUserClipPlanes == other.MaxUserClipPlanes
+            && self.MaxVertexBlendMatrices == other.MaxVertexBlendMatrices
+            && self.MaxVertexBlendMatrixIndex == other.MaxVertexBlendMatrixIndex
+            && self.MaxPointSize == other.MaxPointSize
+            && self.MaxPrimitiveCount == other.MaxPrimitiveCount
+            && self.MaxVertexIndex == other.MaxVertexIndex
+            && self.MaxStreams == other.MaxStreams
+            && self.MaxStreamStride == other.MaxStreamStride
+            && self.VertexShaderVersion == other.VertexShaderVersion
+            && self.MaxVertexShaderConst == other.MaxVertexShaderConst
+            && self.PixelShaderVersion == other.PixelShaderVersion
+            && self.PixelShader1xMaxValue == other.PixelShader1xMaxValue
+            && self.DevCaps2 == other.DevCaps2
+            && self.MaxNpatchTessellationLevel == other.MaxNpatchTessellationLevel
+            && self.Reserved5 == other.Reserved5
+            && self.MasterAdapterOrdinal == other.MasterAdapterOrdinal
+            && self.AdapterOrdinalInGroup == other.AdapterOrdinalInGroup
+            && self.NumberOfAdaptersInGroup == other.NumberOfAdaptersInGroup
+            && self.DeclTypes == other.DeclTypes
+            && self.NumSimultaneousRTs == other.NumSimultaneousRTs
+            && self.StretchRectFilterCaps == other.StretchRectFilterCaps
+            && self.VS20Caps == other.VS20Caps
+            && self.PS20Caps == other.PS20Caps
+            && self.VertexTextureFilterCaps == other.VertexTextureFilterCaps
+            && self.MaxVShaderInstructionsExecuted == other.MaxVShaderInstructionsExecuted
+            && self.MaxPShaderInstructionsExecuted == other.MaxPShaderInstructionsExecuted
+            && self.MaxVertexShader30InstructionSlots == other.MaxVertexShader30InstructionSlots
+            && self.MaxPixelShader30InstructionSlots == other.MaxPixelShader30InstructionSlots
     }
 }
 impl ::core::cmp::Eq for D3DCAPS9 {}
@@ -7631,7 +7615,7 @@ unsafe impl ::windows::core::Abi for D3DCLIPSTATUS9 {
 }
 impl ::core::cmp::PartialEq for D3DCLIPSTATUS9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCLIPSTATUS9>()) == 0 }
+        self.ClipUnion == other.ClipUnion && self.ClipIntersection == other.ClipIntersection
     }
 }
 impl ::core::cmp::Eq for D3DCLIPSTATUS9 {}
@@ -7664,7 +7648,7 @@ unsafe impl ::windows::core::Abi for D3DCOLORVALUE {
 }
 impl ::core::cmp::PartialEq for D3DCOLORVALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCOLORVALUE>()) == 0 }
+        self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for D3DCOLORVALUE {}
@@ -7697,7 +7681,7 @@ unsafe impl ::windows::core::Abi for D3DCOMPOSERECTDESC {
 }
 impl ::core::cmp::PartialEq for D3DCOMPOSERECTDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCOMPOSERECTDESC>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for D3DCOMPOSERECTDESC {}
@@ -7730,7 +7714,7 @@ unsafe impl ::windows::core::Abi for D3DCOMPOSERECTDESTINATION {
 }
 impl ::core::cmp::PartialEq for D3DCOMPOSERECTDESTINATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCOMPOSERECTDESTINATION>()) == 0 }
+        self.SrcRectIndex == other.SrcRectIndex && self.Reserved == other.Reserved && self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for D3DCOMPOSERECTDESTINATION {}
@@ -7769,7 +7753,7 @@ unsafe impl ::windows::core::Abi for D3DDEVICE_CREATION_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DDEVICE_CREATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVICE_CREATION_PARAMETERS>()) == 0 }
+        self.AdapterOrdinal == other.AdapterOrdinal && self.DeviceType == other.DeviceType && self.hFocusWindow == other.hFocusWindow && self.BehaviorFlags == other.BehaviorFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7805,7 +7789,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3D9BANDWIDTHTIMINGS {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3D9BANDWIDTHTIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3D9BANDWIDTHTIMINGS>()) == 0 }
+        self.MaxBandwidthUtilized == other.MaxBandwidthUtilized && self.FrontEndUploadMemoryUtilizedPercent == other.FrontEndUploadMemoryUtilizedPercent && self.VertexRateUtilizedPercent == other.VertexRateUtilizedPercent && self.TriangleSetupRateUtilizedPercent == other.TriangleSetupRateUtilizedPercent && self.FillRateUtilizedPercent == other.FillRateUtilizedPercent
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3D9BANDWIDTHTIMINGS {}
@@ -7836,7 +7820,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3D9CACHEUTILIZATION {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3D9CACHEUTILIZATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3D9CACHEUTILIZATION>()) == 0 }
+        self.TextureCacheHitRate == other.TextureCacheHitRate && self.PostTransformVertexCacheHitRate == other.PostTransformVertexCacheHitRate
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3D9CACHEUTILIZATION {}
@@ -7876,7 +7860,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3D9INTERFACETIMINGS {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3D9INTERFACETIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3D9INTERFACETIMINGS>()) == 0 }
+        self.WaitingForGPUToUseApplicationResourceTimePercent == other.WaitingForGPUToUseApplicationResourceTimePercent && self.WaitingForGPUToAcceptMoreCommandsTimePercent == other.WaitingForGPUToAcceptMoreCommandsTimePercent && self.WaitingForGPUToStayWithinLatencyTimePercent == other.WaitingForGPUToStayWithinLatencyTimePercent && self.WaitingForGPUExclusiveResourceTimePercent == other.WaitingForGPUExclusiveResourceTimePercent && self.WaitingForGPUOtherTimePercent == other.WaitingForGPUOtherTimePercent
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3D9INTERFACETIMINGS {}
@@ -7909,7 +7893,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3D9PIPELINETIMINGS {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3D9PIPELINETIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3D9PIPELINETIMINGS>()) == 0 }
+        self.VertexProcessingTimePercent == other.VertexProcessingTimePercent && self.PixelProcessingTimePercent == other.PixelProcessingTimePercent && self.OtherGPUProcessingTimePercent == other.OtherGPUProcessingTimePercent && self.GPUIdleTimePercent == other.GPUIdleTimePercent
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3D9PIPELINETIMINGS {}
@@ -7940,7 +7924,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3D9STAGETIMINGS {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3D9STAGETIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3D9STAGETIMINGS>()) == 0 }
+        self.MemoryProcessingPercent == other.MemoryProcessingPercent && self.ComputationProcessingPercent == other.ComputationProcessingPercent
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3D9STAGETIMINGS {}
@@ -7971,7 +7955,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_D3DVERTEXSTATS {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_D3DVERTEXSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_D3DVERTEXSTATS>()) == 0 }
+        self.NumRenderedTriangles == other.NumRenderedTriangles && self.NumExtraClippingTriangles == other.NumExtraClippingTriangles
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_D3DVERTEXSTATS {}
@@ -8007,7 +7991,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_RESOURCEMANAGER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DDEVINFO_RESOURCEMANAGER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_RESOURCEMANAGER>()) == 0 }
+        self.stats == other.stats
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8042,7 +8026,7 @@ unsafe impl ::windows::core::Abi for D3DDEVINFO_VCACHE {
 }
 impl ::core::cmp::PartialEq for D3DDEVINFO_VCACHE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDEVINFO_VCACHE>()) == 0 }
+        self.Pattern == other.Pattern && self.OptMethod == other.OptMethod && self.CacheSize == other.CacheSize && self.MagicNumber == other.MagicNumber
     }
 }
 impl ::core::cmp::Eq for D3DDEVINFO_VCACHE {}
@@ -8075,7 +8059,7 @@ unsafe impl ::windows::core::Abi for D3DDISPLAYMODE {
 }
 impl ::core::cmp::PartialEq for D3DDISPLAYMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDISPLAYMODE>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.RefreshRate == other.RefreshRate && self.Format == other.Format
     }
 }
 impl ::core::cmp::Eq for D3DDISPLAYMODE {}
@@ -8110,7 +8094,7 @@ unsafe impl ::windows::core::Abi for D3DDISPLAYMODEEX {
 }
 impl ::core::cmp::PartialEq for D3DDISPLAYMODEEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDISPLAYMODEEX>()) == 0 }
+        self.Size == other.Size && self.Width == other.Width && self.Height == other.Height && self.RefreshRate == other.RefreshRate && self.Format == other.Format && self.ScanLineOrdering == other.ScanLineOrdering
     }
 }
 impl ::core::cmp::Eq for D3DDISPLAYMODEEX {}
@@ -8142,7 +8126,7 @@ unsafe impl ::windows::core::Abi for D3DDISPLAYMODEFILTER {
 }
 impl ::core::cmp::PartialEq for D3DDISPLAYMODEFILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DDISPLAYMODEFILTER>()) == 0 }
+        self.Size == other.Size && self.Format == other.Format && self.ScanLineOrdering == other.ScanLineOrdering
     }
 }
 impl ::core::cmp::Eq for D3DDISPLAYMODEFILTER {}
@@ -8174,7 +8158,7 @@ unsafe impl ::windows::core::Abi for D3DENCRYPTED_BLOCK_INFO {
 }
 impl ::core::cmp::PartialEq for D3DENCRYPTED_BLOCK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DENCRYPTED_BLOCK_INFO>()) == 0 }
+        self.NumEncryptedBytesAtBeginning == other.NumEncryptedBytesAtBeginning && self.NumBytesInSkipPattern == other.NumBytesInSkipPattern && self.NumBytesInEncryptPattern == other.NumBytesInEncryptPattern
     }
 }
 impl ::core::cmp::Eq for D3DENCRYPTED_BLOCK_INFO {}
@@ -8206,7 +8190,7 @@ unsafe impl ::windows::core::Abi for D3DGAMMARAMP {
 }
 impl ::core::cmp::PartialEq for D3DGAMMARAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DGAMMARAMP>()) == 0 }
+        self.red == other.red && self.green == other.green && self.blue == other.blue
     }
 }
 impl ::core::cmp::Eq for D3DGAMMARAMP {}
@@ -8240,7 +8224,7 @@ unsafe impl ::windows::core::Abi for D3DINDEXBUFFER_DESC {
 }
 impl ::core::cmp::PartialEq for D3DINDEXBUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DINDEXBUFFER_DESC>()) == 0 }
+        self.Format == other.Format && self.Type == other.Type && self.Usage == other.Usage && self.Pool == other.Pool && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for D3DINDEXBUFFER_DESC {}
@@ -8288,7 +8272,7 @@ unsafe impl ::windows::core::Abi for D3DLIGHT9 {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for D3DLIGHT9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DLIGHT9>()) == 0 }
+        self.Type == other.Type && self.Diffuse == other.Diffuse && self.Specular == other.Specular && self.Ambient == other.Ambient && self.Position == other.Position && self.Direction == other.Direction && self.Range == other.Range && self.Falloff == other.Falloff && self.Attenuation0 == other.Attenuation0 && self.Attenuation1 == other.Attenuation1 && self.Attenuation2 == other.Attenuation2 && self.Theta == other.Theta && self.Phi == other.Phi
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -8322,7 +8306,7 @@ unsafe impl ::windows::core::Abi for D3DLOCKED_BOX {
 }
 impl ::core::cmp::PartialEq for D3DLOCKED_BOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DLOCKED_BOX>()) == 0 }
+        self.RowPitch == other.RowPitch && self.SlicePitch == other.SlicePitch && self.pBits == other.pBits
     }
 }
 impl ::core::cmp::Eq for D3DLOCKED_BOX {}
@@ -8353,7 +8337,7 @@ unsafe impl ::windows::core::Abi for D3DLOCKED_RECT {
 }
 impl ::core::cmp::PartialEq for D3DLOCKED_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DLOCKED_RECT>()) == 0 }
+        self.Pitch == other.Pitch && self.pBits == other.pBits
     }
 }
 impl ::core::cmp::Eq for D3DLOCKED_RECT {}
@@ -8387,7 +8371,7 @@ unsafe impl ::windows::core::Abi for D3DMATERIAL9 {
 }
 impl ::core::cmp::PartialEq for D3DMATERIAL9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DMATERIAL9>()) == 0 }
+        self.Diffuse == other.Diffuse && self.Ambient == other.Ambient && self.Specular == other.Specular && self.Emissive == other.Emissive && self.Power == other.Power
     }
 }
 impl ::core::cmp::Eq for D3DMATERIAL9 {}
@@ -8417,14 +8401,6 @@ unsafe impl ::windows::core::Abi for D3DMEMORYPRESSURE {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for D3DMEMORYPRESSURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DMEMORYPRESSURE>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for D3DMEMORYPRESSURE {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for D3DMEMORYPRESSURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8450,14 +8426,6 @@ impl ::core::clone::Clone for D3DMEMORYPRESSURE {
 unsafe impl ::windows::core::Abi for D3DMEMORYPRESSURE {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for D3DMEMORYPRESSURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DMEMORYPRESSURE>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for D3DMEMORYPRESSURE {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for D3DMEMORYPRESSURE {
     fn default() -> Self {
@@ -8487,14 +8455,6 @@ unsafe impl ::windows::core::Abi for D3DPRESENTSTATS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for D3DPRESENTSTATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DPRESENTSTATS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for D3DPRESENTSTATS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for D3DPRESENTSTATS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8522,14 +8482,6 @@ impl ::core::clone::Clone for D3DPRESENTSTATS {
 unsafe impl ::windows::core::Abi for D3DPRESENTSTATS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for D3DPRESENTSTATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DPRESENTSTATS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for D3DPRESENTSTATS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for D3DPRESENTSTATS {
     fn default() -> Self {
@@ -8591,7 +8543,7 @@ unsafe impl ::windows::core::Abi for D3DPRESENT_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DPRESENT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DPRESENT_PARAMETERS>()) == 0 }
+        self.BackBufferWidth == other.BackBufferWidth && self.BackBufferHeight == other.BackBufferHeight && self.BackBufferFormat == other.BackBufferFormat && self.BackBufferCount == other.BackBufferCount && self.MultiSampleType == other.MultiSampleType && self.MultiSampleQuality == other.MultiSampleQuality && self.SwapEffect == other.SwapEffect && self.hDeviceWindow == other.hDeviceWindow && self.Windowed == other.Windowed && self.EnableAutoDepthStencil == other.EnableAutoDepthStencil && self.AutoDepthStencilFormat == other.AutoDepthStencilFormat && self.Flags == other.Flags && self.FullScreen_RefreshRateInHz == other.FullScreen_RefreshRateInHz && self.PresentationInterval == other.PresentationInterval
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8627,7 +8579,7 @@ unsafe impl ::windows::core::Abi for D3DPSHADERCAPS2_0 {
 }
 impl ::core::cmp::PartialEq for D3DPSHADERCAPS2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DPSHADERCAPS2_0>()) == 0 }
+        self.Caps == other.Caps && self.DynamicFlowControlDepth == other.DynamicFlowControlDepth && self.NumTemps == other.NumTemps && self.StaticFlowControlDepth == other.StaticFlowControlDepth && self.NumInstructionSlots == other.NumInstructionSlots
     }
 }
 impl ::core::cmp::Eq for D3DPSHADERCAPS2_0 {}
@@ -8658,7 +8610,7 @@ unsafe impl ::windows::core::Abi for D3DRANGE {
 }
 impl ::core::cmp::PartialEq for D3DRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DRANGE>()) == 0 }
+        self.Offset == other.Offset && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for D3DRANGE {}
@@ -8695,7 +8647,7 @@ unsafe impl ::windows::core::Abi for D3DRASTER_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DRASTER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DRASTER_STATUS>()) == 0 }
+        self.InVBlank == other.InVBlank && self.ScanLine == other.ScanLine
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8730,7 +8682,7 @@ unsafe impl ::windows::core::Abi for D3DRECT {
 }
 impl ::core::cmp::PartialEq for D3DRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DRECT>()) == 0 }
+        self.x1 == other.x1 && self.y1 == other.y1 && self.x2 == other.x2 && self.y2 == other.y2
     }
 }
 impl ::core::cmp::Eq for D3DRECT {}
@@ -8766,7 +8718,7 @@ unsafe impl ::windows::core::Abi for D3DRECTPATCH_INFO {
 }
 impl ::core::cmp::PartialEq for D3DRECTPATCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DRECTPATCH_INFO>()) == 0 }
+        self.StartVertexOffsetWidth == other.StartVertexOffsetWidth && self.StartVertexOffsetHeight == other.StartVertexOffsetHeight && self.Width == other.Width && self.Height == other.Height && self.Stride == other.Stride && self.Basis == other.Basis && self.Degree == other.Degree
     }
 }
 impl ::core::cmp::Eq for D3DRECTPATCH_INFO {}
@@ -8824,7 +8776,7 @@ unsafe impl ::windows::core::Abi for D3DRESOURCESTATS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3DRESOURCESTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DRESOURCESTATS>()) == 0 }
+        self.bThrashing == other.bThrashing && self.ApproxBytesDownloaded == other.ApproxBytesDownloaded && self.NumEvicts == other.NumEvicts && self.NumVidCreates == other.NumVidCreates && self.LastPri == other.LastPri && self.NumUsed == other.NumUsed && self.NumUsedInVidMem == other.NumUsedInVidMem && self.WorkingSet == other.WorkingSet && self.WorkingSetBytes == other.WorkingSetBytes && self.TotalManaged == other.TotalManaged && self.TotalBytes == other.TotalBytes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8863,7 +8815,7 @@ unsafe impl ::windows::core::Abi for D3DSURFACE_DESC {
 }
 impl ::core::cmp::PartialEq for D3DSURFACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DSURFACE_DESC>()) == 0 }
+        self.Format == other.Format && self.Type == other.Type && self.Usage == other.Usage && self.Pool == other.Pool && self.MultiSampleType == other.MultiSampleType && self.MultiSampleQuality == other.MultiSampleQuality && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for D3DSURFACE_DESC {}
@@ -8896,7 +8848,7 @@ unsafe impl ::windows::core::Abi for D3DTRIPATCH_INFO {
 }
 impl ::core::cmp::PartialEq for D3DTRIPATCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DTRIPATCH_INFO>()) == 0 }
+        self.StartVertexOffset == other.StartVertexOffset && self.NumVertices == other.NumVertices && self.Basis == other.Basis && self.Degree == other.Degree
     }
 }
 impl ::core::cmp::Eq for D3DTRIPATCH_INFO {}
@@ -8931,7 +8883,7 @@ unsafe impl ::windows::core::Abi for D3DVERTEXBUFFER_DESC {
 }
 impl ::core::cmp::PartialEq for D3DVERTEXBUFFER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVERTEXBUFFER_DESC>()) == 0 }
+        self.Format == other.Format && self.Type == other.Type && self.Usage == other.Usage && self.Pool == other.Pool && self.Size == other.Size && self.FVF == other.FVF
     }
 }
 impl ::core::cmp::Eq for D3DVERTEXBUFFER_DESC {}
@@ -8966,7 +8918,7 @@ unsafe impl ::windows::core::Abi for D3DVERTEXELEMENT9 {
 }
 impl ::core::cmp::PartialEq for D3DVERTEXELEMENT9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVERTEXELEMENT9>()) == 0 }
+        self.Stream == other.Stream && self.Offset == other.Offset && self.Type == other.Type && self.Method == other.Method && self.Usage == other.Usage && self.UsageIndex == other.UsageIndex
     }
 }
 impl ::core::cmp::Eq for D3DVERTEXELEMENT9 {}
@@ -9001,7 +8953,7 @@ unsafe impl ::windows::core::Abi for D3DVIEWPORT9 {
 }
 impl ::core::cmp::PartialEq for D3DVIEWPORT9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVIEWPORT9>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height && self.MinZ == other.MinZ && self.MaxZ == other.MaxZ
     }
 }
 impl ::core::cmp::Eq for D3DVIEWPORT9 {}
@@ -9037,7 +8989,7 @@ unsafe impl ::windows::core::Abi for D3DVOLUME_DESC {
 }
 impl ::core::cmp::PartialEq for D3DVOLUME_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVOLUME_DESC>()) == 0 }
+        self.Format == other.Format && self.Type == other.Type && self.Usage == other.Usage && self.Pool == other.Pool && self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth
     }
 }
 impl ::core::cmp::Eq for D3DVOLUME_DESC {}
@@ -9070,7 +9022,7 @@ unsafe impl ::windows::core::Abi for D3DVSHADERCAPS2_0 {
 }
 impl ::core::cmp::PartialEq for D3DVSHADERCAPS2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DVSHADERCAPS2_0>()) == 0 }
+        self.Caps == other.Caps && self.DynamicFlowControlDepth == other.DynamicFlowControlDepth && self.NumTemps == other.NumTemps && self.StaticFlowControlDepth == other.StaticFlowControlDepth
     }
 }
 impl ::core::cmp::Eq for D3DVSHADERCAPS2_0 {}
@@ -9100,7 +9052,7 @@ unsafe impl ::windows::core::Abi for D3D_OMAC {
 }
 impl ::core::cmp::PartialEq for D3D_OMAC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D_OMAC>()) == 0 }
+        self.Omac == other.Omac
     }
 }
 impl ::core::cmp::Eq for D3D_OMAC {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
@@ -4296,7 +4296,7 @@ unsafe impl ::windows::core::Abi for COMPOSITION_FRAME_STATS {
 }
 impl ::core::cmp::PartialEq for COMPOSITION_FRAME_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITION_FRAME_STATS>()) == 0 }
+        self.startTime == other.startTime && self.targetTime == other.targetTime && self.framePeriod == other.framePeriod
     }
 }
 impl ::core::cmp::Eq for COMPOSITION_FRAME_STATS {}
@@ -4329,7 +4329,7 @@ unsafe impl ::windows::core::Abi for COMPOSITION_STATS {
 }
 impl ::core::cmp::PartialEq for COMPOSITION_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITION_STATS>()) == 0 }
+        self.presentCount == other.presentCount && self.refreshCount == other.refreshCount && self.virtualRefreshCount == other.virtualRefreshCount && self.time == other.time
     }
 }
 impl ::core::cmp::Eq for COMPOSITION_STATS {}
@@ -4369,7 +4369,7 @@ unsafe impl ::windows::core::Abi for COMPOSITION_TARGET_ID {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMPOSITION_TARGET_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITION_TARGET_ID>()) == 0 }
+        self.displayAdapterLuid == other.displayAdapterLuid && self.renderAdapterLuid == other.renderAdapterLuid && self.vidPnSourceId == other.vidPnSourceId && self.vidPnTargetId == other.vidPnTargetId && self.uniqueId == other.uniqueId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4405,7 +4405,7 @@ unsafe impl ::windows::core::Abi for COMPOSITION_TARGET_STATS {
 }
 impl ::core::cmp::PartialEq for COMPOSITION_TARGET_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITION_TARGET_STATS>()) == 0 }
+        self.outstandingPresents == other.outstandingPresents && self.presentTime == other.presentTime && self.vblankDuration == other.vblankDuration && self.presentedStats == other.presentedStats && self.completedStats == other.completedStats
     }
 }
 impl ::core::cmp::Eq for COMPOSITION_TARGET_STATS {}
@@ -4445,7 +4445,7 @@ unsafe impl ::windows::core::Abi for DCOMPOSITION_FRAME_STATISTICS {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for DCOMPOSITION_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCOMPOSITION_FRAME_STATISTICS>()) == 0 }
+        self.lastFrameTime == other.lastFrameTime && self.currentCompositionRate == other.currentCompositionRate && self.currentTime == other.currentTime && self.timeFrequency == other.timeFrequency && self.nextEstimatedFrameTime == other.nextEstimatedFrameTime
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -4479,7 +4479,7 @@ unsafe impl ::windows::core::Abi for DCompositionInkTrailPoint {
 }
 impl ::core::cmp::PartialEq for DCompositionInkTrailPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCompositionInkTrailPoint>()) == 0 }
+        self.x == other.x && self.y == other.y && self.radius == other.radius
     }
 }
 impl ::core::cmp::Eq for DCompositionInkTrailPoint {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -4479,7 +4479,7 @@ unsafe impl ::windows::core::Abi for ACCESSRECTLIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ACCESSRECTLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESSRECTLIST>()) == 0 }
+        self.lpLink == other.lpLink && self.rDest == other.rDest && self.lpOwner == other.lpOwner && self.lpSurfaceData == other.lpSurfaceData && self.dwFlags == other.dwFlags && self.lpHeapAliasInfo == other.lpHeapAliasInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -4520,7 +4520,7 @@ unsafe impl ::windows::core::Abi for ATTACHLIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ATTACHLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTACHLIST>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpLink == other.lpLink && self.lpAttached == other.lpAttached && self.lpIAttached == other.lpIAttached
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -4561,7 +4561,7 @@ unsafe impl ::windows::core::Abi for DBLNODE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DBLNODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBLNODE>()) == 0 }
+        self.next == other.next && self.prev == other.prev && self.object == other.object && self.object_int == other.object_int
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -4601,7 +4601,7 @@ unsafe impl ::windows::core::Abi for DD32BITDRIVERDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD32BITDRIVERDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD32BITDRIVERDATA>()) == 0 }
+        self.szName == other.szName && self.szEntryPoint == other.szEntryPoint && self.dwContext == other.dwContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4636,7 +4636,7 @@ unsafe impl ::windows::core::Abi for DDARGB {
 }
 impl ::core::cmp::PartialEq for DDARGB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDARGB>()) == 0 }
+        self.blue == other.blue && self.green == other.green && self.red == other.red && self.alpha == other.alpha
     }
 }
 impl ::core::cmp::Eq for DDARGB {}
@@ -4744,34 +4744,6 @@ impl ::core::clone::Clone for DDBLTFX {
 unsafe impl ::windows::core::Abi for DDBLTFX {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwSize == other.dwSize
-            && self.dwDDFX == other.dwDDFX
-            && self.dwROP == other.dwROP
-            && self.dwDDROP == other.dwDDROP
-            && self.dwRotationAngle == other.dwRotationAngle
-            && self.dwZBufferOpCode == other.dwZBufferOpCode
-            && self.dwZBufferLow == other.dwZBufferLow
-            && self.dwZBufferHigh == other.dwZBufferHigh
-            && self.dwZBufferBaseDest == other.dwZBufferBaseDest
-            && self.dwZDestConstBitDepth == other.dwZDestConstBitDepth
-            && self.Anonymous1 == other.Anonymous1
-            && self.dwZSrcConstBitDepth == other.dwZSrcConstBitDepth
-            && self.Anonymous2 == other.Anonymous2
-            && self.dwAlphaEdgeBlendBitDepth == other.dwAlphaEdgeBlendBitDepth
-            && self.dwAlphaEdgeBlend == other.dwAlphaEdgeBlend
-            && self.dwReserved == other.dwReserved
-            && self.dwAlphaDestConstBitDepth == other.dwAlphaDestConstBitDepth
-            && self.Anonymous3 == other.Anonymous3
-            && self.dwAlphaSrcConstBitDepth == other.dwAlphaSrcConstBitDepth
-            && self.Anonymous4 == other.Anonymous4
-            && self.Anonymous5 == other.Anonymous5
-            && self.ddckDestColorkey == other.ddckDestColorkey
-            && self.ddckSrcColorkey == other.ddckSrcColorkey
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX {}
 impl ::core::default::Default for DDBLTFX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4791,12 +4763,6 @@ impl ::core::clone::Clone for DDBLTFX_0 {
 unsafe impl ::windows::core::Abi for DDBLTFX_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBLTFX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX_0 {}
 impl ::core::default::Default for DDBLTFX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4816,12 +4782,6 @@ impl ::core::clone::Clone for DDBLTFX_1 {
 unsafe impl ::windows::core::Abi for DDBLTFX_1 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBLTFX_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX_1 {}
 impl ::core::default::Default for DDBLTFX_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4841,12 +4801,6 @@ impl ::core::clone::Clone for DDBLTFX_2 {
 unsafe impl ::windows::core::Abi for DDBLTFX_2 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBLTFX_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX_2 {}
 impl ::core::default::Default for DDBLTFX_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4866,12 +4820,6 @@ impl ::core::clone::Clone for DDBLTFX_3 {
 unsafe impl ::windows::core::Abi for DDBLTFX_3 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBLTFX_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX_3 {}
 impl ::core::default::Default for DDBLTFX_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4893,12 +4841,6 @@ impl ::core::clone::Clone for DDBLTFX_4 {
 unsafe impl ::windows::core::Abi for DDBLTFX_4 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDBLTFX_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBLTFX_4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDBLTFX_4 {}
 impl ::core::default::Default for DDBLTFX_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4925,7 +4867,7 @@ unsafe impl ::windows::core::Abi for DDBOBNEXTFIELDINFO {
 }
 impl ::core::cmp::PartialEq for DDBOBNEXTFIELDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDBOBNEXTFIELDINFO>()) == 0 }
+        self.lpSurface == other.lpSurface
     }
 }
 impl ::core::cmp::Eq for DDBOBNEXTFIELDINFO {}
@@ -5027,7 +4969,42 @@ unsafe impl ::windows::core::Abi for DDCAPS_DX1 {
 }
 impl ::core::cmp::PartialEq for DDCAPS_DX1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCAPS_DX1>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCaps == other.dwCaps
+            && self.dwCaps2 == other.dwCaps2
+            && self.dwCKeyCaps == other.dwCKeyCaps
+            && self.dwFXCaps == other.dwFXCaps
+            && self.dwFXAlphaCaps == other.dwFXAlphaCaps
+            && self.dwPalCaps == other.dwPalCaps
+            && self.dwSVCaps == other.dwSVCaps
+            && self.dwAlphaBltConstBitDepths == other.dwAlphaBltConstBitDepths
+            && self.dwAlphaBltPixelBitDepths == other.dwAlphaBltPixelBitDepths
+            && self.dwAlphaBltSurfaceBitDepths == other.dwAlphaBltSurfaceBitDepths
+            && self.dwAlphaOverlayConstBitDepths == other.dwAlphaOverlayConstBitDepths
+            && self.dwAlphaOverlayPixelBitDepths == other.dwAlphaOverlayPixelBitDepths
+            && self.dwAlphaOverlaySurfaceBitDepths == other.dwAlphaOverlaySurfaceBitDepths
+            && self.dwZBufferBitDepths == other.dwZBufferBitDepths
+            && self.dwVidMemTotal == other.dwVidMemTotal
+            && self.dwVidMemFree == other.dwVidMemFree
+            && self.dwMaxVisibleOverlays == other.dwMaxVisibleOverlays
+            && self.dwCurrVisibleOverlays == other.dwCurrVisibleOverlays
+            && self.dwNumFourCCCodes == other.dwNumFourCCCodes
+            && self.dwAlignBoundarySrc == other.dwAlignBoundarySrc
+            && self.dwAlignSizeSrc == other.dwAlignSizeSrc
+            && self.dwAlignBoundaryDest == other.dwAlignBoundaryDest
+            && self.dwAlignSizeDest == other.dwAlignSizeDest
+            && self.dwAlignStrideAlign == other.dwAlignStrideAlign
+            && self.dwRops == other.dwRops
+            && self.ddsCaps == other.ddsCaps
+            && self.dwMinOverlayStretch == other.dwMinOverlayStretch
+            && self.dwMaxOverlayStretch == other.dwMaxOverlayStretch
+            && self.dwMinLiveVideoStretch == other.dwMinLiveVideoStretch
+            && self.dwMaxLiveVideoStretch == other.dwMaxLiveVideoStretch
+            && self.dwMinHwCodecStretch == other.dwMinHwCodecStretch
+            && self.dwMaxHwCodecStretch == other.dwMaxHwCodecStretch
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.dwReserved3 == other.dwReserved3
     }
 }
 impl ::core::cmp::Eq for DDCAPS_DX1 {}
@@ -5159,7 +5136,57 @@ unsafe impl ::windows::core::Abi for DDCAPS_DX3 {
 }
 impl ::core::cmp::PartialEq for DDCAPS_DX3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCAPS_DX3>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCaps == other.dwCaps
+            && self.dwCaps2 == other.dwCaps2
+            && self.dwCKeyCaps == other.dwCKeyCaps
+            && self.dwFXCaps == other.dwFXCaps
+            && self.dwFXAlphaCaps == other.dwFXAlphaCaps
+            && self.dwPalCaps == other.dwPalCaps
+            && self.dwSVCaps == other.dwSVCaps
+            && self.dwAlphaBltConstBitDepths == other.dwAlphaBltConstBitDepths
+            && self.dwAlphaBltPixelBitDepths == other.dwAlphaBltPixelBitDepths
+            && self.dwAlphaBltSurfaceBitDepths == other.dwAlphaBltSurfaceBitDepths
+            && self.dwAlphaOverlayConstBitDepths == other.dwAlphaOverlayConstBitDepths
+            && self.dwAlphaOverlayPixelBitDepths == other.dwAlphaOverlayPixelBitDepths
+            && self.dwAlphaOverlaySurfaceBitDepths == other.dwAlphaOverlaySurfaceBitDepths
+            && self.dwZBufferBitDepths == other.dwZBufferBitDepths
+            && self.dwVidMemTotal == other.dwVidMemTotal
+            && self.dwVidMemFree == other.dwVidMemFree
+            && self.dwMaxVisibleOverlays == other.dwMaxVisibleOverlays
+            && self.dwCurrVisibleOverlays == other.dwCurrVisibleOverlays
+            && self.dwNumFourCCCodes == other.dwNumFourCCCodes
+            && self.dwAlignBoundarySrc == other.dwAlignBoundarySrc
+            && self.dwAlignSizeSrc == other.dwAlignSizeSrc
+            && self.dwAlignBoundaryDest == other.dwAlignBoundaryDest
+            && self.dwAlignSizeDest == other.dwAlignSizeDest
+            && self.dwAlignStrideAlign == other.dwAlignStrideAlign
+            && self.dwRops == other.dwRops
+            && self.ddsCaps == other.ddsCaps
+            && self.dwMinOverlayStretch == other.dwMinOverlayStretch
+            && self.dwMaxOverlayStretch == other.dwMaxOverlayStretch
+            && self.dwMinLiveVideoStretch == other.dwMinLiveVideoStretch
+            && self.dwMaxLiveVideoStretch == other.dwMaxLiveVideoStretch
+            && self.dwMinHwCodecStretch == other.dwMinHwCodecStretch
+            && self.dwMaxHwCodecStretch == other.dwMaxHwCodecStretch
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.dwReserved3 == other.dwReserved3
+            && self.dwSVBCaps == other.dwSVBCaps
+            && self.dwSVBCKeyCaps == other.dwSVBCKeyCaps
+            && self.dwSVBFXCaps == other.dwSVBFXCaps
+            && self.dwSVBRops == other.dwSVBRops
+            && self.dwVSBCaps == other.dwVSBCaps
+            && self.dwVSBCKeyCaps == other.dwVSBCKeyCaps
+            && self.dwVSBFXCaps == other.dwVSBFXCaps
+            && self.dwVSBRops == other.dwVSBRops
+            && self.dwSSBCaps == other.dwSSBCaps
+            && self.dwSSBCKeyCaps == other.dwSSBCKeyCaps
+            && self.dwSSBFXCaps == other.dwSSBFXCaps
+            && self.dwSSBRops == other.dwSSBRops
+            && self.dwReserved4 == other.dwReserved4
+            && self.dwReserved5 == other.dwReserved5
+            && self.dwReserved6 == other.dwReserved6
     }
 }
 impl ::core::cmp::Eq for DDCAPS_DX3 {}
@@ -5301,7 +5328,62 @@ unsafe impl ::windows::core::Abi for DDCAPS_DX5 {
 }
 impl ::core::cmp::PartialEq for DDCAPS_DX5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCAPS_DX5>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCaps == other.dwCaps
+            && self.dwCaps2 == other.dwCaps2
+            && self.dwCKeyCaps == other.dwCKeyCaps
+            && self.dwFXCaps == other.dwFXCaps
+            && self.dwFXAlphaCaps == other.dwFXAlphaCaps
+            && self.dwPalCaps == other.dwPalCaps
+            && self.dwSVCaps == other.dwSVCaps
+            && self.dwAlphaBltConstBitDepths == other.dwAlphaBltConstBitDepths
+            && self.dwAlphaBltPixelBitDepths == other.dwAlphaBltPixelBitDepths
+            && self.dwAlphaBltSurfaceBitDepths == other.dwAlphaBltSurfaceBitDepths
+            && self.dwAlphaOverlayConstBitDepths == other.dwAlphaOverlayConstBitDepths
+            && self.dwAlphaOverlayPixelBitDepths == other.dwAlphaOverlayPixelBitDepths
+            && self.dwAlphaOverlaySurfaceBitDepths == other.dwAlphaOverlaySurfaceBitDepths
+            && self.dwZBufferBitDepths == other.dwZBufferBitDepths
+            && self.dwVidMemTotal == other.dwVidMemTotal
+            && self.dwVidMemFree == other.dwVidMemFree
+            && self.dwMaxVisibleOverlays == other.dwMaxVisibleOverlays
+            && self.dwCurrVisibleOverlays == other.dwCurrVisibleOverlays
+            && self.dwNumFourCCCodes == other.dwNumFourCCCodes
+            && self.dwAlignBoundarySrc == other.dwAlignBoundarySrc
+            && self.dwAlignSizeSrc == other.dwAlignSizeSrc
+            && self.dwAlignBoundaryDest == other.dwAlignBoundaryDest
+            && self.dwAlignSizeDest == other.dwAlignSizeDest
+            && self.dwAlignStrideAlign == other.dwAlignStrideAlign
+            && self.dwRops == other.dwRops
+            && self.ddsCaps == other.ddsCaps
+            && self.dwMinOverlayStretch == other.dwMinOverlayStretch
+            && self.dwMaxOverlayStretch == other.dwMaxOverlayStretch
+            && self.dwMinLiveVideoStretch == other.dwMinLiveVideoStretch
+            && self.dwMaxLiveVideoStretch == other.dwMaxLiveVideoStretch
+            && self.dwMinHwCodecStretch == other.dwMinHwCodecStretch
+            && self.dwMaxHwCodecStretch == other.dwMaxHwCodecStretch
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.dwReserved3 == other.dwReserved3
+            && self.dwSVBCaps == other.dwSVBCaps
+            && self.dwSVBCKeyCaps == other.dwSVBCKeyCaps
+            && self.dwSVBFXCaps == other.dwSVBFXCaps
+            && self.dwSVBRops == other.dwSVBRops
+            && self.dwVSBCaps == other.dwVSBCaps
+            && self.dwVSBCKeyCaps == other.dwVSBCKeyCaps
+            && self.dwVSBFXCaps == other.dwVSBFXCaps
+            && self.dwVSBRops == other.dwVSBRops
+            && self.dwSSBCaps == other.dwSSBCaps
+            && self.dwSSBCKeyCaps == other.dwSSBCKeyCaps
+            && self.dwSSBFXCaps == other.dwSSBFXCaps
+            && self.dwSSBRops == other.dwSSBRops
+            && self.dwMaxVideoPorts == other.dwMaxVideoPorts
+            && self.dwCurrVideoPorts == other.dwCurrVideoPorts
+            && self.dwSVBCaps2 == other.dwSVBCaps2
+            && self.dwNLVBCaps == other.dwNLVBCaps
+            && self.dwNLVBCaps2 == other.dwNLVBCaps2
+            && self.dwNLVBCKeyCaps == other.dwNLVBCKeyCaps
+            && self.dwNLVBFXCaps == other.dwNLVBFXCaps
+            && self.dwNLVBRops == other.dwNLVBRops
     }
 }
 impl ::core::cmp::Eq for DDCAPS_DX5 {}
@@ -5380,12 +5462,6 @@ impl ::core::clone::Clone for DDCAPS_DX6 {
 unsafe impl ::windows::core::Abi for DDCAPS_DX6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDCAPS_DX6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCAPS_DX6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDCAPS_DX6 {}
 impl ::core::default::Default for DDCAPS_DX6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5461,12 +5537,6 @@ impl ::core::clone::Clone for DDCAPS_DX7 {
 unsafe impl ::windows::core::Abi for DDCAPS_DX7 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDCAPS_DX7 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCAPS_DX7>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDCAPS_DX7 {}
 impl ::core::default::Default for DDCAPS_DX7 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5502,7 +5572,7 @@ unsafe impl ::windows::core::Abi for DDCOLORCONTROL {
 }
 impl ::core::cmp::PartialEq for DDCOLORCONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCOLORCONTROL>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.lBrightness == other.lBrightness && self.lContrast == other.lContrast && self.lHue == other.lHue && self.lSaturation == other.lSaturation && self.lSharpness == other.lSharpness && self.lGamma == other.lGamma && self.lColorEnable == other.lColorEnable && self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DDCOLORCONTROL {}
@@ -5533,7 +5603,7 @@ unsafe impl ::windows::core::Abi for DDCOLORKEY {
 }
 impl ::core::cmp::PartialEq for DDCOLORKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCOLORKEY>()) == 0 }
+        self.dwColorSpaceLowValue == other.dwColorSpaceLowValue && self.dwColorSpaceHighValue == other.dwColorSpaceHighValue
     }
 }
 impl ::core::cmp::Eq for DDCOLORKEY {}
@@ -5562,12 +5632,6 @@ impl ::core::clone::Clone for DDCOMPBUFFERINFO {
 unsafe impl ::windows::core::Abi for DDCOMPBUFFERINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDCOMPBUFFERINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCOMPBUFFERINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDCOMPBUFFERINFO {}
 impl ::core::default::Default for DDCOMPBUFFERINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5696,7 +5760,57 @@ unsafe impl ::windows::core::Abi for DDCORECAPS {
 }
 impl ::core::cmp::PartialEq for DDCORECAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDCORECAPS>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCaps == other.dwCaps
+            && self.dwCaps2 == other.dwCaps2
+            && self.dwCKeyCaps == other.dwCKeyCaps
+            && self.dwFXCaps == other.dwFXCaps
+            && self.dwFXAlphaCaps == other.dwFXAlphaCaps
+            && self.dwPalCaps == other.dwPalCaps
+            && self.dwSVCaps == other.dwSVCaps
+            && self.dwAlphaBltConstBitDepths == other.dwAlphaBltConstBitDepths
+            && self.dwAlphaBltPixelBitDepths == other.dwAlphaBltPixelBitDepths
+            && self.dwAlphaBltSurfaceBitDepths == other.dwAlphaBltSurfaceBitDepths
+            && self.dwAlphaOverlayConstBitDepths == other.dwAlphaOverlayConstBitDepths
+            && self.dwAlphaOverlayPixelBitDepths == other.dwAlphaOverlayPixelBitDepths
+            && self.dwAlphaOverlaySurfaceBitDepths == other.dwAlphaOverlaySurfaceBitDepths
+            && self.dwZBufferBitDepths == other.dwZBufferBitDepths
+            && self.dwVidMemTotal == other.dwVidMemTotal
+            && self.dwVidMemFree == other.dwVidMemFree
+            && self.dwMaxVisibleOverlays == other.dwMaxVisibleOverlays
+            && self.dwCurrVisibleOverlays == other.dwCurrVisibleOverlays
+            && self.dwNumFourCCCodes == other.dwNumFourCCCodes
+            && self.dwAlignBoundarySrc == other.dwAlignBoundarySrc
+            && self.dwAlignSizeSrc == other.dwAlignSizeSrc
+            && self.dwAlignBoundaryDest == other.dwAlignBoundaryDest
+            && self.dwAlignSizeDest == other.dwAlignSizeDest
+            && self.dwAlignStrideAlign == other.dwAlignStrideAlign
+            && self.dwRops == other.dwRops
+            && self.ddsCaps == other.ddsCaps
+            && self.dwMinOverlayStretch == other.dwMinOverlayStretch
+            && self.dwMaxOverlayStretch == other.dwMaxOverlayStretch
+            && self.dwMinLiveVideoStretch == other.dwMinLiveVideoStretch
+            && self.dwMaxLiveVideoStretch == other.dwMaxLiveVideoStretch
+            && self.dwMinHwCodecStretch == other.dwMinHwCodecStretch
+            && self.dwMaxHwCodecStretch == other.dwMaxHwCodecStretch
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.dwReserved3 == other.dwReserved3
+            && self.dwSVBCaps == other.dwSVBCaps
+            && self.dwSVBCKeyCaps == other.dwSVBCKeyCaps
+            && self.dwSVBFXCaps == other.dwSVBFXCaps
+            && self.dwSVBRops == other.dwSVBRops
+            && self.dwVSBCaps == other.dwVSBCaps
+            && self.dwVSBCKeyCaps == other.dwVSBCKeyCaps
+            && self.dwVSBFXCaps == other.dwVSBFXCaps
+            && self.dwVSBRops == other.dwVSBRops
+            && self.dwSSBCaps == other.dwSSBCaps
+            && self.dwSSBCKeyCaps == other.dwSSBCKeyCaps
+            && self.dwSSBFXCaps == other.dwSSBFXCaps
+            && self.dwSSBRops == other.dwSSBRops
+            && self.dwMaxVideoPorts == other.dwMaxVideoPorts
+            && self.dwCurrVideoPorts == other.dwCurrVideoPorts
+            && self.dwSVBCaps2 == other.dwSVBCaps2
     }
 }
 impl ::core::cmp::Eq for DDCORECAPS {}
@@ -5739,7 +5853,7 @@ unsafe impl ::windows::core::Abi for DDDEVICEIDENTIFIER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDDEVICEIDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDDEVICEIDENTIFIER>()) == 0 }
+        self.szDriver == other.szDriver && self.szDescription == other.szDescription && self.liDriverVersion == other.liDriverVersion && self.dwVendorId == other.dwVendorId && self.dwDeviceId == other.dwDeviceId && self.dwSubSysId == other.dwSubSysId && self.dwRevision == other.dwRevision && self.guidDeviceIdentifier == other.guidDeviceIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5785,7 +5899,7 @@ unsafe impl ::windows::core::Abi for DDDEVICEIDENTIFIER2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDDEVICEIDENTIFIER2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDDEVICEIDENTIFIER2>()) == 0 }
+        self.szDriver == other.szDriver && self.szDescription == other.szDescription && self.liDriverVersion == other.liDriverVersion && self.dwVendorId == other.dwVendorId && self.dwDeviceId == other.dwDeviceId && self.dwSubSysId == other.dwSubSysId && self.dwRevision == other.dwRevision && self.guidDeviceIdentifier == other.guidDeviceIdentifier && self.dwWHQLLevel == other.dwWHQLLevel
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5812,18 +5926,12 @@ impl ::core::clone::Clone for DDENABLEIRQINFO {
 }
 impl ::core::fmt::Debug for DDENABLEIRQINFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDENABLEIRQINFO").field("dwIRQSources", &self.dwIRQSources).field("dwLine", &self.dwLine).field("IRQCallback", &self.IRQCallback.map(|f| f as usize)).field("lpIRQData", &self.lpIRQData).finish()
+        f.debug_struct("DDENABLEIRQINFO").field("dwIRQSources", &self.dwIRQSources).field("dwLine", &self.dwLine).field("lpIRQData", &self.lpIRQData).finish()
     }
 }
 unsafe impl ::windows::core::Abi for DDENABLEIRQINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDENABLEIRQINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDENABLEIRQINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDENABLEIRQINFO {}
 impl ::core::default::Default for DDENABLEIRQINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5852,7 +5960,7 @@ unsafe impl ::windows::core::Abi for DDFLIPOVERLAYINFO {
 }
 impl ::core::cmp::PartialEq for DDFLIPOVERLAYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDFLIPOVERLAYINFO>()) == 0 }
+        self.lpCurrentSurface == other.lpCurrentSurface && self.lpTargetSurface == other.lpTargetSurface && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DDFLIPOVERLAYINFO {}
@@ -5885,7 +5993,7 @@ unsafe impl ::windows::core::Abi for DDFLIPVIDEOPORTINFO {
 }
 impl ::core::cmp::PartialEq for DDFLIPVIDEOPORTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDFLIPVIDEOPORTINFO>()) == 0 }
+        self.lpVideoPortData == other.lpVideoPortData && self.lpCurrentSurface == other.lpCurrentSurface && self.lpTargetSurface == other.lpTargetSurface && self.dwFlipVPFlags == other.dwFlipVPFlags
     }
 }
 impl ::core::cmp::Eq for DDFLIPVIDEOPORTINFO {}
@@ -5917,7 +6025,7 @@ unsafe impl ::windows::core::Abi for DDGAMMARAMP {
 }
 impl ::core::cmp::PartialEq for DDGAMMARAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGAMMARAMP>()) == 0 }
+        self.red == other.red && self.green == other.green && self.blue == other.blue
     }
 }
 impl ::core::cmp::Eq for DDGAMMARAMP {}
@@ -5947,7 +6055,7 @@ unsafe impl ::windows::core::Abi for DDGETCURRENTAUTOFLIPININFO {
 }
 impl ::core::cmp::PartialEq for DDGETCURRENTAUTOFLIPININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETCURRENTAUTOFLIPININFO>()) == 0 }
+        self.lpVideoPortData == other.lpVideoPortData
     }
 }
 impl ::core::cmp::Eq for DDGETCURRENTAUTOFLIPININFO {}
@@ -5978,7 +6086,7 @@ unsafe impl ::windows::core::Abi for DDGETCURRENTAUTOFLIPOUTINFO {
 }
 impl ::core::cmp::PartialEq for DDGETCURRENTAUTOFLIPOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETCURRENTAUTOFLIPOUTINFO>()) == 0 }
+        self.dwSurfaceIndex == other.dwSurfaceIndex && self.dwVBISurfaceIndex == other.dwVBISurfaceIndex
     }
 }
 impl ::core::cmp::Eq for DDGETCURRENTAUTOFLIPOUTINFO {}
@@ -6008,7 +6116,7 @@ unsafe impl ::windows::core::Abi for DDGETIRQINFO {
 }
 impl ::core::cmp::PartialEq for DDGETIRQINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETIRQINFO>()) == 0 }
+        self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DDGETIRQINFO {}
@@ -6038,7 +6146,7 @@ unsafe impl ::windows::core::Abi for DDGETPOLARITYININFO {
 }
 impl ::core::cmp::PartialEq for DDGETPOLARITYININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETPOLARITYININFO>()) == 0 }
+        self.lpVideoPortData == other.lpVideoPortData
     }
 }
 impl ::core::cmp::Eq for DDGETPOLARITYININFO {}
@@ -6068,7 +6176,7 @@ unsafe impl ::windows::core::Abi for DDGETPOLARITYOUTINFO {
 }
 impl ::core::cmp::PartialEq for DDGETPOLARITYOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETPOLARITYOUTINFO>()) == 0 }
+        self.bPolarity == other.bPolarity
     }
 }
 impl ::core::cmp::Eq for DDGETPOLARITYOUTINFO {}
@@ -6098,7 +6206,7 @@ unsafe impl ::windows::core::Abi for DDGETPREVIOUSAUTOFLIPININFO {
 }
 impl ::core::cmp::PartialEq for DDGETPREVIOUSAUTOFLIPININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETPREVIOUSAUTOFLIPININFO>()) == 0 }
+        self.lpVideoPortData == other.lpVideoPortData
     }
 }
 impl ::core::cmp::Eq for DDGETPREVIOUSAUTOFLIPININFO {}
@@ -6129,7 +6237,7 @@ unsafe impl ::windows::core::Abi for DDGETPREVIOUSAUTOFLIPOUTINFO {
 }
 impl ::core::cmp::PartialEq for DDGETPREVIOUSAUTOFLIPOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETPREVIOUSAUTOFLIPOUTINFO>()) == 0 }
+        self.dwSurfaceIndex == other.dwSurfaceIndex && self.dwVBISurfaceIndex == other.dwVBISurfaceIndex
     }
 }
 impl ::core::cmp::Eq for DDGETPREVIOUSAUTOFLIPOUTINFO {}
@@ -6159,7 +6267,7 @@ unsafe impl ::windows::core::Abi for DDGETTRANSFERSTATUSOUTINFO {
 }
 impl ::core::cmp::PartialEq for DDGETTRANSFERSTATUSOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDGETTRANSFERSTATUSOUTINFO>()) == 0 }
+        self.dwTransferID == other.dwTransferID
     }
 }
 impl ::core::cmp::Eq for DDGETTRANSFERSTATUSOUTINFO {}
@@ -6188,21 +6296,13 @@ impl ::core::clone::Clone for DDHALDDRAWFNS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHALDDRAWFNS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHALDDRAWFNS").field("dwSize", &self.dwSize).field("lpSetInfo", &self.lpSetInfo.map(|f| f as usize)).field("lpVidMemAlloc", &self.lpVidMemAlloc.map(|f| f as usize)).field("lpVidMemFree", &self.lpVidMemFree.map(|f| f as usize)).finish()
+        f.debug_struct("DDHALDDRAWFNS").field("dwSize", &self.dwSize).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHALDDRAWFNS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHALDDRAWFNS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHALDDRAWFNS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHALDDRAWFNS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHALDDRAWFNS {
     fn default() -> Self {
@@ -6245,14 +6345,6 @@ unsafe impl ::windows::core::Abi for DDHALINFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHALINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHALINFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHALINFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHALINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6288,7 +6380,7 @@ unsafe impl ::windows::core::Abi for DDHALMODEINFO {
 }
 impl ::core::cmp::PartialEq for DDHALMODEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHALMODEINFO>()) == 0 }
+        self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.lPitch == other.lPitch && self.dwBPP == other.dwBPP && self.wFlags == other.wFlags && self.wRefreshRate == other.wRefreshRate && self.dwRBitMask == other.dwRBitMask && self.dwGBitMask == other.dwGBitMask && self.dwBBitMask == other.dwBBitMask && self.dwAlphaBitMask == other.dwAlphaBitMask
     }
 }
 impl ::core::cmp::Eq for DDHALMODEINFO {}
@@ -6318,21 +6410,13 @@ impl ::core::clone::Clone for DDHAL_ADDATTACHEDSURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_ADDATTACHEDSURFACEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_ADDATTACHEDSURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpSurfAttached", &self.lpSurfAttached).field("ddRVal", &self.ddRVal).field("AddAttachedSurface", &self.AddAttachedSurface.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_ADDATTACHEDSURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpSurfAttached", &self.lpSurfAttached).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_ADDATTACHEDSURFACEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_ADDATTACHEDSURFACEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_ADDATTACHEDSURFACEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_ADDATTACHEDSURFACEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_ADDATTACHEDSURFACEDATA {
     fn default() -> Self {
@@ -6364,21 +6448,13 @@ impl ::core::clone::Clone for DDHAL_BEGINMOCOMPFRAMEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_BEGINMOCOMPFRAMEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_BEGINMOCOMPFRAMEDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpDestSurface", &self.lpDestSurface).field("dwInputDataSize", &self.dwInputDataSize).field("lpInputData", &self.lpInputData).field("dwOutputDataSize", &self.dwOutputDataSize).field("lpOutputData", &self.lpOutputData).field("ddRVal", &self.ddRVal).field("BeginMoCompFrame", &self.BeginMoCompFrame.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_BEGINMOCOMPFRAMEDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpDestSurface", &self.lpDestSurface).field("dwInputDataSize", &self.dwInputDataSize).field("lpInputData", &self.lpInputData).field("dwOutputDataSize", &self.dwOutputDataSize).field("lpOutputData", &self.lpOutputData).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_BEGINMOCOMPFRAMEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_BEGINMOCOMPFRAMEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_BEGINMOCOMPFRAMEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_BEGINMOCOMPFRAMEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_BEGINMOCOMPFRAMEDATA {
     fn default() -> Self {
@@ -6432,14 +6508,6 @@ unsafe impl ::windows::core::Abi for DDHAL_BLTDATA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_BLTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        self.lpDD == other.lpDD && self.lpDDDestSurface == other.lpDDDestSurface && self.rDest == other.rDest && self.lpDDSrcSurface == other.lpDDSrcSurface && self.rSrc == other.rSrc && self.dwFlags == other.dwFlags && self.dwROPFlags == other.dwROPFlags && self.bltFX == other.bltFX && self.ddRVal == other.ddRVal && self.Blt.map(|f| f as usize) == other.Blt.map(|f| f as usize) && self.IsClipped == other.IsClipped && self.rOrigDest == other.rOrigDest && self.rOrigSrc == other.rOrigSrc && self.dwRectCnt == other.dwRectCnt && self.prDestRects == other.prDestRects
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_BLTDATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_BLTDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6483,44 +6551,13 @@ impl ::core::clone::Clone for DDHAL_CALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CALLBACKS")
-            .field("cbDDCallbacks", &self.cbDDCallbacks)
-            .field("cbDDSurfaceCallbacks", &self.cbDDSurfaceCallbacks)
-            .field("cbDDPaletteCallbacks", &self.cbDDPaletteCallbacks)
-            .field("HALDD", &self.HALDD)
-            .field("HALDDSurface", &self.HALDDSurface)
-            .field("HALDDPalette", &self.HALDDPalette)
-            .field("HELDD", &self.HELDD)
-            .field("HELDDSurface", &self.HELDDSurface)
-            .field("HELDDPalette", &self.HELDDPalette)
-            .field("cbDDExeBufCallbacks", &self.cbDDExeBufCallbacks)
-            .field("HALDDExeBuf", &self.HALDDExeBuf)
-            .field("HELDDExeBuf", &self.HELDDExeBuf)
-            .field("cbDDVideoPortCallbacks", &self.cbDDVideoPortCallbacks)
-            .field("HALDDVideoPort", &self.HALDDVideoPort)
-            .field("cbDDColorControlCallbacks", &self.cbDDColorControlCallbacks)
-            .field("HALDDColorControl", &self.HALDDColorControl)
-            .field("cbDDMiscellaneousCallbacks", &self.cbDDMiscellaneousCallbacks)
-            .field("HALDDMiscellaneous", &self.HALDDMiscellaneous)
-            .field("cbDDKernelCallbacks", &self.cbDDKernelCallbacks)
-            .field("HALDDKernel", &self.HALDDKernel)
-            .field("cbDDMotionCompCallbacks", &self.cbDDMotionCompCallbacks)
-            .field("HALDDMotionComp", &self.HALDDMotionComp)
-            .finish()
+        f.debug_struct("DDHAL_CALLBACKS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CALLBACKS {
     fn default() -> Self {
@@ -6548,21 +6585,13 @@ impl ::core::clone::Clone for DDHAL_CANCREATESURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CANCREATESURFACEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CANCREATESURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurfaceDesc", &self.lpDDSurfaceDesc).field("bIsDifferentPixelFormat", &self.bIsDifferentPixelFormat).field("ddRVal", &self.ddRVal).field("CanCreateSurface", &self.CanCreateSurface.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_CANCREATESURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurfaceDesc", &self.lpDDSurfaceDesc).field("bIsDifferentPixelFormat", &self.bIsDifferentPixelFormat).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CANCREATESURFACEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CANCREATESURFACEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CANCREATESURFACEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CANCREATESURFACEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CANCREATESURFACEDATA {
     fn default() -> Self {
@@ -6589,21 +6618,13 @@ impl ::core::clone::Clone for DDHAL_CANCREATEVPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CANCREATEVPORTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CANCREATEVPORTDATA").field("lpDD", &self.lpDD).field("lpDDVideoPortDesc", &self.lpDDVideoPortDesc).field("ddRVal", &self.ddRVal).field("CanCreateVideoPort", &self.CanCreateVideoPort.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_CANCREATEVPORTDATA").field("lpDD", &self.lpDD).field("lpDDVideoPortDesc", &self.lpDDVideoPortDesc).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CANCREATEVPORTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CANCREATEVPORTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CANCREATEVPORTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CANCREATEVPORTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CANCREATEVPORTDATA {
     fn default() -> Self {
@@ -6632,21 +6653,13 @@ impl ::core::clone::Clone for DDHAL_COLORCONTROLDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_COLORCONTROLDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_COLORCONTROLDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpColorData", &self.lpColorData).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("ColorControl", &self.ColorControl.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_COLORCONTROLDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpColorData", &self.lpColorData).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_COLORCONTROLDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_COLORCONTROLDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_COLORCONTROLDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_COLORCONTROLDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_COLORCONTROLDATA {
     fn default() -> Self {
@@ -6681,14 +6694,6 @@ unsafe impl ::windows::core::Abi for DDHAL_CREATEMOCOMPDATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CREATEMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CREATEMOCOMPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CREATEMOCOMPDATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CREATEMOCOMPDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6716,21 +6721,13 @@ impl ::core::clone::Clone for DDHAL_CREATEPALETTEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CREATEPALETTEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CREATEPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("lpColorTable", &self.lpColorTable).field("ddRVal", &self.ddRVal).field("CreatePalette", &self.CreatePalette.map(|f| f as usize)).field("is_excl", &self.is_excl).finish()
+        f.debug_struct("DDHAL_CREATEPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("lpColorTable", &self.lpColorTable).field("ddRVal", &self.ddRVal).field("is_excl", &self.is_excl).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CREATEPALETTEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CREATEPALETTEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CREATEPALETTEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CREATEPALETTEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CREATEPALETTEDATA {
     fn default() -> Self {
@@ -6759,21 +6756,13 @@ impl ::core::clone::Clone for DDHAL_CREATESURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CREATESURFACEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CREATESURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurfaceDesc", &self.lpDDSurfaceDesc).field("lplpSList", &self.lplpSList).field("dwSCnt", &self.dwSCnt).field("ddRVal", &self.ddRVal).field("CreateSurface", &self.CreateSurface.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_CREATESURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurfaceDesc", &self.lpDDSurfaceDesc).field("lplpSList", &self.lplpSList).field("dwSCnt", &self.dwSCnt).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CREATESURFACEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CREATESURFACEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CREATESURFACEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CREATESURFACEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CREATESURFACEDATA {
     fn default() -> Self {
@@ -6810,7 +6799,7 @@ unsafe impl ::windows::core::Abi for DDHAL_CREATESURFACEEXDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDHAL_CREATESURFACEEXDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CREATESURFACEEXDATA>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpDDLcl == other.lpDDLcl && self.lpDDSLcl == other.lpDDSLcl && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -6842,21 +6831,13 @@ impl ::core::clone::Clone for DDHAL_CREATEVPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_CREATEVPORTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_CREATEVPORTDATA").field("lpDD", &self.lpDD).field("lpDDVideoPortDesc", &self.lpDDVideoPortDesc).field("lpVideoPort", &self.lpVideoPort).field("ddRVal", &self.ddRVal).field("CreateVideoPort", &self.CreateVideoPort.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_CREATEVPORTDATA").field("lpDD", &self.lpDD).field("lpDDVideoPortDesc", &self.lpDDVideoPortDesc).field("lpVideoPort", &self.lpVideoPort).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_CREATEVPORTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_CREATEVPORTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_CREATEVPORTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_CREATEVPORTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_CREATEVPORTDATA {
     fn default() -> Self {
@@ -6891,34 +6872,13 @@ impl ::core::clone::Clone for DDHAL_DDCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("DestroyDriver", &self.DestroyDriver.map(|f| f as usize))
-            .field("CreateSurface", &self.CreateSurface.map(|f| f as usize))
-            .field("SetColorKey", &self.SetColorKey.map(|f| f as usize))
-            .field("SetMode", &self.SetMode.map(|f| f as usize))
-            .field("WaitForVerticalBlank", &self.WaitForVerticalBlank.map(|f| f as usize))
-            .field("CanCreateSurface", &self.CanCreateSurface.map(|f| f as usize))
-            .field("CreatePalette", &self.CreatePalette.map(|f| f as usize))
-            .field("GetScanLine", &self.GetScanLine.map(|f| f as usize))
-            .field("SetExclusiveMode", &self.SetExclusiveMode.map(|f| f as usize))
-            .field("FlipToGDISurface", &self.FlipToGDISurface.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_DDCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDCALLBACKS {
     fn default() -> Self {
@@ -6944,21 +6904,13 @@ impl ::core::clone::Clone for DDHAL_DDCOLORCONTROLCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDCOLORCONTROLCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDCOLORCONTROLCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("ColorControl", &self.ColorControl.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DDCOLORCONTROLCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDCOLORCONTROLCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDCOLORCONTROLCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDCOLORCONTROLCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDCOLORCONTROLCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDCOLORCONTROLCALLBACKS {
     fn default() -> Self {
@@ -6988,29 +6940,13 @@ impl ::core::clone::Clone for DDHAL_DDEXEBUFCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDEXEBUFCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDEXEBUFCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("CanCreateExecuteBuffer", &self.CanCreateExecuteBuffer.map(|f| f as usize))
-            .field("CreateExecuteBuffer", &self.CreateExecuteBuffer.map(|f| f as usize))
-            .field("DestroyExecuteBuffer", &self.DestroyExecuteBuffer.map(|f| f as usize))
-            .field("LockExecuteBuffer", &self.LockExecuteBuffer.map(|f| f as usize))
-            .field("UnlockExecuteBuffer", &self.UnlockExecuteBuffer.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_DDEXEBUFCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDEXEBUFCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDEXEBUFCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDEXEBUFCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDEXEBUFCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDEXEBUFCALLBACKS {
     fn default() -> Self {
@@ -7037,21 +6973,13 @@ impl ::core::clone::Clone for DDHAL_DDKERNELCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDKERNELCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDKERNELCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("SyncSurfaceData", &self.SyncSurfaceData.map(|f| f as usize)).field("SyncVideoPortData", &self.SyncVideoPortData.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DDKERNELCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDKERNELCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDKERNELCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDKERNELCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDKERNELCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDKERNELCALLBACKS {
     fn default() -> Self {
@@ -7080,21 +7008,13 @@ impl ::core::clone::Clone for DDHAL_DDMISCELLANEOUS2CALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDMISCELLANEOUS2CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDMISCELLANEOUS2CALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("Reserved", &self.Reserved).field("CreateSurfaceEx", &self.CreateSurfaceEx.map(|f| f as usize)).field("GetDriverState", &self.GetDriverState.map(|f| f as usize)).field("DestroyDDLocal", &self.DestroyDDLocal.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DDMISCELLANEOUS2CALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("Reserved", &self.Reserved).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDMISCELLANEOUS2CALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDMISCELLANEOUS2CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDMISCELLANEOUS2CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDMISCELLANEOUS2CALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDMISCELLANEOUS2CALLBACKS {
     fn default() -> Self {
@@ -7123,21 +7043,13 @@ impl ::core::clone::Clone for DDHAL_DDMISCELLANEOUSCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDMISCELLANEOUSCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDMISCELLANEOUSCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("GetAvailDriverMemory", &self.GetAvailDriverMemory.map(|f| f as usize)).field("UpdateNonLocalHeap", &self.UpdateNonLocalHeap.map(|f| f as usize)).field("GetHeapAlignment", &self.GetHeapAlignment.map(|f| f as usize)).field("GetSysmemBltStatus", &self.GetSysmemBltStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DDMISCELLANEOUSCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDMISCELLANEOUSCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDMISCELLANEOUSCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDMISCELLANEOUSCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDMISCELLANEOUSCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDMISCELLANEOUSCALLBACKS {
     fn default() -> Self {
@@ -7172,34 +7084,13 @@ impl ::core::clone::Clone for DDHAL_DDMOTIONCOMPCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDMOTIONCOMPCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDMOTIONCOMPCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("GetMoCompGuids", &self.GetMoCompGuids.map(|f| f as usize))
-            .field("GetMoCompFormats", &self.GetMoCompFormats.map(|f| f as usize))
-            .field("CreateMoComp", &self.CreateMoComp.map(|f| f as usize))
-            .field("GetMoCompBuffInfo", &self.GetMoCompBuffInfo.map(|f| f as usize))
-            .field("GetInternalMoCompInfo", &self.GetInternalMoCompInfo.map(|f| f as usize))
-            .field("BeginMoCompFrame", &self.BeginMoCompFrame.map(|f| f as usize))
-            .field("EndMoCompFrame", &self.EndMoCompFrame.map(|f| f as usize))
-            .field("RenderMoComp", &self.RenderMoComp.map(|f| f as usize))
-            .field("QueryMoCompStatus", &self.QueryMoCompStatus.map(|f| f as usize))
-            .field("DestroyMoComp", &self.DestroyMoComp.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_DDMOTIONCOMPCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDMOTIONCOMPCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDMOTIONCOMPCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDMOTIONCOMPCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDMOTIONCOMPCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDMOTIONCOMPCALLBACKS {
     fn default() -> Self {
@@ -7226,21 +7117,13 @@ impl ::core::clone::Clone for DDHAL_DDPALETTECALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDPALETTECALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDPALETTECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("DestroyPalette", &self.DestroyPalette.map(|f| f as usize)).field("SetEntries", &self.SetEntries.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DDPALETTECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDPALETTECALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDPALETTECALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDPALETTECALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDPALETTECALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDPALETTECALLBACKS {
     fn default() -> Self {
@@ -7279,38 +7162,13 @@ impl ::core::clone::Clone for DDHAL_DDSURFACECALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDSURFACECALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDSURFACECALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("DestroySurface", &self.DestroySurface.map(|f| f as usize))
-            .field("Flip", &self.Flip.map(|f| f as usize))
-            .field("SetClipList", &self.SetClipList.map(|f| f as usize))
-            .field("Lock", &self.Lock.map(|f| f as usize))
-            .field("Unlock", &self.Unlock.map(|f| f as usize))
-            .field("Blt", &self.Blt.map(|f| f as usize))
-            .field("SetColorKey", &self.SetColorKey.map(|f| f as usize))
-            .field("AddAttachedSurface", &self.AddAttachedSurface.map(|f| f as usize))
-            .field("GetBltStatus", &self.GetBltStatus.map(|f| f as usize))
-            .field("GetFlipStatus", &self.GetFlipStatus.map(|f| f as usize))
-            .field("UpdateOverlay", &self.UpdateOverlay.map(|f| f as usize))
-            .field("SetOverlayPosition", &self.SetOverlayPosition.map(|f| f as usize))
-            .field("reserved4", &self.reserved4)
-            .field("SetPalette", &self.SetPalette.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_DDSURFACECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("reserved4", &self.reserved4).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDSURFACECALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDSURFACECALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDSURFACECALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDSURFACECALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDSURFACECALLBACKS {
     fn default() -> Self {
@@ -7351,40 +7209,13 @@ impl ::core::clone::Clone for DDHAL_DDVIDEOPORTCALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DDVIDEOPORTCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DDVIDEOPORTCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("CanCreateVideoPort", &self.CanCreateVideoPort.map(|f| f as usize))
-            .field("CreateVideoPort", &self.CreateVideoPort.map(|f| f as usize))
-            .field("FlipVideoPort", &self.FlipVideoPort.map(|f| f as usize))
-            .field("GetVideoPortBandwidth", &self.GetVideoPortBandwidth.map(|f| f as usize))
-            .field("GetVideoPortInputFormats", &self.GetVideoPortInputFormats.map(|f| f as usize))
-            .field("GetVideoPortOutputFormats", &self.GetVideoPortOutputFormats.map(|f| f as usize))
-            .field("lpReserved1", &self.lpReserved1)
-            .field("GetVideoPortField", &self.GetVideoPortField.map(|f| f as usize))
-            .field("GetVideoPortLine", &self.GetVideoPortLine.map(|f| f as usize))
-            .field("GetVideoPortConnectInfo", &self.GetVideoPortConnectInfo.map(|f| f as usize))
-            .field("DestroyVideoPort", &self.DestroyVideoPort.map(|f| f as usize))
-            .field("GetVideoPortFlipStatus", &self.GetVideoPortFlipStatus.map(|f| f as usize))
-            .field("UpdateVideoPort", &self.UpdateVideoPort.map(|f| f as usize))
-            .field("WaitForVideoPortSync", &self.WaitForVideoPortSync.map(|f| f as usize))
-            .field("GetVideoSignalStatus", &self.GetVideoSignalStatus.map(|f| f as usize))
-            .field("ColorControl", &self.ColorControl.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_DDVIDEOPORTCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("lpReserved1", &self.lpReserved1).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DDVIDEOPORTCALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DDVIDEOPORTCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DDVIDEOPORTCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DDVIDEOPORTCALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DDVIDEOPORTCALLBACKS {
     fn default() -> Self {
@@ -7420,7 +7251,7 @@ unsafe impl ::windows::core::Abi for DDHAL_DESTROYDDLOCALDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDHAL_DESTROYDDLOCALDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYDDLOCALDATA>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pDDLcl == other.pDDLcl && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -7450,21 +7281,13 @@ impl ::core::clone::Clone for DDHAL_DESTROYDRIVERDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DESTROYDRIVERDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DESTROYDRIVERDATA").field("lpDD", &self.lpDD).field("ddRVal", &self.ddRVal).field("DestroyDriver", &self.DestroyDriver.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DESTROYDRIVERDATA").field("lpDD", &self.lpDD).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DESTROYDRIVERDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DESTROYDRIVERDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYDRIVERDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DESTROYDRIVERDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DESTROYDRIVERDATA {
     fn default() -> Self {
@@ -7491,21 +7314,13 @@ impl ::core::clone::Clone for DDHAL_DESTROYMOCOMPDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DESTROYMOCOMPDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DESTROYMOCOMPDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("ddRVal", &self.ddRVal).field("DestroyMoComp", &self.DestroyMoComp.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DESTROYMOCOMPDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DESTROYMOCOMPDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DESTROYMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYMOCOMPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DESTROYMOCOMPDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DESTROYMOCOMPDATA {
     fn default() -> Self {
@@ -7532,21 +7347,13 @@ impl ::core::clone::Clone for DDHAL_DESTROYPALETTEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DESTROYPALETTEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DESTROYPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("ddRVal", &self.ddRVal).field("DestroyPalette", &self.DestroyPalette.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DESTROYPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DESTROYPALETTEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DESTROYPALETTEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYPALETTEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DESTROYPALETTEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DESTROYPALETTEDATA {
     fn default() -> Self {
@@ -7573,21 +7380,13 @@ impl ::core::clone::Clone for DDHAL_DESTROYSURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DESTROYSURFACEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DESTROYSURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).field("DestroySurface", &self.DestroySurface.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DESTROYSURFACEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DESTROYSURFACEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DESTROYSURFACEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYSURFACEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DESTROYSURFACEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DESTROYSURFACEDATA {
     fn default() -> Self {
@@ -7614,21 +7413,13 @@ impl ::core::clone::Clone for DDHAL_DESTROYVPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DESTROYVPORTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DESTROYVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("ddRVal", &self.ddRVal).field("DestroyVideoPort", &self.DestroyVideoPort.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DESTROYVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DESTROYVPORTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DESTROYVPORTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DESTROYVPORTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DESTROYVPORTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DESTROYVPORTDATA {
     fn default() -> Self {
@@ -7656,21 +7447,13 @@ impl ::core::clone::Clone for DDHAL_DRVSETCOLORKEYDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_DRVSETCOLORKEYDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_DRVSETCOLORKEYDATA").field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ckNew", &self.ckNew).field("ddRVal", &self.ddRVal).field("SetColorKey", &self.SetColorKey.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_DRVSETCOLORKEYDATA").field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ckNew", &self.ckNew).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_DRVSETCOLORKEYDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_DRVSETCOLORKEYDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_DRVSETCOLORKEYDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_DRVSETCOLORKEYDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_DRVSETCOLORKEYDATA {
     fn default() -> Self {
@@ -7699,21 +7482,13 @@ impl ::core::clone::Clone for DDHAL_ENDMOCOMPFRAMEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_ENDMOCOMPFRAMEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_ENDMOCOMPFRAMEDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpInputData", &self.lpInputData).field("dwInputDataSize", &self.dwInputDataSize).field("ddRVal", &self.ddRVal).field("EndMoCompFrame", &self.EndMoCompFrame.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_ENDMOCOMPFRAMEDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpInputData", &self.lpInputData).field("dwInputDataSize", &self.dwInputDataSize).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_ENDMOCOMPFRAMEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_ENDMOCOMPFRAMEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_ENDMOCOMPFRAMEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_ENDMOCOMPFRAMEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_ENDMOCOMPFRAMEDATA {
     fn default() -> Self {
@@ -7744,21 +7519,13 @@ impl ::core::clone::Clone for DDHAL_FLIPDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_FLIPDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_FLIPDATA").field("lpDD", &self.lpDD).field("lpSurfCurr", &self.lpSurfCurr).field("lpSurfTarg", &self.lpSurfTarg).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("Flip", &self.Flip.map(|f| f as usize)).field("lpSurfCurrLeft", &self.lpSurfCurrLeft).field("lpSurfTargLeft", &self.lpSurfTargLeft).finish()
+        f.debug_struct("DDHAL_FLIPDATA").field("lpDD", &self.lpDD).field("lpSurfCurr", &self.lpSurfCurr).field("lpSurfTarg", &self.lpSurfTarg).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("lpSurfCurrLeft", &self.lpSurfCurrLeft).field("lpSurfTargLeft", &self.lpSurfTargLeft).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_FLIPDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_FLIPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_FLIPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_FLIPDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_FLIPDATA {
     fn default() -> Self {
@@ -7786,21 +7553,13 @@ impl ::core::clone::Clone for DDHAL_FLIPTOGDISURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_FLIPTOGDISURFACEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_FLIPTOGDISURFACEDATA").field("lpDD", &self.lpDD).field("dwToGDI", &self.dwToGDI).field("dwReserved", &self.dwReserved).field("ddRVal", &self.ddRVal).field("FlipToGDISurface", &self.FlipToGDISurface.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_FLIPTOGDISURFACEDATA").field("lpDD", &self.lpDD).field("dwToGDI", &self.dwToGDI).field("dwReserved", &self.dwReserved).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_FLIPTOGDISURFACEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_FLIPTOGDISURFACEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_FLIPTOGDISURFACEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_FLIPTOGDISURFACEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_FLIPTOGDISURFACEDATA {
     fn default() -> Self {
@@ -7829,21 +7588,13 @@ impl ::core::clone::Clone for DDHAL_FLIPVPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_FLIPVPORTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_FLIPVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lpSurfCurr", &self.lpSurfCurr).field("lpSurfTarg", &self.lpSurfTarg).field("ddRVal", &self.ddRVal).field("FlipVideoPort", &self.FlipVideoPort.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_FLIPVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lpSurfCurr", &self.lpSurfCurr).field("lpSurfTarg", &self.lpSurfTarg).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_FLIPVPORTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_FLIPVPORTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_FLIPVPORTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_FLIPVPORTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_FLIPVPORTDATA {
     fn default() -> Self {
@@ -7875,14 +7626,6 @@ unsafe impl ::windows::core::Abi for DDHAL_GETAVAILDRIVERMEMORYDATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETAVAILDRIVERMEMORYDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETAVAILDRIVERMEMORYDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETAVAILDRIVERMEMORYDATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETAVAILDRIVERMEMORYDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7909,21 +7652,13 @@ impl ::core::clone::Clone for DDHAL_GETBLTSTATUSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETBLTSTATUSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETBLTSTATUSDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("GetBltStatus", &self.GetBltStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETBLTSTATUSDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETBLTSTATUSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETBLTSTATUSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETBLTSTATUSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETBLTSTATUSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETBLTSTATUSDATA {
     fn default() -> Self {
@@ -7958,7 +7693,7 @@ unsafe impl ::windows::core::Abi for DDHAL_GETDRIVERINFODATA {
 }
 impl ::core::cmp::PartialEq for DDHAL_GETDRIVERINFODATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETDRIVERINFODATA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidInfo == other.guidInfo && self.dwExpectedSize == other.dwExpectedSize && self.lpvData == other.lpvData && self.dwActualSize == other.dwActualSize && self.ddRVal == other.ddRVal && self.dwContext == other.dwContext
     }
 }
 impl ::core::cmp::Eq for DDHAL_GETDRIVERINFODATA {}
@@ -7985,12 +7720,6 @@ impl ::core::clone::Clone for DDHAL_GETDRIVERSTATEDATA {
 unsafe impl ::windows::core::Abi for DDHAL_GETDRIVERSTATEDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDHAL_GETDRIVERSTATEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETDRIVERSTATEDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDHAL_GETDRIVERSTATEDATA {}
 impl ::core::default::Default for DDHAL_GETDRIVERSTATEDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8010,12 +7739,6 @@ impl ::core::clone::Clone for DDHAL_GETDRIVERSTATEDATA_0 {
 unsafe impl ::windows::core::Abi for DDHAL_GETDRIVERSTATEDATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDHAL_GETDRIVERSTATEDATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETDRIVERSTATEDATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDHAL_GETDRIVERSTATEDATA_0 {}
 impl ::core::default::Default for DDHAL_GETDRIVERSTATEDATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8042,21 +7765,13 @@ impl ::core::clone::Clone for DDHAL_GETFLIPSTATUSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETFLIPSTATUSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETFLIPSTATUSDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("GetFlipStatus", &self.GetFlipStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETFLIPSTATUSDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETFLIPSTATUSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETFLIPSTATUSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETFLIPSTATUSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETFLIPSTATUSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETFLIPSTATUSDATA {
     fn default() -> Self {
@@ -8081,12 +7796,6 @@ impl ::core::clone::Clone for DDHAL_GETHEAPALIGNMENTDATA {
 unsafe impl ::windows::core::Abi for DDHAL_GETHEAPALIGNMENTDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDHAL_GETHEAPALIGNMENTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETHEAPALIGNMENTDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDHAL_GETHEAPALIGNMENTDATA {}
 impl ::core::default::Default for DDHAL_GETHEAPALIGNMENTDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8117,14 +7826,6 @@ impl ::core::clone::Clone for DDHAL_GETINTERNALMOCOMPDATA {
 unsafe impl ::windows::core::Abi for DDHAL_GETINTERNALMOCOMPDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETINTERNALMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETINTERNALMOCOMPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETINTERNALMOCOMPDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETINTERNALMOCOMPDATA {
     fn default() -> Self {
@@ -8158,14 +7859,6 @@ unsafe impl ::windows::core::Abi for DDHAL_GETMOCOMPCOMPBUFFDATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETMOCOMPCOMPBUFFDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETMOCOMPCOMPBUFFDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETMOCOMPCOMPBUFFDATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETMOCOMPCOMPBUFFDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8193,21 +7886,13 @@ impl ::core::clone::Clone for DDHAL_GETMOCOMPFORMATSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETMOCOMPFORMATSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETMOCOMPFORMATSDATA").field("lpDD", &self.lpDD).field("lpGuid", &self.lpGuid).field("dwNumFormats", &self.dwNumFormats).field("lpFormats", &self.lpFormats).field("ddRVal", &self.ddRVal).field("GetMoCompFormats", &self.GetMoCompFormats.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETMOCOMPFORMATSDATA").field("lpDD", &self.lpDD).field("lpGuid", &self.lpGuid).field("dwNumFormats", &self.dwNumFormats).field("lpFormats", &self.lpFormats).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETMOCOMPFORMATSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETMOCOMPFORMATSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETMOCOMPFORMATSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETMOCOMPFORMATSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETMOCOMPFORMATSDATA {
     fn default() -> Self {
@@ -8235,21 +7920,13 @@ impl ::core::clone::Clone for DDHAL_GETMOCOMPGUIDSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETMOCOMPGUIDSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETMOCOMPGUIDSDATA").field("lpDD", &self.lpDD).field("dwNumGuids", &self.dwNumGuids).field("lpGuids", &self.lpGuids).field("ddRVal", &self.ddRVal).field("GetMoCompGuids", &self.GetMoCompGuids.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETMOCOMPGUIDSDATA").field("lpDD", &self.lpDD).field("dwNumGuids", &self.dwNumGuids).field("lpGuids", &self.lpGuids).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETMOCOMPGUIDSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETMOCOMPGUIDSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETMOCOMPGUIDSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETMOCOMPGUIDSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETMOCOMPGUIDSDATA {
     fn default() -> Self {
@@ -8276,21 +7953,13 @@ impl ::core::clone::Clone for DDHAL_GETSCANLINEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETSCANLINEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETSCANLINEDATA").field("lpDD", &self.lpDD).field("dwScanLine", &self.dwScanLine).field("ddRVal", &self.ddRVal).field("GetScanLine", &self.GetScanLine.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETSCANLINEDATA").field("lpDD", &self.lpDD).field("dwScanLine", &self.dwScanLine).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETSCANLINEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETSCANLINEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETSCANLINEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETSCANLINEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETSCANLINEDATA {
     fn default() -> Self {
@@ -8322,21 +7991,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTBANDWIDTHDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTBANDWIDTHDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTBANDWIDTHDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lpddpfFormat", &self.lpddpfFormat).field("dwWidth", &self.dwWidth).field("dwHeight", &self.dwHeight).field("dwFlags", &self.dwFlags).field("lpBandwidth", &self.lpBandwidth).field("ddRVal", &self.ddRVal).field("GetVideoPortBandwidth", &self.GetVideoPortBandwidth.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTBANDWIDTHDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lpddpfFormat", &self.lpddpfFormat).field("dwWidth", &self.dwWidth).field("dwHeight", &self.dwHeight).field("dwFlags", &self.dwFlags).field("lpBandwidth", &self.lpBandwidth).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTBANDWIDTHDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTBANDWIDTHDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTBANDWIDTHDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTBANDWIDTHDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTBANDWIDTHDATA {
     fn default() -> Self {
@@ -8365,21 +8026,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTCONNECTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTCONNECTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTCONNECTDATA").field("lpDD", &self.lpDD).field("dwPortId", &self.dwPortId).field("lpConnect", &self.lpConnect).field("dwNumEntries", &self.dwNumEntries).field("ddRVal", &self.ddRVal).field("GetVideoPortConnectInfo", &self.GetVideoPortConnectInfo.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTCONNECTDATA").field("lpDD", &self.lpDD).field("dwPortId", &self.dwPortId).field("lpConnect", &self.lpConnect).field("dwNumEntries", &self.dwNumEntries).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTCONNECTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTCONNECTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTCONNECTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTCONNECTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTCONNECTDATA {
     fn default() -> Self {
@@ -8407,21 +8060,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTFIELDDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTFIELDDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTFIELDDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("bField", &self.bField).field("ddRVal", &self.ddRVal).field("GetVideoPortField", &self.GetVideoPortField.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTFIELDDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("bField", &self.bField).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTFIELDDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTFIELDDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTFIELDDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTFIELDDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTFIELDDATA {
     fn default() -> Self {
@@ -8448,21 +8093,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTFLIPSTATUSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTFLIPSTATUSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTFLIPSTATUSDATA").field("lpDD", &self.lpDD).field("fpSurface", &self.fpSurface).field("ddRVal", &self.ddRVal).field("GetVideoPortFlipStatus", &self.GetVideoPortFlipStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTFLIPSTATUSDATA").field("lpDD", &self.lpDD).field("fpSurface", &self.fpSurface).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTFLIPSTATUSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTFLIPSTATUSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTFLIPSTATUSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTFLIPSTATUSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTFLIPSTATUSDATA {
     fn default() -> Self {
@@ -8492,21 +8129,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTINPUTFORMATDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTINPUTFORMATDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTINPUTFORMATDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpddpfFormat", &self.lpddpfFormat).field("dwNumFormats", &self.dwNumFormats).field("ddRVal", &self.ddRVal).field("GetVideoPortInputFormats", &self.GetVideoPortInputFormats.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTINPUTFORMATDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpddpfFormat", &self.lpddpfFormat).field("dwNumFormats", &self.dwNumFormats).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTINPUTFORMATDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTINPUTFORMATDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTINPUTFORMATDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTINPUTFORMATDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTINPUTFORMATDATA {
     fn default() -> Self {
@@ -8534,21 +8163,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTLINEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTLINEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTLINEDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwLine", &self.dwLine).field("ddRVal", &self.ddRVal).field("GetVideoPortLine", &self.GetVideoPortLine.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTLINEDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwLine", &self.dwLine).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTLINEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTLINEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTLINEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTLINEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTLINEDATA {
     fn default() -> Self {
@@ -8579,21 +8200,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTOUTPUTFORMATDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTOUTPUTFORMATDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTOUTPUTFORMATDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpddpfInputFormat", &self.lpddpfInputFormat).field("lpddpfOutputFormats", &self.lpddpfOutputFormats).field("dwNumFormats", &self.dwNumFormats).field("ddRVal", &self.ddRVal).field("GetVideoPortOutputFormats", &self.GetVideoPortOutputFormats.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTOUTPUTFORMATDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpddpfInputFormat", &self.lpddpfInputFormat).field("lpddpfOutputFormats", &self.lpddpfOutputFormats).field("dwNumFormats", &self.dwNumFormats).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTOUTPUTFORMATDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTOUTPUTFORMATDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTOUTPUTFORMATDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTOUTPUTFORMATDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTOUTPUTFORMATDATA {
     fn default() -> Self {
@@ -8621,21 +8234,13 @@ impl ::core::clone::Clone for DDHAL_GETVPORTSIGNALDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_GETVPORTSIGNALDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_GETVPORTSIGNALDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwStatus", &self.dwStatus).field("ddRVal", &self.ddRVal).field("GetVideoSignalStatus", &self.GetVideoSignalStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_GETVPORTSIGNALDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwStatus", &self.dwStatus).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_GETVPORTSIGNALDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_GETVPORTSIGNALDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_GETVPORTSIGNALDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_GETVPORTSIGNALDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_GETVPORTSIGNALDATA {
     fn default() -> Self {
@@ -8666,21 +8271,13 @@ impl ::core::clone::Clone for DDHAL_LOCKDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_LOCKDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_LOCKDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("bHasRect", &self.bHasRect).field("rArea", &self.rArea).field("lpSurfData", &self.lpSurfData).field("ddRVal", &self.ddRVal).field("Lock", &self.Lock.map(|f| f as usize)).field("dwFlags", &self.dwFlags).finish()
+        f.debug_struct("DDHAL_LOCKDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("bHasRect", &self.bHasRect).field("rArea", &self.rArea).field("lpSurfData", &self.lpSurfData).field("ddRVal", &self.ddRVal).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_LOCKDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_LOCKDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_LOCKDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_LOCKDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_LOCKDATA {
     fn default() -> Self {
@@ -8709,21 +8306,13 @@ impl ::core::clone::Clone for DDHAL_QUERYMOCOMPSTATUSDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_QUERYMOCOMPSTATUSDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_QUERYMOCOMPSTATUSDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpSurface", &self.lpSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).field("QueryMoCompStatus", &self.QueryMoCompStatus.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_QUERYMOCOMPSTATUSDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("lpSurface", &self.lpSurface).field("dwFlags", &self.dwFlags).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_QUERYMOCOMPSTATUSDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_QUERYMOCOMPSTATUSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_QUERYMOCOMPSTATUSDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_QUERYMOCOMPSTATUSDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_QUERYMOCOMPSTATUSDATA {
     fn default() -> Self {
@@ -8757,33 +8346,13 @@ impl ::core::clone::Clone for DDHAL_RENDERMOCOMPDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_RENDERMOCOMPDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_RENDERMOCOMPDATA")
-            .field("lpDD", &self.lpDD)
-            .field("lpMoComp", &self.lpMoComp)
-            .field("dwNumBuffers", &self.dwNumBuffers)
-            .field("lpBufferInfo", &self.lpBufferInfo)
-            .field("dwFunction", &self.dwFunction)
-            .field("lpInputData", &self.lpInputData)
-            .field("dwInputDataSize", &self.dwInputDataSize)
-            .field("lpOutputData", &self.lpOutputData)
-            .field("dwOutputDataSize", &self.dwOutputDataSize)
-            .field("ddRVal", &self.ddRVal)
-            .field("RenderMoComp", &self.RenderMoComp.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DDHAL_RENDERMOCOMPDATA").field("lpDD", &self.lpDD).field("lpMoComp", &self.lpMoComp).field("dwNumBuffers", &self.dwNumBuffers).field("lpBufferInfo", &self.lpBufferInfo).field("dwFunction", &self.dwFunction).field("lpInputData", &self.lpInputData).field("dwInputDataSize", &self.dwInputDataSize).field("lpOutputData", &self.lpOutputData).field("dwOutputDataSize", &self.dwOutputDataSize).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_RENDERMOCOMPDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_RENDERMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_RENDERMOCOMPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_RENDERMOCOMPDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_RENDERMOCOMPDATA {
     fn default() -> Self {
@@ -8810,21 +8379,13 @@ impl ::core::clone::Clone for DDHAL_SETCLIPLISTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETCLIPLISTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETCLIPLISTDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).field("SetClipList", &self.SetClipList.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_SETCLIPLISTDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETCLIPLISTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETCLIPLISTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETCLIPLISTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETCLIPLISTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETCLIPLISTDATA {
     fn default() -> Self {
@@ -8853,21 +8414,13 @@ impl ::core::clone::Clone for DDHAL_SETCOLORKEYDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETCOLORKEYDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETCOLORKEYDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ckNew", &self.ckNew).field("ddRVal", &self.ddRVal).field("SetColorKey", &self.SetColorKey.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_SETCOLORKEYDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("dwFlags", &self.dwFlags).field("ckNew", &self.ckNew).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETCOLORKEYDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETCOLORKEYDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETCOLORKEYDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETCOLORKEYDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETCOLORKEYDATA {
     fn default() -> Self {
@@ -8897,21 +8450,13 @@ impl ::core::clone::Clone for DDHAL_SETENTRIESDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETENTRIESDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETENTRIESDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("dwBase", &self.dwBase).field("dwNumEntries", &self.dwNumEntries).field("lpEntries", &self.lpEntries).field("ddRVal", &self.ddRVal).field("SetEntries", &self.SetEntries.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_SETENTRIESDATA").field("lpDD", &self.lpDD).field("lpDDPalette", &self.lpDDPalette).field("dwBase", &self.dwBase).field("dwNumEntries", &self.dwNumEntries).field("lpEntries", &self.lpEntries).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETENTRIESDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETENTRIESDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETENTRIESDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETENTRIESDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETENTRIESDATA {
     fn default() -> Self {
@@ -8939,21 +8484,13 @@ impl ::core::clone::Clone for DDHAL_SETEXCLUSIVEMODEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETEXCLUSIVEMODEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETEXCLUSIVEMODEDATA").field("lpDD", &self.lpDD).field("dwEnterExcl", &self.dwEnterExcl).field("dwReserved", &self.dwReserved).field("ddRVal", &self.ddRVal).field("SetExclusiveMode", &self.SetExclusiveMode.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_SETEXCLUSIVEMODEDATA").field("lpDD", &self.lpDD).field("dwEnterExcl", &self.dwEnterExcl).field("dwReserved", &self.dwReserved).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETEXCLUSIVEMODEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETEXCLUSIVEMODEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETEXCLUSIVEMODEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETEXCLUSIVEMODEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETEXCLUSIVEMODEDATA {
     fn default() -> Self {
@@ -8982,21 +8519,13 @@ impl ::core::clone::Clone for DDHAL_SETMODEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETMODEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETMODEDATA").field("lpDD", &self.lpDD).field("dwModeIndex", &self.dwModeIndex).field("ddRVal", &self.ddRVal).field("SetMode", &self.SetMode.map(|f| f as usize)).field("inexcl", &self.inexcl).field("useRefreshRate", &self.useRefreshRate).finish()
+        f.debug_struct("DDHAL_SETMODEDATA").field("lpDD", &self.lpDD).field("dwModeIndex", &self.dwModeIndex).field("ddRVal", &self.ddRVal).field("inexcl", &self.inexcl).field("useRefreshRate", &self.useRefreshRate).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETMODEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETMODEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETMODEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETMODEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETMODEDATA {
     fn default() -> Self {
@@ -9026,21 +8555,13 @@ impl ::core::clone::Clone for DDHAL_SETOVERLAYPOSITIONDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETOVERLAYPOSITIONDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETOVERLAYPOSITIONDATA").field("lpDD", &self.lpDD).field("lpDDSrcSurface", &self.lpDDSrcSurface).field("lpDDDestSurface", &self.lpDDDestSurface).field("lXPos", &self.lXPos).field("lYPos", &self.lYPos).field("ddRVal", &self.ddRVal).field("SetOverlayPosition", &self.SetOverlayPosition.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_SETOVERLAYPOSITIONDATA").field("lpDD", &self.lpDD).field("lpDDSrcSurface", &self.lpDDSrcSurface).field("lpDDDestSurface", &self.lpDDDestSurface).field("lXPos", &self.lXPos).field("lYPos", &self.lYPos).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETOVERLAYPOSITIONDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETOVERLAYPOSITIONDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETOVERLAYPOSITIONDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETOVERLAYPOSITIONDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETOVERLAYPOSITIONDATA {
     fn default() -> Self {
@@ -9069,21 +8590,13 @@ impl ::core::clone::Clone for DDHAL_SETPALETTEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_SETPALETTEDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_SETPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpDDPalette", &self.lpDDPalette).field("ddRVal", &self.ddRVal).field("SetPalette", &self.SetPalette.map(|f| f as usize)).field("Attach", &self.Attach).finish()
+        f.debug_struct("DDHAL_SETPALETTEDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("lpDDPalette", &self.lpDDPalette).field("ddRVal", &self.ddRVal).field("Attach", &self.Attach).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_SETPALETTEDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_SETPALETTEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SETPALETTEDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_SETPALETTEDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_SETPALETTEDATA {
     fn default() -> Self {
@@ -9147,7 +8660,7 @@ unsafe impl ::windows::core::Abi for DDHAL_SYNCSURFACEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDHAL_SYNCSURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SYNCSURFACEDATA>()) == 0 }
+        self.dwSize == other.dwSize && self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.dwSurfaceOffset == other.dwSurfaceOffset && self.fpLockPtr == other.fpLockPtr && self.lPitch == other.lPitch && self.dwOverlayOffset == other.dwOverlayOffset && self.dwOverlaySrcWidth == other.dwOverlaySrcWidth && self.dwOverlaySrcHeight == other.dwOverlaySrcHeight && self.dwOverlayDestWidth == other.dwOverlayDestWidth && self.dwOverlayDestHeight == other.dwOverlayDestHeight && self.dwDriverReserved1 == other.dwDriverReserved1 && self.dwDriverReserved2 == other.dwDriverReserved2 && self.dwDriverReserved3 == other.dwDriverReserved3 && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9194,7 +8707,7 @@ unsafe impl ::windows::core::Abi for DDHAL_SYNCVIDEOPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDHAL_SYNCVIDEOPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_SYNCVIDEOPORTDATA>()) == 0 }
+        self.dwSize == other.dwSize && self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwOriginOffset == other.dwOriginOffset && self.dwHeight == other.dwHeight && self.dwVBIHeight == other.dwVBIHeight && self.dwDriverReserved1 == other.dwDriverReserved1 && self.dwDriverReserved2 == other.dwDriverReserved2 && self.dwDriverReserved3 == other.dwDriverReserved3 && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9225,21 +8738,13 @@ impl ::core::clone::Clone for DDHAL_UNLOCKDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_UNLOCKDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_UNLOCKDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).field("Unlock", &self.Unlock.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_UNLOCKDATA").field("lpDD", &self.lpDD).field("lpDDSurface", &self.lpDDSurface).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_UNLOCKDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_UNLOCKDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_UNLOCKDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_UNLOCKDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_UNLOCKDATA {
     fn default() -> Self {
@@ -9269,21 +8774,13 @@ impl ::core::clone::Clone for DDHAL_UPDATENONLOCALHEAPDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_UPDATENONLOCALHEAPDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_UPDATENONLOCALHEAPDATA").field("lpDD", &self.lpDD).field("dwHeap", &self.dwHeap).field("fpGARTLin", &self.fpGARTLin).field("fpGARTDev", &self.fpGARTDev).field("ulPolicyMaxBytes", &self.ulPolicyMaxBytes).field("ddRVal", &self.ddRVal).field("UpdateNonLocalHeap", &self.UpdateNonLocalHeap.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_UPDATENONLOCALHEAPDATA").field("lpDD", &self.lpDD).field("dwHeap", &self.dwHeap).field("fpGARTLin", &self.fpGARTLin).field("fpGARTDev", &self.fpGARTDev).field("ulPolicyMaxBytes", &self.ulPolicyMaxBytes).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_UPDATENONLOCALHEAPDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_UPDATENONLOCALHEAPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_UPDATENONLOCALHEAPDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_UPDATENONLOCALHEAPDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_UPDATENONLOCALHEAPDATA {
     fn default() -> Self {
@@ -9325,14 +8822,6 @@ unsafe impl ::windows::core::Abi for DDHAL_UPDATEOVERLAYDATA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_UPDATEOVERLAYDATA {
-    fn eq(&self, other: &Self) -> bool {
-        self.lpDD == other.lpDD && self.lpDDDestSurface == other.lpDDDestSurface && self.rDest == other.rDest && self.lpDDSrcSurface == other.lpDDSrcSurface && self.rSrc == other.rSrc && self.dwFlags == other.dwFlags && self.overlayFX == other.overlayFX && self.ddRVal == other.ddRVal && self.UpdateOverlay.map(|f| f as usize) == other.UpdateOverlay.map(|f| f as usize)
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_UPDATEOVERLAYDATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_UPDATEOVERLAYDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9364,21 +8853,13 @@ impl ::core::clone::Clone for DDHAL_UPDATEVPORTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_UPDATEVPORTDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_UPDATEVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lplpDDSurface", &self.lplpDDSurface).field("lplpDDVBISurface", &self.lplpDDVBISurface).field("lpVideoInfo", &self.lpVideoInfo).field("dwFlags", &self.dwFlags).field("dwNumAutoflip", &self.dwNumAutoflip).field("dwNumVBIAutoflip", &self.dwNumVBIAutoflip).field("ddRVal", &self.ddRVal).field("UpdateVideoPort", &self.UpdateVideoPort.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_UPDATEVPORTDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("lplpDDSurface", &self.lplpDDSurface).field("lplpDDVBISurface", &self.lplpDDVBISurface).field("lpVideoInfo", &self.lpVideoInfo).field("dwFlags", &self.dwFlags).field("dwNumAutoflip", &self.dwNumAutoflip).field("dwNumVBIAutoflip", &self.dwNumVBIAutoflip).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_UPDATEVPORTDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_UPDATEVPORTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_UPDATEVPORTDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_UPDATEVPORTDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_UPDATEVPORTDATA {
     fn default() -> Self {
@@ -9407,21 +8888,13 @@ impl ::core::clone::Clone for DDHAL_VPORTCOLORDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_VPORTCOLORDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_VPORTCOLORDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpColorData", &self.lpColorData).field("ddRVal", &self.ddRVal).field("ColorControl", &self.ColorControl.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_VPORTCOLORDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("lpColorData", &self.lpColorData).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_VPORTCOLORDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_VPORTCOLORDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_VPORTCOLORDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_VPORTCOLORDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_VPORTCOLORDATA {
     fn default() -> Self {
@@ -9450,21 +8923,13 @@ impl ::core::clone::Clone for DDHAL_WAITFORVERTICALBLANKDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_WAITFORVERTICALBLANKDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_WAITFORVERTICALBLANKDATA").field("lpDD", &self.lpDD).field("dwFlags", &self.dwFlags).field("bIsInVB", &self.bIsInVB).field("hEvent", &self.hEvent).field("ddRVal", &self.ddRVal).field("WaitForVerticalBlank", &self.WaitForVerticalBlank.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_WAITFORVERTICALBLANKDATA").field("lpDD", &self.lpDD).field("dwFlags", &self.dwFlags).field("bIsInVB", &self.bIsInVB).field("hEvent", &self.hEvent).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_WAITFORVERTICALBLANKDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_WAITFORVERTICALBLANKDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_WAITFORVERTICALBLANKDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_WAITFORVERTICALBLANKDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_WAITFORVERTICALBLANKDATA {
     fn default() -> Self {
@@ -9494,21 +8959,13 @@ impl ::core::clone::Clone for DDHAL_WAITFORVPORTSYNCDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DDHAL_WAITFORVPORTSYNCDATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DDHAL_WAITFORVPORTSYNCDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("dwLine", &self.dwLine).field("dwTimeOut", &self.dwTimeOut).field("ddRVal", &self.ddRVal).field("WaitForVideoPortSync", &self.WaitForVideoPortSync.map(|f| f as usize)).finish()
+        f.debug_struct("DDHAL_WAITFORVPORTSYNCDATA").field("lpDD", &self.lpDD).field("lpVideoPort", &self.lpVideoPort).field("dwFlags", &self.dwFlags).field("dwLine", &self.dwLine).field("dwTimeOut", &self.dwTimeOut).field("ddRVal", &self.ddRVal).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DDHAL_WAITFORVPORTSYNCDATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDHAL_WAITFORVPORTSYNCDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDHAL_WAITFORVPORTSYNCDATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDHAL_WAITFORVPORTSYNCDATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDHAL_WAITFORVPORTSYNCDATA {
     fn default() -> Self {
@@ -9538,7 +8995,7 @@ unsafe impl ::windows::core::Abi for DDKERNELCAPS {
 }
 impl ::core::cmp::PartialEq for DDKERNELCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDKERNELCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCaps == other.dwCaps && self.dwIRQCaps == other.dwIRQCaps
     }
 }
 impl ::core::cmp::Eq for DDKERNELCAPS {}
@@ -9568,7 +9025,7 @@ unsafe impl ::windows::core::Abi for DDLOCKININFO {
 }
 impl ::core::cmp::PartialEq for DDLOCKININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDLOCKININFO>()) == 0 }
+        self.lpSurfaceData == other.lpSurfaceData
     }
 }
 impl ::core::cmp::Eq for DDLOCKININFO {}
@@ -9598,7 +9055,7 @@ unsafe impl ::windows::core::Abi for DDLOCKOUTINFO {
 }
 impl ::core::cmp::PartialEq for DDLOCKOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDLOCKOUTINFO>()) == 0 }
+        self.dwSurfacePtr == other.dwSurfacePtr
     }
 }
 impl ::core::cmp::Eq for DDLOCKOUTINFO {}
@@ -9638,7 +9095,7 @@ unsafe impl ::windows::core::Abi for DDMCBUFFERINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDMCBUFFERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMCBUFFERINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.lpCompSurface == other.lpCompSurface && self.dwDataOffset == other.dwDataOffset && self.dwDataSize == other.dwDataSize && self.lpPrivate == other.lpPrivate
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9669,12 +9126,6 @@ impl ::core::clone::Clone for DDMCCOMPBUFFERINFO {
 unsafe impl ::windows::core::Abi for DDMCCOMPBUFFERINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDMCCOMPBUFFERINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMCCOMPBUFFERINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDMCCOMPBUFFERINFO {}
 impl ::core::default::Default for DDMCCOMPBUFFERINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9711,7 +9162,7 @@ unsafe impl ::windows::core::Abi for DDMOCOMPBUFFERINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDMOCOMPBUFFERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMOCOMPBUFFERINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.lpCompSurface == other.lpCompSurface && self.dwDataOffset == other.dwDataOffset && self.dwDataSize == other.dwDataSize && self.lpPrivate == other.lpPrivate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9767,7 +9218,7 @@ unsafe impl ::windows::core::Abi for DDMONITORINFO {
 }
 impl ::core::cmp::PartialEq for DDMONITORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMONITORINFO>()) == 0 }
+        self.Manufacturer == other.Manufacturer && self.Product == other.Product && self.SerialNumber == other.SerialNumber && self.DeviceIdentifier == other.DeviceIdentifier && self.Mode640x480 == other.Mode640x480 && self.Mode800x600 == other.Mode800x600 && self.Mode1024x768 == other.Mode1024x768 && self.Mode1280x1024 == other.Mode1280x1024 && self.Mode1600x1200 == other.Mode1600x1200 && self.ModeReserved1 == other.ModeReserved1 && self.ModeReserved2 == other.ModeReserved2 && self.ModeReserved3 == other.ModeReserved3
     }
 }
 impl ::core::cmp::Eq for DDMONITORINFO {}
@@ -9792,12 +9243,6 @@ impl ::core::clone::Clone for DDMORESURFACECAPS {
 unsafe impl ::windows::core::Abi for DDMORESURFACECAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDMORESURFACECAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMORESURFACECAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDMORESURFACECAPS {}
 impl ::core::default::Default for DDMORESURFACECAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9818,12 +9263,6 @@ impl ::core::clone::Clone for DDMORESURFACECAPS_0 {
 unsafe impl ::windows::core::Abi for DDMORESURFACECAPS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDMORESURFACECAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDMORESURFACECAPS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDMORESURFACECAPS_0 {}
 impl ::core::default::Default for DDMORESURFACECAPS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9855,7 +9294,7 @@ unsafe impl ::windows::core::Abi for DDNONLOCALVIDMEMCAPS {
 }
 impl ::core::cmp::PartialEq for DDNONLOCALVIDMEMCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDNONLOCALVIDMEMCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwNLVBCaps == other.dwNLVBCaps && self.dwNLVBCaps2 == other.dwNLVBCaps2 && self.dwNLVBCKeyCaps == other.dwNLVBCKeyCaps && self.dwNLVBFXCaps == other.dwNLVBFXCaps && self.dwNLVBRops == other.dwNLVBRops
     }
 }
 impl ::core::cmp::Eq for DDNONLOCALVIDMEMCAPS {}
@@ -9987,7 +9426,57 @@ unsafe impl ::windows::core::Abi for DDNTCORECAPS {
 }
 impl ::core::cmp::PartialEq for DDNTCORECAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDNTCORECAPS>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCaps == other.dwCaps
+            && self.dwCaps2 == other.dwCaps2
+            && self.dwCKeyCaps == other.dwCKeyCaps
+            && self.dwFXCaps == other.dwFXCaps
+            && self.dwFXAlphaCaps == other.dwFXAlphaCaps
+            && self.dwPalCaps == other.dwPalCaps
+            && self.dwSVCaps == other.dwSVCaps
+            && self.dwAlphaBltConstBitDepths == other.dwAlphaBltConstBitDepths
+            && self.dwAlphaBltPixelBitDepths == other.dwAlphaBltPixelBitDepths
+            && self.dwAlphaBltSurfaceBitDepths == other.dwAlphaBltSurfaceBitDepths
+            && self.dwAlphaOverlayConstBitDepths == other.dwAlphaOverlayConstBitDepths
+            && self.dwAlphaOverlayPixelBitDepths == other.dwAlphaOverlayPixelBitDepths
+            && self.dwAlphaOverlaySurfaceBitDepths == other.dwAlphaOverlaySurfaceBitDepths
+            && self.dwZBufferBitDepths == other.dwZBufferBitDepths
+            && self.dwVidMemTotal == other.dwVidMemTotal
+            && self.dwVidMemFree == other.dwVidMemFree
+            && self.dwMaxVisibleOverlays == other.dwMaxVisibleOverlays
+            && self.dwCurrVisibleOverlays == other.dwCurrVisibleOverlays
+            && self.dwNumFourCCCodes == other.dwNumFourCCCodes
+            && self.dwAlignBoundarySrc == other.dwAlignBoundarySrc
+            && self.dwAlignSizeSrc == other.dwAlignSizeSrc
+            && self.dwAlignBoundaryDest == other.dwAlignBoundaryDest
+            && self.dwAlignSizeDest == other.dwAlignSizeDest
+            && self.dwAlignStrideAlign == other.dwAlignStrideAlign
+            && self.dwRops == other.dwRops
+            && self.ddsCaps == other.ddsCaps
+            && self.dwMinOverlayStretch == other.dwMinOverlayStretch
+            && self.dwMaxOverlayStretch == other.dwMaxOverlayStretch
+            && self.dwMinLiveVideoStretch == other.dwMinLiveVideoStretch
+            && self.dwMaxLiveVideoStretch == other.dwMaxLiveVideoStretch
+            && self.dwMinHwCodecStretch == other.dwMinHwCodecStretch
+            && self.dwMaxHwCodecStretch == other.dwMaxHwCodecStretch
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.dwReserved3 == other.dwReserved3
+            && self.dwSVBCaps == other.dwSVBCaps
+            && self.dwSVBCKeyCaps == other.dwSVBCKeyCaps
+            && self.dwSVBFXCaps == other.dwSVBFXCaps
+            && self.dwSVBRops == other.dwSVBRops
+            && self.dwVSBCaps == other.dwVSBCaps
+            && self.dwVSBCKeyCaps == other.dwVSBCKeyCaps
+            && self.dwVSBFXCaps == other.dwVSBFXCaps
+            && self.dwVSBRops == other.dwVSBRops
+            && self.dwSSBCaps == other.dwSSBCaps
+            && self.dwSSBCKeyCaps == other.dwSSBCKeyCaps
+            && self.dwSSBFXCaps == other.dwSSBFXCaps
+            && self.dwSSBRops == other.dwSSBRops
+            && self.dwMaxVideoPorts == other.dwMaxVideoPorts
+            && self.dwCurrVideoPorts == other.dwCurrVideoPorts
+            && self.dwSVBCaps2 == other.dwSVBCaps2
     }
 }
 impl ::core::cmp::Eq for DDNTCORECAPS {}
@@ -10015,12 +9504,6 @@ impl ::core::clone::Clone for DDOPTSURFACEDESC {
 unsafe impl ::windows::core::Abi for DDOPTSURFACEDESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDOPTSURFACEDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDOPTSURFACEDESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDOPTSURFACEDESC {}
 impl ::core::default::Default for DDOPTSURFACEDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10047,7 +9530,7 @@ unsafe impl ::windows::core::Abi for DDOSCAPS {
 }
 impl ::core::cmp::PartialEq for DDOSCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDOSCAPS>()) == 0 }
+        self.dwCaps == other.dwCaps
     }
 }
 impl ::core::cmp::Eq for DDOSCAPS {}
@@ -10093,12 +9576,6 @@ impl ::core::clone::Clone for DDOVERLAYFX {
 unsafe impl ::windows::core::Abi for DDOVERLAYFX {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDOVERLAYFX {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwSize == other.dwSize && self.dwAlphaEdgeBlendBitDepth == other.dwAlphaEdgeBlendBitDepth && self.dwAlphaEdgeBlend == other.dwAlphaEdgeBlend && self.dwReserved == other.dwReserved && self.dwAlphaDestConstBitDepth == other.dwAlphaDestConstBitDepth && self.Anonymous1 == other.Anonymous1 && self.dwAlphaSrcConstBitDepth == other.dwAlphaSrcConstBitDepth && self.Anonymous2 == other.Anonymous2 && self.dckDestColorkey == other.dckDestColorkey && self.dckSrcColorkey == other.dckSrcColorkey && self.dwDDFX == other.dwDDFX && self.dwFlags == other.dwFlags
-    }
-}
-impl ::core::cmp::Eq for DDOVERLAYFX {}
 impl ::core::default::Default for DDOVERLAYFX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10118,12 +9595,6 @@ impl ::core::clone::Clone for DDOVERLAYFX_0 {
 unsafe impl ::windows::core::Abi for DDOVERLAYFX_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDOVERLAYFX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDOVERLAYFX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDOVERLAYFX_0 {}
 impl ::core::default::Default for DDOVERLAYFX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10143,12 +9614,6 @@ impl ::core::clone::Clone for DDOVERLAYFX_1 {
 unsafe impl ::windows::core::Abi for DDOVERLAYFX_1 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for DDOVERLAYFX_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDOVERLAYFX_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDOVERLAYFX_1 {}
 impl ::core::default::Default for DDOVERLAYFX_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10175,12 +9640,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT {}
 impl ::core::default::Default for DDPIXELFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10206,12 +9665,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT_0 {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT_0 {}
 impl ::core::default::Default for DDPIXELFORMAT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10236,12 +9689,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT_1 {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT_1 {}
 impl ::core::default::Default for DDPIXELFORMAT_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10265,12 +9712,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT_2 {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT_2 {}
 impl ::core::default::Default for DDPIXELFORMAT_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10298,7 +9739,7 @@ unsafe impl ::windows::core::Abi for DDPIXELFORMAT_2_0 {
 }
 impl ::core::cmp::PartialEq for DDPIXELFORMAT_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_2_0>()) == 0 }
+        self.wFlipMSTypes == other.wFlipMSTypes && self.wBltMSTypes == other.wBltMSTypes
     }
 }
 impl ::core::cmp::Eq for DDPIXELFORMAT_2_0 {}
@@ -10324,12 +9765,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT_3 {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT_3 {}
 impl ::core::default::Default for DDPIXELFORMAT_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10353,12 +9788,6 @@ impl ::core::clone::Clone for DDPIXELFORMAT_4 {
 unsafe impl ::windows::core::Abi for DDPIXELFORMAT_4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDPIXELFORMAT_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDPIXELFORMAT_4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDPIXELFORMAT_4 {}
 impl ::core::default::Default for DDPIXELFORMAT_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10394,7 +9823,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDMOTIONCOMP_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDMOTIONCOMP_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDMOTIONCOMP_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -10438,14 +9867,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDMOTIONCOMP_LCL {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDMOTIONCOMP_LCL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDMOTIONCOMP_LCL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDMOTIONCOMP_LCL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDMOTIONCOMP_LCL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10484,7 +9905,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWCLIPPER_GBL {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDRAWCLIPPER_GBL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWCLIPPER_GBL>()) == 0 }
+        self.dwRefCnt == other.dwRefCnt && self.dwFlags == other.dwFlags && self.lpDD == other.lpDD && self.dwProcessId == other.dwProcessId && self.dwReserved1 == other.dwReserved1 && self.hWnd == other.hWnd && self.lpStaticClipList == other.lpStaticClipList
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -10525,7 +9946,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWCLIPPER_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDRAWCLIPPER_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWCLIPPER_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -10616,14 +10037,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWPALETTE_GBL {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWPALETTE_GBL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWPALETTE_GBL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWPALETTE_GBL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWPALETTE_GBL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10648,14 +10061,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWPALETTE_GBL_0 {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWPALETTE_GBL_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWPALETTE_GBL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWPALETTE_GBL_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWPALETTE_GBL_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWPALETTE_GBL_0 {
     fn default() -> Self {
@@ -10692,7 +10097,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWPALETTE_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDRAWPALETTE_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWPALETTE_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -10789,14 +10194,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10823,14 +10220,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10855,14 +10244,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWSURFACE_GBL_1 {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_1 {
     fn default() -> Self {
@@ -10889,14 +10270,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10921,14 +10294,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWSURFACE_GBL_3 {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_3 {
     fn default() -> Self {
@@ -10967,12 +10332,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWSURFACE_GBL_MORE {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_MORE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_MORE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_MORE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_MORE {}
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_MORE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10993,12 +10352,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_GBL_MORE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {}
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11034,7 +10387,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11090,14 +10443,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_LCL {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_LCL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_LCL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_LCL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_LCL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11123,14 +10468,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_LCL_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_LCL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_LCL_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_LCL_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_LCL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11155,14 +10492,6 @@ impl ::core::clone::Clone for DDRAWI_DDRAWSURFACE_LCL_1 {
 unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_LCL_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_LCL_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_LCL_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_LCL_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_LCL_1 {
     fn default() -> Self {
@@ -11218,14 +10547,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDRAWSURFACE_MORE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DDRAWSURFACE_MORE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDRAWSURFACE_MORE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DDRAWSURFACE_MORE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DDRAWSURFACE_MORE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11262,7 +10583,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDVIDEOPORT_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDVIDEOPORT_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDVIDEOPORT_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11344,7 +10665,28 @@ unsafe impl ::windows::core::Abi for DDRAWI_DDVIDEOPORT_LCL {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DDVIDEOPORT_LCL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DDVIDEOPORT_LCL>()) == 0 }
+        self.lpDD == other.lpDD
+            && self.ddvpDesc == other.ddvpDesc
+            && self.ddvpInfo == other.ddvpInfo
+            && self.lpSurface == other.lpSurface
+            && self.lpVBISurface == other.lpVBISurface
+            && self.lpFlipInts == other.lpFlipInts
+            && self.dwNumAutoflip == other.dwNumAutoflip
+            && self.dwProcessID == other.dwProcessID
+            && self.dwStateFlags == other.dwStateFlags
+            && self.dwFlags == other.dwFlags
+            && self.dwRefCnt == other.dwRefCnt
+            && self.fpLastFlip == other.fpLastFlip
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
+            && self.hDDVideoPort == other.hDDVideoPort
+            && self.dwNumVBIAutoflip == other.dwNumVBIAutoflip
+            && self.lpVBIDesc == other.lpVBIDesc
+            && self.lpVideoDesc == other.lpVideoDesc
+            && self.lpVBIInfo == other.lpVBIInfo
+            && self.lpVideoInfo == other.lpVideoInfo
+            && self.dwVBIProcessID == other.dwVBIProcessID
+            && self.lpVPNotify == other.lpVPNotify
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11443,14 +10785,6 @@ unsafe impl ::windows::core::Abi for DDRAWI_DIRECTDRAW_GBL {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DIRECTDRAW_GBL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DIRECTDRAW_GBL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DIRECTDRAW_GBL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DIRECTDRAW_GBL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11486,7 +10820,7 @@ unsafe impl ::windows::core::Abi for DDRAWI_DIRECTDRAW_INT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DDRAWI_DIRECTDRAW_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRAWI_DIRECTDRAW_INT>()) == 0 }
+        self.lpVtbl == other.lpVtbl && self.lpLcl == other.lpLcl && self.lpLink == other.lpLink && self.dwIntRefCnt == other.dwIntRefCnt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11590,7 +10924,6 @@ impl ::core::fmt::Debug for DDRAWI_DIRECTDRAW_LCL {
             .field("hWndPopup", &self.hWndPopup)
             .field("hDD", &self.hDD)
             .field("hGammaCalibrator", &self.hGammaCalibrator)
-            .field("lpGammaCalibrator", &self.lpGammaCalibrator.map(|f| f as usize))
             .finish()
     }
 }
@@ -11598,39 +10931,6 @@ impl ::core::fmt::Debug for DDRAWI_DIRECTDRAW_LCL {
 unsafe impl ::windows::core::Abi for DDRAWI_DIRECTDRAW_LCL {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DDRAWI_DIRECTDRAW_LCL {
-    fn eq(&self, other: &Self) -> bool {
-        self.lpDDMore == other.lpDDMore
-            && self.lpGbl == other.lpGbl
-            && self.dwUnused0 == other.dwUnused0
-            && self.dwLocalFlags == other.dwLocalFlags
-            && self.dwLocalRefCnt == other.dwLocalRefCnt
-            && self.dwProcessId == other.dwProcessId
-            && self.pUnkOuter == other.pUnkOuter
-            && self.dwObsolete1 == other.dwObsolete1
-            && self.hWnd == other.hWnd
-            && self.hDC == other.hDC
-            && self.dwErrorMode == other.dwErrorMode
-            && self.lpPrimary == other.lpPrimary
-            && self.lpCB == other.lpCB
-            && self.dwPreferredMode == other.dwPreferredMode
-            && self.hD3DInstance == other.hD3DInstance
-            && self.pD3DIUnknown == other.pD3DIUnknown
-            && self.lpDDCB == other.lpDDCB
-            && self.hDDVxd == other.hDDVxd
-            && self.dwAppHackFlags == other.dwAppHackFlags
-            && self.hFocusWnd == other.hFocusWnd
-            && self.dwHotTracking == other.dwHotTracking
-            && self.dwIMEState == other.dwIMEState
-            && self.hWndPopup == other.hWndPopup
-            && self.hDD == other.hDD
-            && self.hGammaCalibrator == other.hGammaCalibrator
-            && self.lpGammaCalibrator.map(|f| f as usize) == other.lpGammaCalibrator.map(|f| f as usize)
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DDRAWI_DIRECTDRAW_LCL {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DDRAWI_DIRECTDRAW_LCL {
     fn default() -> Self {
@@ -11661,7 +10961,7 @@ unsafe impl ::windows::core::Abi for DDRGBA {
 }
 impl ::core::cmp::PartialEq for DDRGBA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDRGBA>()) == 0 }
+        self.red == other.red && self.green == other.green && self.blue == other.blue && self.alpha == other.alpha
     }
 }
 impl ::core::cmp::Eq for DDRGBA {}
@@ -11691,7 +10991,7 @@ unsafe impl ::windows::core::Abi for DDSCAPS {
 }
 impl ::core::cmp::PartialEq for DDSCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSCAPS>()) == 0 }
+        self.dwCaps == other.dwCaps
     }
 }
 impl ::core::cmp::Eq for DDSCAPS {}
@@ -11717,12 +11017,6 @@ impl ::core::clone::Clone for DDSCAPS2 {
 unsafe impl ::windows::core::Abi for DDSCAPS2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSCAPS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSCAPS2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSCAPS2 {}
 impl ::core::default::Default for DDSCAPS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11743,12 +11037,6 @@ impl ::core::clone::Clone for DDSCAPS2_0 {
 unsafe impl ::windows::core::Abi for DDSCAPS2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSCAPS2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSCAPS2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSCAPS2_0 {}
 impl ::core::default::Default for DDSCAPS2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11770,12 +11058,6 @@ impl ::core::clone::Clone for DDSCAPSEX {
 unsafe impl ::windows::core::Abi for DDSCAPSEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSCAPSEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSCAPSEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSCAPSEX {}
 impl ::core::default::Default for DDSCAPSEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11796,12 +11078,6 @@ impl ::core::clone::Clone for DDSCAPSEX_0 {
 unsafe impl ::windows::core::Abi for DDSCAPSEX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSCAPSEX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSCAPSEX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSCAPSEX_0 {}
 impl ::core::default::Default for DDSCAPSEX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11829,7 +11105,7 @@ unsafe impl ::windows::core::Abi for DDSETSTATEININFO {
 }
 impl ::core::cmp::PartialEq for DDSETSTATEININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSETSTATEININFO>()) == 0 }
+        self.lpSurfaceData == other.lpSurfaceData && self.lpVideoPortData == other.lpVideoPortData
     }
 }
 impl ::core::cmp::Eq for DDSETSTATEININFO {}
@@ -11867,7 +11143,7 @@ unsafe impl ::windows::core::Abi for DDSETSTATEOUTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDSETSTATEOUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSETSTATEOUTINFO>()) == 0 }
+        self.bSoftwareAutoflip == other.bSoftwareAutoflip && self.dwSurfaceIndex == other.dwSurfaceIndex && self.dwVBISurfaceIndex == other.dwVBISurfaceIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11900,7 +11176,7 @@ unsafe impl ::windows::core::Abi for DDSKIPNEXTFIELDINFO {
 }
 impl ::core::cmp::PartialEq for DDSKIPNEXTFIELDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSKIPNEXTFIELDINFO>()) == 0 }
+        self.lpVideoPortData == other.lpVideoPortData && self.dwSkipFlags == other.dwSkipFlags
     }
 }
 impl ::core::cmp::Eq for DDSKIPNEXTFIELDINFO {}
@@ -11941,7 +11217,7 @@ unsafe impl ::windows::core::Abi for DDSTEREOMODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDSTEREOMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSTEREOMODE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwHeight == other.dwHeight && self.dwWidth == other.dwWidth && self.dwBpp == other.dwBpp && self.dwRefreshRate == other.dwRefreshRate && self.bSupported == other.bSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12019,7 +11295,29 @@ unsafe impl ::windows::core::Abi for DDSURFACEDATA {
 }
 impl ::core::cmp::PartialEq for DDSURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDATA>()) == 0 }
+        self.ddsCaps == other.ddsCaps
+            && self.dwSurfaceOffset == other.dwSurfaceOffset
+            && self.fpLockPtr == other.fpLockPtr
+            && self.dwWidth == other.dwWidth
+            && self.dwHeight == other.dwHeight
+            && self.lPitch == other.lPitch
+            && self.dwOverlayFlags == other.dwOverlayFlags
+            && self.dwOverlayOffset == other.dwOverlayOffset
+            && self.dwOverlaySrcWidth == other.dwOverlaySrcWidth
+            && self.dwOverlaySrcHeight == other.dwOverlaySrcHeight
+            && self.dwOverlayDestWidth == other.dwOverlayDestWidth
+            && self.dwOverlayDestHeight == other.dwOverlayDestHeight
+            && self.dwVideoPortId == other.dwVideoPortId
+            && self.dwFormatFlags == other.dwFormatFlags
+            && self.dwFormatFourCC == other.dwFormatFourCC
+            && self.dwFormatBitCount == other.dwFormatBitCount
+            && self.dwRBitMask == other.dwRBitMask
+            && self.dwGBitMask == other.dwGBitMask
+            && self.dwBBitMask == other.dwBBitMask
+            && self.dwDriverReserved1 == other.dwDriverReserved1
+            && self.dwDriverReserved2 == other.dwDriverReserved2
+            && self.dwDriverReserved3 == other.dwDriverReserved3
+            && self.dwDriverReserved4 == other.dwDriverReserved4
     }
 }
 impl ::core::cmp::Eq for DDSURFACEDATA {}
@@ -12057,12 +11355,6 @@ impl ::core::clone::Clone for DDSURFACEDESC {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC {}
 impl ::core::default::Default for DDSURFACEDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12083,12 +11375,6 @@ impl ::core::clone::Clone for DDSURFACEDESC_0 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC_0 {}
 impl ::core::default::Default for DDSURFACEDESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12110,12 +11396,6 @@ impl ::core::clone::Clone for DDSURFACEDESC_1 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC_1 {}
 impl ::core::default::Default for DDSURFACEDESC_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12151,12 +11431,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2 {}
 impl ::core::default::Default for DDSURFACEDESC2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12177,12 +11451,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2_0 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2_0 {}
 impl ::core::default::Default for DDSURFACEDESC2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12203,12 +11471,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2_1 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2_1 {}
 impl ::core::default::Default for DDSURFACEDESC2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12230,12 +11492,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2_2 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2_2 {}
 impl ::core::default::Default for DDSURFACEDESC2_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12256,12 +11512,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2_3 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2_3 {}
 impl ::core::default::Default for DDSURFACEDESC2_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12282,12 +11532,6 @@ impl ::core::clone::Clone for DDSURFACEDESC2_4 {
 unsafe impl ::windows::core::Abi for DDSURFACEDESC2_4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DDSURFACEDESC2_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDSURFACEDESC2_4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DDSURFACEDESC2_4 {}
 impl ::core::default::Default for DDSURFACEDESC2_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12319,7 +11563,7 @@ unsafe impl ::windows::core::Abi for DDTRANSFERININFO {
 }
 impl ::core::cmp::PartialEq for DDTRANSFERININFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDTRANSFERININFO>()) == 0 }
+        self.lpSurfaceData == other.lpSurfaceData && self.dwStartLine == other.dwStartLine && self.dwEndLine == other.dwEndLine && self.dwTransferID == other.dwTransferID && self.dwTransferFlags == other.dwTransferFlags && self.lpDestMDL == other.lpDestMDL
     }
 }
 impl ::core::cmp::Eq for DDTRANSFERININFO {}
@@ -12349,7 +11593,7 @@ unsafe impl ::windows::core::Abi for DDTRANSFEROUTINFO {
 }
 impl ::core::cmp::PartialEq for DDTRANSFEROUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDTRANSFEROUTINFO>()) == 0 }
+        self.dwBufferPolarity == other.dwBufferPolarity
     }
 }
 impl ::core::cmp::Eq for DDTRANSFEROUTINFO {}
@@ -12381,7 +11625,7 @@ unsafe impl ::windows::core::Abi for DDVERSIONDATA {
 }
 impl ::core::cmp::PartialEq for DDVERSIONDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVERSIONDATA>()) == 0 }
+        self.dwHALVersion == other.dwHALVersion && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for DDVERSIONDATA {}
@@ -12418,7 +11662,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTBANDWIDTH {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTBANDWIDTH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTBANDWIDTH>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCaps == other.dwCaps && self.dwOverlay == other.dwOverlay && self.dwColorkey == other.dwColorkey && self.dwYInterpolate == other.dwYInterpolate && self.dwYInterpAndColorkey == other.dwYInterpAndColorkey && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTBANDWIDTH {}
@@ -12486,7 +11730,25 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTCAPS {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTCAPS>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwFlags == other.dwFlags
+            && self.dwMaxWidth == other.dwMaxWidth
+            && self.dwMaxVBIWidth == other.dwMaxVBIWidth
+            && self.dwMaxHeight == other.dwMaxHeight
+            && self.dwVideoPortID == other.dwVideoPortID
+            && self.dwCaps == other.dwCaps
+            && self.dwFX == other.dwFX
+            && self.dwNumAutoFlipSurfaces == other.dwNumAutoFlipSurfaces
+            && self.dwAlignVideoPortBoundary == other.dwAlignVideoPortBoundary
+            && self.dwAlignVideoPortPrescaleWidth == other.dwAlignVideoPortPrescaleWidth
+            && self.dwAlignVideoPortCropBoundary == other.dwAlignVideoPortCropBoundary
+            && self.dwAlignVideoPortCropWidth == other.dwAlignVideoPortCropWidth
+            && self.dwPreshrinkXStep == other.dwPreshrinkXStep
+            && self.dwPreshrinkYStep == other.dwPreshrinkYStep
+            && self.dwNumVBIAutoFlipSurfaces == other.dwNumVBIAutoFlipSurfaces
+            && self.dwNumPreferredAutoflip == other.dwNumPreferredAutoflip
+            && self.wNumFilterTapsX == other.wNumFilterTapsX
+            && self.wNumFilterTapsY == other.wNumFilterTapsY
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTCAPS {}
@@ -12520,7 +11782,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTCONNECT {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTCONNECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTCONNECT>()) == 0 }
+        self.dwSize == other.dwSize && self.dwPortWidth == other.dwPortWidth && self.guidTypeID == other.guidTypeID && self.dwFlags == other.dwFlags && self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTCONNECT {}
@@ -12557,7 +11819,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTDATA {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTDATA>()) == 0 }
+        self.dwVideoPortId == other.dwVideoPortId && self.dwVPFlags == other.dwVPFlags && self.dwOriginOffset == other.dwOriginOffset && self.dwHeight == other.dwHeight && self.dwVBIHeight == other.dwVBIHeight && self.dwDriverReserved1 == other.dwDriverReserved1 && self.dwDriverReserved2 == other.dwDriverReserved2 && self.dwDriverReserved3 == other.dwDriverReserved3
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTDATA {}
@@ -12609,7 +11871,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTDESC {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFieldWidth == other.dwFieldWidth && self.dwVBIWidth == other.dwVBIWidth && self.dwFieldHeight == other.dwFieldHeight && self.dwMicrosecondsPerField == other.dwMicrosecondsPerField && self.dwMaxPixelsPerSecond == other.dwMaxPixelsPerSecond && self.dwVideoPortID == other.dwVideoPortID && self.dwReserved1 == other.dwReserved1 && self.VideoPortType == other.VideoPortType && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTDESC {}
@@ -12671,7 +11933,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDVIDEOPORTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwOriginX == other.dwOriginX && self.dwOriginY == other.dwOriginY && self.dwVPFlags == other.dwVPFlags && self.rCrop == other.rCrop && self.dwPrescaleWidth == other.dwPrescaleWidth && self.dwPrescaleHeight == other.dwPrescaleHeight && self.lpddpfInputFormat == other.lpddpfInputFormat && self.lpddpfVBIInputFormat == other.lpddpfVBIInputFormat && self.lpddpfVBIOutputFormat == other.lpddpfVBIOutputFormat && self.dwVBIHeight == other.dwVBIHeight && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12706,7 +11968,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTNOTIFY {
 }
 impl ::core::cmp::PartialEq for DDVIDEOPORTNOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTNOTIFY>()) == 0 }
+        self.ApproximateTimeStamp == other.ApproximateTimeStamp && self.lField == other.lField && self.dwSurfaceIndex == other.dwSurfaceIndex && self.lDone == other.lDone
     }
 }
 impl ::core::cmp::Eq for DDVIDEOPORTNOTIFY {}
@@ -12748,7 +12010,7 @@ unsafe impl ::windows::core::Abi for DDVIDEOPORTSTATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DDVIDEOPORTSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDVIDEOPORTSTATUS>()) == 0 }
+        self.dwSize == other.dwSize && self.bInUse == other.bInUse && self.dwFlags == other.dwFlags && self.dwReserved1 == other.dwReserved1 && self.VideoPortType == other.VideoPortType && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12790,7 +12052,7 @@ unsafe impl ::windows::core::Abi for DD_ADDATTACHEDSURFACEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_ADDATTACHEDSURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_ADDATTACHEDSURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.lpSurfAttached == other.lpSurfAttached && self.ddRVal == other.ddRVal && self.AddAttachedSurface == other.AddAttachedSurface
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12829,7 +12091,7 @@ unsafe impl ::windows::core::Abi for DD_ATTACHLIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_ATTACHLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_ATTACHLIST>()) == 0 }
+        self.lpLink == other.lpLink && self.lpAttached == other.lpAttached
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12874,7 +12136,7 @@ unsafe impl ::windows::core::Abi for DD_BEGINMOCOMPFRAMEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_BEGINMOCOMPFRAMEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_BEGINMOCOMPFRAMEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpMoComp == other.lpMoComp && self.lpDestSurface == other.lpDestSurface && self.dwInputDataSize == other.dwInputDataSize && self.lpInputData == other.lpInputData && self.dwOutputDataSize == other.dwOutputDataSize && self.lpOutputData == other.lpOutputData && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12936,14 +12198,6 @@ unsafe impl ::windows::core::Abi for DD_BLTDATA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_BLTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        self.lpDD == other.lpDD && self.lpDDDestSurface == other.lpDDDestSurface && self.rDest == other.rDest && self.lpDDSrcSurface == other.lpDDSrcSurface && self.rSrc == other.rSrc && self.dwFlags == other.dwFlags && self.dwROPFlags == other.dwROPFlags && self.bltFX == other.bltFX && self.ddRVal == other.ddRVal && self.Blt == other.Blt && self.IsClipped == other.IsClipped && self.rOrigDest == other.rOrigDest && self.rOrigSrc == other.rOrigSrc && self.dwRectCnt == other.dwRectCnt && self.prDestRects == other.prDestRects && self.dwAFlags == other.dwAFlags && self.ddargbScaleFactors == other.ddargbScaleFactors
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_BLTDATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_BLTDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12976,33 +12230,13 @@ impl ::core::clone::Clone for DD_CALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for DD_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_CALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("DestroyDriver", &self.DestroyDriver.map(|f| f as usize))
-            .field("CreateSurface", &self.CreateSurface.map(|f| f as usize))
-            .field("SetColorKey", &self.SetColorKey.map(|f| f as usize))
-            .field("SetMode", &self.SetMode.map(|f| f as usize))
-            .field("WaitForVerticalBlank", &self.WaitForVerticalBlank.map(|f| f as usize))
-            .field("CanCreateSurface", &self.CanCreateSurface.map(|f| f as usize))
-            .field("CreatePalette", &self.CreatePalette.map(|f| f as usize))
-            .field("GetScanLine", &self.GetScanLine.map(|f| f as usize))
-            .field("MapMemory", &self.MapMemory.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DD_CALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for DD_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DD_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DD_CALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DD_CALLBACKS {
     fn default() -> Self {
@@ -13034,7 +12268,7 @@ unsafe impl ::windows::core::Abi for DD_CANCREATESURFACEDATA {
 }
 impl ::core::cmp::PartialEq for DD_CANCREATESURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CANCREATESURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurfaceDesc == other.lpDDSurfaceDesc && self.bIsDifferentPixelFormat == other.bIsDifferentPixelFormat && self.ddRVal == other.ddRVal && self.CanCreateSurface == other.CanCreateSurface
     }
 }
 impl ::core::cmp::Eq for DD_CANCREATESURFACEDATA {}
@@ -13067,7 +12301,7 @@ unsafe impl ::windows::core::Abi for DD_CANCREATEVPORTDATA {
 }
 impl ::core::cmp::PartialEq for DD_CANCREATEVPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CANCREATEVPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDVideoPortDesc == other.lpDDVideoPortDesc && self.ddRVal == other.ddRVal && self.CanCreateVideoPort == other.CanCreateVideoPort
     }
 }
 impl ::core::cmp::Eq for DD_CANCREATEVPORTDATA {}
@@ -13097,7 +12331,7 @@ unsafe impl ::windows::core::Abi for DD_CLIPPER_GLOBAL {
 }
 impl ::core::cmp::PartialEq for DD_CLIPPER_GLOBAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CLIPPER_GLOBAL>()) == 0 }
+        self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DD_CLIPPER_GLOBAL {}
@@ -13127,7 +12361,7 @@ unsafe impl ::windows::core::Abi for DD_CLIPPER_LOCAL {
 }
 impl ::core::cmp::PartialEq for DD_CLIPPER_LOCAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CLIPPER_LOCAL>()) == 0 }
+        self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DD_CLIPPER_LOCAL {}
@@ -13155,21 +12389,13 @@ impl ::core::clone::Clone for DD_COLORCONTROLCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_COLORCONTROLCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_COLORCONTROLCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("ColorControl", &self.ColorControl.map(|f| f as usize)).finish()
+        f.debug_struct("DD_COLORCONTROLCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_COLORCONTROLCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_COLORCONTROLCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_COLORCONTROLCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_COLORCONTROLCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_COLORCONTROLCALLBACKS {
     fn default() -> Self {
@@ -13208,7 +12434,7 @@ unsafe impl ::windows::core::Abi for DD_COLORCONTROLDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_COLORCONTROLDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_COLORCONTROLDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.lpColorData == other.lpColorData && self.dwFlags == other.dwFlags && self.ddRVal == other.ddRVal && self.ColorControl == other.ColorControl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13241,12 +12467,6 @@ impl ::core::clone::Clone for DD_CREATEMOCOMPDATA {
 unsafe impl ::windows::core::Abi for DD_CREATEMOCOMPDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_CREATEMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CREATEMOCOMPDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_CREATEMOCOMPDATA {}
 impl ::core::default::Default for DD_CREATEMOCOMPDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13284,7 +12504,7 @@ unsafe impl ::windows::core::Abi for DD_CREATEPALETTEDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DD_CREATEPALETTEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CREATEPALETTEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDPalette == other.lpDDPalette && self.lpColorTable == other.lpColorTable && self.ddRVal == other.ddRVal && self.CreatePalette == other.CreatePalette && self.is_excl == other.is_excl
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13327,7 +12547,7 @@ unsafe impl ::windows::core::Abi for DD_CREATESURFACEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_CREATESURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CREATESURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurfaceDesc == other.lpDDSurfaceDesc && self.lplpSList == other.lplpSList && self.dwSCnt == other.dwSCnt && self.ddRVal == other.ddRVal && self.CreateSurface == other.CreateSurface
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13368,7 +12588,7 @@ unsafe impl ::windows::core::Abi for DD_CREATESURFACEEXDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_CREATESURFACEEXDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CREATESURFACEEXDATA>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpDDLcl == other.lpDDLcl && self.lpDDSLcl == other.lpDDSLcl && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13410,7 +12630,7 @@ unsafe impl ::windows::core::Abi for DD_CREATEVPORTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_CREATEVPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_CREATEVPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDVideoPortDesc == other.lpDDVideoPortDesc && self.lpVideoPort == other.lpVideoPort && self.ddRVal == other.ddRVal && self.CreateVideoPort == other.CreateVideoPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13444,21 +12664,13 @@ impl ::core::clone::Clone for DD_D3DBUFCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_D3DBUFCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_D3DBUFCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("CanCreateD3DBuffer", &self.CanCreateD3DBuffer.map(|f| f as usize)).field("CreateD3DBuffer", &self.CreateD3DBuffer.map(|f| f as usize)).field("DestroyD3DBuffer", &self.DestroyD3DBuffer.map(|f| f as usize)).field("LockD3DBuffer", &self.LockD3DBuffer.map(|f| f as usize)).field("UnlockD3DBuffer", &self.UnlockD3DBuffer.map(|f| f as usize)).finish()
+        f.debug_struct("DD_D3DBUFCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_D3DBUFCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_D3DBUFCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_D3DBUFCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_D3DBUFCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_D3DBUFCALLBACKS {
     fn default() -> Self {
@@ -13488,7 +12700,7 @@ unsafe impl ::windows::core::Abi for DD_DESTROYDDLOCALDATA {
 }
 impl ::core::cmp::PartialEq for DD_DESTROYDDLOCALDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DESTROYDDLOCALDATA>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pDDLcl == other.pDDLcl && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_DESTROYDDLOCALDATA {}
@@ -13520,7 +12732,7 @@ unsafe impl ::windows::core::Abi for DD_DESTROYMOCOMPDATA {
 }
 impl ::core::cmp::PartialEq for DD_DESTROYMOCOMPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DESTROYMOCOMPDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpMoComp == other.lpMoComp && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_DESTROYMOCOMPDATA {}
@@ -13553,7 +12765,7 @@ unsafe impl ::windows::core::Abi for DD_DESTROYPALETTEDATA {
 }
 impl ::core::cmp::PartialEq for DD_DESTROYPALETTEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DESTROYPALETTEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDPalette == other.lpDDPalette && self.ddRVal == other.ddRVal && self.DestroyPalette == other.DestroyPalette
     }
 }
 impl ::core::cmp::Eq for DD_DESTROYPALETTEDATA {}
@@ -13592,7 +12804,7 @@ unsafe impl ::windows::core::Abi for DD_DESTROYSURFACEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_DESTROYSURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DESTROYSURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.ddRVal == other.ddRVal && self.DestroySurface == other.DestroySurface
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13633,7 +12845,7 @@ unsafe impl ::windows::core::Abi for DD_DESTROYVPORTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_DESTROYVPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DESTROYVPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.ddRVal == other.ddRVal && self.DestroyVideoPort == other.DestroyVideoPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13668,7 +12880,7 @@ unsafe impl ::windows::core::Abi for DD_DIRECTDRAW_GLOBAL {
 }
 impl ::core::cmp::PartialEq for DD_DIRECTDRAW_GLOBAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DIRECTDRAW_GLOBAL>()) == 0 }
+        self.dhpdev == other.dhpdev && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.lpDDVideoPortCaps == other.lpDDVideoPortCaps
     }
 }
 impl ::core::cmp::Eq for DD_DIRECTDRAW_GLOBAL {}
@@ -13698,7 +12910,7 @@ unsafe impl ::windows::core::Abi for DD_DIRECTDRAW_LOCAL {
 }
 impl ::core::cmp::PartialEq for DD_DIRECTDRAW_LOCAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DIRECTDRAW_LOCAL>()) == 0 }
+        self.lpGbl == other.lpGbl
     }
 }
 impl ::core::cmp::Eq for DD_DIRECTDRAW_LOCAL {}
@@ -13738,7 +12950,7 @@ unsafe impl ::windows::core::Abi for DD_DRVSETCOLORKEYDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_DRVSETCOLORKEYDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_DRVSETCOLORKEYDATA>()) == 0 }
+        self.lpDDSurface == other.lpDDSurface && self.dwFlags == other.dwFlags && self.ckNew == other.ckNew && self.ddRVal == other.ddRVal && self.SetColorKey == other.SetColorKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13774,7 +12986,7 @@ unsafe impl ::windows::core::Abi for DD_ENDMOCOMPFRAMEDATA {
 }
 impl ::core::cmp::PartialEq for DD_ENDMOCOMPFRAMEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_ENDMOCOMPFRAMEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpMoComp == other.lpMoComp && self.lpInputData == other.lpInputData && self.dwInputDataSize == other.dwInputDataSize && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_ENDMOCOMPFRAMEDATA {}
@@ -13817,7 +13029,7 @@ unsafe impl ::windows::core::Abi for DD_FLIPDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_FLIPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_FLIPDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpSurfCurr == other.lpSurfCurr && self.lpSurfTarg == other.lpSurfTarg && self.dwFlags == other.dwFlags && self.ddRVal == other.ddRVal && self.Flip == other.Flip && self.lpSurfCurrLeft == other.lpSurfCurrLeft && self.lpSurfTargLeft == other.lpSurfTargLeft
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13853,7 +13065,7 @@ unsafe impl ::windows::core::Abi for DD_FLIPTOGDISURFACEDATA {
 }
 impl ::core::cmp::PartialEq for DD_FLIPTOGDISURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_FLIPTOGDISURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwToGDI == other.dwToGDI && self.dwReserved == other.dwReserved && self.ddRVal == other.ddRVal && self.FlipToGDISurface == other.FlipToGDISurface
     }
 }
 impl ::core::cmp::Eq for DD_FLIPTOGDISURFACEDATA {}
@@ -13894,7 +13106,7 @@ unsafe impl ::windows::core::Abi for DD_FLIPVPORTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_FLIPVPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_FLIPVPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.lpSurfCurr == other.lpSurfCurr && self.lpSurfTarg == other.lpSurfTarg && self.ddRVal == other.ddRVal && self.FlipVideoPort == other.FlipVideoPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13935,7 +13147,7 @@ unsafe impl ::windows::core::Abi for DD_FREEDRIVERMEMORYDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_FREEDRIVERMEMORYDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_FREEDRIVERMEMORYDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.ddRVal == other.ddRVal && self.FreeDriverMemory == other.FreeDriverMemory
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13972,7 +13184,7 @@ unsafe impl ::windows::core::Abi for DD_GETAVAILDRIVERMEMORYDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETAVAILDRIVERMEMORYDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETAVAILDRIVERMEMORYDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.DDSCaps == other.DDSCaps && self.dwTotal == other.dwTotal && self.dwFree == other.dwFree && self.ddRVal == other.ddRVal && self.GetAvailDriverMemory == other.GetAvailDriverMemory
     }
 }
 impl ::core::cmp::Eq for DD_GETAVAILDRIVERMEMORYDATA {}
@@ -14012,7 +13224,7 @@ unsafe impl ::windows::core::Abi for DD_GETBLTSTATUSDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETBLTSTATUSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETBLTSTATUSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.dwFlags == other.dwFlags && self.ddRVal == other.ddRVal && self.GetBltStatus == other.GetBltStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14051,7 +13263,7 @@ unsafe impl ::windows::core::Abi for DD_GETDRIVERINFODATA {
 }
 impl ::core::cmp::PartialEq for DD_GETDRIVERINFODATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETDRIVERINFODATA>()) == 0 }
+        self.dhpdev == other.dhpdev && self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidInfo == other.guidInfo && self.dwExpectedSize == other.dwExpectedSize && self.lpvData == other.lpvData && self.dwActualSize == other.dwActualSize && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_GETDRIVERINFODATA {}
@@ -14078,12 +13290,6 @@ impl ::core::clone::Clone for DD_GETDRIVERSTATEDATA {
 unsafe impl ::windows::core::Abi for DD_GETDRIVERSTATEDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_GETDRIVERSTATEDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETDRIVERSTATEDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_GETDRIVERSTATEDATA {}
 impl ::core::default::Default for DD_GETDRIVERSTATEDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14104,12 +13310,6 @@ impl ::core::clone::Clone for DD_GETDRIVERSTATEDATA_0 {
 unsafe impl ::windows::core::Abi for DD_GETDRIVERSTATEDATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_GETDRIVERSTATEDATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETDRIVERSTATEDATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_GETDRIVERSTATEDATA_0 {}
 impl ::core::default::Default for DD_GETDRIVERSTATEDATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14146,7 +13346,7 @@ unsafe impl ::windows::core::Abi for DD_GETFLIPSTATUSDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETFLIPSTATUSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETFLIPSTATUSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.dwFlags == other.dwFlags && self.ddRVal == other.ddRVal && self.GetFlipStatus == other.GetFlipStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14175,12 +13375,6 @@ impl ::core::clone::Clone for DD_GETHEAPALIGNMENTDATA {
 unsafe impl ::windows::core::Abi for DD_GETHEAPALIGNMENTDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_GETHEAPALIGNMENTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETHEAPALIGNMENTDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_GETHEAPALIGNMENTDATA {}
 impl ::core::default::Default for DD_GETHEAPALIGNMENTDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14206,12 +13400,6 @@ impl ::core::clone::Clone for DD_GETINTERNALMOCOMPDATA {
 unsafe impl ::windows::core::Abi for DD_GETINTERNALMOCOMPDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_GETINTERNALMOCOMPDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETINTERNALMOCOMPDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_GETINTERNALMOCOMPDATA {}
 impl ::core::default::Default for DD_GETINTERNALMOCOMPDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14238,12 +13426,6 @@ impl ::core::clone::Clone for DD_GETMOCOMPCOMPBUFFDATA {
 unsafe impl ::windows::core::Abi for DD_GETMOCOMPCOMPBUFFDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_GETMOCOMPCOMPBUFFDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETMOCOMPCOMPBUFFDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_GETMOCOMPCOMPBUFFDATA {}
 impl ::core::default::Default for DD_GETMOCOMPCOMPBUFFDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14274,7 +13456,7 @@ unsafe impl ::windows::core::Abi for DD_GETMOCOMPFORMATSDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETMOCOMPFORMATSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETMOCOMPFORMATSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpGuid == other.lpGuid && self.dwNumFormats == other.dwNumFormats && self.lpFormats == other.lpFormats && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_GETMOCOMPFORMATSDATA {}
@@ -14307,7 +13489,7 @@ unsafe impl ::windows::core::Abi for DD_GETMOCOMPGUIDSDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETMOCOMPGUIDSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETMOCOMPGUIDSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwNumGuids == other.dwNumGuids && self.lpGuids == other.lpGuids && self.ddRVal == other.ddRVal
     }
 }
 impl ::core::cmp::Eq for DD_GETMOCOMPGUIDSDATA {}
@@ -14340,7 +13522,7 @@ unsafe impl ::windows::core::Abi for DD_GETSCANLINEDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETSCANLINEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETSCANLINEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwScanLine == other.dwScanLine && self.ddRVal == other.ddRVal && self.GetScanLine == other.GetScanLine
     }
 }
 impl ::core::cmp::Eq for DD_GETSCANLINEDATA {}
@@ -14384,7 +13566,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTBANDWIDTHDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTBANDWIDTHDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTBANDWIDTHDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.lpddpfFormat == other.lpddpfFormat && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.dwFlags == other.dwFlags && self.lpBandwidth == other.lpBandwidth && self.ddRVal == other.ddRVal && self.GetVideoPortBandwidth == other.GetVideoPortBandwidth
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14421,7 +13603,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTCONNECTDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETVPORTCONNECTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTCONNECTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwPortId == other.dwPortId && self.lpConnect == other.lpConnect && self.dwNumEntries == other.dwNumEntries && self.ddRVal == other.ddRVal && self.GetVideoPortConnectInfo == other.GetVideoPortConnectInfo
     }
 }
 impl ::core::cmp::Eq for DD_GETVPORTCONNECTDATA {}
@@ -14461,7 +13643,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTFIELDDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTFIELDDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTFIELDDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.bField == other.bField && self.ddRVal == other.ddRVal && self.GetVideoPortField == other.GetVideoPortField
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14496,7 +13678,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTFLIPSTATUSDATA {
 }
 impl ::core::cmp::PartialEq for DD_GETVPORTFLIPSTATUSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTFLIPSTATUSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.fpSurface == other.fpSurface && self.ddRVal == other.ddRVal && self.GetVideoPortFlipStatus == other.GetVideoPortFlipStatus
     }
 }
 impl ::core::cmp::Eq for DD_GETVPORTFLIPSTATUSDATA {}
@@ -14538,7 +13720,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTINPUTFORMATDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTINPUTFORMATDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTINPUTFORMATDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwFlags == other.dwFlags && self.lpddpfFormat == other.lpddpfFormat && self.dwNumFormats == other.dwNumFormats && self.ddRVal == other.ddRVal && self.GetVideoPortInputFormats == other.GetVideoPortInputFormats
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14580,7 +13762,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTLINEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTLINEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTLINEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwLine == other.dwLine && self.ddRVal == other.ddRVal && self.GetVideoPortLine == other.GetVideoPortLine
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14625,7 +13807,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTOUTPUTFORMATDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTOUTPUTFORMATDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTOUTPUTFORMATDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwFlags == other.dwFlags && self.lpddpfInputFormat == other.lpddpfInputFormat && self.lpddpfOutputFormats == other.lpddpfOutputFormats && self.dwNumFormats == other.dwNumFormats && self.ddRVal == other.ddRVal && self.GetVideoPortInputFormats == other.GetVideoPortInputFormats
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14667,7 +13849,7 @@ unsafe impl ::windows::core::Abi for DD_GETVPORTSIGNALDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_GETVPORTSIGNALDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_GETVPORTSIGNALDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwStatus == other.dwStatus && self.ddRVal == other.ddRVal && self.GetVideoSignalStatus == other.GetVideoSignalStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14704,14 +13886,6 @@ unsafe impl ::windows::core::Abi for DD_HALINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_HALINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_HALINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_HALINFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_HALINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14735,12 +13909,6 @@ impl ::core::clone::Clone for DD_HALINFO_V4 {
 unsafe impl ::windows::core::Abi for DD_HALINFO_V4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_HALINFO_V4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_HALINFO_V4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_HALINFO_V4 {}
 impl ::core::default::Default for DD_HALINFO_V4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14766,21 +13934,13 @@ impl ::core::clone::Clone for DD_KERNELCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_KERNELCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_KERNELCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("SyncSurfaceData", &self.SyncSurfaceData.map(|f| f as usize)).field("SyncVideoPortData", &self.SyncVideoPortData.map(|f| f as usize)).finish()
+        f.debug_struct("DD_KERNELCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_KERNELCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_KERNELCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_KERNELCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_KERNELCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_KERNELCALLBACKS {
     fn default() -> Self {
@@ -14822,7 +13982,7 @@ unsafe impl ::windows::core::Abi for DD_LOCKDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_LOCKDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_LOCKDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.bHasRect == other.bHasRect && self.rArea == other.rArea && self.lpSurfData == other.lpSurfData && self.ddRVal == other.ddRVal && self.Lock == other.Lock && self.dwFlags == other.dwFlags && self.fpProcess == other.fpProcess
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14864,7 +14024,7 @@ unsafe impl ::windows::core::Abi for DD_MAPMEMORYDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_MAPMEMORYDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MAPMEMORYDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.bMap == other.bMap && self.hProcess == other.hProcess && self.fpProcess == other.fpProcess && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14897,21 +14057,13 @@ impl ::core::clone::Clone for DD_MISCELLANEOUS2CALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_MISCELLANEOUS2CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_MISCELLANEOUS2CALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("AlphaBlt", &self.AlphaBlt.map(|f| f as usize)).field("CreateSurfaceEx", &self.CreateSurfaceEx.map(|f| f as usize)).field("GetDriverState", &self.GetDriverState.map(|f| f as usize)).field("DestroyDDLocal", &self.DestroyDDLocal.map(|f| f as usize)).finish()
+        f.debug_struct("DD_MISCELLANEOUS2CALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_MISCELLANEOUS2CALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_MISCELLANEOUS2CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MISCELLANEOUS2CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_MISCELLANEOUS2CALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_MISCELLANEOUS2CALLBACKS {
     fn default() -> Self {
@@ -14933,18 +14085,12 @@ impl ::core::clone::Clone for DD_MISCELLANEOUSCALLBACKS {
 }
 impl ::core::fmt::Debug for DD_MISCELLANEOUSCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_MISCELLANEOUSCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("GetAvailDriverMemory", &self.GetAvailDriverMemory.map(|f| f as usize)).finish()
+        f.debug_struct("DD_MISCELLANEOUSCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 unsafe impl ::windows::core::Abi for DD_MISCELLANEOUSCALLBACKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_MISCELLANEOUSCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MISCELLANEOUSCALLBACKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_MISCELLANEOUSCALLBACKS {}
 impl ::core::default::Default for DD_MISCELLANEOUSCALLBACKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14979,7 +14125,7 @@ unsafe impl ::windows::core::Abi for DD_MORECAPS {
 }
 impl ::core::cmp::PartialEq for DD_MORECAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MORECAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwAlphaCaps == other.dwAlphaCaps && self.dwSVBAlphaCaps == other.dwSVBAlphaCaps && self.dwVSBAlphaCaps == other.dwVSBAlphaCaps && self.dwSSBAlphaCaps == other.dwSSBAlphaCaps && self.dwFilterCaps == other.dwFilterCaps && self.dwSVBFilterCaps == other.dwSVBFilterCaps && self.dwVSBFilterCaps == other.dwVSBFilterCaps && self.dwSSBFilterCaps == other.dwSSBFilterCaps
     }
 }
 impl ::core::cmp::Eq for DD_MORECAPS {}
@@ -15004,12 +14150,6 @@ impl ::core::clone::Clone for DD_MORESURFACECAPS {
 unsafe impl ::windows::core::Abi for DD_MORESURFACECAPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_MORESURFACECAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MORESURFACECAPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_MORESURFACECAPS {}
 impl ::core::default::Default for DD_MORESURFACECAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15030,12 +14170,6 @@ impl ::core::clone::Clone for DD_MORESURFACECAPS_0 {
 unsafe impl ::windows::core::Abi for DD_MORESURFACECAPS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_MORESURFACECAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MORESURFACECAPS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_MORESURFACECAPS_0 {}
 impl ::core::default::Default for DD_MORESURFACECAPS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15069,34 +14203,13 @@ impl ::core::clone::Clone for DD_MOTIONCOMPCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_MOTIONCOMPCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_MOTIONCOMPCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("GetMoCompGuids", &self.GetMoCompGuids.map(|f| f as usize))
-            .field("GetMoCompFormats", &self.GetMoCompFormats.map(|f| f as usize))
-            .field("CreateMoComp", &self.CreateMoComp.map(|f| f as usize))
-            .field("GetMoCompBuffInfo", &self.GetMoCompBuffInfo.map(|f| f as usize))
-            .field("GetInternalMoCompInfo", &self.GetInternalMoCompInfo.map(|f| f as usize))
-            .field("BeginMoCompFrame", &self.BeginMoCompFrame.map(|f| f as usize))
-            .field("EndMoCompFrame", &self.EndMoCompFrame.map(|f| f as usize))
-            .field("RenderMoComp", &self.RenderMoComp.map(|f| f as usize))
-            .field("QueryMoCompStatus", &self.QueryMoCompStatus.map(|f| f as usize))
-            .field("DestroyMoComp", &self.DestroyMoComp.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DD_MOTIONCOMPCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_MOTIONCOMPCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_MOTIONCOMPCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MOTIONCOMPCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_MOTIONCOMPCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_MOTIONCOMPCALLBACKS {
     fn default() -> Self {
@@ -15127,12 +14240,6 @@ impl ::core::clone::Clone for DD_MOTIONCOMP_LOCAL {
 unsafe impl ::windows::core::Abi for DD_MOTIONCOMP_LOCAL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DD_MOTIONCOMP_LOCAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_MOTIONCOMP_LOCAL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DD_MOTIONCOMP_LOCAL {}
 impl ::core::default::Default for DD_MOTIONCOMP_LOCAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15164,7 +14271,7 @@ unsafe impl ::windows::core::Abi for DD_NONLOCALVIDMEMCAPS {
 }
 impl ::core::cmp::PartialEq for DD_NONLOCALVIDMEMCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_NONLOCALVIDMEMCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwNLVBCaps == other.dwNLVBCaps && self.dwNLVBCaps2 == other.dwNLVBCaps2 && self.dwNLVBCKeyCaps == other.dwNLVBCKeyCaps && self.dwNLVBFXCaps == other.dwNLVBFXCaps && self.dwNLVBRops == other.dwNLVBRops
     }
 }
 impl ::core::cmp::Eq for DD_NONLOCALVIDMEMCAPS {}
@@ -15194,21 +14301,13 @@ impl ::core::clone::Clone for DD_NTCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_NTCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_NTCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("FreeDriverMemory", &self.FreeDriverMemory.map(|f| f as usize)).field("SetExclusiveMode", &self.SetExclusiveMode.map(|f| f as usize)).field("FlipToGDISurface", &self.FlipToGDISurface.map(|f| f as usize)).finish()
+        f.debug_struct("DD_NTCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_NTCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_NTCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_NTCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_NTCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_NTCALLBACKS {
     fn default() -> Self {
@@ -15237,7 +14336,7 @@ unsafe impl ::windows::core::Abi for DD_NTPRIVATEDRIVERCAPS {
 }
 impl ::core::cmp::PartialEq for DD_NTPRIVATEDRIVERCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_NTPRIVATEDRIVERCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwPrivateCaps == other.dwPrivateCaps
     }
 }
 impl ::core::cmp::Eq for DD_NTPRIVATEDRIVERCAPS {}
@@ -15266,21 +14365,13 @@ impl ::core::clone::Clone for DD_PALETTECALLBACKS {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::fmt::Debug for DD_PALETTECALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_PALETTECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("DestroyPalette", &self.DestroyPalette.map(|f| f as usize)).field("SetEntries", &self.SetEntries.map(|f| f as usize)).finish()
+        f.debug_struct("DD_PALETTECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 unsafe impl ::windows::core::Abi for DD_PALETTECALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::PartialEq for DD_PALETTECALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_PALETTECALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::Eq for DD_PALETTECALLBACKS {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::default::Default for DD_PALETTECALLBACKS {
     fn default() -> Self {
@@ -15308,7 +14399,7 @@ unsafe impl ::windows::core::Abi for DD_PALETTE_GLOBAL {
 }
 impl ::core::cmp::PartialEq for DD_PALETTE_GLOBAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_PALETTE_GLOBAL>()) == 0 }
+        self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DD_PALETTE_GLOBAL {}
@@ -15339,7 +14430,7 @@ unsafe impl ::windows::core::Abi for DD_PALETTE_LOCAL {
 }
 impl ::core::cmp::PartialEq for DD_PALETTE_LOCAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_PALETTE_LOCAL>()) == 0 }
+        self.dwReserved0 == other.dwReserved0 && self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for DD_PALETTE_LOCAL {}
@@ -15379,7 +14470,7 @@ unsafe impl ::windows::core::Abi for DD_QUERYMOCOMPSTATUSDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_QUERYMOCOMPSTATUSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_QUERYMOCOMPSTATUSDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpMoComp == other.lpMoComp && self.lpSurface == other.lpSurface && self.dwFlags == other.dwFlags && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15426,7 +14517,7 @@ unsafe impl ::windows::core::Abi for DD_RENDERMOCOMPDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_RENDERMOCOMPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_RENDERMOCOMPDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpMoComp == other.lpMoComp && self.dwNumBuffers == other.dwNumBuffers && self.lpBufferInfo == other.lpBufferInfo && self.dwFunction == other.dwFunction && self.lpInputData == other.lpInputData && self.dwInputDataSize == other.dwInputDataSize && self.lpOutputData == other.lpOutputData && self.dwOutputDataSize == other.dwOutputDataSize && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15467,7 +14558,7 @@ unsafe impl ::windows::core::Abi for DD_SETCLIPLISTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SETCLIPLISTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETCLIPLISTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.ddRVal == other.ddRVal && self.SetClipList == other.SetClipList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15510,7 +14601,7 @@ unsafe impl ::windows::core::Abi for DD_SETCOLORKEYDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SETCOLORKEYDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETCOLORKEYDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.dwFlags == other.dwFlags && self.ckNew == other.ckNew && self.ddRVal == other.ddRVal && self.SetColorKey == other.SetColorKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15554,7 +14645,7 @@ unsafe impl ::windows::core::Abi for DD_SETENTRIESDATA {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for DD_SETENTRIESDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETENTRIESDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDPalette == other.lpDDPalette && self.dwBase == other.dwBase && self.dwNumEntries == other.dwNumEntries && self.lpEntries == other.lpEntries && self.ddRVal == other.ddRVal && self.SetEntries == other.SetEntries
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -15590,7 +14681,7 @@ unsafe impl ::windows::core::Abi for DD_SETEXCLUSIVEMODEDATA {
 }
 impl ::core::cmp::PartialEq for DD_SETEXCLUSIVEMODEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETEXCLUSIVEMODEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwEnterExcl == other.dwEnterExcl && self.dwReserved == other.dwReserved && self.ddRVal == other.ddRVal && self.SetExclusiveMode == other.SetExclusiveMode
     }
 }
 impl ::core::cmp::Eq for DD_SETEXCLUSIVEMODEDATA {}
@@ -15632,7 +14723,7 @@ unsafe impl ::windows::core::Abi for DD_SETOVERLAYPOSITIONDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SETOVERLAYPOSITIONDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETOVERLAYPOSITIONDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSrcSurface == other.lpDDSrcSurface && self.lpDDDestSurface == other.lpDDDestSurface && self.lXPos == other.lXPos && self.lYPos == other.lYPos && self.ddRVal == other.ddRVal && self.SetOverlayPosition == other.SetOverlayPosition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15675,7 +14766,7 @@ unsafe impl ::windows::core::Abi for DD_SETPALETTEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SETPALETTEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SETPALETTEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.lpDDPalette == other.lpDDPalette && self.ddRVal == other.ddRVal && self.SetPalette == other.SetPalette && self.Attach == other.Attach
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15718,7 +14809,7 @@ unsafe impl ::windows::core::Abi for DD_STEREOMODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_STEREOMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_STEREOMODE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwHeight == other.dwHeight && self.dwWidth == other.dwWidth && self.dwBpp == other.dwBpp && self.dwRefreshRate == other.dwRefreshRate && self.bSupported == other.bSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15761,38 +14852,13 @@ impl ::core::clone::Clone for DD_SURFACECALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_SURFACECALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_SURFACECALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("DestroySurface", &self.DestroySurface.map(|f| f as usize))
-            .field("Flip", &self.Flip.map(|f| f as usize))
-            .field("SetClipList", &self.SetClipList.map(|f| f as usize))
-            .field("Lock", &self.Lock.map(|f| f as usize))
-            .field("Unlock", &self.Unlock.map(|f| f as usize))
-            .field("Blt", &self.Blt.map(|f| f as usize))
-            .field("SetColorKey", &self.SetColorKey.map(|f| f as usize))
-            .field("AddAttachedSurface", &self.AddAttachedSurface.map(|f| f as usize))
-            .field("GetBltStatus", &self.GetBltStatus.map(|f| f as usize))
-            .field("GetFlipStatus", &self.GetFlipStatus.map(|f| f as usize))
-            .field("UpdateOverlay", &self.UpdateOverlay.map(|f| f as usize))
-            .field("SetOverlayPosition", &self.SetOverlayPosition.map(|f| f as usize))
-            .field("reserved4", &self.reserved4)
-            .field("SetPalette", &self.SetPalette.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DD_SURFACECALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("reserved4", &self.reserved4).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_SURFACECALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACECALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACECALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACECALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACECALLBACKS {
     fn default() -> Self {
@@ -15829,14 +14895,6 @@ unsafe impl ::windows::core::Abi for DD_SURFACE_GLOBAL {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_GLOBAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_GLOBAL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_GLOBAL {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_GLOBAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15861,14 +14919,6 @@ impl ::core::clone::Clone for DD_SURFACE_GLOBAL_0 {
 unsafe impl ::windows::core::Abi for DD_SURFACE_GLOBAL_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_GLOBAL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_GLOBAL_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_GLOBAL_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_GLOBAL_0 {
     fn default() -> Self {
@@ -15896,14 +14946,6 @@ unsafe impl ::windows::core::Abi for DD_SURFACE_GLOBAL_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_GLOBAL_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_GLOBAL_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_GLOBAL_1 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_GLOBAL_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15928,14 +14970,6 @@ impl ::core::clone::Clone for DD_SURFACE_GLOBAL_2 {
 unsafe impl ::windows::core::Abi for DD_SURFACE_GLOBAL_2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_GLOBAL_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_GLOBAL_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_GLOBAL_2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_GLOBAL_2 {
     fn default() -> Self {
@@ -15969,7 +15003,7 @@ unsafe impl ::windows::core::Abi for DD_SURFACE_INT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SURFACE_INT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_INT>()) == 0 }
+        self.lpLcl == other.lpLcl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16008,14 +15042,6 @@ unsafe impl ::windows::core::Abi for DD_SURFACE_LOCAL {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_LOCAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_LOCAL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_LOCAL {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_LOCAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16041,14 +15067,6 @@ unsafe impl ::windows::core::Abi for DD_SURFACE_LOCAL_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_LOCAL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_LOCAL_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_LOCAL_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_LOCAL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16073,14 +15091,6 @@ impl ::core::clone::Clone for DD_SURFACE_LOCAL_1 {
 unsafe impl ::windows::core::Abi for DD_SURFACE_LOCAL_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_LOCAL_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_LOCAL_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_LOCAL_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_LOCAL_1 {
     fn default() -> Self {
@@ -16109,14 +15119,6 @@ impl ::core::clone::Clone for DD_SURFACE_MORE {
 unsafe impl ::windows::core::Abi for DD_SURFACE_MORE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_SURFACE_MORE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SURFACE_MORE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_SURFACE_MORE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_SURFACE_MORE {
     fn default() -> Self {
@@ -16172,7 +15174,7 @@ unsafe impl ::windows::core::Abi for DD_SYNCSURFACEDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SYNCSURFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SYNCSURFACEDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.dwSurfaceOffset == other.dwSurfaceOffset && self.fpLockPtr == other.fpLockPtr && self.lPitch == other.lPitch && self.dwOverlayOffset == other.dwOverlayOffset && self.dwDriverReserved1 == other.dwDriverReserved1 && self.dwDriverReserved2 == other.dwDriverReserved2 && self.dwDriverReserved3 == other.dwDriverReserved3 && self.dwDriverReserved4 == other.dwDriverReserved4 && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16218,7 +15220,7 @@ unsafe impl ::windows::core::Abi for DD_SYNCVIDEOPORTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_SYNCVIDEOPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_SYNCVIDEOPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwOriginOffset == other.dwOriginOffset && self.dwHeight == other.dwHeight && self.dwVBIHeight == other.dwVBIHeight && self.dwDriverReserved1 == other.dwDriverReserved1 && self.dwDriverReserved2 == other.dwDriverReserved2 && self.dwDriverReserved3 == other.dwDriverReserved3 && self.ddRVal == other.ddRVal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16259,7 +15261,7 @@ unsafe impl ::windows::core::Abi for DD_UNLOCKDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_UNLOCKDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_UNLOCKDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpDDSurface == other.lpDDSurface && self.ddRVal == other.ddRVal && self.Unlock == other.Unlock
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16297,7 +15299,7 @@ unsafe impl ::windows::core::Abi for DD_UPDATENONLOCALHEAPDATA {
 }
 impl ::core::cmp::PartialEq for DD_UPDATENONLOCALHEAPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_UPDATENONLOCALHEAPDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwHeap == other.dwHeap && self.fpGARTLin == other.fpGARTLin && self.fpGARTDev == other.fpGARTDev && self.ulPolicyMaxBytes == other.ulPolicyMaxBytes && self.ddRVal == other.ddRVal && self.UpdateNonLocalHeap == other.UpdateNonLocalHeap
     }
 }
 impl ::core::cmp::Eq for DD_UPDATENONLOCALHEAPDATA {}
@@ -16341,14 +15343,6 @@ unsafe impl ::windows::core::Abi for DD_UPDATEOVERLAYDATA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_UPDATEOVERLAYDATA {
-    fn eq(&self, other: &Self) -> bool {
-        self.lpDD == other.lpDD && self.lpDDDestSurface == other.lpDDDestSurface && self.rDest == other.rDest && self.lpDDSrcSurface == other.lpDDSrcSurface && self.rSrc == other.rSrc && self.dwFlags == other.dwFlags && self.overlayFX == other.overlayFX && self.ddRVal == other.ddRVal && self.UpdateOverlay == other.UpdateOverlay
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_UPDATEOVERLAYDATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_UPDATEOVERLAYDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16390,7 +15384,7 @@ unsafe impl ::windows::core::Abi for DD_UPDATEVPORTDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_UPDATEVPORTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_UPDATEVPORTDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.lplpDDSurface == other.lplpDDSurface && self.lplpDDVBISurface == other.lplpDDVBISurface && self.lpVideoInfo == other.lpVideoInfo && self.dwFlags == other.dwFlags && self.dwNumAutoflip == other.dwNumAutoflip && self.dwNumVBIAutoflip == other.dwNumVBIAutoflip && self.ddRVal == other.ddRVal && self.UpdateVideoPort == other.UpdateVideoPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16435,40 +15429,13 @@ impl ::core::clone::Clone for DD_VIDEOPORTCALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DD_VIDEOPORTCALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DD_VIDEOPORTCALLBACKS")
-            .field("dwSize", &self.dwSize)
-            .field("dwFlags", &self.dwFlags)
-            .field("CanCreateVideoPort", &self.CanCreateVideoPort.map(|f| f as usize))
-            .field("CreateVideoPort", &self.CreateVideoPort.map(|f| f as usize))
-            .field("FlipVideoPort", &self.FlipVideoPort.map(|f| f as usize))
-            .field("GetVideoPortBandwidth", &self.GetVideoPortBandwidth.map(|f| f as usize))
-            .field("GetVideoPortInputFormats", &self.GetVideoPortInputFormats.map(|f| f as usize))
-            .field("GetVideoPortOutputFormats", &self.GetVideoPortOutputFormats.map(|f| f as usize))
-            .field("lpReserved1", &self.lpReserved1)
-            .field("GetVideoPortField", &self.GetVideoPortField.map(|f| f as usize))
-            .field("GetVideoPortLine", &self.GetVideoPortLine.map(|f| f as usize))
-            .field("GetVideoPortConnectInfo", &self.GetVideoPortConnectInfo.map(|f| f as usize))
-            .field("DestroyVideoPort", &self.DestroyVideoPort.map(|f| f as usize))
-            .field("GetVideoPortFlipStatus", &self.GetVideoPortFlipStatus.map(|f| f as usize))
-            .field("UpdateVideoPort", &self.UpdateVideoPort.map(|f| f as usize))
-            .field("WaitForVideoPortSync", &self.WaitForVideoPortSync.map(|f| f as usize))
-            .field("GetVideoSignalStatus", &self.GetVideoSignalStatus.map(|f| f as usize))
-            .field("ColorControl", &self.ColorControl.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DD_VIDEOPORTCALLBACKS").field("dwSize", &self.dwSize).field("dwFlags", &self.dwFlags).field("lpReserved1", &self.lpReserved1).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DD_VIDEOPORTCALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DD_VIDEOPORTCALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_VIDEOPORTCALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DD_VIDEOPORTCALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DD_VIDEOPORTCALLBACKS {
     fn default() -> Self {
@@ -16511,7 +15478,7 @@ unsafe impl ::windows::core::Abi for DD_VIDEOPORT_LOCAL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_VIDEOPORT_LOCAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_VIDEOPORT_LOCAL>()) == 0 }
+        self.lpDD == other.lpDD && self.ddvpDesc == other.ddvpDesc && self.ddvpInfo == other.ddvpInfo && self.lpSurface == other.lpSurface && self.lpVBISurface == other.lpVBISurface && self.dwNumAutoflip == other.dwNumAutoflip && self.dwNumVBIAutoflip == other.dwNumVBIAutoflip && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16554,7 +15521,7 @@ unsafe impl ::windows::core::Abi for DD_VPORTCOLORDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_VPORTCOLORDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_VPORTCOLORDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwFlags == other.dwFlags && self.lpColorData == other.lpColorData && self.ddRVal == other.ddRVal && self.ColorControl == other.ColorControl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16591,7 +15558,7 @@ unsafe impl ::windows::core::Abi for DD_WAITFORVERTICALBLANKDATA {
 }
 impl ::core::cmp::PartialEq for DD_WAITFORVERTICALBLANKDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_WAITFORVERTICALBLANKDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.dwFlags == other.dwFlags && self.bIsInVB == other.bIsInVB && self.hEvent == other.hEvent && self.ddRVal == other.ddRVal && self.WaitForVerticalBlank == other.WaitForVerticalBlank
     }
 }
 impl ::core::cmp::Eq for DD_WAITFORVERTICALBLANKDATA {}
@@ -16633,7 +15600,7 @@ unsafe impl ::windows::core::Abi for DD_WAITFORVPORTSYNCDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DD_WAITFORVPORTSYNCDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DD_WAITFORVPORTSYNCDATA>()) == 0 }
+        self.lpDD == other.lpDD && self.lpVideoPort == other.lpVideoPort && self.dwFlags == other.dwFlags && self.dwLine == other.dwLine && self.dwTimeOut == other.dwTimeOut && self.ddRVal == other.ddRVal && self.UpdateVideoPort == other.UpdateVideoPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16678,40 +15645,13 @@ impl ::core::clone::Clone for DXAPI_INTERFACE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DXAPI_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DXAPI_INTERFACE")
-            .field("Size", &self.Size)
-            .field("Version", &self.Version)
-            .field("Context", &self.Context)
-            .field("InterfaceReference", &self.InterfaceReference)
-            .field("InterfaceDereference", &self.InterfaceDereference)
-            .field("DxGetIrqInfo", &self.DxGetIrqInfo.map(|f| f as usize))
-            .field("DxEnableIrq", &self.DxEnableIrq.map(|f| f as usize))
-            .field("DxSkipNextField", &self.DxSkipNextField.map(|f| f as usize))
-            .field("DxBobNextField", &self.DxBobNextField.map(|f| f as usize))
-            .field("DxSetState", &self.DxSetState.map(|f| f as usize))
-            .field("DxLock", &self.DxLock.map(|f| f as usize))
-            .field("DxFlipOverlay", &self.DxFlipOverlay.map(|f| f as usize))
-            .field("DxFlipVideoPort", &self.DxFlipVideoPort.map(|f| f as usize))
-            .field("DxGetPolarity", &self.DxGetPolarity.map(|f| f as usize))
-            .field("DxGetCurrentAutoflip", &self.DxGetCurrentAutoflip.map(|f| f as usize))
-            .field("DxGetPreviousAutoflip", &self.DxGetPreviousAutoflip.map(|f| f as usize))
-            .field("DxTransfer", &self.DxTransfer.map(|f| f as usize))
-            .field("DxGetTransferStatus", &self.DxGetTransferStatus.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DXAPI_INTERFACE").field("Size", &self.Size).field("Version", &self.Version).field("Context", &self.Context).field("InterfaceReference", &self.InterfaceReference).field("InterfaceDereference", &self.InterfaceDereference).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DXAPI_INTERFACE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DXAPI_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXAPI_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DXAPI_INTERFACE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DXAPI_INTERFACE {
     fn default() -> Self {
@@ -16739,7 +15679,7 @@ unsafe impl ::windows::core::Abi for DX_IRQDATA {
 }
 impl ::core::cmp::PartialEq for DX_IRQDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DX_IRQDATA>()) == 0 }
+        self.dwIrqFlags == other.dwIrqFlags
     }
 }
 impl ::core::cmp::Eq for DX_IRQDATA {}
@@ -16771,7 +15711,7 @@ unsafe impl ::windows::core::Abi for HEAPALIAS {
 }
 impl ::core::cmp::PartialEq for HEAPALIAS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAPALIAS>()) == 0 }
+        self.fpVidMem == other.fpVidMem && self.lpAlias == other.lpAlias && self.dwAliasSize == other.dwAliasSize
     }
 }
 impl ::core::cmp::Eq for HEAPALIAS {}
@@ -16804,7 +15744,7 @@ unsafe impl ::windows::core::Abi for HEAPALIASINFO {
 }
 impl ::core::cmp::PartialEq for HEAPALIASINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAPALIASINFO>()) == 0 }
+        self.dwRefCnt == other.dwRefCnt && self.dwFlags == other.dwFlags && self.dwNumHeaps == other.dwNumHeaps && self.lpAliases == other.lpAliases
     }
 }
 impl ::core::cmp::Eq for HEAPALIASINFO {}
@@ -16836,12 +15776,6 @@ impl ::core::clone::Clone for HEAPALIGNMENT {
 unsafe impl ::windows::core::Abi for HEAPALIGNMENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HEAPALIGNMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAPALIGNMENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HEAPALIGNMENT {}
 impl ::core::default::Default for HEAPALIGNMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16906,7 +15840,7 @@ unsafe impl ::windows::core::Abi for MDL {
 }
 impl ::core::cmp::PartialEq for MDL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDL>()) == 0 }
+        self.MdlNext == other.MdlNext && self.MdlSize == other.MdlSize && self.MdlFlags == other.MdlFlags && self.Process == other.Process && self.lpMappedSystemVa == other.lpMappedSystemVa && self.lpStartVa == other.lpStartVa && self.ByteCount == other.ByteCount && self.ByteOffset == other.ByteOffset
     }
 }
 impl ::core::cmp::Eq for MDL {}
@@ -16942,7 +15876,7 @@ unsafe impl ::windows::core::Abi for PROCESS_LIST {
 }
 impl ::core::cmp::PartialEq for PROCESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_LIST>()) == 0 }
+        self.lpLink == other.lpLink && self.dwProcessId == other.dwProcessId && self.dwRefCnt == other.dwRefCnt && self.dwAlphaDepth == other.dwAlphaDepth && self.dwZDepth == other.dwZDepth
     }
 }
 impl ::core::cmp::Eq for PROCESS_LIST {}
@@ -16965,12 +15899,6 @@ impl ::core::clone::Clone for SURFACEALIGNMENT {
 unsafe impl ::windows::core::Abi for SURFACEALIGNMENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SURFACEALIGNMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SURFACEALIGNMENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SURFACEALIGNMENT {}
 impl ::core::default::Default for SURFACEALIGNMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16991,12 +15919,6 @@ impl ::core::clone::Clone for SURFACEALIGNMENT_0 {
 unsafe impl ::windows::core::Abi for SURFACEALIGNMENT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SURFACEALIGNMENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SURFACEALIGNMENT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SURFACEALIGNMENT_0 {}
 impl ::core::default::Default for SURFACEALIGNMENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17026,7 +15948,7 @@ unsafe impl ::windows::core::Abi for SURFACEALIGNMENT_0_0 {
 }
 impl ::core::cmp::PartialEq for SURFACEALIGNMENT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SURFACEALIGNMENT_0_0>()) == 0 }
+        self.dwStartAlignment == other.dwStartAlignment && self.dwPitchAlignment == other.dwPitchAlignment && self.dwFlags == other.dwFlags && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for SURFACEALIGNMENT_0_0 {}
@@ -17059,7 +15981,7 @@ unsafe impl ::windows::core::Abi for SURFACEALIGNMENT_0_1 {
 }
 impl ::core::cmp::PartialEq for SURFACEALIGNMENT_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SURFACEALIGNMENT_0_1>()) == 0 }
+        self.dwXAlignment == other.dwXAlignment && self.dwYAlignment == other.dwYAlignment && self.dwFlags == other.dwFlags && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for SURFACEALIGNMENT_0_1 {}
@@ -17092,14 +16014,6 @@ unsafe impl ::windows::core::Abi for VIDEOMEMORY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDEOMEMORY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOMEMORY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDEOMEMORY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDEOMEMORY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17125,14 +16039,6 @@ unsafe impl ::windows::core::Abi for VIDEOMEMORY_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDEOMEMORY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOMEMORY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDEOMEMORY_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDEOMEMORY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17157,14 +16063,6 @@ impl ::core::clone::Clone for VIDEOMEMORY_1 {
 unsafe impl ::windows::core::Abi for VIDEOMEMORY_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDEOMEMORY_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOMEMORY_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDEOMEMORY_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDEOMEMORY_1 {
     fn default() -> Self {
@@ -17196,12 +16094,6 @@ impl ::core::clone::Clone for VIDEOMEMORYINFO {
 unsafe impl ::windows::core::Abi for VIDEOMEMORYINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIDEOMEMORYINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOMEMORYINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIDEOMEMORYINFO {}
 impl ::core::default::Default for VIDEOMEMORYINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17231,14 +16123,6 @@ unsafe impl ::windows::core::Abi for VIDMEM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDMEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDMEM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDMEM {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDMEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17264,14 +16148,6 @@ unsafe impl ::windows::core::Abi for VIDMEM_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDMEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDMEM_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDMEM_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDMEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17296,14 +16172,6 @@ impl ::core::clone::Clone for VIDMEM_1 {
 unsafe impl ::windows::core::Abi for VIDMEM_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDMEM_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDMEM_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDMEM_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDMEM_1 {
     fn default() -> Self {
@@ -17340,14 +16208,6 @@ impl ::core::clone::Clone for VIDMEMINFO {
 unsafe impl ::windows::core::Abi for VIDMEMINFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VIDMEMINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDMEMINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VIDMEMINFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VIDMEMINFO {
     fn default() -> Self {
@@ -17389,14 +16249,6 @@ unsafe impl ::windows::core::Abi for VMEMHEAP {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for VMEMHEAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VMEMHEAP>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for VMEMHEAP {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for VMEMHEAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17432,7 +16284,7 @@ unsafe impl ::windows::core::Abi for VMEML {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VMEML {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VMEML>()) == 0 }
+        self.next == other.next && self.ptr == other.ptr && self.size == other.size && self.bDiscardable == other.bDiscardable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17484,7 +16336,7 @@ unsafe impl ::windows::core::Abi for VMEMR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VMEMR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VMEMR>()) == 0 }
+        self.next == other.next && self.prev == other.prev && self.pUp == other.pUp && self.pDown == other.pDown && self.pLeft == other.pLeft && self.pRight == other.pRight && self.ptr == other.ptr && self.size == other.size && self.x == other.x && self.y == other.y && self.cx == other.cx && self.cy == other.cy && self.flags == other.flags && self.pBits == other.pBits && self.bDiscardable == other.bDiscardable
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -14649,7 +14649,7 @@ unsafe impl ::windows::core::Abi for DWRITE_CARET_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_CARET_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_CARET_METRICS>()) == 0 }
+        self.slopeRise == other.slopeRise && self.slopeRun == other.slopeRun && self.offset == other.offset
     }
 }
 impl ::core::cmp::Eq for DWRITE_CARET_METRICS {}
@@ -14681,7 +14681,7 @@ unsafe impl ::windows::core::Abi for DWRITE_CLUSTER_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_CLUSTER_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_CLUSTER_METRICS>()) == 0 }
+        self.width == other.width && self.length == other.length && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_CLUSTER_METRICS {}
@@ -14714,7 +14714,7 @@ unsafe impl ::windows::core::Abi for DWRITE_COLOR_F {
 }
 impl ::core::cmp::PartialEq for DWRITE_COLOR_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_COLOR_F>()) == 0 }
+        self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for DWRITE_COLOR_F {}
@@ -14831,7 +14831,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FILE_FRAGMENT {
 }
 impl ::core::cmp::PartialEq for DWRITE_FILE_FRAGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FILE_FRAGMENT>()) == 0 }
+        self.fileOffset == other.fileOffset && self.fragmentSize == other.fragmentSize
     }
 }
 impl ::core::cmp::Eq for DWRITE_FILE_FRAGMENT {}
@@ -14863,7 +14863,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_AXIS_RANGE {
 }
 impl ::core::cmp::PartialEq for DWRITE_FONT_AXIS_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_AXIS_RANGE>()) == 0 }
+        self.axisTag == other.axisTag && self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for DWRITE_FONT_AXIS_RANGE {}
@@ -14894,7 +14894,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_AXIS_VALUE {
 }
 impl ::core::cmp::PartialEq for DWRITE_FONT_AXIS_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_AXIS_VALUE>()) == 0 }
+        self.axisTag == other.axisTag && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for DWRITE_FONT_AXIS_VALUE {}
@@ -14925,7 +14925,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_FEATURE {
 }
 impl ::core::cmp::PartialEq for DWRITE_FONT_FEATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_FEATURE>()) == 0 }
+        self.nameTag == other.nameTag && self.parameter == other.parameter
     }
 }
 impl ::core::cmp::Eq for DWRITE_FONT_FEATURE {}
@@ -14975,7 +14975,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_FONT_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_METRICS>()) == 0 }
+        self.designUnitsPerEm == other.designUnitsPerEm && self.ascent == other.ascent && self.descent == other.descent && self.lineGap == other.lineGap && self.capHeight == other.capHeight && self.xHeight == other.xHeight && self.underlinePosition == other.underlinePosition && self.underlineThickness == other.underlineThickness && self.strikethroughPosition == other.strikethroughPosition && self.strikethroughThickness == other.strikethroughThickness
     }
 }
 impl ::core::cmp::Eq for DWRITE_FONT_METRICS {}
@@ -15039,7 +15039,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_METRICS1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DWRITE_FONT_METRICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_METRICS1>()) == 0 }
+        self.Base == other.Base && self.glyphBoxLeft == other.glyphBoxLeft && self.glyphBoxTop == other.glyphBoxTop && self.glyphBoxRight == other.glyphBoxRight && self.glyphBoxBottom == other.glyphBoxBottom && self.subscriptPositionX == other.subscriptPositionX && self.subscriptPositionY == other.subscriptPositionY && self.subscriptSizeX == other.subscriptSizeX && self.subscriptSizeY == other.subscriptSizeY && self.superscriptPositionX == other.superscriptPositionX && self.superscriptPositionY == other.superscriptPositionY && self.superscriptSizeX == other.superscriptSizeX && self.superscriptSizeY == other.superscriptSizeY && self.hasTypographicMetrics == other.hasTypographicMetrics
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15073,7 +15073,7 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_PROPERTY {
 }
 impl ::core::cmp::PartialEq for DWRITE_FONT_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_FONT_PROPERTY>()) == 0 }
+        self.propertyId == other.propertyId && self.propertyValue == other.propertyValue && self.localeName == other.localeName
     }
 }
 impl ::core::cmp::Eq for DWRITE_FONT_PROPERTY {}
@@ -15117,7 +15117,7 @@ unsafe impl ::windows::core::Abi for DWRITE_GLYPH_IMAGE_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ::core::cmp::PartialEq for DWRITE_GLYPH_IMAGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_GLYPH_IMAGE_DATA>()) == 0 }
+        self.imageData == other.imageData && self.imageDataSize == other.imageDataSize && self.uniqueDataId == other.uniqueDataId && self.pixelsPerEm == other.pixelsPerEm && self.pixelSize == other.pixelSize && self.horizontalLeftOrigin == other.horizontalLeftOrigin && self.horizontalRightOrigin == other.horizontalRightOrigin && self.verticalTopOrigin == other.verticalTopOrigin && self.verticalBottomOrigin == other.verticalBottomOrigin
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
@@ -15155,7 +15155,7 @@ unsafe impl ::windows::core::Abi for DWRITE_GLYPH_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_GLYPH_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_GLYPH_METRICS>()) == 0 }
+        self.leftSideBearing == other.leftSideBearing && self.advanceWidth == other.advanceWidth && self.rightSideBearing == other.rightSideBearing && self.topSideBearing == other.topSideBearing && self.advanceHeight == other.advanceHeight && self.bottomSideBearing == other.bottomSideBearing && self.verticalOriginY == other.verticalOriginY
     }
 }
 impl ::core::cmp::Eq for DWRITE_GLYPH_METRICS {}
@@ -15186,7 +15186,7 @@ unsafe impl ::windows::core::Abi for DWRITE_GLYPH_OFFSET {
 }
 impl ::core::cmp::PartialEq for DWRITE_GLYPH_OFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_GLYPH_OFFSET>()) == 0 }
+        self.advanceOffset == other.advanceOffset && self.ascenderOffset == other.ascenderOffset
     }
 }
 impl ::core::cmp::Eq for DWRITE_GLYPH_OFFSET {}
@@ -15272,7 +15272,7 @@ unsafe impl ::windows::core::Abi for DWRITE_GLYPH_RUN_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for DWRITE_GLYPH_RUN_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_GLYPH_RUN_DESCRIPTION>()) == 0 }
+        self.localeName == other.localeName && self.string == other.string && self.stringLength == other.stringLength && self.clusterMap == other.clusterMap && self.textPosition == other.textPosition
     }
 }
 impl ::core::cmp::Eq for DWRITE_GLYPH_RUN_DESCRIPTION {}
@@ -15316,7 +15316,7 @@ unsafe impl ::windows::core::Abi for DWRITE_HIT_TEST_METRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DWRITE_HIT_TEST_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_HIT_TEST_METRICS>()) == 0 }
+        self.textPosition == other.textPosition && self.length == other.length && self.left == other.left && self.top == other.top && self.width == other.width && self.height == other.height && self.bidiLevel == other.bidiLevel && self.isText == other.isText && self.isTrimmed == other.isTrimmed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15357,7 +15357,7 @@ unsafe impl ::windows::core::Abi for DWRITE_INLINE_OBJECT_METRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DWRITE_INLINE_OBJECT_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_INLINE_OBJECT_METRICS>()) == 0 }
+        self.width == other.width && self.height == other.height && self.baseline == other.baseline && self.supportsSideways == other.supportsSideways
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15392,7 +15392,7 @@ unsafe impl ::windows::core::Abi for DWRITE_JUSTIFICATION_OPPORTUNITY {
 }
 impl ::core::cmp::PartialEq for DWRITE_JUSTIFICATION_OPPORTUNITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_JUSTIFICATION_OPPORTUNITY>()) == 0 }
+        self.expansionMinimum == other.expansionMinimum && self.expansionMaximum == other.expansionMaximum && self.compressionMaximum == other.compressionMaximum && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_JUSTIFICATION_OPPORTUNITY {}
@@ -15422,7 +15422,7 @@ unsafe impl ::windows::core::Abi for DWRITE_LINE_BREAKPOINT {
 }
 impl ::core::cmp::PartialEq for DWRITE_LINE_BREAKPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_LINE_BREAKPOINT>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_LINE_BREAKPOINT {}
@@ -15463,7 +15463,7 @@ unsafe impl ::windows::core::Abi for DWRITE_LINE_METRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DWRITE_LINE_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_LINE_METRICS>()) == 0 }
+        self.length == other.length && self.trailingWhitespaceLength == other.trailingWhitespaceLength && self.newlineLength == other.newlineLength && self.height == other.height && self.baseline == other.baseline && self.isTrimmed == other.isTrimmed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15503,7 +15503,7 @@ unsafe impl ::windows::core::Abi for DWRITE_LINE_METRICS1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DWRITE_LINE_METRICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_LINE_METRICS1>()) == 0 }
+        self.Base == other.Base && self.leadingBefore == other.leadingBefore && self.leadingAfter == other.leadingAfter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15539,7 +15539,7 @@ unsafe impl ::windows::core::Abi for DWRITE_LINE_SPACING {
 }
 impl ::core::cmp::PartialEq for DWRITE_LINE_SPACING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_LINE_SPACING>()) == 0 }
+        self.method == other.method && self.height == other.height && self.baseline == other.baseline && self.leadingBefore == other.leadingBefore && self.fontLineGapUsage == other.fontLineGapUsage
     }
 }
 impl ::core::cmp::Eq for DWRITE_LINE_SPACING {}
@@ -15574,7 +15574,7 @@ unsafe impl ::windows::core::Abi for DWRITE_MATRIX {
 }
 impl ::core::cmp::PartialEq for DWRITE_MATRIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_MATRIX>()) == 0 }
+        self.m11 == other.m11 && self.m12 == other.m12 && self.m21 == other.m21 && self.m22 == other.m22 && self.dx == other.dx && self.dy == other.dy
     }
 }
 impl ::core::cmp::Eq for DWRITE_MATRIX {}
@@ -15607,7 +15607,7 @@ unsafe impl ::windows::core::Abi for DWRITE_OVERHANG_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_OVERHANG_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_OVERHANG_METRICS>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for DWRITE_OVERHANG_METRICS {}
@@ -15635,12 +15635,6 @@ impl ::core::clone::Clone for DWRITE_PANOSE {
 unsafe impl ::windows::core::Abi for DWRITE_PANOSE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DWRITE_PANOSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_PANOSE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DWRITE_PANOSE {}
 impl ::core::default::Default for DWRITE_PANOSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15676,7 +15670,7 @@ unsafe impl ::windows::core::Abi for DWRITE_PANOSE_0 {
 }
 impl ::core::cmp::PartialEq for DWRITE_PANOSE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_PANOSE_0>()) == 0 }
+        self.familyKind == other.familyKind && self.decorativeClass == other.decorativeClass && self.weight == other.weight && self.aspect == other.aspect && self.contrast == other.contrast && self.serifVariant == other.serifVariant && self.fill == other.fill && self.lining == other.lining && self.decorativeTopology == other.decorativeTopology && self.characterRange == other.characterRange
     }
 }
 impl ::core::cmp::Eq for DWRITE_PANOSE_0 {}
@@ -15715,7 +15709,7 @@ unsafe impl ::windows::core::Abi for DWRITE_PANOSE_1 {
 }
 impl ::core::cmp::PartialEq for DWRITE_PANOSE_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_PANOSE_1>()) == 0 }
+        self.familyKind == other.familyKind && self.toolKind == other.toolKind && self.weight == other.weight && self.spacing == other.spacing && self.aspectRatio == other.aspectRatio && self.contrast == other.contrast && self.scriptTopology == other.scriptTopology && self.scriptForm == other.scriptForm && self.finials == other.finials && self.xAscent == other.xAscent
     }
 }
 impl ::core::cmp::Eq for DWRITE_PANOSE_1 {}
@@ -15754,7 +15748,7 @@ unsafe impl ::windows::core::Abi for DWRITE_PANOSE_2 {
 }
 impl ::core::cmp::PartialEq for DWRITE_PANOSE_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_PANOSE_2>()) == 0 }
+        self.familyKind == other.familyKind && self.symbolKind == other.symbolKind && self.weight == other.weight && self.spacing == other.spacing && self.aspectRatioAndContrast == other.aspectRatioAndContrast && self.aspectRatio94 == other.aspectRatio94 && self.aspectRatio119 == other.aspectRatio119 && self.aspectRatio157 == other.aspectRatio157 && self.aspectRatio163 == other.aspectRatio163 && self.aspectRatio211 == other.aspectRatio211
     }
 }
 impl ::core::cmp::Eq for DWRITE_PANOSE_2 {}
@@ -15793,7 +15787,7 @@ unsafe impl ::windows::core::Abi for DWRITE_PANOSE_3 {
 }
 impl ::core::cmp::PartialEq for DWRITE_PANOSE_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_PANOSE_3>()) == 0 }
+        self.familyKind == other.familyKind && self.serifStyle == other.serifStyle && self.weight == other.weight && self.proportion == other.proportion && self.contrast == other.contrast && self.strokeVariation == other.strokeVariation && self.armStyle == other.armStyle && self.letterform == other.letterform && self.midline == other.midline && self.xHeight == other.xHeight
     }
 }
 impl ::core::cmp::Eq for DWRITE_PANOSE_3 {}
@@ -15824,7 +15818,7 @@ unsafe impl ::windows::core::Abi for DWRITE_SCRIPT_ANALYSIS {
 }
 impl ::core::cmp::PartialEq for DWRITE_SCRIPT_ANALYSIS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_SCRIPT_ANALYSIS>()) == 0 }
+        self.script == other.script && self.shapes == other.shapes
     }
 }
 impl ::core::cmp::Eq for DWRITE_SCRIPT_ANALYSIS {}
@@ -15858,7 +15852,7 @@ unsafe impl ::windows::core::Abi for DWRITE_SCRIPT_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for DWRITE_SCRIPT_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_SCRIPT_PROPERTIES>()) == 0 }
+        self.isoScriptCode == other.isoScriptCode && self.isoScriptNumber == other.isoScriptNumber && self.clusterLookahead == other.clusterLookahead && self.justificationCharacter == other.justificationCharacter && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_SCRIPT_PROPERTIES {}
@@ -15888,7 +15882,7 @@ unsafe impl ::windows::core::Abi for DWRITE_SHAPING_GLYPH_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for DWRITE_SHAPING_GLYPH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_SHAPING_GLYPH_PROPERTIES>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_SHAPING_GLYPH_PROPERTIES {}
@@ -15918,7 +15912,7 @@ unsafe impl ::windows::core::Abi for DWRITE_SHAPING_TEXT_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for DWRITE_SHAPING_TEXT_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_SHAPING_TEXT_PROPERTIES>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DWRITE_SHAPING_TEXT_PROPERTIES {}
@@ -15954,7 +15948,7 @@ unsafe impl ::windows::core::Abi for DWRITE_STRIKETHROUGH {
 }
 impl ::core::cmp::PartialEq for DWRITE_STRIKETHROUGH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_STRIKETHROUGH>()) == 0 }
+        self.width == other.width && self.thickness == other.thickness && self.offset == other.offset && self.readingDirection == other.readingDirection && self.flowDirection == other.flowDirection && self.localeName == other.localeName && self.measuringMode == other.measuringMode
     }
 }
 impl ::core::cmp::Eq for DWRITE_STRIKETHROUGH {}
@@ -15992,7 +15986,7 @@ unsafe impl ::windows::core::Abi for DWRITE_TEXT_METRICS {
 }
 impl ::core::cmp::PartialEq for DWRITE_TEXT_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_TEXT_METRICS>()) == 0 }
+        self.left == other.left && self.top == other.top && self.width == other.width && self.widthIncludingTrailingWhitespace == other.widthIncludingTrailingWhitespace && self.height == other.height && self.layoutWidth == other.layoutWidth && self.layoutHeight == other.layoutHeight && self.maxBidiReorderingDepth == other.maxBidiReorderingDepth && self.lineCount == other.lineCount
     }
 }
 impl ::core::cmp::Eq for DWRITE_TEXT_METRICS {}
@@ -16023,7 +16017,7 @@ unsafe impl ::windows::core::Abi for DWRITE_TEXT_METRICS1 {
 }
 impl ::core::cmp::PartialEq for DWRITE_TEXT_METRICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_TEXT_METRICS1>()) == 0 }
+        self.Base == other.Base && self.heightIncludingTrailingWhitespace == other.heightIncludingTrailingWhitespace
     }
 }
 impl ::core::cmp::Eq for DWRITE_TEXT_METRICS1 {}
@@ -16054,7 +16048,7 @@ unsafe impl ::windows::core::Abi for DWRITE_TEXT_RANGE {
 }
 impl ::core::cmp::PartialEq for DWRITE_TEXT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_TEXT_RANGE>()) == 0 }
+        self.startPosition == other.startPosition && self.length == other.length
     }
 }
 impl ::core::cmp::Eq for DWRITE_TEXT_RANGE {}
@@ -16086,7 +16080,7 @@ unsafe impl ::windows::core::Abi for DWRITE_TRIMMING {
 }
 impl ::core::cmp::PartialEq for DWRITE_TRIMMING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_TRIMMING>()) == 0 }
+        self.granularity == other.granularity && self.delimiter == other.delimiter && self.delimiterCount == other.delimiterCount
     }
 }
 impl ::core::cmp::Eq for DWRITE_TRIMMING {}
@@ -16117,7 +16111,7 @@ unsafe impl ::windows::core::Abi for DWRITE_TYPOGRAPHIC_FEATURES {
 }
 impl ::core::cmp::PartialEq for DWRITE_TYPOGRAPHIC_FEATURES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_TYPOGRAPHIC_FEATURES>()) == 0 }
+        self.features == other.features && self.featureCount == other.featureCount
     }
 }
 impl ::core::cmp::Eq for DWRITE_TYPOGRAPHIC_FEATURES {}
@@ -16154,7 +16148,7 @@ unsafe impl ::windows::core::Abi for DWRITE_UNDERLINE {
 }
 impl ::core::cmp::PartialEq for DWRITE_UNDERLINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_UNDERLINE>()) == 0 }
+        self.width == other.width && self.thickness == other.thickness && self.offset == other.offset && self.runHeight == other.runHeight && self.readingDirection == other.readingDirection && self.flowDirection == other.flowDirection && self.localeName == other.localeName && self.measuringMode == other.measuringMode
     }
 }
 impl ::core::cmp::Eq for DWRITE_UNDERLINE {}
@@ -16185,7 +16179,7 @@ unsafe impl ::windows::core::Abi for DWRITE_UNICODE_RANGE {
 }
 impl ::core::cmp::PartialEq for DWRITE_UNICODE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWRITE_UNICODE_RANGE>()) == 0 }
+        self.first == other.first && self.last == other.last
     }
 }
 impl ::core::cmp::Eq for DWRITE_UNICODE_RANGE {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
@@ -744,14 +744,6 @@ unsafe impl ::windows::core::Abi for DWM_BLURBEHIND {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DWM_BLURBEHIND {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWM_BLURBEHIND>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DWM_BLURBEHIND {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DWM_BLURBEHIND {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -783,14 +775,6 @@ unsafe impl ::windows::core::Abi for DWM_PRESENT_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DWM_PRESENT_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWM_PRESENT_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DWM_PRESENT_PARAMETERS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DWM_PRESENT_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -819,14 +803,6 @@ impl ::core::clone::Clone for DWM_THUMBNAIL_PROPERTIES {
 unsafe impl ::windows::core::Abi for DWM_THUMBNAIL_PROPERTIES {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DWM_THUMBNAIL_PROPERTIES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWM_THUMBNAIL_PROPERTIES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DWM_THUMBNAIL_PROPERTIES {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DWM_THUMBNAIL_PROPERTIES {
     fn default() -> Self {
@@ -886,12 +862,6 @@ impl ::core::clone::Clone for DWM_TIMING_INFO {
 unsafe impl ::windows::core::Abi for DWM_TIMING_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DWM_TIMING_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWM_TIMING_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DWM_TIMING_INFO {}
 impl ::core::default::Default for DWM_TIMING_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -916,12 +886,6 @@ impl ::core::clone::Clone for MilMatrix3x2D {
 unsafe impl ::windows::core::Abi for MilMatrix3x2D {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MilMatrix3x2D {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MilMatrix3x2D>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MilMatrix3x2D {}
 impl ::core::default::Default for MilMatrix3x2D {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -942,12 +906,6 @@ impl ::core::clone::Clone for UNSIGNED_RATIO {
 unsafe impl ::windows::core::Abi for UNSIGNED_RATIO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UNSIGNED_RATIO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNSIGNED_RATIO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UNSIGNED_RATIO {}
 impl ::core::default::Default for UNSIGNED_RATIO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/Common/mod.rs
@@ -507,7 +507,7 @@ unsafe impl ::windows::core::Abi for DXGI_GAMMA_CONTROL {
 }
 impl ::core::cmp::PartialEq for DXGI_GAMMA_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_GAMMA_CONTROL>()) == 0 }
+        self.Scale == other.Scale && self.Offset == other.Offset && self.GammaCurve == other.GammaCurve
     }
 }
 impl ::core::cmp::Eq for DXGI_GAMMA_CONTROL {}
@@ -547,7 +547,7 @@ unsafe impl ::windows::core::Abi for DXGI_GAMMA_CONTROL_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_GAMMA_CONTROL_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_GAMMA_CONTROL_CAPABILITIES>()) == 0 }
+        self.ScaleAndOffsetSupported == other.ScaleAndOffsetSupported && self.MaxConvertedValue == other.MaxConvertedValue && self.MinConvertedValue == other.MinConvertedValue && self.NumGammaControlPoints == other.NumGammaControlPoints && self.ControlPointPositions == other.ControlPointPositions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -580,7 +580,7 @@ unsafe impl ::windows::core::Abi for DXGI_JPEG_AC_HUFFMAN_TABLE {
 }
 impl ::core::cmp::PartialEq for DXGI_JPEG_AC_HUFFMAN_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_JPEG_AC_HUFFMAN_TABLE>()) == 0 }
+        self.CodeCounts == other.CodeCounts && self.CodeValues == other.CodeValues
     }
 }
 impl ::core::cmp::Eq for DXGI_JPEG_AC_HUFFMAN_TABLE {}
@@ -611,7 +611,7 @@ unsafe impl ::windows::core::Abi for DXGI_JPEG_DC_HUFFMAN_TABLE {
 }
 impl ::core::cmp::PartialEq for DXGI_JPEG_DC_HUFFMAN_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_JPEG_DC_HUFFMAN_TABLE>()) == 0 }
+        self.CodeCounts == other.CodeCounts && self.CodeValues == other.CodeValues
     }
 }
 impl ::core::cmp::Eq for DXGI_JPEG_DC_HUFFMAN_TABLE {}
@@ -641,7 +641,7 @@ unsafe impl ::windows::core::Abi for DXGI_JPEG_QUANTIZATION_TABLE {
 }
 impl ::core::cmp::PartialEq for DXGI_JPEG_QUANTIZATION_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_JPEG_QUANTIZATION_TABLE>()) == 0 }
+        self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DXGI_JPEG_QUANTIZATION_TABLE {}
@@ -676,7 +676,7 @@ unsafe impl ::windows::core::Abi for DXGI_MODE_DESC {
 }
 impl ::core::cmp::PartialEq for DXGI_MODE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_MODE_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.RefreshRate == other.RefreshRate && self.Format == other.Format && self.ScanlineOrdering == other.ScanlineOrdering && self.Scaling == other.Scaling
     }
 }
 impl ::core::cmp::Eq for DXGI_MODE_DESC {}
@@ -707,7 +707,7 @@ unsafe impl ::windows::core::Abi for DXGI_RATIONAL {
 }
 impl ::core::cmp::PartialEq for DXGI_RATIONAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_RATIONAL>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for DXGI_RATIONAL {}
@@ -739,7 +739,7 @@ unsafe impl ::windows::core::Abi for DXGI_RGB {
 }
 impl ::core::cmp::PartialEq for DXGI_RGB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_RGB>()) == 0 }
+        self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue
     }
 }
 impl ::core::cmp::Eq for DXGI_RGB {}
@@ -770,7 +770,7 @@ unsafe impl ::windows::core::Abi for DXGI_SAMPLE_DESC {
 }
 impl ::core::cmp::PartialEq for DXGI_SAMPLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SAMPLE_DESC>()) == 0 }
+        self.Count == other.Count && self.Quality == other.Quality
     }
 }
 impl ::core::cmp::Eq for DXGI_SAMPLE_DESC {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -7814,7 +7814,7 @@ unsafe impl ::windows::core::Abi for DXGI_ADAPTER_DESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_ADAPTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_ADAPTER_DESC>()) == 0 }
+        self.Description == other.Description && self.VendorId == other.VendorId && self.DeviceId == other.DeviceId && self.SubSysId == other.SubSysId && self.Revision == other.Revision && self.DedicatedVideoMemory == other.DedicatedVideoMemory && self.DedicatedSystemMemory == other.DedicatedSystemMemory && self.SharedSystemMemory == other.SharedSystemMemory && self.AdapterLuid == other.AdapterLuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7861,7 +7861,7 @@ unsafe impl ::windows::core::Abi for DXGI_ADAPTER_DESC1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_ADAPTER_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_ADAPTER_DESC1>()) == 0 }
+        self.Description == other.Description && self.VendorId == other.VendorId && self.DeviceId == other.DeviceId && self.SubSysId == other.SubSysId && self.Revision == other.Revision && self.DedicatedVideoMemory == other.DedicatedVideoMemory && self.DedicatedSystemMemory == other.DedicatedSystemMemory && self.SharedSystemMemory == other.SharedSystemMemory && self.AdapterLuid == other.AdapterLuid && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7923,7 +7923,7 @@ unsafe impl ::windows::core::Abi for DXGI_ADAPTER_DESC2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_ADAPTER_DESC2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_ADAPTER_DESC2>()) == 0 }
+        self.Description == other.Description && self.VendorId == other.VendorId && self.DeviceId == other.DeviceId && self.SubSysId == other.SubSysId && self.Revision == other.Revision && self.DedicatedVideoMemory == other.DedicatedVideoMemory && self.DedicatedSystemMemory == other.DedicatedSystemMemory && self.SharedSystemMemory == other.SharedSystemMemory && self.AdapterLuid == other.AdapterLuid && self.Flags == other.Flags && self.GraphicsPreemptionGranularity == other.GraphicsPreemptionGranularity && self.ComputePreemptionGranularity == other.ComputePreemptionGranularity
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7985,7 +7985,7 @@ unsafe impl ::windows::core::Abi for DXGI_ADAPTER_DESC3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_ADAPTER_DESC3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_ADAPTER_DESC3>()) == 0 }
+        self.Description == other.Description && self.VendorId == other.VendorId && self.DeviceId == other.DeviceId && self.SubSysId == other.SubSysId && self.Revision == other.Revision && self.DedicatedVideoMemory == other.DedicatedVideoMemory && self.DedicatedSystemMemory == other.DedicatedSystemMemory && self.SharedSystemMemory == other.SharedSystemMemory && self.AdapterLuid == other.AdapterLuid && self.Flags == other.Flags && self.GraphicsPreemptionGranularity == other.GraphicsPreemptionGranularity && self.ComputePreemptionGranularity == other.ComputePreemptionGranularity
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8017,7 +8017,7 @@ unsafe impl ::windows::core::Abi for DXGI_DECODE_SWAP_CHAIN_DESC {
 }
 impl ::core::cmp::PartialEq for DXGI_DECODE_SWAP_CHAIN_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_DECODE_SWAP_CHAIN_DESC>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for DXGI_DECODE_SWAP_CHAIN_DESC {}
@@ -8048,7 +8048,7 @@ unsafe impl ::windows::core::Abi for DXGI_DISPLAY_COLOR_SPACE {
 }
 impl ::core::cmp::PartialEq for DXGI_DISPLAY_COLOR_SPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_DISPLAY_COLOR_SPACE>()) == 0 }
+        self.PrimaryCoordinates == other.PrimaryCoordinates && self.WhitePoints == other.WhitePoints
     }
 }
 impl ::core::cmp::Eq for DXGI_DISPLAY_COLOR_SPACE {}
@@ -8082,7 +8082,7 @@ unsafe impl ::windows::core::Abi for DXGI_FRAME_STATISTICS {
 }
 impl ::core::cmp::PartialEq for DXGI_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_FRAME_STATISTICS>()) == 0 }
+        self.PresentCount == other.PresentCount && self.PresentRefreshCount == other.PresentRefreshCount && self.SyncRefreshCount == other.SyncRefreshCount && self.SyncQPCTime == other.SyncQPCTime && self.SyncGPUTime == other.SyncGPUTime
     }
 }
 impl ::core::cmp::Eq for DXGI_FRAME_STATISTICS {}
@@ -8118,7 +8118,7 @@ unsafe impl ::windows::core::Abi for DXGI_FRAME_STATISTICS_MEDIA {
 }
 impl ::core::cmp::PartialEq for DXGI_FRAME_STATISTICS_MEDIA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_FRAME_STATISTICS_MEDIA>()) == 0 }
+        self.PresentCount == other.PresentCount && self.PresentRefreshCount == other.PresentRefreshCount && self.SyncRefreshCount == other.SyncRefreshCount && self.SyncQPCTime == other.SyncQPCTime && self.SyncGPUTime == other.SyncGPUTime && self.CompositionMode == other.CompositionMode && self.ApprovedPresentDuration == other.ApprovedPresentDuration
     }
 }
 impl ::core::cmp::Eq for DXGI_FRAME_STATISTICS_MEDIA {}
@@ -8155,7 +8155,7 @@ unsafe impl ::windows::core::Abi for DXGI_HDR_METADATA_HDR10 {
 }
 impl ::core::cmp::PartialEq for DXGI_HDR_METADATA_HDR10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_HDR_METADATA_HDR10>()) == 0 }
+        self.RedPrimary == other.RedPrimary && self.GreenPrimary == other.GreenPrimary && self.BluePrimary == other.BluePrimary && self.WhitePoint == other.WhitePoint && self.MaxMasteringLuminance == other.MaxMasteringLuminance && self.MinMasteringLuminance == other.MinMasteringLuminance && self.MaxContentLightLevel == other.MaxContentLightLevel && self.MaxFrameAverageLightLevel == other.MaxFrameAverageLightLevel
     }
 }
 impl ::core::cmp::Eq for DXGI_HDR_METADATA_HDR10 {}
@@ -8185,7 +8185,7 @@ unsafe impl ::windows::core::Abi for DXGI_HDR_METADATA_HDR10PLUS {
 }
 impl ::core::cmp::PartialEq for DXGI_HDR_METADATA_HDR10PLUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_HDR_METADATA_HDR10PLUS>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DXGI_HDR_METADATA_HDR10PLUS {}
@@ -8216,7 +8216,7 @@ unsafe impl ::windows::core::Abi for DXGI_INFO_QUEUE_FILTER {
 }
 impl ::core::cmp::PartialEq for DXGI_INFO_QUEUE_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_INFO_QUEUE_FILTER>()) == 0 }
+        self.AllowList == other.AllowList && self.DenyList == other.DenyList
     }
 }
 impl ::core::cmp::Eq for DXGI_INFO_QUEUE_FILTER {}
@@ -8251,7 +8251,7 @@ unsafe impl ::windows::core::Abi for DXGI_INFO_QUEUE_FILTER_DESC {
 }
 impl ::core::cmp::PartialEq for DXGI_INFO_QUEUE_FILTER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_INFO_QUEUE_FILTER_DESC>()) == 0 }
+        self.NumCategories == other.NumCategories && self.pCategoryList == other.pCategoryList && self.NumSeverities == other.NumSeverities && self.pSeverityList == other.pSeverityList && self.NumIDs == other.NumIDs && self.pIDList == other.pIDList
     }
 }
 impl ::core::cmp::Eq for DXGI_INFO_QUEUE_FILTER_DESC {}
@@ -8286,7 +8286,7 @@ unsafe impl ::windows::core::Abi for DXGI_INFO_QUEUE_MESSAGE {
 }
 impl ::core::cmp::PartialEq for DXGI_INFO_QUEUE_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_INFO_QUEUE_MESSAGE>()) == 0 }
+        self.Producer == other.Producer && self.Category == other.Category && self.Severity == other.Severity && self.ID == other.ID && self.pDescription == other.pDescription && self.DescriptionByteLength == other.DescriptionByteLength
     }
 }
 impl ::core::cmp::Eq for DXGI_INFO_QUEUE_MESSAGE {}
@@ -8317,7 +8317,7 @@ unsafe impl ::windows::core::Abi for DXGI_MAPPED_RECT {
 }
 impl ::core::cmp::PartialEq for DXGI_MAPPED_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_MAPPED_RECT>()) == 0 }
+        self.Pitch == other.Pitch && self.pBits == other.pBits
     }
 }
 impl ::core::cmp::Eq for DXGI_MAPPED_RECT {}
@@ -8352,7 +8352,7 @@ unsafe impl ::windows::core::Abi for DXGI_MATRIX_3X2_F {
 }
 impl ::core::cmp::PartialEq for DXGI_MATRIX_3X2_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_MATRIX_3X2_F>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._21 == other._21 && self._22 == other._22 && self._31 == other._31 && self._32 == other._32
     }
 }
 impl ::core::cmp::Eq for DXGI_MATRIX_3X2_F {}
@@ -8394,7 +8394,7 @@ unsafe impl ::windows::core::Abi for DXGI_MODE_DESC1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for DXGI_MODE_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_MODE_DESC1>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.RefreshRate == other.RefreshRate && self.Format == other.Format && self.ScanlineOrdering == other.ScanlineOrdering && self.Scaling == other.Scaling && self.Stereo == other.Stereo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -8434,7 +8434,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTDUPL_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for DXGI_OUTDUPL_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTDUPL_DESC>()) == 0 }
+        self.ModeDesc == other.ModeDesc && self.Rotation == other.Rotation && self.DesktopImageInSystemMemory == other.DesktopImageInSystemMemory
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -8488,7 +8488,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTDUPL_FRAME_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_OUTDUPL_FRAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTDUPL_FRAME_INFO>()) == 0 }
+        self.LastPresentTime == other.LastPresentTime && self.LastMouseUpdateTime == other.LastMouseUpdateTime && self.AccumulatedFrames == other.AccumulatedFrames && self.RectsCoalesced == other.RectsCoalesced && self.ProtectedContentMaskedOut == other.ProtectedContentMaskedOut && self.PointerPosition == other.PointerPosition && self.TotalMetadataBufferSize == other.TotalMetadataBufferSize && self.PointerShapeBufferSize == other.PointerShapeBufferSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8527,7 +8527,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTDUPL_MOVE_RECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_OUTDUPL_MOVE_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTDUPL_MOVE_RECT>()) == 0 }
+        self.SourcePoint == other.SourcePoint && self.DestinationRect == other.DestinationRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8566,7 +8566,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTDUPL_POINTER_POSITION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_OUTDUPL_POINTER_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTDUPL_POINTER_POSITION>()) == 0 }
+        self.Position == other.Position && self.Visible == other.Visible
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8608,7 +8608,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTDUPL_POINTER_SHAPE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_OUTDUPL_POINTER_SHAPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTDUPL_POINTER_SHAPE_INFO>()) == 0 }
+        self.Type == other.Type && self.Width == other.Width && self.Height == other.Height && self.Pitch == other.Pitch && self.HotSpot == other.HotSpot
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8650,7 +8650,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTPUT_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DXGI_OUTPUT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTPUT_DESC>()) == 0 }
+        self.DeviceName == other.DeviceName && self.DesktopCoordinates == other.DesktopCoordinates && self.AttachedToDesktop == other.AttachedToDesktop && self.Rotation == other.Rotation && self.Monitor == other.Monitor
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
@@ -8716,7 +8716,7 @@ unsafe impl ::windows::core::Abi for DXGI_OUTPUT_DESC1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DXGI_OUTPUT_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_OUTPUT_DESC1>()) == 0 }
+        self.DeviceName == other.DeviceName && self.DesktopCoordinates == other.DesktopCoordinates && self.AttachedToDesktop == other.AttachedToDesktop && self.Rotation == other.Rotation && self.Monitor == other.Monitor && self.BitsPerColor == other.BitsPerColor && self.ColorSpace == other.ColorSpace && self.RedPrimary == other.RedPrimary && self.GreenPrimary == other.GreenPrimary && self.BluePrimary == other.BluePrimary && self.WhitePoint == other.WhitePoint && self.MinLuminance == other.MinLuminance && self.MaxLuminance == other.MaxLuminance && self.MaxFullFrameLuminance == other.MaxFullFrameLuminance
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
@@ -8757,7 +8757,7 @@ unsafe impl ::windows::core::Abi for DXGI_PRESENT_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_PRESENT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_PRESENT_PARAMETERS>()) == 0 }
+        self.DirtyRectsCount == other.DirtyRectsCount && self.pDirtyRects == other.pDirtyRects && self.pScrollRect == other.pScrollRect && self.pScrollOffset == other.pScrollOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8792,7 +8792,7 @@ unsafe impl ::windows::core::Abi for DXGI_QUERY_VIDEO_MEMORY_INFO {
 }
 impl ::core::cmp::PartialEq for DXGI_QUERY_VIDEO_MEMORY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_QUERY_VIDEO_MEMORY_INFO>()) == 0 }
+        self.Budget == other.Budget && self.CurrentUsage == other.CurrentUsage && self.AvailableForReservation == other.AvailableForReservation && self.CurrentReservation == other.CurrentReservation
     }
 }
 impl ::core::cmp::Eq for DXGI_QUERY_VIDEO_MEMORY_INFO {}
@@ -8825,7 +8825,7 @@ unsafe impl ::windows::core::Abi for DXGI_RGBA {
 }
 impl ::core::cmp::PartialEq for DXGI_RGBA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_RGBA>()) == 0 }
+        self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
     }
 }
 impl ::core::cmp::Eq for DXGI_RGBA {}
@@ -8861,7 +8861,7 @@ unsafe impl ::windows::core::Abi for DXGI_SHARED_RESOURCE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXGI_SHARED_RESOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SHARED_RESOURCE>()) == 0 }
+        self.Handle == other.Handle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8902,7 +8902,7 @@ unsafe impl ::windows::core::Abi for DXGI_SURFACE_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for DXGI_SURFACE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SURFACE_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format && self.SampleDesc == other.SampleDesc
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -8947,7 +8947,7 @@ unsafe impl ::windows::core::Abi for DXGI_SWAP_CHAIN_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for DXGI_SWAP_CHAIN_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SWAP_CHAIN_DESC>()) == 0 }
+        self.BufferDesc == other.BufferDesc && self.SampleDesc == other.SampleDesc && self.BufferUsage == other.BufferUsage && self.BufferCount == other.BufferCount && self.OutputWindow == other.OutputWindow && self.Windowed == other.Windowed && self.SwapEffect == other.SwapEffect && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -8995,7 +8995,7 @@ unsafe impl ::windows::core::Abi for DXGI_SWAP_CHAIN_DESC1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for DXGI_SWAP_CHAIN_DESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SWAP_CHAIN_DESC1>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format && self.Stereo == other.Stereo && self.SampleDesc == other.SampleDesc && self.BufferUsage == other.BufferUsage && self.BufferCount == other.BufferCount && self.Scaling == other.Scaling && self.SwapEffect == other.SwapEffect && self.AlphaMode == other.AlphaMode && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -9036,7 +9036,7 @@ unsafe impl ::windows::core::Abi for DXGI_SWAP_CHAIN_FULLSCREEN_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for DXGI_SWAP_CHAIN_FULLSCREEN_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXGI_SWAP_CHAIN_FULLSCREEN_DESC>()) == 0 }
+        self.RefreshRate == other.RefreshRate && self.ScanlineOrdering == other.ScanlineOrdering && self.Scaling == other.Scaling && self.Windowed == other.Windowed
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -9524,7 +9524,7 @@ unsafe impl ::windows::core::Abi for ABC {
 }
 impl ::core::cmp::PartialEq for ABC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ABC>()) == 0 }
+        self.abcA == other.abcA && self.abcB == other.abcB && self.abcC == other.abcC
     }
 }
 impl ::core::cmp::Eq for ABC {}
@@ -9556,7 +9556,7 @@ unsafe impl ::windows::core::Abi for ABCFLOAT {
 }
 impl ::core::cmp::PartialEq for ABCFLOAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ABCFLOAT>()) == 0 }
+        self.abcfA == other.abcfA && self.abcfB == other.abcfB && self.abcfC == other.abcfC
     }
 }
 impl ::core::cmp::Eq for ABCFLOAT {}
@@ -9586,7 +9586,7 @@ unsafe impl ::windows::core::Abi for ABORTPATH {
 }
 impl ::core::cmp::PartialEq for ABORTPATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ABORTPATH>()) == 0 }
+        self.emr == other.emr
     }
 }
 impl ::core::cmp::Eq for ABORTPATH {}
@@ -9618,7 +9618,7 @@ unsafe impl ::windows::core::Abi for AXESLISTA {
 }
 impl ::core::cmp::PartialEq for AXESLISTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AXESLISTA>()) == 0 }
+        self.axlReserved == other.axlReserved && self.axlNumAxes == other.axlNumAxes && self.axlAxisInfo == other.axlAxisInfo
     }
 }
 impl ::core::cmp::Eq for AXESLISTA {}
@@ -9650,7 +9650,7 @@ unsafe impl ::windows::core::Abi for AXESLISTW {
 }
 impl ::core::cmp::PartialEq for AXESLISTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AXESLISTW>()) == 0 }
+        self.axlReserved == other.axlReserved && self.axlNumAxes == other.axlNumAxes && self.axlAxisInfo == other.axlAxisInfo
     }
 }
 impl ::core::cmp::Eq for AXESLISTW {}
@@ -9682,7 +9682,7 @@ unsafe impl ::windows::core::Abi for AXISINFOA {
 }
 impl ::core::cmp::PartialEq for AXISINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AXISINFOA>()) == 0 }
+        self.axMinValue == other.axMinValue && self.axMaxValue == other.axMaxValue && self.axAxisName == other.axAxisName
     }
 }
 impl ::core::cmp::Eq for AXISINFOA {}
@@ -9714,7 +9714,7 @@ unsafe impl ::windows::core::Abi for AXISINFOW {
 }
 impl ::core::cmp::PartialEq for AXISINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AXISINFOW>()) == 0 }
+        self.axMinValue == other.axMinValue && self.axMaxValue == other.axMaxValue && self.axAxisName == other.axAxisName
     }
 }
 impl ::core::cmp::Eq for AXISINFOW {}
@@ -9750,7 +9750,7 @@ unsafe impl ::windows::core::Abi for BITMAP {
 }
 impl ::core::cmp::PartialEq for BITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAP>()) == 0 }
+        self.bmType == other.bmType && self.bmWidth == other.bmWidth && self.bmHeight == other.bmHeight && self.bmWidthBytes == other.bmWidthBytes && self.bmPlanes == other.bmPlanes && self.bmBitsPixel == other.bmBitsPixel && self.bmBits == other.bmBits
     }
 }
 impl ::core::cmp::Eq for BITMAP {}
@@ -9784,7 +9784,7 @@ unsafe impl ::windows::core::Abi for BITMAPCOREHEADER {
 }
 impl ::core::cmp::PartialEq for BITMAPCOREHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPCOREHEADER>()) == 0 }
+        self.bcSize == other.bcSize && self.bcWidth == other.bcWidth && self.bcHeight == other.bcHeight && self.bcPlanes == other.bcPlanes && self.bcBitCount == other.bcBitCount
     }
 }
 impl ::core::cmp::Eq for BITMAPCOREHEADER {}
@@ -9815,7 +9815,7 @@ unsafe impl ::windows::core::Abi for BITMAPCOREINFO {
 }
 impl ::core::cmp::PartialEq for BITMAPCOREINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPCOREINFO>()) == 0 }
+        self.bmciHeader == other.bmciHeader && self.bmciColors == other.bmciColors
     }
 }
 impl ::core::cmp::Eq for BITMAPCOREINFO {}
@@ -9842,12 +9842,6 @@ impl ::core::clone::Clone for BITMAPFILEHEADER {
 unsafe impl ::windows::core::Abi for BITMAPFILEHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BITMAPFILEHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPFILEHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BITMAPFILEHEADER {}
 impl ::core::default::Default for BITMAPFILEHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9875,7 +9869,7 @@ unsafe impl ::windows::core::Abi for BITMAPINFO {
 }
 impl ::core::cmp::PartialEq for BITMAPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPINFO>()) == 0 }
+        self.bmiHeader == other.bmiHeader && self.bmiColors == other.bmiColors
     }
 }
 impl ::core::cmp::Eq for BITMAPINFO {}
@@ -9915,7 +9909,7 @@ unsafe impl ::windows::core::Abi for BITMAPINFOHEADER {
 }
 impl ::core::cmp::PartialEq for BITMAPINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPINFOHEADER>()) == 0 }
+        self.biSize == other.biSize && self.biWidth == other.biWidth && self.biHeight == other.biHeight && self.biPlanes == other.biPlanes && self.biBitCount == other.biBitCount && self.biCompression == other.biCompression && self.biSizeImage == other.biSizeImage && self.biXPelsPerMeter == other.biXPelsPerMeter && self.biYPelsPerMeter == other.biYPelsPerMeter && self.biClrUsed == other.biClrUsed && self.biClrImportant == other.biClrImportant
     }
 }
 impl ::core::cmp::Eq for BITMAPINFOHEADER {}
@@ -9985,7 +9979,26 @@ unsafe impl ::windows::core::Abi for BITMAPV4HEADER {
 }
 impl ::core::cmp::PartialEq for BITMAPV4HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPV4HEADER>()) == 0 }
+        self.bV4Size == other.bV4Size
+            && self.bV4Width == other.bV4Width
+            && self.bV4Height == other.bV4Height
+            && self.bV4Planes == other.bV4Planes
+            && self.bV4BitCount == other.bV4BitCount
+            && self.bV4V4Compression == other.bV4V4Compression
+            && self.bV4SizeImage == other.bV4SizeImage
+            && self.bV4XPelsPerMeter == other.bV4XPelsPerMeter
+            && self.bV4YPelsPerMeter == other.bV4YPelsPerMeter
+            && self.bV4ClrUsed == other.bV4ClrUsed
+            && self.bV4ClrImportant == other.bV4ClrImportant
+            && self.bV4RedMask == other.bV4RedMask
+            && self.bV4GreenMask == other.bV4GreenMask
+            && self.bV4BlueMask == other.bV4BlueMask
+            && self.bV4AlphaMask == other.bV4AlphaMask
+            && self.bV4CSType == other.bV4CSType
+            && self.bV4Endpoints == other.bV4Endpoints
+            && self.bV4GammaRed == other.bV4GammaRed
+            && self.bV4GammaGreen == other.bV4GammaGreen
+            && self.bV4GammaBlue == other.bV4GammaBlue
     }
 }
 impl ::core::cmp::Eq for BITMAPV4HEADER {}
@@ -10063,7 +10076,30 @@ unsafe impl ::windows::core::Abi for BITMAPV5HEADER {
 }
 impl ::core::cmp::PartialEq for BITMAPV5HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAPV5HEADER>()) == 0 }
+        self.bV5Size == other.bV5Size
+            && self.bV5Width == other.bV5Width
+            && self.bV5Height == other.bV5Height
+            && self.bV5Planes == other.bV5Planes
+            && self.bV5BitCount == other.bV5BitCount
+            && self.bV5Compression == other.bV5Compression
+            && self.bV5SizeImage == other.bV5SizeImage
+            && self.bV5XPelsPerMeter == other.bV5XPelsPerMeter
+            && self.bV5YPelsPerMeter == other.bV5YPelsPerMeter
+            && self.bV5ClrUsed == other.bV5ClrUsed
+            && self.bV5ClrImportant == other.bV5ClrImportant
+            && self.bV5RedMask == other.bV5RedMask
+            && self.bV5GreenMask == other.bV5GreenMask
+            && self.bV5BlueMask == other.bV5BlueMask
+            && self.bV5AlphaMask == other.bV5AlphaMask
+            && self.bV5CSType == other.bV5CSType
+            && self.bV5Endpoints == other.bV5Endpoints
+            && self.bV5GammaRed == other.bV5GammaRed
+            && self.bV5GammaGreen == other.bV5GammaGreen
+            && self.bV5GammaBlue == other.bV5GammaBlue
+            && self.bV5Intent == other.bV5Intent
+            && self.bV5ProfileData == other.bV5ProfileData
+            && self.bV5ProfileSize == other.bV5ProfileSize
+            && self.bV5Reserved == other.bV5Reserved
     }
 }
 impl ::core::cmp::Eq for BITMAPV5HEADER {}
@@ -10096,7 +10132,7 @@ unsafe impl ::windows::core::Abi for BLENDFUNCTION {
 }
 impl ::core::cmp::PartialEq for BLENDFUNCTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLENDFUNCTION>()) == 0 }
+        self.BlendOp == other.BlendOp && self.BlendFlags == other.BlendFlags && self.SourceConstantAlpha == other.SourceConstantAlpha && self.AlphaFormat == other.AlphaFormat
     }
 }
 impl ::core::cmp::Eq for BLENDFUNCTION {}
@@ -10128,7 +10164,7 @@ unsafe impl ::windows::core::Abi for CIEXYZ {
 }
 impl ::core::cmp::PartialEq for CIEXYZ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CIEXYZ>()) == 0 }
+        self.ciexyzX == other.ciexyzX && self.ciexyzY == other.ciexyzY && self.ciexyzZ == other.ciexyzZ
     }
 }
 impl ::core::cmp::Eq for CIEXYZ {}
@@ -10160,7 +10196,7 @@ unsafe impl ::windows::core::Abi for CIEXYZTRIPLE {
 }
 impl ::core::cmp::PartialEq for CIEXYZTRIPLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CIEXYZTRIPLE>()) == 0 }
+        self.ciexyzRed == other.ciexyzRed && self.ciexyzGreen == other.ciexyzGreen && self.ciexyzBlue == other.ciexyzBlue
     }
 }
 impl ::core::cmp::Eq for CIEXYZTRIPLE {}
@@ -10214,7 +10250,7 @@ unsafe impl ::windows::core::Abi for COLORADJUSTMENT {
 }
 impl ::core::cmp::PartialEq for COLORADJUSTMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORADJUSTMENT>()) == 0 }
+        self.caSize == other.caSize && self.caFlags == other.caFlags && self.caIlluminantIndex == other.caIlluminantIndex && self.caRedGamma == other.caRedGamma && self.caGreenGamma == other.caGreenGamma && self.caBlueGamma == other.caBlueGamma && self.caReferenceBlack == other.caReferenceBlack && self.caReferenceWhite == other.caReferenceWhite && self.caContrast == other.caContrast && self.caBrightness == other.caBrightness && self.caColorfulness == other.caColorfulness && self.caRedGreenTint == other.caRedGreenTint
     }
 }
 impl ::core::cmp::Eq for COLORADJUSTMENT {}
@@ -10283,7 +10319,7 @@ unsafe impl ::windows::core::Abi for DESIGNVECTOR {
 }
 impl ::core::cmp::PartialEq for DESIGNVECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DESIGNVECTOR>()) == 0 }
+        self.dvReserved == other.dvReserved && self.dvNumAxes == other.dvNumAxes && self.dvValues == other.dvValues
     }
 }
 impl ::core::cmp::Eq for DESIGNVECTOR {}
@@ -10337,14 +10373,6 @@ unsafe impl ::windows::core::Abi for DEVMODEA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10369,14 +10397,6 @@ impl ::core::clone::Clone for DEVMODEA_0 {
 unsafe impl ::windows::core::Abi for DEVMODEA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEA_0 {
     fn default() -> Self {
@@ -10417,7 +10437,7 @@ unsafe impl ::windows::core::Abi for DEVMODEA_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DEVMODEA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEA_0_0>()) == 0 }
+        self.dmOrientation == other.dmOrientation && self.dmPaperSize == other.dmPaperSize && self.dmPaperLength == other.dmPaperLength && self.dmPaperWidth == other.dmPaperWidth && self.dmScale == other.dmScale && self.dmCopies == other.dmCopies && self.dmDefaultSource == other.dmDefaultSource && self.dmPrintQuality == other.dmPrintQuality
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
@@ -10457,7 +10477,7 @@ unsafe impl ::windows::core::Abi for DEVMODEA_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DEVMODEA_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEA_0_1>()) == 0 }
+        self.dmPosition == other.dmPosition && self.dmDisplayOrientation == other.dmDisplayOrientation && self.dmDisplayFixedOutput == other.dmDisplayFixedOutput
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
@@ -10487,14 +10507,6 @@ impl ::core::clone::Clone for DEVMODEA_1 {
 unsafe impl ::windows::core::Abi for DEVMODEA_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEA_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEA_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEA_1 {
     fn default() -> Self {
@@ -10546,14 +10558,6 @@ unsafe impl ::windows::core::Abi for DEVMODEW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10578,14 +10582,6 @@ impl ::core::clone::Clone for DEVMODEW_0 {
 unsafe impl ::windows::core::Abi for DEVMODEW_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEW_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEW_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEW_0 {
     fn default() -> Self {
@@ -10626,7 +10622,7 @@ unsafe impl ::windows::core::Abi for DEVMODEW_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DEVMODEW_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEW_0_0>()) == 0 }
+        self.dmOrientation == other.dmOrientation && self.dmPaperSize == other.dmPaperSize && self.dmPaperLength == other.dmPaperLength && self.dmPaperWidth == other.dmPaperWidth && self.dmScale == other.dmScale && self.dmCopies == other.dmCopies && self.dmDefaultSource == other.dmDefaultSource && self.dmPrintQuality == other.dmPrintQuality
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
@@ -10666,7 +10662,7 @@ unsafe impl ::windows::core::Abi for DEVMODEW_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DEVMODEW_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEW_0_1>()) == 0 }
+        self.dmPosition == other.dmPosition && self.dmDisplayOrientation == other.dmDisplayOrientation && self.dmDisplayFixedOutput == other.dmDisplayFixedOutput
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
@@ -10696,14 +10692,6 @@ impl ::core::clone::Clone for DEVMODEW_1 {
 unsafe impl ::windows::core::Abi for DEVMODEW_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for DEVMODEW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVMODEW_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for DEVMODEW_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for DEVMODEW_1 {
     fn default() -> Self {
@@ -10741,7 +10729,7 @@ unsafe impl ::windows::core::Abi for DIBSECTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIBSECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIBSECTION>()) == 0 }
+        self.dsBm == other.dsBm && self.dsBmih == other.dsBmih && self.dsBitfields == other.dsBitfields && self.dshSection == other.dshSection && self.dsOffset == other.dsOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10784,7 +10772,7 @@ unsafe impl ::windows::core::Abi for DISPLAY_DEVICEA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISPLAY_DEVICEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAY_DEVICEA>()) == 0 }
+        self.cb == other.cb && self.DeviceName == other.DeviceName && self.DeviceString == other.DeviceString && self.StateFlags == other.StateFlags && self.DeviceID == other.DeviceID && self.DeviceKey == other.DeviceKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10821,7 +10809,7 @@ unsafe impl ::windows::core::Abi for DISPLAY_DEVICEW {
 }
 impl ::core::cmp::PartialEq for DISPLAY_DEVICEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPLAY_DEVICEW>()) == 0 }
+        self.cb == other.cb && self.DeviceName == other.DeviceName && self.DeviceString == other.DeviceString && self.StateFlags == other.StateFlags && self.DeviceID == other.DeviceID && self.DeviceKey == other.DeviceKey
     }
 }
 impl ::core::cmp::Eq for DISPLAY_DEVICEW {}
@@ -10855,7 +10843,7 @@ unsafe impl ::windows::core::Abi for DRAWTEXTPARAMS {
 }
 impl ::core::cmp::PartialEq for DRAWTEXTPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAWTEXTPARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.iTabLength == other.iTabLength && self.iLeftMargin == other.iLeftMargin && self.iRightMargin == other.iRightMargin && self.uiLengthDrawn == other.uiLengthDrawn
     }
 }
 impl ::core::cmp::Eq for DRAWTEXTPARAMS {}
@@ -10886,7 +10874,7 @@ unsafe impl ::windows::core::Abi for EMR {
 }
 impl ::core::cmp::PartialEq for EMR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMR>()) == 0 }
+        self.iType == other.iType && self.nSize == other.nSize
     }
 }
 impl ::core::cmp::Eq for EMR {}
@@ -10958,7 +10946,7 @@ unsafe impl ::windows::core::Abi for EMRALPHABLEND {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRALPHABLEND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRALPHABLEND>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.cxDest == other.cxDest && self.cyDest == other.cyDest && self.dwRop == other.dwRop && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11000,7 +10988,7 @@ unsafe impl ::windows::core::Abi for EMRANGLEARC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRANGLEARC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRANGLEARC>()) == 0 }
+        self.emr == other.emr && self.ptlCenter == other.ptlCenter && self.nRadius == other.nRadius && self.eStartAngle == other.eStartAngle && self.eSweepAngle == other.eSweepAngle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11041,7 +11029,7 @@ unsafe impl ::windows::core::Abi for EMRARC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRARC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRARC>()) == 0 }
+        self.emr == other.emr && self.rclBox == other.rclBox && self.ptlStart == other.ptlStart && self.ptlEnd == other.ptlEnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11111,7 +11099,7 @@ unsafe impl ::windows::core::Abi for EMRBITBLT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRBITBLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRBITBLT>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.cxDest == other.cxDest && self.cyDest == other.cyDest && self.dwRop == other.dwRop && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11147,7 +11135,7 @@ unsafe impl ::windows::core::Abi for EMRCOLORCORRECTPALETTE {
 }
 impl ::core::cmp::PartialEq for EMRCOLORCORRECTPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCOLORCORRECTPALETTE>()) == 0 }
+        self.emr == other.emr && self.ihPalette == other.ihPalette && self.nFirstEntry == other.nFirstEntry && self.nPalEntries == other.nPalEntries && self.nReserved == other.nReserved
     }
 }
 impl ::core::cmp::Eq for EMRCOLORCORRECTPALETTE {}
@@ -11182,7 +11170,7 @@ unsafe impl ::windows::core::Abi for EMRCOLORMATCHTOTARGET {
 }
 impl ::core::cmp::PartialEq for EMRCOLORMATCHTOTARGET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCOLORMATCHTOTARGET>()) == 0 }
+        self.emr == other.emr && self.dwAction == other.dwAction && self.dwFlags == other.dwFlags && self.cbName == other.cbName && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for EMRCOLORMATCHTOTARGET {}
@@ -11220,7 +11208,7 @@ unsafe impl ::windows::core::Abi for EMRCREATEBRUSHINDIRECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRCREATEBRUSHINDIRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATEBRUSHINDIRECT>()) == 0 }
+        self.emr == other.emr && self.ihBrush == other.ihBrush && self.lb == other.lb
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11258,7 +11246,7 @@ unsafe impl ::windows::core::Abi for EMRCREATEDIBPATTERNBRUSHPT {
 }
 impl ::core::cmp::PartialEq for EMRCREATEDIBPATTERNBRUSHPT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATEDIBPATTERNBRUSHPT>()) == 0 }
+        self.emr == other.emr && self.ihBrush == other.ihBrush && self.iUsage == other.iUsage && self.offBmi == other.offBmi && self.cbBmi == other.cbBmi && self.offBits == other.offBits && self.cbBits == other.cbBits
     }
 }
 impl ::core::cmp::Eq for EMRCREATEDIBPATTERNBRUSHPT {}
@@ -11294,7 +11282,7 @@ unsafe impl ::windows::core::Abi for EMRCREATEMONOBRUSH {
 }
 impl ::core::cmp::PartialEq for EMRCREATEMONOBRUSH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATEMONOBRUSH>()) == 0 }
+        self.emr == other.emr && self.ihBrush == other.ihBrush && self.iUsage == other.iUsage && self.offBmi == other.offBmi && self.cbBmi == other.cbBmi && self.offBits == other.offBits && self.cbBits == other.cbBits
     }
 }
 impl ::core::cmp::Eq for EMRCREATEMONOBRUSH {}
@@ -11326,7 +11314,7 @@ unsafe impl ::windows::core::Abi for EMRCREATEPALETTE {
 }
 impl ::core::cmp::PartialEq for EMRCREATEPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATEPALETTE>()) == 0 }
+        self.emr == other.emr && self.ihPal == other.ihPal && self.lgpl == other.lgpl
     }
 }
 impl ::core::cmp::Eq for EMRCREATEPALETTE {}
@@ -11364,7 +11352,7 @@ unsafe impl ::windows::core::Abi for EMRCREATEPEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRCREATEPEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATEPEN>()) == 0 }
+        self.emr == other.emr && self.ihPen == other.ihPen && self.lopn == other.lopn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11403,7 +11391,7 @@ unsafe impl ::windows::core::Abi for EMRELLIPSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRELLIPSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRELLIPSE>()) == 0 }
+        self.emr == other.emr && self.rclBox == other.rclBox
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11438,7 +11426,7 @@ unsafe impl ::windows::core::Abi for EMREOF {
 }
 impl ::core::cmp::PartialEq for EMREOF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREOF>()) == 0 }
+        self.emr == other.emr && self.nPalEntries == other.nPalEntries && self.offPalEntries == other.offPalEntries && self.nSizeLast == other.nSizeLast
     }
 }
 impl ::core::cmp::Eq for EMREOF {}
@@ -11475,7 +11463,7 @@ unsafe impl ::windows::core::Abi for EMREXCLUDECLIPRECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMREXCLUDECLIPRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXCLUDECLIPRECT>()) == 0 }
+        self.emr == other.emr && self.rclClip == other.rclClip
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11509,7 +11497,7 @@ unsafe impl ::windows::core::Abi for EMREXTCREATEFONTINDIRECTW {
 }
 impl ::core::cmp::PartialEq for EMREXTCREATEFONTINDIRECTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTCREATEFONTINDIRECTW>()) == 0 }
+        self.emr == other.emr && self.ihFont == other.ihFont && self.elfw == other.elfw
     }
 }
 impl ::core::cmp::Eq for EMREXTCREATEFONTINDIRECTW {}
@@ -11551,7 +11539,7 @@ unsafe impl ::windows::core::Abi for EMREXTCREATEPEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMREXTCREATEPEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTCREATEPEN>()) == 0 }
+        self.emr == other.emr && self.ihPen == other.ihPen && self.offBmi == other.offBmi && self.cbBmi == other.cbBmi && self.offBits == other.offBits && self.cbBits == other.cbBits && self.elp == other.elp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11586,7 +11574,7 @@ unsafe impl ::windows::core::Abi for EMREXTESCAPE {
 }
 impl ::core::cmp::PartialEq for EMREXTESCAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTESCAPE>()) == 0 }
+        self.emr == other.emr && self.iEscape == other.iEscape && self.cbEscData == other.cbEscData && self.EscData == other.EscData
     }
 }
 impl ::core::cmp::Eq for EMREXTESCAPE {}
@@ -11625,7 +11613,7 @@ unsafe impl ::windows::core::Abi for EMREXTFLOODFILL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMREXTFLOODFILL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTFLOODFILL>()) == 0 }
+        self.emr == other.emr && self.ptlStart == other.ptlStart && self.crColor == other.crColor && self.iMode == other.iMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11660,7 +11648,7 @@ unsafe impl ::windows::core::Abi for EMREXTSELECTCLIPRGN {
 }
 impl ::core::cmp::PartialEq for EMREXTSELECTCLIPRGN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTSELECTCLIPRGN>()) == 0 }
+        self.emr == other.emr && self.cbRgnData == other.cbRgnData && self.iMode == other.iMode && self.RgnData == other.RgnData
     }
 }
 impl ::core::cmp::Eq for EMREXTSELECTCLIPRGN {}
@@ -11701,7 +11689,7 @@ unsafe impl ::windows::core::Abi for EMREXTTEXTOUTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMREXTTEXTOUTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMREXTTEXTOUTA>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.iGraphicsMode == other.iGraphicsMode && self.exScale == other.exScale && self.eyScale == other.eyScale && self.emrtext == other.emrtext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11740,7 +11728,7 @@ unsafe impl ::windows::core::Abi for EMRFILLPATH {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRFILLPATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRFILLPATH>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11782,7 +11770,7 @@ unsafe impl ::windows::core::Abi for EMRFILLRGN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRFILLRGN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRFILLRGN>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cbRgnData == other.cbRgnData && self.ihBrush == other.ihBrush && self.RgnData == other.RgnData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11817,7 +11805,7 @@ unsafe impl ::windows::core::Abi for EMRFORMAT {
 }
 impl ::core::cmp::PartialEq for EMRFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRFORMAT>()) == 0 }
+        self.dSignature == other.dSignature && self.nVersion == other.nVersion && self.cbData == other.cbData && self.offData == other.offData
     }
 }
 impl ::core::cmp::Eq for EMRFORMAT {}
@@ -11858,7 +11846,7 @@ unsafe impl ::windows::core::Abi for EMRFRAMERGN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRFRAMERGN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRFRAMERGN>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cbRgnData == other.cbRgnData && self.ihBrush == other.ihBrush && self.szlStroke == other.szlStroke && self.RgnData == other.RgnData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11892,7 +11880,7 @@ unsafe impl ::windows::core::Abi for EMRGDICOMMENT {
 }
 impl ::core::cmp::PartialEq for EMRGDICOMMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRGDICOMMENT>()) == 0 }
+        self.emr == other.emr && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for EMRGDICOMMENT {}
@@ -11931,7 +11919,7 @@ unsafe impl ::windows::core::Abi for EMRGLSBOUNDEDRECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRGLSBOUNDEDRECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRGLSBOUNDEDRECORD>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11965,7 +11953,7 @@ unsafe impl ::windows::core::Abi for EMRGLSRECORD {
 }
 impl ::core::cmp::PartialEq for EMRGLSRECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRGLSRECORD>()) == 0 }
+        self.emr == other.emr && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for EMRGLSRECORD {}
@@ -12006,7 +11994,7 @@ unsafe impl ::windows::core::Abi for EMRGRADIENTFILL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRGRADIENTFILL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRGRADIENTFILL>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.nVer == other.nVer && self.nTri == other.nTri && self.ulMode == other.ulMode && self.Ver == other.Ver
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12047,7 +12035,7 @@ unsafe impl ::windows::core::Abi for EMRINVERTRGN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRINVERTRGN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRINVERTRGN>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cbRgnData == other.cbRgnData && self.RgnData == other.RgnData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12086,7 +12074,7 @@ unsafe impl ::windows::core::Abi for EMRLINETO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRLINETO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRLINETO>()) == 0 }
+        self.emr == other.emr && self.ptl == other.ptl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12170,7 +12158,7 @@ unsafe impl ::windows::core::Abi for EMRMASKBLT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRMASKBLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRMASKBLT>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.cxDest == other.cxDest && self.cyDest == other.cyDest && self.dwRop == other.dwRop && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.xMask == other.xMask && self.yMask == other.yMask && self.iUsageMask == other.iUsageMask && self.offBmiMask == other.offBmiMask && self.cbBmiMask == other.cbBmiMask && self.offBitsMask == other.offBitsMask && self.cbBitsMask == other.cbBitsMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12204,7 +12192,7 @@ unsafe impl ::windows::core::Abi for EMRMODIFYWORLDTRANSFORM {
 }
 impl ::core::cmp::PartialEq for EMRMODIFYWORLDTRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRMODIFYWORLDTRANSFORM>()) == 0 }
+        self.emr == other.emr && self.xform == other.xform && self.iMode == other.iMode
     }
 }
 impl ::core::cmp::Eq for EMRMODIFYWORLDTRANSFORM {}
@@ -12238,7 +12226,7 @@ unsafe impl ::windows::core::Abi for EMRNAMEDESCAPE {
 }
 impl ::core::cmp::PartialEq for EMRNAMEDESCAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRNAMEDESCAPE>()) == 0 }
+        self.emr == other.emr && self.iEscape == other.iEscape && self.cbDriver == other.cbDriver && self.cbEscData == other.cbEscData && self.EscData == other.EscData
     }
 }
 impl ::core::cmp::Eq for EMRNAMEDESCAPE {}
@@ -12275,7 +12263,7 @@ unsafe impl ::windows::core::Abi for EMROFFSETCLIPRGN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMROFFSETCLIPRGN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMROFFSETCLIPRGN>()) == 0 }
+        self.emr == other.emr && self.ptlOffset == other.ptlOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12355,7 +12343,7 @@ unsafe impl ::windows::core::Abi for EMRPLGBLT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPLGBLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPLGBLT>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.aptlDest == other.aptlDest && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.xMask == other.xMask && self.yMask == other.yMask && self.iUsageMask == other.iUsageMask && self.offBmiMask == other.offBmiMask && self.cbBmiMask == other.cbBmiMask && self.offBitsMask == other.offBitsMask && self.cbBitsMask == other.cbBitsMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12397,7 +12385,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYDRAW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYDRAW>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cptl == other.cptl && self.aptl == other.aptl && self.abTypes == other.abTypes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12439,7 +12427,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYDRAW16 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYDRAW16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYDRAW16>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cpts == other.cpts && self.apts == other.apts && self.abTypes == other.abTypes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12480,7 +12468,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYLINE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYLINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYLINE>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cptl == other.cptl && self.aptl == other.aptl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12521,7 +12509,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYLINE16 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYLINE16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYLINE16>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.cpts == other.cpts && self.apts == other.apts
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12564,7 +12552,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYPOLYLINE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYPOLYLINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYPOLYLINE>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.nPolys == other.nPolys && self.cptl == other.cptl && self.aPolyCounts == other.aPolyCounts && self.aptl == other.aptl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12607,7 +12595,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYPOLYLINE16 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYPOLYLINE16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYPOLYLINE16>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.nPolys == other.nPolys && self.cpts == other.cpts && self.aPolyCounts == other.aPolyCounts && self.apts == other.apts
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12651,7 +12639,7 @@ unsafe impl ::windows::core::Abi for EMRPOLYTEXTOUTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRPOLYTEXTOUTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPOLYTEXTOUTA>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.iGraphicsMode == other.iGraphicsMode && self.exScale == other.exScale && self.eyScale == other.eyScale && self.cStrings == other.cStrings && self.aemrtext == other.aemrtext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12685,7 +12673,7 @@ unsafe impl ::windows::core::Abi for EMRRESIZEPALETTE {
 }
 impl ::core::cmp::PartialEq for EMRRESIZEPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRRESIZEPALETTE>()) == 0 }
+        self.emr == other.emr && self.ihPal == other.ihPal && self.cEntries == other.cEntries
     }
 }
 impl ::core::cmp::Eq for EMRRESIZEPALETTE {}
@@ -12716,7 +12704,7 @@ unsafe impl ::windows::core::Abi for EMRRESTOREDC {
 }
 impl ::core::cmp::PartialEq for EMRRESTOREDC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRRESTOREDC>()) == 0 }
+        self.emr == other.emr && self.iRelative == other.iRelative
     }
 }
 impl ::core::cmp::Eq for EMRRESTOREDC {}
@@ -12754,7 +12742,7 @@ unsafe impl ::windows::core::Abi for EMRROUNDRECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRROUNDRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRROUNDRECT>()) == 0 }
+        self.emr == other.emr && self.rclBox == other.rclBox && self.szlCorner == other.szlCorner
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12790,7 +12778,7 @@ unsafe impl ::windows::core::Abi for EMRSCALEVIEWPORTEXTEX {
 }
 impl ::core::cmp::PartialEq for EMRSCALEVIEWPORTEXTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSCALEVIEWPORTEXTEX>()) == 0 }
+        self.emr == other.emr && self.xNum == other.xNum && self.xDenom == other.xDenom && self.yNum == other.yNum && self.yDenom == other.yDenom
     }
 }
 impl ::core::cmp::Eq for EMRSCALEVIEWPORTEXTEX {}
@@ -12821,7 +12809,7 @@ unsafe impl ::windows::core::Abi for EMRSELECTCLIPPATH {
 }
 impl ::core::cmp::PartialEq for EMRSELECTCLIPPATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSELECTCLIPPATH>()) == 0 }
+        self.emr == other.emr && self.iMode == other.iMode
     }
 }
 impl ::core::cmp::Eq for EMRSELECTCLIPPATH {}
@@ -12852,7 +12840,7 @@ unsafe impl ::windows::core::Abi for EMRSELECTOBJECT {
 }
 impl ::core::cmp::PartialEq for EMRSELECTOBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSELECTOBJECT>()) == 0 }
+        self.emr == other.emr && self.ihObject == other.ihObject
     }
 }
 impl ::core::cmp::Eq for EMRSELECTOBJECT {}
@@ -12883,7 +12871,7 @@ unsafe impl ::windows::core::Abi for EMRSELECTPALETTE {
 }
 impl ::core::cmp::PartialEq for EMRSELECTPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSELECTPALETTE>()) == 0 }
+        self.emr == other.emr && self.ihPal == other.ihPal
     }
 }
 impl ::core::cmp::Eq for EMRSELECTPALETTE {}
@@ -12914,7 +12902,7 @@ unsafe impl ::windows::core::Abi for EMRSETARCDIRECTION {
 }
 impl ::core::cmp::PartialEq for EMRSETARCDIRECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETARCDIRECTION>()) == 0 }
+        self.emr == other.emr && self.iArcDirection == other.iArcDirection
     }
 }
 impl ::core::cmp::Eq for EMRSETARCDIRECTION {}
@@ -12945,7 +12933,7 @@ unsafe impl ::windows::core::Abi for EMRSETCOLORADJUSTMENT {
 }
 impl ::core::cmp::PartialEq for EMRSETCOLORADJUSTMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETCOLORADJUSTMENT>()) == 0 }
+        self.emr == other.emr && self.ColorAdjustment == other.ColorAdjustment
     }
 }
 impl ::core::cmp::Eq for EMRSETCOLORADJUSTMENT {}
@@ -12976,7 +12964,7 @@ unsafe impl ::windows::core::Abi for EMRSETCOLORSPACE {
 }
 impl ::core::cmp::PartialEq for EMRSETCOLORSPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETCOLORSPACE>()) == 0 }
+        self.emr == other.emr && self.ihCS == other.ihCS
     }
 }
 impl ::core::cmp::Eq for EMRSETCOLORSPACE {}
@@ -13042,7 +13030,7 @@ unsafe impl ::windows::core::Abi for EMRSETDIBITSTODEVICE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSETDIBITSTODEVICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETDIBITSTODEVICE>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.iUsageSrc == other.iUsageSrc && self.iStartScan == other.iStartScan && self.cScans == other.cScans
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13078,7 +13066,7 @@ unsafe impl ::windows::core::Abi for EMRSETICMPROFILE {
 }
 impl ::core::cmp::PartialEq for EMRSETICMPROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETICMPROFILE>()) == 0 }
+        self.emr == other.emr && self.dwFlags == other.dwFlags && self.cbName == other.cbName && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for EMRSETICMPROFILE {}
@@ -13109,7 +13097,7 @@ unsafe impl ::windows::core::Abi for EMRSETMAPPERFLAGS {
 }
 impl ::core::cmp::PartialEq for EMRSETMAPPERFLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETMAPPERFLAGS>()) == 0 }
+        self.emr == other.emr && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for EMRSETMAPPERFLAGS {}
@@ -13140,7 +13128,7 @@ unsafe impl ::windows::core::Abi for EMRSETMITERLIMIT {
 }
 impl ::core::cmp::PartialEq for EMRSETMITERLIMIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETMITERLIMIT>()) == 0 }
+        self.emr == other.emr && self.eMiterLimit == other.eMiterLimit
     }
 }
 impl ::core::cmp::Eq for EMRSETMITERLIMIT {}
@@ -13174,7 +13162,7 @@ unsafe impl ::windows::core::Abi for EMRSETPALETTEENTRIES {
 }
 impl ::core::cmp::PartialEq for EMRSETPALETTEENTRIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETPALETTEENTRIES>()) == 0 }
+        self.emr == other.emr && self.ihPal == other.ihPal && self.iStart == other.iStart && self.cEntries == other.cEntries && self.aPalEntries == other.aPalEntries
     }
 }
 impl ::core::cmp::Eq for EMRSETPALETTEENTRIES {}
@@ -13212,7 +13200,7 @@ unsafe impl ::windows::core::Abi for EMRSETPIXELV {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSETPIXELV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETPIXELV>()) == 0 }
+        self.emr == other.emr && self.ptlPixel == other.ptlPixel && self.crColor == other.crColor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13251,7 +13239,7 @@ unsafe impl ::windows::core::Abi for EMRSETTEXTCOLOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSETTEXTCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETTEXTCOLOR>()) == 0 }
+        self.emr == other.emr && self.crColor == other.crColor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13290,7 +13278,7 @@ unsafe impl ::windows::core::Abi for EMRSETVIEWPORTEXTEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSETVIEWPORTEXTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETVIEWPORTEXTEX>()) == 0 }
+        self.emr == other.emr && self.szlExtent == other.szlExtent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13329,7 +13317,7 @@ unsafe impl ::windows::core::Abi for EMRSETVIEWPORTORGEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSETVIEWPORTORGEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETVIEWPORTORGEX>()) == 0 }
+        self.emr == other.emr && self.ptlOrigin == other.ptlOrigin
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13362,7 +13350,7 @@ unsafe impl ::windows::core::Abi for EMRSETWORLDTRANSFORM {
 }
 impl ::core::cmp::PartialEq for EMRSETWORLDTRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSETWORLDTRANSFORM>()) == 0 }
+        self.emr == other.emr && self.xform == other.xform
     }
 }
 impl ::core::cmp::Eq for EMRSETWORLDTRANSFORM {}
@@ -13434,7 +13422,7 @@ unsafe impl ::windows::core::Abi for EMRSTRETCHBLT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSTRETCHBLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSTRETCHBLT>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.cxDest == other.cxDest && self.cyDest == other.cyDest && self.dwRop == other.dwRop && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13504,7 +13492,7 @@ unsafe impl ::windows::core::Abi for EMRSTRETCHDIBITS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRSTRETCHDIBITS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRSTRETCHDIBITS>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.iUsageSrc == other.iUsageSrc && self.dwRop == other.dwRop && self.cxDest == other.cxDest && self.cyDest == other.cyDest
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13547,7 +13535,7 @@ unsafe impl ::windows::core::Abi for EMRTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRTEXT>()) == 0 }
+        self.ptlReference == other.ptlReference && self.nChars == other.nChars && self.offString == other.offString && self.fOptions == other.fOptions && self.rcl == other.rcl && self.offDx == other.offDx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13621,7 +13609,7 @@ unsafe impl ::windows::core::Abi for EMRTRANSPARENTBLT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EMRTRANSPARENTBLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRTRANSPARENTBLT>()) == 0 }
+        self.emr == other.emr && self.rclBounds == other.rclBounds && self.xDest == other.xDest && self.yDest == other.yDest && self.cxDest == other.cxDest && self.cyDest == other.cyDest && self.dwRop == other.dwRop && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.xformSrc == other.xformSrc && self.crBkColorSrc == other.crBkColorSrc && self.iUsageSrc == other.iUsageSrc && self.offBmiSrc == other.offBmiSrc && self.cbBmiSrc == other.cbBmiSrc && self.offBitsSrc == other.offBitsSrc && self.cbBitsSrc == other.cbBitsSrc && self.cxSrc == other.cxSrc && self.cySrc == other.cySrc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13697,7 +13685,7 @@ unsafe impl ::windows::core::Abi for ENHMETAHEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENHMETAHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENHMETAHEADER>()) == 0 }
+        self.iType == other.iType && self.nSize == other.nSize && self.rclBounds == other.rclBounds && self.rclFrame == other.rclFrame && self.dSignature == other.dSignature && self.nVersion == other.nVersion && self.nBytes == other.nBytes && self.nRecords == other.nRecords && self.nHandles == other.nHandles && self.sReserved == other.sReserved && self.nDescription == other.nDescription && self.offDescription == other.offDescription && self.nPalEntries == other.nPalEntries && self.szlDevice == other.szlDevice && self.szlMillimeters == other.szlMillimeters && self.cbPixelFormat == other.cbPixelFormat && self.offPixelFormat == other.offPixelFormat && self.bOpenGL == other.bOpenGL && self.szlMicrometers == other.szlMicrometers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13731,7 +13719,7 @@ unsafe impl ::windows::core::Abi for ENHMETARECORD {
 }
 impl ::core::cmp::PartialEq for ENHMETARECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENHMETARECORD>()) == 0 }
+        self.iType == other.iType && self.nSize == other.nSize && self.dParm == other.dParm
     }
 }
 impl ::core::cmp::Eq for ENHMETARECORD {}
@@ -13769,7 +13757,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENUMLOGFONTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTA>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13810,7 +13798,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENUMLOGFONTEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTEXA>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle && self.elfScript == other.elfScript
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13849,7 +13837,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTEXDVA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENUMLOGFONTEXDVA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTEXDVA>()) == 0 }
+        self.elfEnumLogfontEx == other.elfEnumLogfontEx && self.elfDesignVector == other.elfDesignVector
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13882,7 +13870,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTEXDVW {
 }
 impl ::core::cmp::PartialEq for ENUMLOGFONTEXDVW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTEXDVW>()) == 0 }
+        self.elfEnumLogfontEx == other.elfEnumLogfontEx && self.elfDesignVector == other.elfDesignVector
     }
 }
 impl ::core::cmp::Eq for ENUMLOGFONTEXDVW {}
@@ -13915,7 +13903,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTEXW {
 }
 impl ::core::cmp::PartialEq for ENUMLOGFONTEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTEXW>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle && self.elfScript == other.elfScript
     }
 }
 impl ::core::cmp::Eq for ENUMLOGFONTEXW {}
@@ -13947,7 +13935,7 @@ unsafe impl ::windows::core::Abi for ENUMLOGFONTW {
 }
 impl ::core::cmp::PartialEq for ENUMLOGFONTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMLOGFONTW>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle
     }
 }
 impl ::core::cmp::Eq for ENUMLOGFONTW {}
@@ -13992,7 +13980,7 @@ unsafe impl ::windows::core::Abi for EXTLOGFONTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXTLOGFONTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTLOGFONTA>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle && self.elfVersion == other.elfVersion && self.elfStyleSize == other.elfStyleSize && self.elfMatch == other.elfMatch && self.elfReserved == other.elfReserved && self.elfVendorId == other.elfVendorId && self.elfCulture == other.elfCulture && self.elfPanose == other.elfPanose
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14033,7 +14021,7 @@ unsafe impl ::windows::core::Abi for EXTLOGFONTW {
 }
 impl ::core::cmp::PartialEq for EXTLOGFONTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTLOGFONTW>()) == 0 }
+        self.elfLogFont == other.elfLogFont && self.elfFullName == other.elfFullName && self.elfStyle == other.elfStyle && self.elfVersion == other.elfVersion && self.elfStyleSize == other.elfStyleSize && self.elfMatch == other.elfMatch && self.elfReserved == other.elfReserved && self.elfVendorId == other.elfVendorId && self.elfCulture == other.elfCulture && self.elfPanose == other.elfPanose
     }
 }
 impl ::core::cmp::Eq for EXTLOGFONTW {}
@@ -14075,7 +14063,7 @@ unsafe impl ::windows::core::Abi for EXTLOGPEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXTLOGPEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTLOGPEN>()) == 0 }
+        self.elpPenStyle == other.elpPenStyle && self.elpWidth == other.elpWidth && self.elpBrushStyle == other.elpBrushStyle && self.elpColor == other.elpColor && self.elpHatch == other.elpHatch && self.elpNumEntries == other.elpNumEntries && self.elpStyleEntry == other.elpStyleEntry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14119,7 +14107,7 @@ unsafe impl ::windows::core::Abi for EXTLOGPEN32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXTLOGPEN32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTLOGPEN32>()) == 0 }
+        self.elpPenStyle == other.elpPenStyle && self.elpWidth == other.elpWidth && self.elpBrushStyle == other.elpBrushStyle && self.elpColor == other.elpColor && self.elpHatch == other.elpHatch && self.elpNumEntries == other.elpNumEntries && self.elpStyleEntry == other.elpStyleEntry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14152,7 +14140,7 @@ unsafe impl ::windows::core::Abi for FIXED {
 }
 impl ::core::cmp::PartialEq for FIXED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIXED>()) == 0 }
+        self.fract == other.fract && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for FIXED {}
@@ -14190,7 +14178,7 @@ unsafe impl ::windows::core::Abi for GCP_RESULTSA {
 }
 impl ::core::cmp::PartialEq for GCP_RESULTSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GCP_RESULTSA>()) == 0 }
+        self.lStructSize == other.lStructSize && self.lpOutString == other.lpOutString && self.lpOrder == other.lpOrder && self.lpDx == other.lpDx && self.lpCaretPos == other.lpCaretPos && self.lpClass == other.lpClass && self.lpGlyphs == other.lpGlyphs && self.nGlyphs == other.nGlyphs && self.nMaxFit == other.nMaxFit
     }
 }
 impl ::core::cmp::Eq for GCP_RESULTSA {}
@@ -14228,7 +14216,7 @@ unsafe impl ::windows::core::Abi for GCP_RESULTSW {
 }
 impl ::core::cmp::PartialEq for GCP_RESULTSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GCP_RESULTSW>()) == 0 }
+        self.lStructSize == other.lStructSize && self.lpOutString == other.lpOutString && self.lpOrder == other.lpOrder && self.lpDx == other.lpDx && self.lpCaretPos == other.lpCaretPos && self.lpClass == other.lpClass && self.lpGlyphs == other.lpGlyphs && self.nGlyphs == other.nGlyphs && self.nMaxFit == other.nMaxFit
     }
 }
 impl ::core::cmp::Eq for GCP_RESULTSW {}
@@ -14268,7 +14256,7 @@ unsafe impl ::windows::core::Abi for GLYPHMETRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GLYPHMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHMETRICS>()) == 0 }
+        self.gmBlackBoxX == other.gmBlackBoxX && self.gmBlackBoxY == other.gmBlackBoxY && self.gmptGlyphOrigin == other.gmptGlyphOrigin && self.gmCellIncX == other.gmCellIncX && self.gmCellIncY == other.gmCellIncY
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14304,7 +14292,7 @@ unsafe impl ::windows::core::Abi for GLYPHSET {
 }
 impl ::core::cmp::PartialEq for GLYPHSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHSET>()) == 0 }
+        self.cbThis == other.cbThis && self.flAccel == other.flAccel && self.cGlyphsSupported == other.cGlyphsSupported && self.cRanges == other.cRanges && self.ranges == other.ranges
     }
 }
 impl ::core::cmp::Eq for GLYPHSET {}
@@ -14335,7 +14323,7 @@ unsafe impl ::windows::core::Abi for GRADIENT_RECT {
 }
 impl ::core::cmp::PartialEq for GRADIENT_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GRADIENT_RECT>()) == 0 }
+        self.UpperLeft == other.UpperLeft && self.LowerRight == other.LowerRight
     }
 }
 impl ::core::cmp::Eq for GRADIENT_RECT {}
@@ -14367,7 +14355,7 @@ unsafe impl ::windows::core::Abi for GRADIENT_TRIANGLE {
 }
 impl ::core::cmp::PartialEq for GRADIENT_TRIANGLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GRADIENT_TRIANGLE>()) == 0 }
+        self.Vertex1 == other.Vertex1 && self.Vertex2 == other.Vertex2 && self.Vertex3 == other.Vertex3
     }
 }
 impl ::core::cmp::Eq for GRADIENT_TRIANGLE {}
@@ -14397,7 +14385,7 @@ unsafe impl ::windows::core::Abi for HANDLETABLE {
 }
 impl ::core::cmp::PartialEq for HANDLETABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HANDLETABLE>()) == 0 }
+        self.objectHandle == other.objectHandle
     }
 }
 impl ::core::cmp::Eq for HANDLETABLE {}
@@ -14875,7 +14863,7 @@ unsafe impl ::windows::core::Abi for KERNINGPAIR {
 }
 impl ::core::cmp::PartialEq for KERNINGPAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERNINGPAIR>()) == 0 }
+        self.wFirst == other.wFirst && self.wSecond == other.wSecond && self.iKernAmount == other.iKernAmount
     }
 }
 impl ::core::cmp::Eq for KERNINGPAIR {}
@@ -14913,7 +14901,7 @@ unsafe impl ::windows::core::Abi for LOGBRUSH {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOGBRUSH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGBRUSH>()) == 0 }
+        self.lbStyle == other.lbStyle && self.lbColor == other.lbColor && self.lbHatch == other.lbHatch
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14953,7 +14941,7 @@ unsafe impl ::windows::core::Abi for LOGBRUSH32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOGBRUSH32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGBRUSH32>()) == 0 }
+        self.lbStyle == other.lbStyle && self.lbColor == other.lbColor && self.lbHatch == other.lbHatch
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15019,7 +15007,7 @@ unsafe impl ::windows::core::Abi for LOGFONTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOGFONTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGFONTA>()) == 0 }
+        self.lfHeight == other.lfHeight && self.lfWidth == other.lfWidth && self.lfEscapement == other.lfEscapement && self.lfOrientation == other.lfOrientation && self.lfWeight == other.lfWeight && self.lfItalic == other.lfItalic && self.lfUnderline == other.lfUnderline && self.lfStrikeOut == other.lfStrikeOut && self.lfCharSet == other.lfCharSet && self.lfOutPrecision == other.lfOutPrecision && self.lfClipPrecision == other.lfClipPrecision && self.lfQuality == other.lfQuality && self.lfPitchAndFamily == other.lfPitchAndFamily && self.lfFaceName == other.lfFaceName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15079,7 +15067,7 @@ unsafe impl ::windows::core::Abi for LOGFONTW {
 }
 impl ::core::cmp::PartialEq for LOGFONTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGFONTW>()) == 0 }
+        self.lfHeight == other.lfHeight && self.lfWidth == other.lfWidth && self.lfEscapement == other.lfEscapement && self.lfOrientation == other.lfOrientation && self.lfWeight == other.lfWeight && self.lfItalic == other.lfItalic && self.lfUnderline == other.lfUnderline && self.lfStrikeOut == other.lfStrikeOut && self.lfCharSet == other.lfCharSet && self.lfOutPrecision == other.lfOutPrecision && self.lfClipPrecision == other.lfClipPrecision && self.lfQuality == other.lfQuality && self.lfPitchAndFamily == other.lfPitchAndFamily && self.lfFaceName == other.lfFaceName
     }
 }
 impl ::core::cmp::Eq for LOGFONTW {}
@@ -15111,7 +15099,7 @@ unsafe impl ::windows::core::Abi for LOGPALETTE {
 }
 impl ::core::cmp::PartialEq for LOGPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGPALETTE>()) == 0 }
+        self.palVersion == other.palVersion && self.palNumEntries == other.palNumEntries && self.palPalEntry == other.palPalEntry
     }
 }
 impl ::core::cmp::Eq for LOGPALETTE {}
@@ -15149,7 +15137,7 @@ unsafe impl ::windows::core::Abi for LOGPEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOGPEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGPEN>()) == 0 }
+        self.lopnStyle == other.lopnStyle && self.lopnWidth == other.lopnWidth && self.lopnColor == other.lopnColor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15184,7 +15172,7 @@ unsafe impl ::windows::core::Abi for MAT2 {
 }
 impl ::core::cmp::PartialEq for MAT2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAT2>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22
     }
 }
 impl ::core::cmp::Eq for MAT2 {}
@@ -15213,12 +15201,6 @@ impl ::core::clone::Clone for METAHEADER {
 unsafe impl ::windows::core::Abi for METAHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for METAHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METAHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for METAHEADER {}
 impl ::core::default::Default for METAHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15247,7 +15229,7 @@ unsafe impl ::windows::core::Abi for METARECORD {
 }
 impl ::core::cmp::PartialEq for METARECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METARECORD>()) == 0 }
+        self.rdSize == other.rdSize && self.rdFunction == other.rdFunction && self.rdParm == other.rdParm
     }
 }
 impl ::core::cmp::Eq for METARECORD {}
@@ -15286,7 +15268,7 @@ unsafe impl ::windows::core::Abi for MONITORINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONITORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcMonitor == other.rcMonitor && self.rcWork == other.rcWork && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15325,7 +15307,7 @@ unsafe impl ::windows::core::Abi for MONITORINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONITORINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORINFOEXA>()) == 0 }
+        self.monitorInfo == other.monitorInfo && self.szDevice == other.szDevice
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15364,7 +15346,7 @@ unsafe impl ::windows::core::Abi for MONITORINFOEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONITORINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORINFOEXW>()) == 0 }
+        self.monitorInfo == other.monitorInfo && self.szDevice == other.szDevice
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15444,7 +15426,30 @@ unsafe impl ::windows::core::Abi for NEWTEXTMETRICA {
 }
 impl ::core::cmp::PartialEq for NEWTEXTMETRICA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWTEXTMETRICA>()) == 0 }
+        self.tmHeight == other.tmHeight
+            && self.tmAscent == other.tmAscent
+            && self.tmDescent == other.tmDescent
+            && self.tmInternalLeading == other.tmInternalLeading
+            && self.tmExternalLeading == other.tmExternalLeading
+            && self.tmAveCharWidth == other.tmAveCharWidth
+            && self.tmMaxCharWidth == other.tmMaxCharWidth
+            && self.tmWeight == other.tmWeight
+            && self.tmOverhang == other.tmOverhang
+            && self.tmDigitizedAspectX == other.tmDigitizedAspectX
+            && self.tmDigitizedAspectY == other.tmDigitizedAspectY
+            && self.tmFirstChar == other.tmFirstChar
+            && self.tmLastChar == other.tmLastChar
+            && self.tmDefaultChar == other.tmDefaultChar
+            && self.tmBreakChar == other.tmBreakChar
+            && self.tmItalic == other.tmItalic
+            && self.tmUnderlined == other.tmUnderlined
+            && self.tmStruckOut == other.tmStruckOut
+            && self.tmPitchAndFamily == other.tmPitchAndFamily
+            && self.tmCharSet == other.tmCharSet
+            && self.ntmFlags == other.ntmFlags
+            && self.ntmSizeEM == other.ntmSizeEM
+            && self.ntmCellHeight == other.ntmCellHeight
+            && self.ntmAvgWidth == other.ntmAvgWidth
     }
 }
 impl ::core::cmp::Eq for NEWTEXTMETRICA {}
@@ -15522,7 +15527,30 @@ unsafe impl ::windows::core::Abi for NEWTEXTMETRICW {
 }
 impl ::core::cmp::PartialEq for NEWTEXTMETRICW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWTEXTMETRICW>()) == 0 }
+        self.tmHeight == other.tmHeight
+            && self.tmAscent == other.tmAscent
+            && self.tmDescent == other.tmDescent
+            && self.tmInternalLeading == other.tmInternalLeading
+            && self.tmExternalLeading == other.tmExternalLeading
+            && self.tmAveCharWidth == other.tmAveCharWidth
+            && self.tmMaxCharWidth == other.tmMaxCharWidth
+            && self.tmWeight == other.tmWeight
+            && self.tmOverhang == other.tmOverhang
+            && self.tmDigitizedAspectX == other.tmDigitizedAspectX
+            && self.tmDigitizedAspectY == other.tmDigitizedAspectY
+            && self.tmFirstChar == other.tmFirstChar
+            && self.tmLastChar == other.tmLastChar
+            && self.tmDefaultChar == other.tmDefaultChar
+            && self.tmBreakChar == other.tmBreakChar
+            && self.tmItalic == other.tmItalic
+            && self.tmUnderlined == other.tmUnderlined
+            && self.tmStruckOut == other.tmStruckOut
+            && self.tmPitchAndFamily == other.tmPitchAndFamily
+            && self.tmCharSet == other.tmCharSet
+            && self.ntmFlags == other.ntmFlags
+            && self.ntmSizeEM == other.ntmSizeEM
+            && self.ntmCellHeight == other.ntmCellHeight
+            && self.ntmAvgWidth == other.ntmAvgWidth
     }
 }
 impl ::core::cmp::Eq for NEWTEXTMETRICW {}
@@ -15622,7 +15650,38 @@ unsafe impl ::windows::core::Abi for OUTLINETEXTMETRICA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OUTLINETEXTMETRICA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OUTLINETEXTMETRICA>()) == 0 }
+        self.otmSize == other.otmSize
+            && self.otmTextMetrics == other.otmTextMetrics
+            && self.otmFiller == other.otmFiller
+            && self.otmPanoseNumber == other.otmPanoseNumber
+            && self.otmfsSelection == other.otmfsSelection
+            && self.otmfsType == other.otmfsType
+            && self.otmsCharSlopeRise == other.otmsCharSlopeRise
+            && self.otmsCharSlopeRun == other.otmsCharSlopeRun
+            && self.otmItalicAngle == other.otmItalicAngle
+            && self.otmEMSquare == other.otmEMSquare
+            && self.otmAscent == other.otmAscent
+            && self.otmDescent == other.otmDescent
+            && self.otmLineGap == other.otmLineGap
+            && self.otmsCapEmHeight == other.otmsCapEmHeight
+            && self.otmsXHeight == other.otmsXHeight
+            && self.otmrcFontBox == other.otmrcFontBox
+            && self.otmMacAscent == other.otmMacAscent
+            && self.otmMacDescent == other.otmMacDescent
+            && self.otmMacLineGap == other.otmMacLineGap
+            && self.otmusMinimumPPEM == other.otmusMinimumPPEM
+            && self.otmptSubscriptSize == other.otmptSubscriptSize
+            && self.otmptSubscriptOffset == other.otmptSubscriptOffset
+            && self.otmptSuperscriptSize == other.otmptSuperscriptSize
+            && self.otmptSuperscriptOffset == other.otmptSuperscriptOffset
+            && self.otmsStrikeoutSize == other.otmsStrikeoutSize
+            && self.otmsStrikeoutPosition == other.otmsStrikeoutPosition
+            && self.otmsUnderscoreSize == other.otmsUnderscoreSize
+            && self.otmsUnderscorePosition == other.otmsUnderscorePosition
+            && self.otmpFamilyName == other.otmpFamilyName
+            && self.otmpFaceName == other.otmpFaceName
+            && self.otmpStyleName == other.otmpStyleName
+            && self.otmpFullName == other.otmpFullName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15724,7 +15783,38 @@ unsafe impl ::windows::core::Abi for OUTLINETEXTMETRICW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OUTLINETEXTMETRICW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OUTLINETEXTMETRICW>()) == 0 }
+        self.otmSize == other.otmSize
+            && self.otmTextMetrics == other.otmTextMetrics
+            && self.otmFiller == other.otmFiller
+            && self.otmPanoseNumber == other.otmPanoseNumber
+            && self.otmfsSelection == other.otmfsSelection
+            && self.otmfsType == other.otmfsType
+            && self.otmsCharSlopeRise == other.otmsCharSlopeRise
+            && self.otmsCharSlopeRun == other.otmsCharSlopeRun
+            && self.otmItalicAngle == other.otmItalicAngle
+            && self.otmEMSquare == other.otmEMSquare
+            && self.otmAscent == other.otmAscent
+            && self.otmDescent == other.otmDescent
+            && self.otmLineGap == other.otmLineGap
+            && self.otmsCapEmHeight == other.otmsCapEmHeight
+            && self.otmsXHeight == other.otmsXHeight
+            && self.otmrcFontBox == other.otmrcFontBox
+            && self.otmMacAscent == other.otmMacAscent
+            && self.otmMacDescent == other.otmMacDescent
+            && self.otmMacLineGap == other.otmMacLineGap
+            && self.otmusMinimumPPEM == other.otmusMinimumPPEM
+            && self.otmptSubscriptSize == other.otmptSubscriptSize
+            && self.otmptSubscriptOffset == other.otmptSubscriptOffset
+            && self.otmptSuperscriptSize == other.otmptSuperscriptSize
+            && self.otmptSuperscriptOffset == other.otmptSuperscriptOffset
+            && self.otmsStrikeoutSize == other.otmsStrikeoutSize
+            && self.otmsStrikeoutPosition == other.otmsStrikeoutPosition
+            && self.otmsUnderscoreSize == other.otmsUnderscoreSize
+            && self.otmsUnderscorePosition == other.otmsUnderscorePosition
+            && self.otmpFamilyName == other.otmpFamilyName
+            && self.otmpFaceName == other.otmpFaceName
+            && self.otmpStyleName == other.otmpStyleName
+            && self.otmpFullName == other.otmpFullName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15767,7 +15857,7 @@ unsafe impl ::windows::core::Abi for PAINTSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PAINTSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAINTSTRUCT>()) == 0 }
+        self.hdc == other.hdc && self.fErase == other.fErase && self.rcPaint == other.rcPaint && self.fRestore == other.fRestore && self.fIncUpdate == other.fIncUpdate && self.rgbReserved == other.rgbReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15802,7 +15892,7 @@ unsafe impl ::windows::core::Abi for PALETTEENTRY {
 }
 impl ::core::cmp::PartialEq for PALETTEENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PALETTEENTRY>()) == 0 }
+        self.peRed == other.peRed && self.peGreen == other.peGreen && self.peBlue == other.peBlue && self.peFlags == other.peFlags
     }
 }
 impl ::core::cmp::Eq for PALETTEENTRY {}
@@ -15841,7 +15931,7 @@ unsafe impl ::windows::core::Abi for PANOSE {
 }
 impl ::core::cmp::PartialEq for PANOSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PANOSE>()) == 0 }
+        self.bFamilyType == other.bFamilyType && self.bSerifStyle == other.bSerifStyle && self.bWeight == other.bWeight && self.bProportion == other.bProportion && self.bContrast == other.bContrast && self.bStrokeVariation == other.bStrokeVariation && self.bArmStyle == other.bArmStyle && self.bLetterform == other.bLetterform && self.bMidline == other.bMidline && self.bXHeight == other.bXHeight
     }
 }
 impl ::core::cmp::Eq for PANOSE {}
@@ -15875,7 +15965,7 @@ unsafe impl ::windows::core::Abi for PELARRAY {
 }
 impl ::core::cmp::PartialEq for PELARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PELARRAY>()) == 0 }
+        self.paXCount == other.paXCount && self.paYCount == other.paYCount && self.paXExt == other.paXExt && self.paYExt == other.paYExt && self.paRGBs == other.paRGBs
     }
 }
 impl ::core::cmp::Eq for PELARRAY {}
@@ -15906,7 +15996,7 @@ unsafe impl ::windows::core::Abi for POINTFX {
 }
 impl ::core::cmp::PartialEq for POINTFX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTFX>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTFX {}
@@ -15948,7 +16038,7 @@ unsafe impl ::windows::core::Abi for POLYTEXTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLYTEXTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLYTEXTA>()) == 0 }
+        self.x == other.x && self.y == other.y && self.n == other.n && self.lpstr == other.lpstr && self.uiFlags == other.uiFlags && self.rcl == other.rcl && self.pdx == other.pdx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15992,7 +16082,7 @@ unsafe impl ::windows::core::Abi for POLYTEXTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLYTEXTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLYTEXTW>()) == 0 }
+        self.x == other.x && self.y == other.y && self.n == other.n && self.lpstr == other.lpstr && self.uiFlags == other.uiFlags && self.rcl == other.rcl && self.pdx == other.pdx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16026,7 +16116,7 @@ unsafe impl ::windows::core::Abi for RASTERIZER_STATUS {
 }
 impl ::core::cmp::PartialEq for RASTERIZER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASTERIZER_STATUS>()) == 0 }
+        self.nSize == other.nSize && self.wFlags == other.wFlags && self.nLanguageID == other.nLanguageID
     }
 }
 impl ::core::cmp::Eq for RASTERIZER_STATUS {}
@@ -16059,7 +16149,7 @@ unsafe impl ::windows::core::Abi for RGBQUAD {
 }
 impl ::core::cmp::PartialEq for RGBQUAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGBQUAD>()) == 0 }
+        self.rgbBlue == other.rgbBlue && self.rgbGreen == other.rgbGreen && self.rgbRed == other.rgbRed && self.rgbReserved == other.rgbReserved
     }
 }
 impl ::core::cmp::Eq for RGBQUAD {}
@@ -16091,7 +16181,7 @@ unsafe impl ::windows::core::Abi for RGBTRIPLE {
 }
 impl ::core::cmp::PartialEq for RGBTRIPLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGBTRIPLE>()) == 0 }
+        self.rgbtBlue == other.rgbtBlue && self.rgbtGreen == other.rgbtGreen && self.rgbtRed == other.rgbtRed
     }
 }
 impl ::core::cmp::Eq for RGBTRIPLE {}
@@ -16128,7 +16218,7 @@ unsafe impl ::windows::core::Abi for RGNDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RGNDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGNDATA>()) == 0 }
+        self.rdh == other.rdh && self.Buffer == other.Buffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16170,7 +16260,7 @@ unsafe impl ::windows::core::Abi for RGNDATAHEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RGNDATAHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGNDATAHEADER>()) == 0 }
+        self.dwSize == other.dwSize && self.iType == other.iType && self.nCount == other.nCount && self.nRgnSize == other.nRgnSize && self.rcBound == other.rcBound
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16242,7 +16332,26 @@ unsafe impl ::windows::core::Abi for TEXTMETRICA {
 }
 impl ::core::cmp::PartialEq for TEXTMETRICA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXTMETRICA>()) == 0 }
+        self.tmHeight == other.tmHeight
+            && self.tmAscent == other.tmAscent
+            && self.tmDescent == other.tmDescent
+            && self.tmInternalLeading == other.tmInternalLeading
+            && self.tmExternalLeading == other.tmExternalLeading
+            && self.tmAveCharWidth == other.tmAveCharWidth
+            && self.tmMaxCharWidth == other.tmMaxCharWidth
+            && self.tmWeight == other.tmWeight
+            && self.tmOverhang == other.tmOverhang
+            && self.tmDigitizedAspectX == other.tmDigitizedAspectX
+            && self.tmDigitizedAspectY == other.tmDigitizedAspectY
+            && self.tmFirstChar == other.tmFirstChar
+            && self.tmLastChar == other.tmLastChar
+            && self.tmDefaultChar == other.tmDefaultChar
+            && self.tmBreakChar == other.tmBreakChar
+            && self.tmItalic == other.tmItalic
+            && self.tmUnderlined == other.tmUnderlined
+            && self.tmStruckOut == other.tmStruckOut
+            && self.tmPitchAndFamily == other.tmPitchAndFamily
+            && self.tmCharSet == other.tmCharSet
     }
 }
 impl ::core::cmp::Eq for TEXTMETRICA {}
@@ -16312,7 +16421,26 @@ unsafe impl ::windows::core::Abi for TEXTMETRICW {
 }
 impl ::core::cmp::PartialEq for TEXTMETRICW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXTMETRICW>()) == 0 }
+        self.tmHeight == other.tmHeight
+            && self.tmAscent == other.tmAscent
+            && self.tmDescent == other.tmDescent
+            && self.tmInternalLeading == other.tmInternalLeading
+            && self.tmExternalLeading == other.tmExternalLeading
+            && self.tmAveCharWidth == other.tmAveCharWidth
+            && self.tmMaxCharWidth == other.tmMaxCharWidth
+            && self.tmWeight == other.tmWeight
+            && self.tmOverhang == other.tmOverhang
+            && self.tmDigitizedAspectX == other.tmDigitizedAspectX
+            && self.tmDigitizedAspectY == other.tmDigitizedAspectY
+            && self.tmFirstChar == other.tmFirstChar
+            && self.tmLastChar == other.tmLastChar
+            && self.tmDefaultChar == other.tmDefaultChar
+            && self.tmBreakChar == other.tmBreakChar
+            && self.tmItalic == other.tmItalic
+            && self.tmUnderlined == other.tmUnderlined
+            && self.tmStruckOut == other.tmStruckOut
+            && self.tmPitchAndFamily == other.tmPitchAndFamily
+            && self.tmCharSet == other.tmCharSet
     }
 }
 impl ::core::cmp::Eq for TEXTMETRICW {}
@@ -16347,7 +16475,7 @@ unsafe impl ::windows::core::Abi for TRIVERTEX {
 }
 impl ::core::cmp::PartialEq for TRIVERTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRIVERTEX>()) == 0 }
+        self.x == other.x && self.y == other.y && self.Red == other.Red && self.Green == other.Green && self.Blue == other.Blue && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for TRIVERTEX {}
@@ -16379,7 +16507,7 @@ unsafe impl ::windows::core::Abi for TTEMBEDINFO {
 }
 impl ::core::cmp::PartialEq for TTEMBEDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTEMBEDINFO>()) == 0 }
+        self.usStructSize == other.usStructSize && self.usRootStrSize == other.usRootStrSize && self.pusRootStr == other.pusRootStr
     }
 }
 impl ::core::cmp::Eq for TTEMBEDINFO {}
@@ -16411,7 +16539,7 @@ unsafe impl ::windows::core::Abi for TTLOADINFO {
 }
 impl ::core::cmp::PartialEq for TTLOADINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTLOADINFO>()) == 0 }
+        self.usStructSize == other.usStructSize && self.usRefStrSize == other.usRefStrSize && self.pusRefStr == other.pusRefStr
     }
 }
 impl ::core::cmp::Eq for TTLOADINFO {}
@@ -16443,7 +16571,7 @@ unsafe impl ::windows::core::Abi for TTPOLYCURVE {
 }
 impl ::core::cmp::PartialEq for TTPOLYCURVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTPOLYCURVE>()) == 0 }
+        self.wType == other.wType && self.cpfx == other.cpfx && self.apfx == other.apfx
     }
 }
 impl ::core::cmp::Eq for TTPOLYCURVE {}
@@ -16475,7 +16603,7 @@ unsafe impl ::windows::core::Abi for TTPOLYGONHEADER {
 }
 impl ::core::cmp::PartialEq for TTPOLYGONHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTPOLYGONHEADER>()) == 0 }
+        self.cb == other.cb && self.dwType == other.dwType && self.pfxStart == other.pfxStart
     }
 }
 impl ::core::cmp::Eq for TTPOLYGONHEADER {}
@@ -16511,7 +16639,7 @@ unsafe impl ::windows::core::Abi for TTVALIDATIONTESTSPARAMS {
 }
 impl ::core::cmp::PartialEq for TTVALIDATIONTESTSPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTVALIDATIONTESTSPARAMS>()) == 0 }
+        self.ulStructSize == other.ulStructSize && self.lTestFromSize == other.lTestFromSize && self.lTestToSize == other.lTestToSize && self.ulCharSet == other.ulCharSet && self.usReserved1 == other.usReserved1 && self.usCharCodeCount == other.usCharCodeCount && self.pusCharCodeSet == other.pusCharCodeSet
     }
 }
 impl ::core::cmp::Eq for TTVALIDATIONTESTSPARAMS {}
@@ -16547,7 +16675,7 @@ unsafe impl ::windows::core::Abi for TTVALIDATIONTESTSPARAMSEX {
 }
 impl ::core::cmp::PartialEq for TTVALIDATIONTESTSPARAMSEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTVALIDATIONTESTSPARAMSEX>()) == 0 }
+        self.ulStructSize == other.ulStructSize && self.lTestFromSize == other.lTestFromSize && self.lTestToSize == other.lTestToSize && self.ulCharSet == other.ulCharSet && self.usReserved1 == other.usReserved1 && self.usCharCodeCount == other.usCharCodeCount && self.pulCharCodeSet == other.pulCharCodeSet
     }
 }
 impl ::core::cmp::Eq for TTVALIDATIONTESTSPARAMSEX {}
@@ -16578,7 +16706,7 @@ unsafe impl ::windows::core::Abi for WCRANGE {
 }
 impl ::core::cmp::PartialEq for WCRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCRANGE>()) == 0 }
+        self.wcLow == other.wcLow && self.cGlyphs == other.cGlyphs
     }
 }
 impl ::core::cmp::Eq for WCRANGE {}
@@ -16609,7 +16737,7 @@ unsafe impl ::windows::core::Abi for WGLSWAP {
 }
 impl ::core::cmp::PartialEq for WGLSWAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WGLSWAP>()) == 0 }
+        self.hdc == other.hdc && self.uiFlags == other.uiFlags
     }
 }
 impl ::core::cmp::Eq for WGLSWAP {}
@@ -16644,7 +16772,7 @@ unsafe impl ::windows::core::Abi for XFORM {
 }
 impl ::core::cmp::PartialEq for XFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XFORM>()) == 0 }
+        self.eM11 == other.eM11 && self.eM12 == other.eM12 && self.eM21 == other.eM21 && self.eM22 == other.eM22 && self.eDx == other.eDx && self.eDy == other.eDy
     }
 }
 impl ::core::cmp::Eq for XFORM {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -6593,7 +6593,7 @@ unsafe impl ::windows::core::Abi for WICBitmapPattern {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WICBitmapPattern {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICBitmapPattern>()) == 0 }
+        self.Position == other.Position && self.Length == other.Length && self.Pattern == other.Pattern && self.Mask == other.Mask && self.EndOfStream == other.EndOfStream
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6628,7 +6628,7 @@ unsafe impl ::windows::core::Abi for WICBitmapPlane {
 }
 impl ::core::cmp::PartialEq for WICBitmapPlane {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICBitmapPlane>()) == 0 }
+        self.Format == other.Format && self.pbBuffer == other.pbBuffer && self.cbStride == other.cbStride && self.cbBufferSize == other.cbBufferSize
     }
 }
 impl ::core::cmp::Eq for WICBitmapPlane {}
@@ -6660,7 +6660,7 @@ unsafe impl ::windows::core::Abi for WICBitmapPlaneDescription {
 }
 impl ::core::cmp::PartialEq for WICBitmapPlaneDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICBitmapPlaneDescription>()) == 0 }
+        self.Format == other.Format && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for WICBitmapPlaneDescription {}
@@ -6699,7 +6699,7 @@ unsafe impl ::windows::core::Abi for WICDdsFormatInfo {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for WICDdsFormatInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICDdsFormatInfo>()) == 0 }
+        self.DxgiFormat == other.DxgiFormat && self.BytesPerBlock == other.BytesPerBlock && self.BlockWidth == other.BlockWidth && self.BlockHeight == other.BlockHeight
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6744,7 +6744,7 @@ unsafe impl ::windows::core::Abi for WICDdsParameters {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for WICDdsParameters {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICDdsParameters>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Depth == other.Depth && self.MipLevels == other.MipLevels && self.ArraySize == other.ArraySize && self.DxgiFormat == other.DxgiFormat && self.Dimension == other.Dimension && self.AlphaMode == other.AlphaMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6788,7 +6788,7 @@ unsafe impl ::windows::core::Abi for WICImageParameters {
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for WICImageParameters {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICImageParameters>()) == 0 }
+        self.PixelFormat == other.PixelFormat && self.DpiX == other.DpiX && self.DpiY == other.DpiY && self.Top == other.Top && self.Left == other.Left && self.PixelWidth == other.PixelWidth && self.PixelHeight == other.PixelHeight
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -6827,7 +6827,7 @@ unsafe impl ::windows::core::Abi for WICJpegFrameHeader {
 }
 impl ::core::cmp::PartialEq for WICJpegFrameHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICJpegFrameHeader>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.TransferMatrix == other.TransferMatrix && self.ScanType == other.ScanType && self.cComponents == other.cComponents && self.ComponentIdentifiers == other.ComponentIdentifiers && self.SampleFactors == other.SampleFactors && self.QuantizationTableIndices == other.QuantizationTableIndices
     }
 }
 impl ::core::cmp::Eq for WICJpegFrameHeader {}
@@ -6873,7 +6873,7 @@ unsafe impl ::windows::core::Abi for WICJpegScanHeader {
 }
 impl ::core::cmp::PartialEq for WICJpegScanHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICJpegScanHeader>()) == 0 }
+        self.cComponents == other.cComponents && self.RestartInterval == other.RestartInterval && self.ComponentSelectors == other.ComponentSelectors && self.HuffmanTableIndices == other.HuffmanTableIndices && self.StartSpectralSelection == other.StartSpectralSelection && self.EndSpectralSelection == other.EndSpectralSelection && self.SuccessiveApproximationHigh == other.SuccessiveApproximationHigh && self.SuccessiveApproximationLow == other.SuccessiveApproximationLow
     }
 }
 impl ::core::cmp::Eq for WICJpegScanHeader {}
@@ -6906,7 +6906,7 @@ unsafe impl ::windows::core::Abi for WICMetadataHeader {
 }
 impl ::core::cmp::PartialEq for WICMetadataHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICMetadataHeader>()) == 0 }
+        self.Position == other.Position && self.Length == other.Length && self.Header == other.Header && self.DataOffset == other.DataOffset
     }
 }
 impl ::core::cmp::Eq for WICMetadataHeader {}
@@ -6940,7 +6940,7 @@ unsafe impl ::windows::core::Abi for WICMetadataPattern {
 }
 impl ::core::cmp::PartialEq for WICMetadataPattern {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICMetadataPattern>()) == 0 }
+        self.Position == other.Position && self.Length == other.Length && self.Pattern == other.Pattern && self.Mask == other.Mask && self.DataOffset == other.DataOffset
     }
 }
 impl ::core::cmp::Eq for WICMetadataPattern {}
@@ -7006,7 +7006,24 @@ unsafe impl ::windows::core::Abi for WICRawCapabilitiesInfo {
 }
 impl ::core::cmp::PartialEq for WICRawCapabilitiesInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICRawCapabilitiesInfo>()) == 0 }
+        self.cbSize == other.cbSize
+            && self.CodecMajorVersion == other.CodecMajorVersion
+            && self.CodecMinorVersion == other.CodecMinorVersion
+            && self.ExposureCompensationSupport == other.ExposureCompensationSupport
+            && self.ContrastSupport == other.ContrastSupport
+            && self.RGBWhitePointSupport == other.RGBWhitePointSupport
+            && self.NamedWhitePointSupport == other.NamedWhitePointSupport
+            && self.NamedWhitePointSupportMask == other.NamedWhitePointSupportMask
+            && self.KelvinWhitePointSupport == other.KelvinWhitePointSupport
+            && self.GammaSupport == other.GammaSupport
+            && self.TintSupport == other.TintSupport
+            && self.SaturationSupport == other.SaturationSupport
+            && self.SharpnessSupport == other.SharpnessSupport
+            && self.NoiseReductionSupport == other.NoiseReductionSupport
+            && self.DestinationColorProfileSupport == other.DestinationColorProfileSupport
+            && self.ToneCurveSupport == other.ToneCurveSupport
+            && self.RotationSupport == other.RotationSupport
+            && self.RenderModeSupport == other.RenderModeSupport
     }
 }
 impl ::core::cmp::Eq for WICRawCapabilitiesInfo {}
@@ -7037,7 +7054,7 @@ unsafe impl ::windows::core::Abi for WICRawToneCurve {
 }
 impl ::core::cmp::PartialEq for WICRawToneCurve {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICRawToneCurve>()) == 0 }
+        self.cPoints == other.cPoints && self.aPoints == other.aPoints
     }
 }
 impl ::core::cmp::Eq for WICRawToneCurve {}
@@ -7068,7 +7085,7 @@ unsafe impl ::windows::core::Abi for WICRawToneCurvePoint {
 }
 impl ::core::cmp::PartialEq for WICRawToneCurvePoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICRawToneCurvePoint>()) == 0 }
+        self.Input == other.Input && self.Output == other.Output
     }
 }
 impl ::core::cmp::Eq for WICRawToneCurvePoint {}
@@ -7101,7 +7118,7 @@ unsafe impl ::windows::core::Abi for WICRect {
 }
 impl ::core::cmp::PartialEq for WICRect {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WICRect>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for WICRect {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -4144,7 +4144,7 @@ unsafe impl ::windows::core::Abi for EMRPIXELFORMAT {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for EMRPIXELFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRPIXELFORMAT>()) == 0 }
+        self.emr == other.emr && self.pfd == other.pfd
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4186,7 +4186,7 @@ unsafe impl ::windows::core::Abi for GLYPHMETRICSFLOAT {
 }
 impl ::core::cmp::PartialEq for GLYPHMETRICSFLOAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHMETRICSFLOAT>()) == 0 }
+        self.gmfBlackBoxX == other.gmfBlackBoxX && self.gmfBlackBoxY == other.gmfBlackBoxY && self.gmfptGlyphOrigin == other.gmfptGlyphOrigin && self.gmfCellIncX == other.gmfCellIncX && self.gmfCellIncY == other.gmfCellIncY
     }
 }
 impl ::core::cmp::Eq for GLYPHMETRICSFLOAT {}
@@ -4302,7 +4302,30 @@ unsafe impl ::windows::core::Abi for LAYERPLANEDESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LAYERPLANEDESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LAYERPLANEDESCRIPTOR>()) == 0 }
+        self.nSize == other.nSize
+            && self.nVersion == other.nVersion
+            && self.dwFlags == other.dwFlags
+            && self.iPixelType == other.iPixelType
+            && self.cColorBits == other.cColorBits
+            && self.cRedBits == other.cRedBits
+            && self.cRedShift == other.cRedShift
+            && self.cGreenBits == other.cGreenBits
+            && self.cGreenShift == other.cGreenShift
+            && self.cBlueBits == other.cBlueBits
+            && self.cBlueShift == other.cBlueShift
+            && self.cAlphaBits == other.cAlphaBits
+            && self.cAlphaShift == other.cAlphaShift
+            && self.cAccumBits == other.cAccumBits
+            && self.cAccumRedBits == other.cAccumRedBits
+            && self.cAccumGreenBits == other.cAccumGreenBits
+            && self.cAccumBlueBits == other.cAccumBlueBits
+            && self.cAccumAlphaBits == other.cAccumAlphaBits
+            && self.cDepthBits == other.cDepthBits
+            && self.cStencilBits == other.cStencilBits
+            && self.cAuxBuffers == other.cAuxBuffers
+            && self.iLayerPlane == other.iLayerPlane
+            && self.bReserved == other.bReserved
+            && self.crTransparent == other.crTransparent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4386,7 +4409,32 @@ unsafe impl ::windows::core::Abi for PIXELFORMATDESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for PIXELFORMATDESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PIXELFORMATDESCRIPTOR>()) == 0 }
+        self.nSize == other.nSize
+            && self.nVersion == other.nVersion
+            && self.dwFlags == other.dwFlags
+            && self.iPixelType == other.iPixelType
+            && self.cColorBits == other.cColorBits
+            && self.cRedBits == other.cRedBits
+            && self.cRedShift == other.cRedShift
+            && self.cGreenBits == other.cGreenBits
+            && self.cGreenShift == other.cGreenShift
+            && self.cBlueBits == other.cBlueBits
+            && self.cBlueShift == other.cBlueShift
+            && self.cAlphaBits == other.cAlphaBits
+            && self.cAlphaShift == other.cAlphaShift
+            && self.cAccumBits == other.cAccumBits
+            && self.cAccumRedBits == other.cAccumRedBits
+            && self.cAccumGreenBits == other.cAccumGreenBits
+            && self.cAccumBlueBits == other.cAccumBlueBits
+            && self.cAccumAlphaBits == other.cAccumAlphaBits
+            && self.cDepthBits == other.cDepthBits
+            && self.cStencilBits == other.cStencilBits
+            && self.cAuxBuffers == other.cAuxBuffers
+            && self.iLayerType == other.iLayerType
+            && self.bReserved == other.bReserved
+            && self.dwLayerMask == other.dwLayerMask
+            && self.dwVisibleMask == other.dwVisibleMask
+            && self.dwDamageMask == other.dwDamageMask
     }
 }
 impl ::core::cmp::Eq for PIXELFORMATDESCRIPTOR {}
@@ -4417,7 +4465,7 @@ unsafe impl ::windows::core::Abi for POINTFLOAT {
 }
 impl ::core::cmp::PartialEq for POINTFLOAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTFLOAT>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTFLOAT {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -12974,7 +12974,7 @@ unsafe impl ::windows::core::Abi for ADDJOB_INFO_1A {
 }
 impl ::core::cmp::PartialEq for ADDJOB_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDJOB_INFO_1A>()) == 0 }
+        self.Path == other.Path && self.JobId == other.JobId
     }
 }
 impl ::core::cmp::Eq for ADDJOB_INFO_1A {}
@@ -13005,7 +13005,7 @@ unsafe impl ::windows::core::Abi for ADDJOB_INFO_1W {
 }
 impl ::core::cmp::PartialEq for ADDJOB_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDJOB_INFO_1W>()) == 0 }
+        self.Path == other.Path && self.JobId == other.JobId
     }
 }
 impl ::core::cmp::Eq for ADDJOB_INFO_1W {}
@@ -13041,7 +13041,7 @@ unsafe impl ::windows::core::Abi for ATTRIBUTE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for ATTRIBUTE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTRIBUTE_INFO_1>()) == 0 }
+        self.dwJobNumberOfPagesPerSide == other.dwJobNumberOfPagesPerSide && self.dwDrvNumberOfPagesPerSide == other.dwDrvNumberOfPagesPerSide && self.dwNupBorderFlags == other.dwNupBorderFlags && self.dwJobPageOrderFlags == other.dwJobPageOrderFlags && self.dwDrvPageOrderFlags == other.dwDrvPageOrderFlags && self.dwJobNumberOfCopies == other.dwJobNumberOfCopies && self.dwDrvNumberOfCopies == other.dwDrvNumberOfCopies
     }
 }
 impl ::core::cmp::Eq for ATTRIBUTE_INFO_1 {}
@@ -13087,7 +13087,7 @@ unsafe impl ::windows::core::Abi for ATTRIBUTE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for ATTRIBUTE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTRIBUTE_INFO_2>()) == 0 }
+        self.dwJobNumberOfPagesPerSide == other.dwJobNumberOfPagesPerSide && self.dwDrvNumberOfPagesPerSide == other.dwDrvNumberOfPagesPerSide && self.dwNupBorderFlags == other.dwNupBorderFlags && self.dwJobPageOrderFlags == other.dwJobPageOrderFlags && self.dwDrvPageOrderFlags == other.dwDrvPageOrderFlags && self.dwJobNumberOfCopies == other.dwJobNumberOfCopies && self.dwDrvNumberOfCopies == other.dwDrvNumberOfCopies && self.dwColorOptimization == other.dwColorOptimization
     }
 }
 impl ::core::cmp::Eq for ATTRIBUTE_INFO_2 {}
@@ -13137,7 +13137,7 @@ unsafe impl ::windows::core::Abi for ATTRIBUTE_INFO_3 {
 }
 impl ::core::cmp::PartialEq for ATTRIBUTE_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTRIBUTE_INFO_3>()) == 0 }
+        self.dwJobNumberOfPagesPerSide == other.dwJobNumberOfPagesPerSide && self.dwDrvNumberOfPagesPerSide == other.dwDrvNumberOfPagesPerSide && self.dwNupBorderFlags == other.dwNupBorderFlags && self.dwJobPageOrderFlags == other.dwJobPageOrderFlags && self.dwDrvPageOrderFlags == other.dwDrvPageOrderFlags && self.dwJobNumberOfCopies == other.dwJobNumberOfCopies && self.dwDrvNumberOfCopies == other.dwDrvNumberOfCopies && self.dwColorOptimization == other.dwColorOptimization && self.dmPrintQuality == other.dmPrintQuality && self.dmYResolution == other.dmYResolution
     }
 }
 impl ::core::cmp::Eq for ATTRIBUTE_INFO_3 {}
@@ -13197,7 +13197,21 @@ unsafe impl ::windows::core::Abi for ATTRIBUTE_INFO_4 {
 }
 impl ::core::cmp::PartialEq for ATTRIBUTE_INFO_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTRIBUTE_INFO_4>()) == 0 }
+        self.dwJobNumberOfPagesPerSide == other.dwJobNumberOfPagesPerSide
+            && self.dwDrvNumberOfPagesPerSide == other.dwDrvNumberOfPagesPerSide
+            && self.dwNupBorderFlags == other.dwNupBorderFlags
+            && self.dwJobPageOrderFlags == other.dwJobPageOrderFlags
+            && self.dwDrvPageOrderFlags == other.dwDrvPageOrderFlags
+            && self.dwJobNumberOfCopies == other.dwJobNumberOfCopies
+            && self.dwDrvNumberOfCopies == other.dwDrvNumberOfCopies
+            && self.dwColorOptimization == other.dwColorOptimization
+            && self.dmPrintQuality == other.dmPrintQuality
+            && self.dmYResolution == other.dmYResolution
+            && self.dwDuplexFlags == other.dwDuplexFlags
+            && self.dwNupDirection == other.dwNupDirection
+            && self.dwBookletFlags == other.dwBookletFlags
+            && self.dwScalingPercentX == other.dwScalingPercentX
+            && self.dwScalingPercentY == other.dwScalingPercentY
     }
 }
 impl ::core::cmp::Eq for ATTRIBUTE_INFO_4 {}
@@ -13225,14 +13239,6 @@ impl ::core::clone::Clone for BIDI_DATA {
 unsafe impl ::windows::core::Abi for BIDI_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_DATA {
     fn default() -> Self {
@@ -13262,14 +13268,6 @@ unsafe impl ::windows::core::Abi for BIDI_DATA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_DATA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13297,14 +13295,6 @@ unsafe impl ::windows::core::Abi for BIDI_REQUEST_CONTAINER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_REQUEST_CONTAINER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_REQUEST_CONTAINER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_REQUEST_CONTAINER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_REQUEST_CONTAINER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13330,14 +13320,6 @@ impl ::core::clone::Clone for BIDI_REQUEST_DATA {
 unsafe impl ::windows::core::Abi for BIDI_REQUEST_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_REQUEST_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_REQUEST_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_REQUEST_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_REQUEST_DATA {
     fn default() -> Self {
@@ -13366,14 +13348,6 @@ unsafe impl ::windows::core::Abi for BIDI_RESPONSE_CONTAINER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_RESPONSE_CONTAINER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_RESPONSE_CONTAINER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_RESPONSE_CONTAINER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_RESPONSE_CONTAINER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13400,14 +13374,6 @@ impl ::core::clone::Clone for BIDI_RESPONSE_DATA {
 unsafe impl ::windows::core::Abi for BIDI_RESPONSE_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BIDI_RESPONSE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDI_RESPONSE_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BIDI_RESPONSE_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BIDI_RESPONSE_DATA {
     fn default() -> Self {
@@ -13436,7 +13402,7 @@ unsafe impl ::windows::core::Abi for BINARY_CONTAINER {
 }
 impl ::core::cmp::PartialEq for BINARY_CONTAINER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BINARY_CONTAINER>()) == 0 }
+        self.cbBuf == other.cbBuf && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for BINARY_CONTAINER {}
@@ -13461,12 +13427,6 @@ impl ::core::clone::Clone for BranchOfficeJobData {
 unsafe impl ::windows::core::Abi for BranchOfficeJobData {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BranchOfficeJobData {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobData>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BranchOfficeJobData {}
 impl ::core::default::Default for BranchOfficeJobData {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13490,12 +13450,6 @@ impl ::core::clone::Clone for BranchOfficeJobData_0 {
 unsafe impl ::windows::core::Abi for BranchOfficeJobData_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BranchOfficeJobData_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobData_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BranchOfficeJobData_0 {}
 impl ::core::default::Default for BranchOfficeJobData_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13516,12 +13470,6 @@ impl ::core::clone::Clone for BranchOfficeJobDataContainer {
 unsafe impl ::windows::core::Abi for BranchOfficeJobDataContainer {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BranchOfficeJobDataContainer {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobDataContainer>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BranchOfficeJobDataContainer {}
 impl ::core::default::Default for BranchOfficeJobDataContainer {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13572,7 +13520,7 @@ unsafe impl ::windows::core::Abi for BranchOfficeJobDataError {
 }
 impl ::core::cmp::PartialEq for BranchOfficeJobDataError {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobDataError>()) == 0 }
+        self.LastError == other.LastError && self.pDocumentName == other.pDocumentName && self.pUserName == other.pUserName && self.pPrinterName == other.pPrinterName && self.pDataType == other.pDataType && self.TotalSize == other.TotalSize && self.PrintedSize == other.PrintedSize && self.TotalPages == other.TotalPages && self.PrintedPages == other.PrintedPages && self.pMachineName == other.pMachineName && self.pJobError == other.pJobError && self.pErrorDescription == other.pErrorDescription
     }
 }
 impl ::core::cmp::Eq for BranchOfficeJobDataError {}
@@ -13604,7 +13552,7 @@ unsafe impl ::windows::core::Abi for BranchOfficeJobDataPipelineFailed {
 }
 impl ::core::cmp::PartialEq for BranchOfficeJobDataPipelineFailed {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobDataPipelineFailed>()) == 0 }
+        self.pDocumentName == other.pDocumentName && self.pPrinterName == other.pPrinterName && self.pExtraErrorInfo == other.pExtraErrorInfo
     }
 }
 impl ::core::cmp::Eq for BranchOfficeJobDataPipelineFailed {}
@@ -13641,7 +13589,7 @@ unsafe impl ::windows::core::Abi for BranchOfficeJobDataPrinted {
 }
 impl ::core::cmp::PartialEq for BranchOfficeJobDataPrinted {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobDataPrinted>()) == 0 }
+        self.Status == other.Status && self.pDocumentName == other.pDocumentName && self.pUserName == other.pUserName && self.pMachineName == other.pMachineName && self.pPrinterName == other.pPrinterName && self.pPortName == other.pPortName && self.Size == other.Size && self.TotalPages == other.TotalPages
     }
 }
 impl ::core::cmp::Eq for BranchOfficeJobDataPrinted {}
@@ -13677,7 +13625,7 @@ unsafe impl ::windows::core::Abi for BranchOfficeJobDataRendered {
 }
 impl ::core::cmp::PartialEq for BranchOfficeJobDataRendered {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeJobDataRendered>()) == 0 }
+        self.Size == other.Size && self.ICMMethod == other.ICMMethod && self.Color == other.Color && self.PrintQuality == other.PrintQuality && self.YResolution == other.YResolution && self.Copies == other.Copies && self.TTOption == other.TTOption
     }
 }
 impl ::core::cmp::Eq for BranchOfficeJobDataRendered {}
@@ -13707,7 +13655,7 @@ unsafe impl ::windows::core::Abi for BranchOfficeLogOfflineFileFull {
 }
 impl ::core::cmp::PartialEq for BranchOfficeLogOfflineFileFull {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BranchOfficeLogOfflineFileFull>()) == 0 }
+        self.pMachineName == other.pMachineName
     }
 }
 impl ::core::cmp::Eq for BranchOfficeLogOfflineFileFull {}
@@ -13755,7 +13703,6 @@ impl ::core::fmt::Debug for COMPROPSHEETUI {
             .field("pCallerName", &self.pCallerName)
             .field("UserData", &self.UserData)
             .field("pHelpFile", &self.pHelpFile)
-            .field("pfnCallBack", &self.pfnCallBack.map(|f| f as usize))
             .field("pOptItem", &self.pOptItem)
             .field("pDlgPage", &self.pDlgPage)
             .field("cOptItem", &self.cOptItem)
@@ -13772,14 +13719,6 @@ impl ::core::fmt::Debug for COMPROPSHEETUI {
 unsafe impl ::windows::core::Abi for COMPROPSHEETUI {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for COMPROPSHEETUI {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPROPSHEETUI>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for COMPROPSHEETUI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for COMPROPSHEETUI {
     fn default() -> Self {
@@ -13808,7 +13747,7 @@ unsafe impl ::windows::core::Abi for CONFIG_INFO_DATA_1 {
 }
 impl ::core::cmp::PartialEq for CONFIG_INFO_DATA_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFIG_INFO_DATA_1>()) == 0 }
+        self.Reserved == other.Reserved && self.dwVersion == other.dwVersion
     }
 }
 impl ::core::cmp::Eq for CONFIG_INFO_DATA_1 {}
@@ -13847,7 +13786,7 @@ unsafe impl ::windows::core::Abi for CORE_PRINTER_DRIVERA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CORE_PRINTER_DRIVERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CORE_PRINTER_DRIVERA>()) == 0 }
+        self.CoreDriverGUID == other.CoreDriverGUID && self.ftDriverDate == other.ftDriverDate && self.dwlDriverVersion == other.dwlDriverVersion && self.szPackageID == other.szPackageID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13888,7 +13827,7 @@ unsafe impl ::windows::core::Abi for CORE_PRINTER_DRIVERW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CORE_PRINTER_DRIVERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CORE_PRINTER_DRIVERW>()) == 0 }
+        self.CoreDriverGUID == other.CoreDriverGUID && self.ftDriverDate == other.ftDriverDate && self.dwlDriverVersion == other.dwlDriverVersion && self.szPackageID == other.szPackageID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13927,14 +13866,6 @@ unsafe impl ::windows::core::Abi for CPSUICBPARAM {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CPSUICBPARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPSUICBPARAM>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CPSUICBPARAM {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CPSUICBPARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13959,14 +13890,6 @@ impl ::core::clone::Clone for CPSUICBPARAM_0 {
 unsafe impl ::windows::core::Abi for CPSUICBPARAM_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CPSUICBPARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPSUICBPARAM_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CPSUICBPARAM_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CPSUICBPARAM_0 {
     fn default() -> Self {
@@ -13995,7 +13918,7 @@ unsafe impl ::windows::core::Abi for CPSUIDATABLOCK {
 }
 impl ::core::cmp::PartialEq for CPSUIDATABLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPSUIDATABLOCK>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for CPSUIDATABLOCK {}
@@ -14027,7 +13950,7 @@ unsafe impl ::windows::core::Abi for CUSTOMSIZEPARAM {
 }
 impl ::core::cmp::PartialEq for CUSTOMSIZEPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CUSTOMSIZEPARAM>()) == 0 }
+        self.dwOrder == other.dwOrder && self.lMinVal == other.lMinVal && self.lMaxVal == other.lMaxVal
     }
 }
 impl ::core::cmp::Eq for CUSTOMSIZEPARAM {}
@@ -14057,7 +13980,7 @@ unsafe impl ::windows::core::Abi for DATATYPES_INFO_1A {
 }
 impl ::core::cmp::PartialEq for DATATYPES_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATATYPES_INFO_1A>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DATATYPES_INFO_1A {}
@@ -14087,7 +14010,7 @@ unsafe impl ::windows::core::Abi for DATATYPES_INFO_1W {
 }
 impl ::core::cmp::PartialEq for DATATYPES_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATATYPES_INFO_1W>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DATATYPES_INFO_1W {}
@@ -14121,7 +14044,7 @@ unsafe impl ::windows::core::Abi for DATA_HEADER {
 }
 impl ::core::cmp::PartialEq for DATA_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATA_HEADER>()) == 0 }
+        self.dwSignature == other.dwSignature && self.wSize == other.wSize && self.wDataID == other.wDataID && self.dwDataSize == other.dwDataSize && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for DATA_HEADER {}
@@ -14154,7 +14077,7 @@ unsafe impl ::windows::core::Abi for DELETE_PORT_DATA_1 {
 }
 impl ::core::cmp::PartialEq for DELETE_PORT_DATA_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETE_PORT_DATA_1>()) == 0 }
+        self.psztPortName == other.psztPortName && self.Reserved == other.Reserved && self.dwVersion == other.dwVersion && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for DELETE_PORT_DATA_1 {}
@@ -14193,7 +14116,7 @@ unsafe impl ::windows::core::Abi for DEVICEPROPERTYHEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICEPROPERTYHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEPROPERTYHEADER>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.hPrinter == other.hPrinter && self.pszPrinterName == other.pszPrinterName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14237,7 +14160,7 @@ unsafe impl ::windows::core::Abi for DEVQUERYPRINT_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DEVQUERYPRINT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVQUERYPRINT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.Level == other.Level && self.hPrinter == other.hPrinter && self.pDevMode == other.pDevMode && self.pszErrorStr == other.pszErrorStr && self.cchErrorStr == other.cchErrorStr && self.cchNeeded == other.cchNeeded
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -14272,14 +14195,6 @@ unsafe impl ::windows::core::Abi for DLGPAGE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for DLGPAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLGPAGE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for DLGPAGE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for DLGPAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14304,14 +14219,6 @@ impl ::core::clone::Clone for DLGPAGE_0 {
 unsafe impl ::windows::core::Abi for DLGPAGE_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for DLGPAGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLGPAGE_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for DLGPAGE_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for DLGPAGE_0 {
     fn default() -> Self {
@@ -14348,7 +14255,7 @@ unsafe impl ::windows::core::Abi for DOCEVENT_CREATEDCPRE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DOCEVENT_CREATEDCPRE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCEVENT_CREATEDCPRE>()) == 0 }
+        self.pszDriver == other.pszDriver && self.pszDevice == other.pszDevice && self.pdm == other.pdm && self.bIC == other.bIC
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -14382,7 +14289,7 @@ unsafe impl ::windows::core::Abi for DOCEVENT_ESCAPE {
 }
 impl ::core::cmp::PartialEq for DOCEVENT_ESCAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCEVENT_ESCAPE>()) == 0 }
+        self.iEscape == other.iEscape && self.cjInput == other.cjInput && self.pvInData == other.pvInData
     }
 }
 impl ::core::cmp::Eq for DOCEVENT_ESCAPE {}
@@ -14416,7 +14323,7 @@ unsafe impl ::windows::core::Abi for DOCEVENT_FILTER {
 }
 impl ::core::cmp::PartialEq for DOCEVENT_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCEVENT_FILTER>()) == 0 }
+        self.cbSize == other.cbSize && self.cElementsAllocated == other.cElementsAllocated && self.cElementsNeeded == other.cElementsNeeded && self.cElementsReturned == other.cElementsReturned && self.aDocEventCall == other.aDocEventCall
     }
 }
 impl ::core::cmp::Eq for DOCEVENT_FILTER {}
@@ -14459,7 +14366,7 @@ unsafe impl ::windows::core::Abi for DOCUMENTPROPERTYHEADER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for DOCUMENTPROPERTYHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCUMENTPROPERTYHEADER>()) == 0 }
+        self.cbSize == other.cbSize && self.Reserved == other.Reserved && self.hPrinter == other.hPrinter && self.pszPrinterName == other.pszPrinterName && self.pdmIn == other.pdmIn && self.pdmOut == other.pdmOut && self.cbOut == other.cbOut && self.fMode == other.fMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -14493,7 +14400,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_1A {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_1A>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_1A {}
@@ -14525,7 +14432,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_1W {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_1W>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_1W {}
@@ -14559,7 +14466,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_2A {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_2A>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype && self.dwMode == other.dwMode && self.JobId == other.JobId
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_2A {}
@@ -14593,7 +14500,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_2W {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_2W>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype && self.dwMode == other.dwMode && self.JobId == other.JobId
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_2W {}
@@ -14626,7 +14533,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_3A {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_3A>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_3A {}
@@ -14659,7 +14566,7 @@ unsafe impl ::windows::core::Abi for DOC_INFO_3W {
 }
 impl ::core::cmp::PartialEq for DOC_INFO_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOC_INFO_3W>()) == 0 }
+        self.pDocName == other.pDocName && self.pOutputFile == other.pOutputFile && self.pDatatype == other.pDatatype && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DOC_INFO_3W {}
@@ -14689,7 +14596,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_1A {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_1A>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_1A {}
@@ -14719,7 +14626,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_1W {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_1W>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_1W {}
@@ -14754,7 +14661,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_2A {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_2A>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_2A {}
@@ -14789,7 +14696,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_2W {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_2W>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_2W {}
@@ -14828,7 +14735,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_3A {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_3A>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_3A {}
@@ -14867,7 +14774,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_3W {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_3W>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_3W {}
@@ -14919,7 +14826,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_4A {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_4A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_4A>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType && self.pszzPreviousNames == other.pszzPreviousNames
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_4A {}
@@ -14971,7 +14878,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_4W {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_4W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_4W>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType && self.pszzPreviousNames == other.pszzPreviousNames
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_4W {}
@@ -15009,7 +14916,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_5A {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_5A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_5A>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.dwDriverAttributes == other.dwDriverAttributes && self.dwConfigVersion == other.dwConfigVersion && self.dwDriverVersion == other.dwDriverVersion
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_5A {}
@@ -15047,7 +14954,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_5W {
 }
 impl ::core::cmp::PartialEq for DRIVER_INFO_5W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_5W>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.dwDriverAttributes == other.dwDriverAttributes && self.dwConfigVersion == other.dwConfigVersion && self.dwDriverVersion == other.dwDriverVersion
     }
 }
 impl ::core::cmp::Eq for DRIVER_INFO_5W {}
@@ -15117,7 +15024,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_6A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRIVER_INFO_6A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_6A>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType && self.pszzPreviousNames == other.pszzPreviousNames && self.ftDriverDate == other.ftDriverDate && self.dwlDriverVersion == other.dwlDriverVersion && self.pszMfgName == other.pszMfgName && self.pszOEMUrl == other.pszOEMUrl && self.pszHardwareID == other.pszHardwareID && self.pszProvider == other.pszProvider
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15189,7 +15096,7 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_6W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRIVER_INFO_6W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_6W>()) == 0 }
+        self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType && self.pszzPreviousNames == other.pszzPreviousNames && self.ftDriverDate == other.ftDriverDate && self.dwlDriverVersion == other.dwlDriverVersion && self.pszMfgName == other.pszMfgName && self.pszOEMUrl == other.pszOEMUrl && self.pszHardwareID == other.pszHardwareID && self.pszProvider == other.pszProvider
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15277,7 +15184,31 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_8A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRIVER_INFO_8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_8A>()) == 0 }
+        self.cVersion == other.cVersion
+            && self.pName == other.pName
+            && self.pEnvironment == other.pEnvironment
+            && self.pDriverPath == other.pDriverPath
+            && self.pDataFile == other.pDataFile
+            && self.pConfigFile == other.pConfigFile
+            && self.pHelpFile == other.pHelpFile
+            && self.pDependentFiles == other.pDependentFiles
+            && self.pMonitorName == other.pMonitorName
+            && self.pDefaultDataType == other.pDefaultDataType
+            && self.pszzPreviousNames == other.pszzPreviousNames
+            && self.ftDriverDate == other.ftDriverDate
+            && self.dwlDriverVersion == other.dwlDriverVersion
+            && self.pszMfgName == other.pszMfgName
+            && self.pszOEMUrl == other.pszOEMUrl
+            && self.pszHardwareID == other.pszHardwareID
+            && self.pszProvider == other.pszProvider
+            && self.pszPrintProcessor == other.pszPrintProcessor
+            && self.pszVendorSetup == other.pszVendorSetup
+            && self.pszzColorProfiles == other.pszzColorProfiles
+            && self.pszInfPath == other.pszInfPath
+            && self.dwPrinterDriverAttributes == other.dwPrinterDriverAttributes
+            && self.pszzCoreDriverDependencies == other.pszzCoreDriverDependencies
+            && self.ftMinInboxDriverVerDate == other.ftMinInboxDriverVerDate
+            && self.dwlMinInboxDriverVerVersion == other.dwlMinInboxDriverVerVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15365,7 +15296,31 @@ unsafe impl ::windows::core::Abi for DRIVER_INFO_8W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRIVER_INFO_8W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_INFO_8W>()) == 0 }
+        self.cVersion == other.cVersion
+            && self.pName == other.pName
+            && self.pEnvironment == other.pEnvironment
+            && self.pDriverPath == other.pDriverPath
+            && self.pDataFile == other.pDataFile
+            && self.pConfigFile == other.pConfigFile
+            && self.pHelpFile == other.pHelpFile
+            && self.pDependentFiles == other.pDependentFiles
+            && self.pMonitorName == other.pMonitorName
+            && self.pDefaultDataType == other.pDefaultDataType
+            && self.pszzPreviousNames == other.pszzPreviousNames
+            && self.ftDriverDate == other.ftDriverDate
+            && self.dwlDriverVersion == other.dwlDriverVersion
+            && self.pszMfgName == other.pszMfgName
+            && self.pszOEMUrl == other.pszOEMUrl
+            && self.pszHardwareID == other.pszHardwareID
+            && self.pszProvider == other.pszProvider
+            && self.pszPrintProcessor == other.pszPrintProcessor
+            && self.pszVendorSetup == other.pszVendorSetup
+            && self.pszzColorProfiles == other.pszzColorProfiles
+            && self.pszInfPath == other.pszInfPath
+            && self.dwPrinterDriverAttributes == other.dwPrinterDriverAttributes
+            && self.pszzCoreDriverDependencies == other.pszzCoreDriverDependencies
+            && self.ftMinInboxDriverVerDate == other.ftMinInboxDriverVerDate
+            && self.dwlMinInboxDriverVerVersion == other.dwlMinInboxDriverVerVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15398,7 +15353,7 @@ unsafe impl ::windows::core::Abi for DRIVER_UPGRADE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for DRIVER_UPGRADE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_UPGRADE_INFO_1>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pOldDriverDirectory == other.pOldDriverDirectory
     }
 }
 impl ::core::cmp::Eq for DRIVER_UPGRADE_INFO_1 {}
@@ -15454,7 +15409,7 @@ unsafe impl ::windows::core::Abi for DRIVER_UPGRADE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for DRIVER_UPGRADE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_UPGRADE_INFO_2>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pOldDriverDirectory == other.pOldDriverDirectory && self.cVersion == other.cVersion && self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDriverPath == other.pDriverPath && self.pDataFile == other.pDataFile && self.pConfigFile == other.pConfigFile && self.pHelpFile == other.pHelpFile && self.pDependentFiles == other.pDependentFiles && self.pMonitorName == other.pMonitorName && self.pDefaultDataType == other.pDefaultDataType && self.pszzPreviousNames == other.pszzPreviousNames
     }
 }
 impl ::core::cmp::Eq for DRIVER_UPGRADE_INFO_2 {}
@@ -15491,7 +15446,7 @@ unsafe impl ::windows::core::Abi for EXTCHKBOX {
 }
 impl ::core::cmp::PartialEq for EXTCHKBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTCHKBOX>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.pTitle == other.pTitle && self.pSeparator == other.pSeparator && self.pCheckedName == other.pCheckedName && self.IconID == other.IconID && self.wReserved == other.wReserved && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for EXTCHKBOX {}
@@ -15525,14 +15480,6 @@ unsafe impl ::windows::core::Abi for EXTPUSH {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for EXTPUSH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTPUSH>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for EXTPUSH {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for EXTPUSH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15558,14 +15505,6 @@ unsafe impl ::windows::core::Abi for EXTPUSH_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for EXTPUSH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTPUSH_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for EXTPUSH_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for EXTPUSH_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15590,14 +15529,6 @@ impl ::core::clone::Clone for EXTPUSH_1 {
 unsafe impl ::windows::core::Abi for EXTPUSH_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for EXTPUSH_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTPUSH_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for EXTPUSH_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for EXTPUSH_1 {
     fn default() -> Self {
@@ -15677,7 +15608,32 @@ unsafe impl ::windows::core::Abi for EXTTEXTMETRIC {
 }
 impl ::core::cmp::PartialEq for EXTTEXTMETRIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTTEXTMETRIC>()) == 0 }
+        self.emSize == other.emSize
+            && self.emPointSize == other.emPointSize
+            && self.emOrientation == other.emOrientation
+            && self.emMasterHeight == other.emMasterHeight
+            && self.emMinScale == other.emMinScale
+            && self.emMaxScale == other.emMaxScale
+            && self.emMasterUnits == other.emMasterUnits
+            && self.emCapHeight == other.emCapHeight
+            && self.emXHeight == other.emXHeight
+            && self.emLowerCaseAscent == other.emLowerCaseAscent
+            && self.emLowerCaseDescent == other.emLowerCaseDescent
+            && self.emSlant == other.emSlant
+            && self.emSuperScript == other.emSuperScript
+            && self.emSubScript == other.emSubScript
+            && self.emSuperScriptSize == other.emSuperScriptSize
+            && self.emSubScriptSize == other.emSubScriptSize
+            && self.emUnderlineOffset == other.emUnderlineOffset
+            && self.emUnderlineWidth == other.emUnderlineWidth
+            && self.emDoubleUpperUnderlineOffset == other.emDoubleUpperUnderlineOffset
+            && self.emDoubleLowerUnderlineOffset == other.emDoubleLowerUnderlineOffset
+            && self.emDoubleUpperUnderlineWidth == other.emDoubleUpperUnderlineWidth
+            && self.emDoubleLowerUnderlineWidth == other.emDoubleLowerUnderlineWidth
+            && self.emStrikeOutOffset == other.emStrikeOutOffset
+            && self.emStrikeOutWidth == other.emStrikeOutWidth
+            && self.emKernPairs == other.emKernPairs
+            && self.emKernTracks == other.emKernTracks
     }
 }
 impl ::core::cmp::Eq for EXTTEXTMETRIC {}
@@ -15716,7 +15672,7 @@ unsafe impl ::windows::core::Abi for FORM_INFO_1A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FORM_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORM_INFO_1A>()) == 0 }
+        self.Flags == other.Flags && self.pName == other.pName && self.Size == other.Size && self.ImageableArea == other.ImageableArea
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15757,7 +15713,7 @@ unsafe impl ::windows::core::Abi for FORM_INFO_1W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FORM_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORM_INFO_1W>()) == 0 }
+        self.Flags == other.Flags && self.pName == other.pName && self.Size == other.Size && self.ImageableArea == other.ImageableArea
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15804,7 +15760,7 @@ unsafe impl ::windows::core::Abi for FORM_INFO_2A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FORM_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORM_INFO_2A>()) == 0 }
+        self.Flags == other.Flags && self.pName == other.pName && self.Size == other.Size && self.ImageableArea == other.ImageableArea && self.pKeyword == other.pKeyword && self.StringType == other.StringType && self.pMuiDll == other.pMuiDll && self.dwResourceId == other.dwResourceId && self.pDisplayName == other.pDisplayName && self.wLangId == other.wLangId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15851,7 +15807,7 @@ unsafe impl ::windows::core::Abi for FORM_INFO_2W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FORM_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORM_INFO_2W>()) == 0 }
+        self.Flags == other.Flags && self.pName == other.pName && self.Size == other.Size && self.ImageableArea == other.ImageableArea && self.pKeyword == other.pKeyword && self.StringType == other.StringType && self.pMuiDll == other.pMuiDll && self.dwResourceId == other.dwResourceId && self.pDisplayName == other.pDisplayName && self.wLangId == other.wLangId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15884,7 +15840,7 @@ unsafe impl ::windows::core::Abi for GLYPHRUN {
 }
 impl ::core::cmp::PartialEq for GLYPHRUN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLYPHRUN>()) == 0 }
+        self.wcLow == other.wcLow && self.wGlyphCount == other.wGlyphCount
     }
 }
 impl ::core::cmp::Eq for GLYPHRUN {}
@@ -15919,7 +15875,7 @@ unsafe impl ::windows::core::Abi for INSERTPSUIPAGE_INFO {
 }
 impl ::core::cmp::PartialEq for INSERTPSUIPAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSERTPSUIPAGE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.Type == other.Type && self.Mode == other.Mode && self.dwData1 == other.dwData1 && self.dwData2 == other.dwData2 && self.dwData3 == other.dwData3
     }
 }
 impl ::core::cmp::Eq for INSERTPSUIPAGE_INFO {}
@@ -15950,7 +15906,7 @@ unsafe impl ::windows::core::Abi for INVOC {
 }
 impl ::core::cmp::PartialEq for INVOC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INVOC>()) == 0 }
+        self.dwCount == other.dwCount && self.loOffset == other.loOffset
     }
 }
 impl ::core::cmp::Eq for INVOC {}
@@ -16063,7 +16019,7 @@ unsafe impl ::windows::core::Abi for JOB_INFO_1A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JOB_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_1A>()) == 0 }
+        self.JobId == other.JobId && self.pPrinterName == other.pPrinterName && self.pMachineName == other.pMachineName && self.pUserName == other.pUserName && self.pDocument == other.pDocument && self.pDatatype == other.pDatatype && self.pStatus == other.pStatus && self.Status == other.Status && self.Priority == other.Priority && self.Position == other.Position && self.TotalPages == other.TotalPages && self.PagesPrinted == other.PagesPrinted && self.Submitted == other.Submitted
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16127,7 +16083,7 @@ unsafe impl ::windows::core::Abi for JOB_INFO_1W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JOB_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_1W>()) == 0 }
+        self.JobId == other.JobId && self.pPrinterName == other.pPrinterName && self.pMachineName == other.pMachineName && self.pUserName == other.pUserName && self.pDocument == other.pDocument && self.pDatatype == other.pDatatype && self.pStatus == other.pStatus && self.Status == other.Status && self.Priority == other.Priority && self.Position == other.Position && self.TotalPages == other.TotalPages && self.PagesPrinted == other.PagesPrinted && self.Submitted == other.Submitted
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16211,7 +16167,29 @@ unsafe impl ::windows::core::Abi for JOB_INFO_2A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for JOB_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_2A>()) == 0 }
+        self.JobId == other.JobId
+            && self.pPrinterName == other.pPrinterName
+            && self.pMachineName == other.pMachineName
+            && self.pUserName == other.pUserName
+            && self.pDocument == other.pDocument
+            && self.pNotifyName == other.pNotifyName
+            && self.pDatatype == other.pDatatype
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pParameters == other.pParameters
+            && self.pDriverName == other.pDriverName
+            && self.pDevMode == other.pDevMode
+            && self.pStatus == other.pStatus
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Status == other.Status
+            && self.Priority == other.Priority
+            && self.Position == other.Position
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.TotalPages == other.TotalPages
+            && self.Size == other.Size
+            && self.Submitted == other.Submitted
+            && self.Time == other.Time
+            && self.PagesPrinted == other.PagesPrinted
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -16295,7 +16273,29 @@ unsafe impl ::windows::core::Abi for JOB_INFO_2W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for JOB_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_2W>()) == 0 }
+        self.JobId == other.JobId
+            && self.pPrinterName == other.pPrinterName
+            && self.pMachineName == other.pMachineName
+            && self.pUserName == other.pUserName
+            && self.pDocument == other.pDocument
+            && self.pNotifyName == other.pNotifyName
+            && self.pDatatype == other.pDatatype
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pParameters == other.pParameters
+            && self.pDriverName == other.pDriverName
+            && self.pDevMode == other.pDevMode
+            && self.pStatus == other.pStatus
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Status == other.Status
+            && self.Priority == other.Priority
+            && self.Position == other.Position
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.TotalPages == other.TotalPages
+            && self.Size == other.Size
+            && self.Submitted == other.Submitted
+            && self.Time == other.Time
+            && self.PagesPrinted == other.PagesPrinted
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -16329,7 +16329,7 @@ unsafe impl ::windows::core::Abi for JOB_INFO_3 {
 }
 impl ::core::cmp::PartialEq for JOB_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_3>()) == 0 }
+        self.JobId == other.JobId && self.NextJobId == other.NextJobId && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for JOB_INFO_3 {}
@@ -16413,7 +16413,30 @@ unsafe impl ::windows::core::Abi for JOB_INFO_4A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for JOB_INFO_4A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_4A>()) == 0 }
+        self.JobId == other.JobId
+            && self.pPrinterName == other.pPrinterName
+            && self.pMachineName == other.pMachineName
+            && self.pUserName == other.pUserName
+            && self.pDocument == other.pDocument
+            && self.pNotifyName == other.pNotifyName
+            && self.pDatatype == other.pDatatype
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pParameters == other.pParameters
+            && self.pDriverName == other.pDriverName
+            && self.pDevMode == other.pDevMode
+            && self.pStatus == other.pStatus
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Status == other.Status
+            && self.Priority == other.Priority
+            && self.Position == other.Position
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.TotalPages == other.TotalPages
+            && self.Size == other.Size
+            && self.Submitted == other.Submitted
+            && self.Time == other.Time
+            && self.PagesPrinted == other.PagesPrinted
+            && self.SizeHigh == other.SizeHigh
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -16499,7 +16522,30 @@ unsafe impl ::windows::core::Abi for JOB_INFO_4W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for JOB_INFO_4W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_INFO_4W>()) == 0 }
+        self.JobId == other.JobId
+            && self.pPrinterName == other.pPrinterName
+            && self.pMachineName == other.pMachineName
+            && self.pUserName == other.pUserName
+            && self.pDocument == other.pDocument
+            && self.pNotifyName == other.pNotifyName
+            && self.pDatatype == other.pDatatype
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pParameters == other.pParameters
+            && self.pDriverName == other.pDriverName
+            && self.pDevMode == other.pDevMode
+            && self.pStatus == other.pStatus
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Status == other.Status
+            && self.Priority == other.Priority
+            && self.Position == other.Position
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.TotalPages == other.TotalPages
+            && self.Size == other.Size
+            && self.Submitted == other.Submitted
+            && self.Time == other.Time
+            && self.PagesPrinted == other.PagesPrinted
+            && self.SizeHigh == other.SizeHigh
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -16539,7 +16585,7 @@ unsafe impl ::windows::core::Abi for KERNDATA {
 #[cfg(feature = "Win32_Devices_Display")]
 impl ::core::cmp::PartialEq for KERNDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERNDATA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwKernPairNum == other.dwKernPairNum && self.KernPair == other.KernPair
     }
 }
 #[cfg(feature = "Win32_Devices_Display")]
@@ -16566,12 +16612,6 @@ impl ::core::clone::Clone for MAPTABLE {
 unsafe impl ::windows::core::Abi for MAPTABLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MAPTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPTABLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MAPTABLE {}
 impl ::core::default::Default for MAPTABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16609,7 +16649,7 @@ unsafe impl ::windows::core::Abi for MESSAGEBOX_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MESSAGEBOX_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MESSAGEBOX_PARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.pTitle == other.pTitle && self.pMessage == other.pMessage && self.Style == other.Style && self.dwTimeout == other.dwTimeout && self.bWait == other.bWait
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16675,7 +16715,7 @@ unsafe impl ::windows::core::Abi for MONITOR {
 }
 impl ::core::cmp::PartialEq for MONITOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR>()) == 0 }
+        self.pfnEnumPorts == other.pfnEnumPorts && self.pfnOpenPort == other.pfnOpenPort && self.pfnOpenPortEx == other.pfnOpenPortEx && self.pfnStartDocPort == other.pfnStartDocPort && self.pfnWritePort == other.pfnWritePort && self.pfnReadPort == other.pfnReadPort && self.pfnEndDocPort == other.pfnEndDocPort && self.pfnClosePort == other.pfnClosePort && self.pfnAddPort == other.pfnAddPort && self.pfnAddPortEx == other.pfnAddPortEx && self.pfnConfigurePort == other.pfnConfigurePort && self.pfnDeletePort == other.pfnDeletePort && self.pfnGetPrinterDataFromPort == other.pfnGetPrinterDataFromPort && self.pfnSetPortTimeOuts == other.pfnSetPortTimeOuts && self.pfnXcvOpenPort == other.pfnXcvOpenPort && self.pfnXcvDataPort == other.pfnXcvDataPort && self.pfnXcvClosePort == other.pfnXcvClosePort
     }
 }
 impl ::core::cmp::Eq for MONITOR {}
@@ -16751,7 +16791,29 @@ unsafe impl ::windows::core::Abi for MONITOR2 {
 }
 impl ::core::cmp::PartialEq for MONITOR2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR2>()) == 0 }
+        self.cbSize == other.cbSize
+            && self.pfnEnumPorts == other.pfnEnumPorts
+            && self.pfnOpenPort == other.pfnOpenPort
+            && self.pfnOpenPortEx == other.pfnOpenPortEx
+            && self.pfnStartDocPort == other.pfnStartDocPort
+            && self.pfnWritePort == other.pfnWritePort
+            && self.pfnReadPort == other.pfnReadPort
+            && self.pfnEndDocPort == other.pfnEndDocPort
+            && self.pfnClosePort == other.pfnClosePort
+            && self.pfnAddPort == other.pfnAddPort
+            && self.pfnAddPortEx == other.pfnAddPortEx
+            && self.pfnConfigurePort == other.pfnConfigurePort
+            && self.pfnDeletePort == other.pfnDeletePort
+            && self.pfnGetPrinterDataFromPort == other.pfnGetPrinterDataFromPort
+            && self.pfnSetPortTimeOuts == other.pfnSetPortTimeOuts
+            && self.pfnXcvOpenPort == other.pfnXcvOpenPort
+            && self.pfnXcvDataPort == other.pfnXcvDataPort
+            && self.pfnXcvClosePort == other.pfnXcvClosePort
+            && self.pfnShutdown == other.pfnShutdown
+            && self.pfnSendRecvBidiDataFromPort == other.pfnSendRecvBidiDataFromPort
+            && self.pfnNotifyUsedPorts == other.pfnNotifyUsedPorts
+            && self.pfnNotifyUnusedPorts == other.pfnNotifyUnusedPorts
+            && self.pfnPowerEvent == other.pfnPowerEvent
     }
 }
 impl ::core::cmp::Eq for MONITOR2 {}
@@ -16782,7 +16844,7 @@ unsafe impl ::windows::core::Abi for MONITOREX {
 }
 impl ::core::cmp::PartialEq for MONITOREX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOREX>()) == 0 }
+        self.dwMonitorSize == other.dwMonitorSize && self.Monitor == other.Monitor
     }
 }
 impl ::core::cmp::Eq for MONITOREX {}
@@ -16823,7 +16885,7 @@ unsafe impl ::windows::core::Abi for MONITORINIT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::cmp::PartialEq for MONITORINIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORINIT>()) == 0 }
+        self.cbSize == other.cbSize && self.hSpooler == other.hSpooler && self.hckRegistryRoot == other.hckRegistryRoot && self.pMonitorReg == other.pMonitorReg && self.bLocal == other.bLocal && self.pszServerName == other.pszServerName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
@@ -16865,7 +16927,7 @@ unsafe impl ::windows::core::Abi for MONITORREG {
 }
 impl ::core::cmp::PartialEq for MONITORREG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORREG>()) == 0 }
+        self.cbSize == other.cbSize && self.fpCreateKey == other.fpCreateKey && self.fpOpenKey == other.fpOpenKey && self.fpCloseKey == other.fpCloseKey && self.fpDeleteKey == other.fpDeleteKey && self.fpEnumKey == other.fpEnumKey && self.fpQueryInfoKey == other.fpQueryInfoKey && self.fpSetValue == other.fpSetValue && self.fpDeleteValue == other.fpDeleteValue && self.fpEnumValue == other.fpEnumValue && self.fpQueryValue == other.fpQueryValue
     }
 }
 impl ::core::cmp::Eq for MONITORREG {}
@@ -16898,7 +16960,7 @@ unsafe impl ::windows::core::Abi for MONITORUI {
 }
 impl ::core::cmp::PartialEq for MONITORUI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITORUI>()) == 0 }
+        self.dwMonitorUISize == other.dwMonitorUISize && self.pfnAddPortUI == other.pfnAddPortUI && self.pfnConfigurePortUI == other.pfnConfigurePortUI && self.pfnDeletePortUI == other.pfnDeletePortUI
     }
 }
 impl ::core::cmp::Eq for MONITORUI {}
@@ -16928,7 +16990,7 @@ unsafe impl ::windows::core::Abi for MONITOR_INFO_1A {
 }
 impl ::core::cmp::PartialEq for MONITOR_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR_INFO_1A>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for MONITOR_INFO_1A {}
@@ -16958,7 +17020,7 @@ unsafe impl ::windows::core::Abi for MONITOR_INFO_1W {
 }
 impl ::core::cmp::PartialEq for MONITOR_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR_INFO_1W>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for MONITOR_INFO_1W {}
@@ -16990,7 +17052,7 @@ unsafe impl ::windows::core::Abi for MONITOR_INFO_2A {
 }
 impl ::core::cmp::PartialEq for MONITOR_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR_INFO_2A>()) == 0 }
+        self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDLLName == other.pDLLName
     }
 }
 impl ::core::cmp::Eq for MONITOR_INFO_2A {}
@@ -17022,7 +17084,7 @@ unsafe impl ::windows::core::Abi for MONITOR_INFO_2W {
 }
 impl ::core::cmp::PartialEq for MONITOR_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR_INFO_2W>()) == 0 }
+        self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDLLName == other.pDLLName
     }
 }
 impl ::core::cmp::Eq for MONITOR_INFO_2W {}
@@ -17047,12 +17109,6 @@ impl ::core::clone::Clone for MXDC_ESCAPE_HEADER_T {
 unsafe impl ::windows::core::Abi for MXDC_ESCAPE_HEADER_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_ESCAPE_HEADER_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_ESCAPE_HEADER_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_ESCAPE_HEADER_T {}
 impl ::core::default::Default for MXDC_ESCAPE_HEADER_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17073,12 +17129,6 @@ impl ::core::clone::Clone for MXDC_GET_FILENAME_DATA_T {
 unsafe impl ::windows::core::Abi for MXDC_GET_FILENAME_DATA_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_GET_FILENAME_DATA_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_GET_FILENAME_DATA_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_GET_FILENAME_DATA_T {}
 impl ::core::default::Default for MXDC_GET_FILENAME_DATA_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17099,12 +17149,6 @@ impl ::core::clone::Clone for MXDC_PRINTTICKET_DATA_T {
 unsafe impl ::windows::core::Abi for MXDC_PRINTTICKET_DATA_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_PRINTTICKET_DATA_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_PRINTTICKET_DATA_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_PRINTTICKET_DATA_T {}
 impl ::core::default::Default for MXDC_PRINTTICKET_DATA_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17125,12 +17169,6 @@ impl ::core::clone::Clone for MXDC_PRINTTICKET_ESCAPE_T {
 unsafe impl ::windows::core::Abi for MXDC_PRINTTICKET_ESCAPE_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_PRINTTICKET_ESCAPE_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_PRINTTICKET_ESCAPE_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_PRINTTICKET_ESCAPE_T {}
 impl ::core::default::Default for MXDC_PRINTTICKET_ESCAPE_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17151,12 +17189,6 @@ impl ::core::clone::Clone for MXDC_S0PAGE_DATA_T {
 unsafe impl ::windows::core::Abi for MXDC_S0PAGE_DATA_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_S0PAGE_DATA_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_S0PAGE_DATA_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_S0PAGE_DATA_T {}
 impl ::core::default::Default for MXDC_S0PAGE_DATA_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17177,12 +17209,6 @@ impl ::core::clone::Clone for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
 unsafe impl ::windows::core::Abi for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {}
 impl ::core::default::Default for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17203,12 +17229,6 @@ impl ::core::clone::Clone for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
 unsafe impl ::windows::core::Abi for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_S0PAGE_RESOURCE_ESCAPE_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_S0PAGE_RESOURCE_ESCAPE_T {}
 impl ::core::default::Default for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17232,12 +17252,6 @@ impl ::core::clone::Clone for MXDC_XPS_S0PAGE_RESOURCE_T {
 unsafe impl ::windows::core::Abi for MXDC_XPS_S0PAGE_RESOURCE_T {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MXDC_XPS_S0PAGE_RESOURCE_T {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MXDC_XPS_S0PAGE_RESOURCE_T>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MXDC_XPS_S0PAGE_RESOURCE_T {}
 impl ::core::default::Default for MXDC_XPS_S0PAGE_RESOURCE_T {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17263,21 +17277,13 @@ impl ::core::clone::Clone for NOTIFICATION_CONFIG_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for NOTIFICATION_CONFIG_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NOTIFICATION_CONFIG_1").field("cbSize", &self.cbSize).field("fdwFlags", &self.fdwFlags).field("pfnNotifyCallback", &self.pfnNotifyCallback.map(|f| f as usize)).field("pContext", &self.pContext).finish()
+        f.debug_struct("NOTIFICATION_CONFIG_1").field("cbSize", &self.cbSize).field("fdwFlags", &self.fdwFlags).field("pContext", &self.pContext).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for NOTIFICATION_CONFIG_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NOTIFICATION_CONFIG_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFICATION_CONFIG_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NOTIFICATION_CONFIG_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NOTIFICATION_CONFIG_1 {
     fn default() -> Self {
@@ -17330,7 +17336,6 @@ impl ::core::fmt::Debug for OEMCUIPPARAM {
             .field("pOEMOptItems", &self.pOEMOptItems)
             .field("cOEMOptItems", &self.cOEMOptItems)
             .field("pOEMUserData", &self.pOEMUserData)
-            .field("OEMCUIPCallback", &self.OEMCUIPCallback.map(|f| f as usize))
             .finish()
     }
 }
@@ -17338,14 +17343,6 @@ impl ::core::fmt::Debug for OEMCUIPPARAM {
 unsafe impl ::windows::core::Abi for OEMCUIPPARAM {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OEMCUIPPARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMCUIPPARAM>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OEMCUIPPARAM {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OEMCUIPPARAM {
     fn default() -> Self {
@@ -17387,7 +17384,7 @@ unsafe impl ::windows::core::Abi for OEMDMPARAM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for OEMDMPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMDMPARAM>()) == 0 }
+        self.cbSize == other.cbSize && self.pdriverobj == other.pdriverobj && self.hPrinter == other.hPrinter && self.hModule == other.hModule && self.pPublicDMIn == other.pPublicDMIn && self.pPublicDMOut == other.pPublicDMOut && self.pOEMDMIn == other.pOEMDMIn && self.pOEMDMOut == other.pOEMDMOut && self.cbBufSize == other.cbBufSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -17430,7 +17427,7 @@ unsafe impl ::windows::core::Abi for OEMFONTINSTPARAM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OEMFONTINSTPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMFONTINSTPARAM>()) == 0 }
+        self.cbSize == other.cbSize && self.hPrinter == other.hPrinter && self.hModule == other.hModule && self.hHeap == other.hHeap && self.dwFlags == other.dwFlags && self.pFontInstallerName == other.pFontInstallerName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17469,7 +17466,7 @@ unsafe impl ::windows::core::Abi for OEMUIOBJ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OEMUIOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMUIOBJ>()) == 0 }
+        self.cbSize == other.cbSize && self.pOemUIProcs == other.pOemUIProcs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17498,21 +17495,13 @@ impl ::core::clone::Clone for OEMUIPROCS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for OEMUIPROCS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OEMUIPROCS").field("DrvGetDriverSetting", &self.DrvGetDriverSetting.map(|f| f as usize)).field("DrvUpdateUISetting", &self.DrvUpdateUISetting.map(|f| f as usize)).finish()
+        f.debug_struct("OEMUIPROCS").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for OEMUIPROCS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OEMUIPROCS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMUIPROCS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OEMUIPROCS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OEMUIPROCS {
     fn default() -> Self {
@@ -17556,7 +17545,7 @@ unsafe impl ::windows::core::Abi for OEMUIPSPARAM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for OEMUIPSPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEMUIPSPARAM>()) == 0 }
+        self.cbSize == other.cbSize && self.poemuiobj == other.poemuiobj && self.hPrinter == other.hPrinter && self.pPrinterName == other.pPrinterName && self.hModule == other.hModule && self.hOEMHeap == other.hOEMHeap && self.pPublicDM == other.pPublicDM && self.pOEMDM == other.pOEMDM && self.pOEMUserData == other.pOEMUserData && self.dwFlags == other.dwFlags && self.pOemEntry == other.pOemEntry
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -17590,7 +17579,7 @@ unsafe impl ::windows::core::Abi for OEM_DMEXTRAHEADER {
 }
 impl ::core::cmp::PartialEq for OEM_DMEXTRAHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OEM_DMEXTRAHEADER>()) == 0 }
+        self.dwSize == other.dwSize && self.dwSignature == other.dwSignature && self.dwVersion == other.dwVersion
     }
 }
 impl ::core::cmp::Eq for OEM_DMEXTRAHEADER {}
@@ -17630,7 +17619,7 @@ unsafe impl ::windows::core::Abi for OIEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OIEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OIEXT>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.hInstCaller == other.hInstCaller && self.pHelpFile == other.pHelpFile && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17673,7 +17662,7 @@ unsafe impl ::windows::core::Abi for OPTCOMBO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPTCOMBO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTCOMBO>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.cListItem == other.cListItem && self.pListItem == other.pListItem && self.Sel == other.Sel && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17717,14 +17706,6 @@ unsafe impl ::windows::core::Abi for OPTITEM {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OPTITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTITEM>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OPTITEM {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OPTITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17750,14 +17731,6 @@ unsafe impl ::windows::core::Abi for OPTITEM_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OPTITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTITEM_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OPTITEM_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OPTITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17782,14 +17755,6 @@ impl ::core::clone::Clone for OPTITEM_1 {
 unsafe impl ::windows::core::Abi for OPTITEM_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OPTITEM_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTITEM_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OPTITEM_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OPTITEM_1 {
     fn default() -> Self {
@@ -17829,7 +17794,7 @@ unsafe impl ::windows::core::Abi for OPTPARAM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPTPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTPARAM>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.Style == other.Style && self.pData == other.pData && self.IconID == other.IconID && self.lParam == other.lParam && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17875,7 +17840,7 @@ unsafe impl ::windows::core::Abi for OPTTYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPTTYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTTYPE>()) == 0 }
+        self.cbSize == other.cbSize && self.Type == other.Type && self.Flags == other.Flags && self.Count == other.Count && self.BegCtrlID == other.BegCtrlID && self.pOptParam == other.pOptParam && self.Style == other.Style && self.wReserved == other.wReserved && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17935,7 +17900,7 @@ unsafe impl ::windows::core::Abi for PORT_DATA_1 {
 }
 impl ::core::cmp::PartialEq for PORT_DATA_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_DATA_1>()) == 0 }
+        self.sztPortName == other.sztPortName && self.dwVersion == other.dwVersion && self.dwProtocol == other.dwProtocol && self.cbSize == other.cbSize && self.dwReserved == other.dwReserved && self.sztHostAddress == other.sztHostAddress && self.sztSNMPCommunity == other.sztSNMPCommunity && self.dwDoubleSpool == other.dwDoubleSpool && self.sztQueue == other.sztQueue && self.sztIPAddress == other.sztIPAddress && self.Reserved == other.Reserved && self.dwPortNumber == other.dwPortNumber && self.dwSNMPEnabled == other.dwSNMPEnabled && self.dwSNMPDevIndex == other.dwSNMPDevIndex
     }
 }
 impl ::core::cmp::Eq for PORT_DATA_1 {}
@@ -17993,7 +17958,7 @@ unsafe impl ::windows::core::Abi for PORT_DATA_2 {
 }
 impl ::core::cmp::PartialEq for PORT_DATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_DATA_2>()) == 0 }
+        self.sztPortName == other.sztPortName && self.dwVersion == other.dwVersion && self.dwProtocol == other.dwProtocol && self.cbSize == other.cbSize && self.dwReserved == other.dwReserved && self.sztHostAddress == other.sztHostAddress && self.sztSNMPCommunity == other.sztSNMPCommunity && self.dwDoubleSpool == other.dwDoubleSpool && self.sztQueue == other.sztQueue && self.Reserved == other.Reserved && self.dwPortNumber == other.dwPortNumber && self.dwSNMPEnabled == other.dwSNMPEnabled && self.dwSNMPDevIndex == other.dwSNMPDevIndex && self.dwPortMonitorMibIndex == other.dwPortMonitorMibIndex
     }
 }
 impl ::core::cmp::Eq for PORT_DATA_2 {}
@@ -18025,7 +17990,7 @@ unsafe impl ::windows::core::Abi for PORT_DATA_LIST_1 {
 }
 impl ::core::cmp::PartialEq for PORT_DATA_LIST_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_DATA_LIST_1>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cPortData == other.cPortData && self.pPortData == other.pPortData
     }
 }
 impl ::core::cmp::Eq for PORT_DATA_LIST_1 {}
@@ -18055,7 +18020,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_1A {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_1A>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_1A {}
@@ -18085,7 +18050,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_1W {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_1W>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_1W {}
@@ -18119,7 +18084,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_2A {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_2A>()) == 0 }
+        self.pPortName == other.pPortName && self.pMonitorName == other.pMonitorName && self.pDescription == other.pDescription && self.fPortType == other.fPortType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_2A {}
@@ -18153,7 +18118,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_2W {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_2W>()) == 0 }
+        self.pPortName == other.pPortName && self.pMonitorName == other.pMonitorName && self.pDescription == other.pDescription && self.fPortType == other.fPortType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_2W {}
@@ -18185,7 +18150,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_3A {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_3A>()) == 0 }
+        self.dwStatus == other.dwStatus && self.pszStatus == other.pszStatus && self.dwSeverity == other.dwSeverity
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_3A {}
@@ -18217,7 +18182,7 @@ unsafe impl ::windows::core::Abi for PORT_INFO_3W {
 }
 impl ::core::cmp::PartialEq for PORT_INFO_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PORT_INFO_3W>()) == 0 }
+        self.dwStatus == other.dwStatus && self.pszStatus == other.pszStatus && self.dwSeverity == other.dwSeverity
     }
 }
 impl ::core::cmp::Eq for PORT_INFO_3W {}
@@ -18248,7 +18213,7 @@ unsafe impl ::windows::core::Abi for PRINTER_CONNECTION_INFO_1A {
 }
 impl ::core::cmp::PartialEq for PRINTER_CONNECTION_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_CONNECTION_INFO_1A>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pszDriverName == other.pszDriverName
     }
 }
 impl ::core::cmp::Eq for PRINTER_CONNECTION_INFO_1A {}
@@ -18279,7 +18244,7 @@ unsafe impl ::windows::core::Abi for PRINTER_CONNECTION_INFO_1W {
 }
 impl ::core::cmp::PartialEq for PRINTER_CONNECTION_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_CONNECTION_INFO_1W>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pszDriverName == other.pszDriverName
     }
 }
 impl ::core::cmp::Eq for PRINTER_CONNECTION_INFO_1W {}
@@ -18317,7 +18282,7 @@ unsafe impl ::windows::core::Abi for PRINTER_DEFAULTSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_DEFAULTSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_DEFAULTSA>()) == 0 }
+        self.pDatatype == other.pDatatype && self.pDevMode == other.pDevMode && self.DesiredAccess == other.DesiredAccess
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -18357,7 +18322,7 @@ unsafe impl ::windows::core::Abi for PRINTER_DEFAULTSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_DEFAULTSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_DEFAULTSW>()) == 0 }
+        self.pDatatype == other.pDatatype && self.pDevMode == other.pDevMode && self.DesiredAccess == other.DesiredAccess
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -18393,7 +18358,7 @@ unsafe impl ::windows::core::Abi for PRINTER_ENUM_VALUESA {
 }
 impl ::core::cmp::PartialEq for PRINTER_ENUM_VALUESA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_ENUM_VALUESA>()) == 0 }
+        self.pValueName == other.pValueName && self.cbValueName == other.cbValueName && self.dwType == other.dwType && self.pData == other.pData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for PRINTER_ENUM_VALUESA {}
@@ -18427,7 +18392,7 @@ unsafe impl ::windows::core::Abi for PRINTER_ENUM_VALUESW {
 }
 impl ::core::cmp::PartialEq for PRINTER_ENUM_VALUESW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_ENUM_VALUESW>()) == 0 }
+        self.pValueName == other.pValueName && self.cbValueName == other.cbValueName && self.dwType == other.dwType && self.pData == other.pData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for PRINTER_ENUM_VALUESW {}
@@ -18459,7 +18424,7 @@ unsafe impl ::windows::core::Abi for PRINTER_EVENT_ATTRIBUTES_INFO {
 }
 impl ::core::cmp::PartialEq for PRINTER_EVENT_ATTRIBUTES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_EVENT_ATTRIBUTES_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwOldAttributes == other.dwOldAttributes && self.dwNewAttributes == other.dwNewAttributes
     }
 }
 impl ::core::cmp::Eq for PRINTER_EVENT_ATTRIBUTES_INFO {}
@@ -18492,7 +18457,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_1A {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_1A>()) == 0 }
+        self.Flags == other.Flags && self.pDescription == other.pDescription && self.pName == other.pName && self.pComment == other.pComment
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_1A {}
@@ -18525,7 +18490,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_1W {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_1W>()) == 0 }
+        self.Flags == other.Flags && self.pDescription == other.pDescription && self.pName == other.pName && self.pComment == other.pComment
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_1W {}
@@ -18603,7 +18568,27 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_2A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_2A>()) == 0 }
+        self.pServerName == other.pServerName
+            && self.pPrinterName == other.pPrinterName
+            && self.pShareName == other.pShareName
+            && self.pPortName == other.pPortName
+            && self.pDriverName == other.pDriverName
+            && self.pComment == other.pComment
+            && self.pLocation == other.pLocation
+            && self.pDevMode == other.pDevMode
+            && self.pSepFile == other.pSepFile
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pDatatype == other.pDatatype
+            && self.pParameters == other.pParameters
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Attributes == other.Attributes
+            && self.Priority == other.Priority
+            && self.DefaultPriority == other.DefaultPriority
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.Status == other.Status
+            && self.cJobs == other.cJobs
+            && self.AveragePPM == other.AveragePPM
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -18683,7 +18668,27 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_2W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_2W>()) == 0 }
+        self.pServerName == other.pServerName
+            && self.pPrinterName == other.pPrinterName
+            && self.pShareName == other.pShareName
+            && self.pPortName == other.pPortName
+            && self.pDriverName == other.pDriverName
+            && self.pComment == other.pComment
+            && self.pLocation == other.pLocation
+            && self.pDevMode == other.pDevMode
+            && self.pSepFile == other.pSepFile
+            && self.pPrintProcessor == other.pPrintProcessor
+            && self.pDatatype == other.pDatatype
+            && self.pParameters == other.pParameters
+            && self.pSecurityDescriptor == other.pSecurityDescriptor
+            && self.Attributes == other.Attributes
+            && self.Priority == other.Priority
+            && self.DefaultPriority == other.DefaultPriority
+            && self.StartTime == other.StartTime
+            && self.UntilTime == other.UntilTime
+            && self.Status == other.Status
+            && self.cJobs == other.cJobs
+            && self.AveragePPM == other.AveragePPM
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_SystemServices"))]
@@ -18721,7 +18726,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_3 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for PRINTER_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_3>()) == 0 }
+        self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -18755,7 +18760,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_4A {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_4A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_4A>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pServerName == other.pServerName && self.Attributes == other.Attributes
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_4A {}
@@ -18787,7 +18792,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_4W {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_4W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_4W>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pServerName == other.pServerName && self.Attributes == other.Attributes
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_4W {}
@@ -18821,7 +18826,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_5A {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_5A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_5A>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pPortName == other.pPortName && self.Attributes == other.Attributes && self.DeviceNotSelectedTimeout == other.DeviceNotSelectedTimeout && self.TransmissionRetryTimeout == other.TransmissionRetryTimeout
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_5A {}
@@ -18855,7 +18860,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_5W {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_5W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_5W>()) == 0 }
+        self.pPrinterName == other.pPrinterName && self.pPortName == other.pPortName && self.Attributes == other.Attributes && self.DeviceNotSelectedTimeout == other.DeviceNotSelectedTimeout && self.TransmissionRetryTimeout == other.TransmissionRetryTimeout
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_5W {}
@@ -18885,7 +18890,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_6 {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_6>()) == 0 }
+        self.dwStatus == other.dwStatus
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_6 {}
@@ -18916,7 +18921,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_7A {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_7A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_7A>()) == 0 }
+        self.pszObjectGUID == other.pszObjectGUID && self.dwAction == other.dwAction
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_7A {}
@@ -18947,7 +18952,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_7W {
 }
 impl ::core::cmp::PartialEq for PRINTER_INFO_7W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_7W>()) == 0 }
+        self.pszObjectGUID == other.pszObjectGUID && self.dwAction == other.dwAction
     }
 }
 impl ::core::cmp::Eq for PRINTER_INFO_7W {}
@@ -18983,7 +18988,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_8A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_8A>()) == 0 }
+        self.pDevMode == other.pDevMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -19021,7 +19026,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_8W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_8W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_8W>()) == 0 }
+        self.pDevMode == other.pDevMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -19059,7 +19064,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_9A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_9A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_9A>()) == 0 }
+        self.pDevMode == other.pDevMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -19097,7 +19102,7 @@ unsafe impl ::windows::core::Abi for PRINTER_INFO_9W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTER_INFO_9W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_INFO_9W>()) == 0 }
+        self.pDevMode == other.pDevMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -19125,12 +19130,6 @@ impl ::core::clone::Clone for PRINTER_NOTIFY_INFO {
 unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRINTER_NOTIFY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRINTER_NOTIFY_INFO {}
 impl ::core::default::Default for PRINTER_NOTIFY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19154,12 +19153,6 @@ impl ::core::clone::Clone for PRINTER_NOTIFY_INFO_DATA {
 unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_INFO_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRINTER_NOTIFY_INFO_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_INFO_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRINTER_NOTIFY_INFO_DATA {}
 impl ::core::default::Default for PRINTER_NOTIFY_INFO_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19180,12 +19173,6 @@ impl ::core::clone::Clone for PRINTER_NOTIFY_INFO_DATA_0 {
 unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_INFO_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRINTER_NOTIFY_INFO_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_INFO_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRINTER_NOTIFY_INFO_DATA_0 {}
 impl ::core::default::Default for PRINTER_NOTIFY_INFO_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19213,7 +19200,7 @@ unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_INFO_DATA_0_0 {
 }
 impl ::core::cmp::PartialEq for PRINTER_NOTIFY_INFO_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_INFO_DATA_0_0>()) == 0 }
+        self.cbBuf == other.cbBuf && self.pBuf == other.pBuf
     }
 }
 impl ::core::cmp::Eq for PRINTER_NOTIFY_INFO_DATA_0_0 {}
@@ -19245,7 +19232,7 @@ unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_INIT {
 }
 impl ::core::cmp::PartialEq for PRINTER_NOTIFY_INIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_INIT>()) == 0 }
+        self.Size == other.Size && self.Reserved == other.Reserved && self.PollTime == other.PollTime
     }
 }
 impl ::core::cmp::Eq for PRINTER_NOTIFY_INIT {}
@@ -19278,7 +19265,7 @@ unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_OPTIONS {
 }
 impl ::core::cmp::PartialEq for PRINTER_NOTIFY_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_OPTIONS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Count == other.Count && self.pTypes == other.pTypes
     }
 }
 impl ::core::cmp::Eq for PRINTER_NOTIFY_OPTIONS {}
@@ -19313,7 +19300,7 @@ unsafe impl ::windows::core::Abi for PRINTER_NOTIFY_OPTIONS_TYPE {
 }
 impl ::core::cmp::PartialEq for PRINTER_NOTIFY_OPTIONS_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_NOTIFY_OPTIONS_TYPE>()) == 0 }
+        self.Type == other.Type && self.Reserved0 == other.Reserved0 && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Count == other.Count && self.pFields == other.pFields
     }
 }
 impl ::core::cmp::Eq for PRINTER_NOTIFY_OPTIONS_TYPE {}
@@ -19344,7 +19331,7 @@ unsafe impl ::windows::core::Abi for PRINTER_OPTIONSA {
 }
 impl ::core::cmp::PartialEq for PRINTER_OPTIONSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_OPTIONSA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for PRINTER_OPTIONSA {}
@@ -19375,7 +19362,7 @@ unsafe impl ::windows::core::Abi for PRINTER_OPTIONSW {
 }
 impl ::core::cmp::PartialEq for PRINTER_OPTIONSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTER_OPTIONSW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for PRINTER_OPTIONSW {}
@@ -19529,7 +19516,65 @@ unsafe impl ::windows::core::Abi for PRINTIFI32 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for PRINTIFI32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTIFI32>()) == 0 }
+        self.cjThis == other.cjThis
+            && self.cjIfiExtra == other.cjIfiExtra
+            && self.dpwszFamilyName == other.dpwszFamilyName
+            && self.dpwszStyleName == other.dpwszStyleName
+            && self.dpwszFaceName == other.dpwszFaceName
+            && self.dpwszUniqueName == other.dpwszUniqueName
+            && self.dpFontSim == other.dpFontSim
+            && self.lEmbedId == other.lEmbedId
+            && self.lItalicAngle == other.lItalicAngle
+            && self.lCharBias == other.lCharBias
+            && self.dpCharSets == other.dpCharSets
+            && self.jWinCharSet == other.jWinCharSet
+            && self.jWinPitchAndFamily == other.jWinPitchAndFamily
+            && self.usWinWeight == other.usWinWeight
+            && self.flInfo == other.flInfo
+            && self.fsSelection == other.fsSelection
+            && self.fsType == other.fsType
+            && self.fwdUnitsPerEm == other.fwdUnitsPerEm
+            && self.fwdLowestPPEm == other.fwdLowestPPEm
+            && self.fwdWinAscender == other.fwdWinAscender
+            && self.fwdWinDescender == other.fwdWinDescender
+            && self.fwdMacAscender == other.fwdMacAscender
+            && self.fwdMacDescender == other.fwdMacDescender
+            && self.fwdMacLineGap == other.fwdMacLineGap
+            && self.fwdTypoAscender == other.fwdTypoAscender
+            && self.fwdTypoDescender == other.fwdTypoDescender
+            && self.fwdTypoLineGap == other.fwdTypoLineGap
+            && self.fwdAveCharWidth == other.fwdAveCharWidth
+            && self.fwdMaxCharInc == other.fwdMaxCharInc
+            && self.fwdCapHeight == other.fwdCapHeight
+            && self.fwdXHeight == other.fwdXHeight
+            && self.fwdSubscriptXSize == other.fwdSubscriptXSize
+            && self.fwdSubscriptYSize == other.fwdSubscriptYSize
+            && self.fwdSubscriptXOffset == other.fwdSubscriptXOffset
+            && self.fwdSubscriptYOffset == other.fwdSubscriptYOffset
+            && self.fwdSuperscriptXSize == other.fwdSuperscriptXSize
+            && self.fwdSuperscriptYSize == other.fwdSuperscriptYSize
+            && self.fwdSuperscriptXOffset == other.fwdSuperscriptXOffset
+            && self.fwdSuperscriptYOffset == other.fwdSuperscriptYOffset
+            && self.fwdUnderscoreSize == other.fwdUnderscoreSize
+            && self.fwdUnderscorePosition == other.fwdUnderscorePosition
+            && self.fwdStrikeoutSize == other.fwdStrikeoutSize
+            && self.fwdStrikeoutPosition == other.fwdStrikeoutPosition
+            && self.chFirstChar == other.chFirstChar
+            && self.chLastChar == other.chLastChar
+            && self.chDefaultChar == other.chDefaultChar
+            && self.chBreakChar == other.chBreakChar
+            && self.wcFirstChar == other.wcFirstChar
+            && self.wcLastChar == other.wcLastChar
+            && self.wcDefaultChar == other.wcDefaultChar
+            && self.wcBreakChar == other.wcBreakChar
+            && self.ptlBaseline == other.ptlBaseline
+            && self.ptlAspect == other.ptlAspect
+            && self.ptlCaret == other.ptlCaret
+            && self.rclFontBox == other.rclFontBox
+            && self.achVendId == other.achVendId
+            && self.cKerningPairs == other.cKerningPairs
+            && self.ulPanoseCulture == other.ulPanoseCulture
+            && self.panose == other.panose
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -19573,7 +19618,7 @@ unsafe impl ::windows::core::Abi for PRINTPROCESSOROPENDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::cmp::PartialEq for PRINTPROCESSOROPENDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROCESSOROPENDATA>()) == 0 }
+        self.pDevMode == other.pDevMode && self.pDatatype == other.pDatatype && self.pParameters == other.pParameters && self.pDocumentName == other.pDocumentName && self.JobId == other.JobId && self.pOutputFile == other.pOutputFile && self.pPrinterName == other.pPrinterName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -19608,7 +19653,7 @@ unsafe impl ::windows::core::Abi for PRINTPROCESSOR_CAPS_1 {
 }
 impl ::core::cmp::PartialEq for PRINTPROCESSOR_CAPS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROCESSOR_CAPS_1>()) == 0 }
+        self.dwLevel == other.dwLevel && self.dwNupOptions == other.dwNupOptions && self.dwPageOrderFlags == other.dwPageOrderFlags && self.dwNumberOfCopies == other.dwNumberOfCopies
     }
 }
 impl ::core::cmp::Eq for PRINTPROCESSOR_CAPS_1 {}
@@ -19656,7 +19701,7 @@ unsafe impl ::windows::core::Abi for PRINTPROCESSOR_CAPS_2 {
 }
 impl ::core::cmp::PartialEq for PRINTPROCESSOR_CAPS_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROCESSOR_CAPS_2>()) == 0 }
+        self.dwLevel == other.dwLevel && self.dwNupOptions == other.dwNupOptions && self.dwPageOrderFlags == other.dwPageOrderFlags && self.dwNumberOfCopies == other.dwNumberOfCopies && self.dwDuplexHandlingCaps == other.dwDuplexHandlingCaps && self.dwNupDirectionCaps == other.dwNupDirectionCaps && self.dwNupBorderCaps == other.dwNupBorderCaps && self.dwBookletHandlingCaps == other.dwBookletHandlingCaps && self.dwScalingCaps == other.dwScalingCaps
     }
 }
 impl ::core::cmp::Eq for PRINTPROCESSOR_CAPS_2 {}
@@ -19686,7 +19731,7 @@ unsafe impl ::windows::core::Abi for PRINTPROCESSOR_INFO_1A {
 }
 impl ::core::cmp::PartialEq for PRINTPROCESSOR_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROCESSOR_INFO_1A>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for PRINTPROCESSOR_INFO_1A {}
@@ -19716,7 +19761,7 @@ unsafe impl ::windows::core::Abi for PRINTPROCESSOR_INFO_1W {
 }
 impl ::core::cmp::PartialEq for PRINTPROCESSOR_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROCESSOR_INFO_1W>()) == 0 }
+        self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for PRINTPROCESSOR_INFO_1W {}
@@ -19958,7 +20003,112 @@ unsafe impl ::windows::core::Abi for PRINTPROVIDOR {
 }
 impl ::core::cmp::PartialEq for PRINTPROVIDOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPROVIDOR>()) == 0 }
+        self.fpOpenPrinter == other.fpOpenPrinter
+            && self.fpSetJob == other.fpSetJob
+            && self.fpGetJob == other.fpGetJob
+            && self.fpEnumJobs == other.fpEnumJobs
+            && self.fpAddPrinter == other.fpAddPrinter
+            && self.fpDeletePrinter == other.fpDeletePrinter
+            && self.fpSetPrinter == other.fpSetPrinter
+            && self.fpGetPrinter == other.fpGetPrinter
+            && self.fpEnumPrinters == other.fpEnumPrinters
+            && self.fpAddPrinterDriver == other.fpAddPrinterDriver
+            && self.fpEnumPrinterDrivers == other.fpEnumPrinterDrivers
+            && self.fpGetPrinterDriver == other.fpGetPrinterDriver
+            && self.fpGetPrinterDriverDirectory == other.fpGetPrinterDriverDirectory
+            && self.fpDeletePrinterDriver == other.fpDeletePrinterDriver
+            && self.fpAddPrintProcessor == other.fpAddPrintProcessor
+            && self.fpEnumPrintProcessors == other.fpEnumPrintProcessors
+            && self.fpGetPrintProcessorDirectory == other.fpGetPrintProcessorDirectory
+            && self.fpDeletePrintProcessor == other.fpDeletePrintProcessor
+            && self.fpEnumPrintProcessorDatatypes == other.fpEnumPrintProcessorDatatypes
+            && self.fpStartDocPrinter == other.fpStartDocPrinter
+            && self.fpStartPagePrinter == other.fpStartPagePrinter
+            && self.fpWritePrinter == other.fpWritePrinter
+            && self.fpEndPagePrinter == other.fpEndPagePrinter
+            && self.fpAbortPrinter == other.fpAbortPrinter
+            && self.fpReadPrinter == other.fpReadPrinter
+            && self.fpEndDocPrinter == other.fpEndDocPrinter
+            && self.fpAddJob == other.fpAddJob
+            && self.fpScheduleJob == other.fpScheduleJob
+            && self.fpGetPrinterData == other.fpGetPrinterData
+            && self.fpSetPrinterData == other.fpSetPrinterData
+            && self.fpWaitForPrinterChange == other.fpWaitForPrinterChange
+            && self.fpClosePrinter == other.fpClosePrinter
+            && self.fpAddForm == other.fpAddForm
+            && self.fpDeleteForm == other.fpDeleteForm
+            && self.fpGetForm == other.fpGetForm
+            && self.fpSetForm == other.fpSetForm
+            && self.fpEnumForms == other.fpEnumForms
+            && self.fpEnumMonitors == other.fpEnumMonitors
+            && self.fpEnumPorts == other.fpEnumPorts
+            && self.fpAddPort == other.fpAddPort
+            && self.fpConfigurePort == other.fpConfigurePort
+            && self.fpDeletePort == other.fpDeletePort
+            && self.fpCreatePrinterIC == other.fpCreatePrinterIC
+            && self.fpPlayGdiScriptOnPrinterIC == other.fpPlayGdiScriptOnPrinterIC
+            && self.fpDeletePrinterIC == other.fpDeletePrinterIC
+            && self.fpAddPrinterConnection == other.fpAddPrinterConnection
+            && self.fpDeletePrinterConnection == other.fpDeletePrinterConnection
+            && self.fpPrinterMessageBox == other.fpPrinterMessageBox
+            && self.fpAddMonitor == other.fpAddMonitor
+            && self.fpDeleteMonitor == other.fpDeleteMonitor
+            && self.fpResetPrinter == other.fpResetPrinter
+            && self.fpGetPrinterDriverEx == other.fpGetPrinterDriverEx
+            && self.fpFindFirstPrinterChangeNotification == other.fpFindFirstPrinterChangeNotification
+            && self.fpFindClosePrinterChangeNotification == other.fpFindClosePrinterChangeNotification
+            && self.fpAddPortEx == other.fpAddPortEx
+            && self.fpShutDown == other.fpShutDown
+            && self.fpRefreshPrinterChangeNotification == other.fpRefreshPrinterChangeNotification
+            && self.fpOpenPrinterEx == other.fpOpenPrinterEx
+            && self.fpAddPrinterEx == other.fpAddPrinterEx
+            && self.fpSetPort == other.fpSetPort
+            && self.fpEnumPrinterData == other.fpEnumPrinterData
+            && self.fpDeletePrinterData == other.fpDeletePrinterData
+            && self.fpClusterSplOpen == other.fpClusterSplOpen
+            && self.fpClusterSplClose == other.fpClusterSplClose
+            && self.fpClusterSplIsAlive == other.fpClusterSplIsAlive
+            && self.fpSetPrinterDataEx == other.fpSetPrinterDataEx
+            && self.fpGetPrinterDataEx == other.fpGetPrinterDataEx
+            && self.fpEnumPrinterDataEx == other.fpEnumPrinterDataEx
+            && self.fpEnumPrinterKey == other.fpEnumPrinterKey
+            && self.fpDeletePrinterDataEx == other.fpDeletePrinterDataEx
+            && self.fpDeletePrinterKey == other.fpDeletePrinterKey
+            && self.fpSeekPrinter == other.fpSeekPrinter
+            && self.fpDeletePrinterDriverEx == other.fpDeletePrinterDriverEx
+            && self.fpAddPerMachineConnection == other.fpAddPerMachineConnection
+            && self.fpDeletePerMachineConnection == other.fpDeletePerMachineConnection
+            && self.fpEnumPerMachineConnections == other.fpEnumPerMachineConnections
+            && self.fpXcvData == other.fpXcvData
+            && self.fpAddPrinterDriverEx == other.fpAddPrinterDriverEx
+            && self.fpSplReadPrinter == other.fpSplReadPrinter
+            && self.fpDriverUnloadComplete == other.fpDriverUnloadComplete
+            && self.fpGetSpoolFileInfo == other.fpGetSpoolFileInfo
+            && self.fpCommitSpoolData == other.fpCommitSpoolData
+            && self.fpCloseSpoolFileHandle == other.fpCloseSpoolFileHandle
+            && self.fpFlushPrinter == other.fpFlushPrinter
+            && self.fpSendRecvBidiData == other.fpSendRecvBidiData
+            && self.fpAddPrinterConnection2 == other.fpAddPrinterConnection2
+            && self.fpGetPrintClassObject == other.fpGetPrintClassObject
+            && self.fpReportJobProcessingProgress == other.fpReportJobProcessingProgress
+            && self.fpEnumAndLogProvidorObjects == other.fpEnumAndLogProvidorObjects
+            && self.fpInternalGetPrinterDriver == other.fpInternalGetPrinterDriver
+            && self.fpFindCompatibleDriver == other.fpFindCompatibleDriver
+            && self.fpGetJobNamedPropertyValue == other.fpGetJobNamedPropertyValue
+            && self.fpSetJobNamedProperty == other.fpSetJobNamedProperty
+            && self.fpDeleteJobNamedProperty == other.fpDeleteJobNamedProperty
+            && self.fpEnumJobNamedProperties == other.fpEnumJobNamedProperties
+            && self.fpPowerEvent == other.fpPowerEvent
+            && self.fpGetUserPropertyBag == other.fpGetUserPropertyBag
+            && self.fpCanShutdown == other.fpCanShutdown
+            && self.fpLogJobInfoForBranchOffice == other.fpLogJobInfoForBranchOffice
+            && self.fpRegeneratePrintDeviceCapabilities == other.fpRegeneratePrintDeviceCapabilities
+            && self.fpPrintSupportOperation == other.fpPrintSupportOperation
+            && self.fpIppCreateJobOnPrinter == other.fpIppCreateJobOnPrinter
+            && self.fpIppGetJobAttributes == other.fpIppGetJobAttributes
+            && self.fpIppSetJobAttributes == other.fpIppSetJobAttributes
+            && self.fpIppGetPrinterAttributes == other.fpIppGetPrinterAttributes
+            && self.fpIppSetPrinterAttributes == other.fpIppSetPrinterAttributes
     }
 }
 impl ::core::cmp::Eq for PRINTPROVIDOR {}
@@ -19989,7 +20139,7 @@ unsafe impl ::windows::core::Abi for PRINT_EXECUTION_DATA {
 }
 impl ::core::cmp::PartialEq for PRINT_EXECUTION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINT_EXECUTION_DATA>()) == 0 }
+        self.context == other.context && self.clientAppPID == other.clientAppPID
     }
 }
 impl ::core::cmp::Eq for PRINT_EXECUTION_DATA {}
@@ -20020,7 +20170,7 @@ unsafe impl ::windows::core::Abi for PRINT_FEATURE_OPTION {
 }
 impl ::core::cmp::PartialEq for PRINT_FEATURE_OPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINT_FEATURE_OPTION>()) == 0 }
+        self.pszFeature == other.pszFeature && self.pszOption == other.pszOption
     }
 }
 impl ::core::cmp::Eq for PRINT_FEATURE_OPTION {}
@@ -20060,7 +20210,7 @@ unsafe impl ::windows::core::Abi for PROPSHEETUI_GETICON_INFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for PROPSHEETUI_GETICON_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETUI_GETICON_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.Flags == other.Flags && self.cxIcon == other.cxIcon && self.cyIcon == other.cyIcon && self.hIcon == other.hIcon
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -20096,21 +20246,13 @@ impl ::core::clone::Clone for PROPSHEETUI_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PROPSHEETUI_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PROPSHEETUI_INFO").field("cbSize", &self.cbSize).field("Version", &self.Version).field("Flags", &self.Flags).field("Reason", &self.Reason).field("hComPropSheet", &self.hComPropSheet).field("pfnComPropSheet", &self.pfnComPropSheet.map(|f| f as usize)).field("lParamInit", &self.lParamInit).field("UserData", &self.UserData).field("Result", &self.Result).finish()
+        f.debug_struct("PROPSHEETUI_INFO").field("cbSize", &self.cbSize).field("Version", &self.Version).field("Flags", &self.Flags).field("Reason", &self.Reason).field("hComPropSheet", &self.hComPropSheet).field("lParamInit", &self.lParamInit).field("UserData", &self.UserData).field("Result", &self.Result).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PROPSHEETUI_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPSHEETUI_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETUI_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPSHEETUI_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPSHEETUI_INFO {
     fn default() -> Self {
@@ -20141,14 +20283,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETUI_INFO_HEADER {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETUI_INFO_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETUI_INFO_HEADER>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETUI_INFO_HEADER {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETUI_INFO_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20173,14 +20307,6 @@ impl ::core::clone::Clone for PROPSHEETUI_INFO_HEADER_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETUI_INFO_HEADER_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETUI_INFO_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETUI_INFO_HEADER_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETUI_INFO_HEADER_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETUI_INFO_HEADER_0 {
     fn default() -> Self {
@@ -20210,7 +20336,7 @@ unsafe impl ::windows::core::Abi for PROVIDOR_INFO_1A {
 }
 impl ::core::cmp::PartialEq for PROVIDOR_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDOR_INFO_1A>()) == 0 }
+        self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDLLName == other.pDLLName
     }
 }
 impl ::core::cmp::Eq for PROVIDOR_INFO_1A {}
@@ -20242,7 +20368,7 @@ unsafe impl ::windows::core::Abi for PROVIDOR_INFO_1W {
 }
 impl ::core::cmp::PartialEq for PROVIDOR_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDOR_INFO_1W>()) == 0 }
+        self.pName == other.pName && self.pEnvironment == other.pEnvironment && self.pDLLName == other.pDLLName
     }
 }
 impl ::core::cmp::Eq for PROVIDOR_INFO_1W {}
@@ -20272,7 +20398,7 @@ unsafe impl ::windows::core::Abi for PROVIDOR_INFO_2A {
 }
 impl ::core::cmp::PartialEq for PROVIDOR_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDOR_INFO_2A>()) == 0 }
+        self.pOrder == other.pOrder
     }
 }
 impl ::core::cmp::Eq for PROVIDOR_INFO_2A {}
@@ -20302,7 +20428,7 @@ unsafe impl ::windows::core::Abi for PROVIDOR_INFO_2W {
 }
 impl ::core::cmp::PartialEq for PROVIDOR_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDOR_INFO_2W>()) == 0 }
+        self.pOrder == other.pOrder
     }
 }
 impl ::core::cmp::Eq for PROVIDOR_INFO_2W {}
@@ -20333,7 +20459,7 @@ unsafe impl ::windows::core::Abi for PSCRIPT5_PRIVATE_DEVMODE {
 }
 impl ::core::cmp::PartialEq for PSCRIPT5_PRIVATE_DEVMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSCRIPT5_PRIVATE_DEVMODE>()) == 0 }
+        self.wReserved == other.wReserved && self.wSize == other.wSize
     }
 }
 impl ::core::cmp::Eq for PSCRIPT5_PRIVATE_DEVMODE {}
@@ -20363,21 +20489,13 @@ impl ::core::clone::Clone for PSPINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PSPINFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PSPINFO").field("cbSize", &self.cbSize).field("wReserved", &self.wReserved).field("hComPropSheet", &self.hComPropSheet).field("hCPSUIPage", &self.hCPSUIPage).field("pfnComPropSheet", &self.pfnComPropSheet.map(|f| f as usize)).finish()
+        f.debug_struct("PSPINFO").field("cbSize", &self.cbSize).field("wReserved", &self.wReserved).field("hComPropSheet", &self.hComPropSheet).field("hCPSUIPage", &self.hCPSUIPage).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PSPINFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PSPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSPINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PSPINFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PSPINFO {
     fn default() -> Self {
@@ -20407,7 +20525,7 @@ unsafe impl ::windows::core::Abi for PUBLISHERINFO {
 }
 impl ::core::cmp::PartialEq for PUBLISHERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBLISHERINFO>()) == 0 }
+        self.dwMode == other.dwMode && self.wMinoutlinePPEM == other.wMinoutlinePPEM && self.wMaxbitmapPPEM == other.wMaxbitmapPPEM
     }
 }
 impl ::core::cmp::Eq for PUBLISHERINFO {}
@@ -20431,12 +20549,6 @@ impl ::core::clone::Clone for PrintNamedProperty {
 unsafe impl ::windows::core::Abi for PrintNamedProperty {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintNamedProperty {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintNamedProperty>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PrintNamedProperty {}
 impl ::core::default::Default for PrintNamedProperty {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20464,7 +20576,7 @@ unsafe impl ::windows::core::Abi for PrintPropertiesCollection {
 }
 impl ::core::cmp::PartialEq for PrintPropertiesCollection {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintPropertiesCollection>()) == 0 }
+        self.numberOfProperties == other.numberOfProperties && self.propertiesCollection == other.propertiesCollection
     }
 }
 impl ::core::cmp::Eq for PrintPropertiesCollection {}
@@ -20488,12 +20600,6 @@ impl ::core::clone::Clone for PrintPropertyValue {
 unsafe impl ::windows::core::Abi for PrintPropertyValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintPropertyValue {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintPropertyValue>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PrintPropertyValue {}
 impl ::core::default::Default for PrintPropertyValue {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20517,12 +20623,6 @@ impl ::core::clone::Clone for PrintPropertyValue_0 {
 unsafe impl ::windows::core::Abi for PrintPropertyValue_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintPropertyValue_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintPropertyValue_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PrintPropertyValue_0 {}
 impl ::core::default::Default for PrintPropertyValue_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20550,7 +20650,7 @@ unsafe impl ::windows::core::Abi for PrintPropertyValue_0_0 {
 }
 impl ::core::cmp::PartialEq for PrintPropertyValue_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintPropertyValue_0_0>()) == 0 }
+        self.cbBuf == other.cbBuf && self.pBuf == other.pBuf
     }
 }
 impl ::core::cmp::Eq for PrintPropertyValue_0_0 {}
@@ -20589,7 +20689,7 @@ unsafe impl ::windows::core::Abi for SETRESULT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SETRESULT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SETRESULT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wReserved == other.wReserved && self.hSetResult == other.hSetResult && self.Result == other.Result
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20628,7 +20728,7 @@ unsafe impl ::windows::core::Abi for SHOWUIPARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SHOWUIPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHOWUIPARAMS>()) == 0 }
+        self.UIType == other.UIType && self.MessageBoxParams == other.MessageBoxParams
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20664,7 +20764,7 @@ unsafe impl ::windows::core::Abi for SIMULATE_CAPS_1 {
 }
 impl ::core::cmp::PartialEq for SIMULATE_CAPS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIMULATE_CAPS_1>()) == 0 }
+        self.dwLevel == other.dwLevel && self.dwPageOrderFlags == other.dwPageOrderFlags && self.dwNumberOfCopies == other.dwNumberOfCopies && self.dwCollate == other.dwCollate && self.dwNupOptions == other.dwNupOptions
     }
 }
 impl ::core::cmp::Eq for SIMULATE_CAPS_1 {}
@@ -20700,7 +20800,7 @@ unsafe impl ::windows::core::Abi for SPLCLIENT_INFO_1 {
 }
 impl ::core::cmp::PartialEq for SPLCLIENT_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPLCLIENT_INFO_1>()) == 0 }
+        self.dwSize == other.dwSize && self.pMachineName == other.pMachineName && self.pUserName == other.pUserName && self.dwBuildNum == other.dwBuildNum && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.wProcessorArchitecture == other.wProcessorArchitecture
     }
 }
 impl ::core::cmp::Eq for SPLCLIENT_INFO_1 {}
@@ -20730,7 +20830,7 @@ unsafe impl ::windows::core::Abi for SPLCLIENT_INFO_2_W2K {
 }
 impl ::core::cmp::PartialEq for SPLCLIENT_INFO_2_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPLCLIENT_INFO_2_W2K>()) == 0 }
+        self.hSplPrinter == other.hSplPrinter
     }
 }
 impl ::core::cmp::Eq for SPLCLIENT_INFO_2_W2K {}
@@ -20766,7 +20866,7 @@ unsafe impl ::windows::core::Abi for SPLCLIENT_INFO_2_WINXP {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SPLCLIENT_INFO_2_WINXP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPLCLIENT_INFO_2_WINXP>()) == 0 }
+        self.hSplPrinter == other.hSplPrinter
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -20804,7 +20904,7 @@ unsafe impl ::windows::core::Abi for SPLCLIENT_INFO_2_WINXP {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for SPLCLIENT_INFO_2_WINXP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPLCLIENT_INFO_2_WINXP>()) == 0 }
+        self.hSplPrinter == other.hSplPrinter
     }
 }
 #[cfg(target_arch = "x86")]
@@ -20845,7 +20945,7 @@ unsafe impl ::windows::core::Abi for SPLCLIENT_INFO_3_VISTA {
 }
 impl ::core::cmp::PartialEq for SPLCLIENT_INFO_3_VISTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPLCLIENT_INFO_3_VISTA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.dwSize == other.dwSize && self.pMachineName == other.pMachineName && self.pUserName == other.pUserName && self.dwBuildNum == other.dwBuildNum && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.wProcessorArchitecture == other.wProcessorArchitecture && self.hSplPrinter == other.hSplPrinter
     }
 }
 impl ::core::cmp::Eq for SPLCLIENT_INFO_3_VISTA {}
@@ -20870,12 +20970,6 @@ impl ::core::clone::Clone for TRANSDATA {
 unsafe impl ::windows::core::Abi for TRANSDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRANSDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRANSDATA {}
 impl ::core::default::Default for TRANSDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20897,12 +20991,6 @@ impl ::core::clone::Clone for TRANSDATA_0 {
 unsafe impl ::windows::core::Abi for TRANSDATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRANSDATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSDATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRANSDATA_0 {}
 impl ::core::default::Default for TRANSDATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20937,7 +21025,7 @@ unsafe impl ::windows::core::Abi for UFF_FILEHEADER {
 }
 impl ::core::cmp::PartialEq for UFF_FILEHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UFF_FILEHEADER>()) == 0 }
+        self.dwSignature == other.dwSignature && self.dwVersion == other.dwVersion && self.dwSize == other.dwSize && self.nFonts == other.nFonts && self.nGlyphSets == other.nGlyphSets && self.nVarData == other.nVarData && self.offFontDir == other.offFontDir && self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for UFF_FILEHEADER {}
@@ -20977,7 +21065,7 @@ unsafe impl ::windows::core::Abi for UFF_FONTDIRECTORY {
 }
 impl ::core::cmp::PartialEq for UFF_FONTDIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UFF_FONTDIRECTORY>()) == 0 }
+        self.dwSignature == other.dwSignature && self.wSize == other.wSize && self.wFontID == other.wFontID && self.sGlyphID == other.sGlyphID && self.wFlags == other.wFlags && self.dwInstallerSig == other.dwInstallerSig && self.offFontName == other.offFontName && self.offCartridgeName == other.offCartridgeName && self.offFontData == other.offFontData && self.offGlyphData == other.offGlyphData && self.offVarData == other.offVarData
     }
 }
 impl ::core::cmp::Eq for UFF_FONTDIRECTORY {}
@@ -21019,7 +21107,7 @@ unsafe impl ::windows::core::Abi for UNIDRVINFO {
 }
 impl ::core::cmp::PartialEq for UNIDRVINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNIDRVINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.flGenFlags == other.flGenFlags && self.wType == other.wType && self.fCaps == other.fCaps && self.wXRes == other.wXRes && self.wYRes == other.wYRes && self.sYAdjust == other.sYAdjust && self.sYMoved == other.sYMoved && self.wPrivateData == other.wPrivateData && self.sShift == other.sShift && self.SelectFont == other.SelectFont && self.UnSelectFont == other.UnSelectFont && self.wReserved == other.wReserved
     }
 }
 impl ::core::cmp::Eq for UNIDRVINFO {}
@@ -21050,7 +21138,7 @@ unsafe impl ::windows::core::Abi for UNIDRV_PRIVATE_DEVMODE {
 }
 impl ::core::cmp::PartialEq for UNIDRV_PRIVATE_DEVMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNIDRV_PRIVATE_DEVMODE>()) == 0 }
+        self.wReserved == other.wReserved && self.wSize == other.wSize
     }
 }
 impl ::core::cmp::Eq for UNIDRV_PRIVATE_DEVMODE {}
@@ -21089,7 +21177,7 @@ unsafe impl ::windows::core::Abi for UNIFM_HDR {
 }
 impl ::core::cmp::PartialEq for UNIFM_HDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNIFM_HDR>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVersion == other.dwVersion && self.ulDefaultCodepage == other.ulDefaultCodepage && self.lGlyphSetDataRCID == other.lGlyphSetDataRCID && self.loUnidrvInfo == other.loUnidrvInfo && self.loIFIMetrics == other.loIFIMetrics && self.loExtTextMetric == other.loExtTextMetric && self.loWidthTable == other.loWidthTable && self.loKernPair == other.loKernPair && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for UNIFM_HDR {}
@@ -21121,7 +21209,7 @@ unsafe impl ::windows::core::Abi for UNI_CODEPAGEINFO {
 }
 impl ::core::cmp::PartialEq for UNI_CODEPAGEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNI_CODEPAGEINFO>()) == 0 }
+        self.dwCodePage == other.dwCodePage && self.SelectSymbolSet == other.SelectSymbolSet && self.UnSelectSymbolSet == other.UnSelectSymbolSet
     }
 }
 impl ::core::cmp::Eq for UNI_CODEPAGEINFO {}
@@ -21173,7 +21261,7 @@ unsafe impl ::windows::core::Abi for UNI_GLYPHSETDATA {
 }
 impl ::core::cmp::PartialEq for UNI_GLYPHSETDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNI_GLYPHSETDATA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVersion == other.dwVersion && self.dwFlags == other.dwFlags && self.lPredefinedID == other.lPredefinedID && self.dwGlyphCount == other.dwGlyphCount && self.dwRunCount == other.dwRunCount && self.loRunOffset == other.loRunOffset && self.dwCodePageCount == other.dwCodePageCount && self.loCodePageOffset == other.loCodePageOffset && self.loMapTableOffset == other.loMapTableOffset && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for UNI_GLYPHSETDATA {}
@@ -21206,7 +21294,7 @@ unsafe impl ::windows::core::Abi for USERDATA {
 }
 impl ::core::cmp::PartialEq for USERDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USERDATA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwItemID == other.dwItemID && self.pKeyWordName == other.pKeyWordName && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for USERDATA {}
@@ -21238,7 +21326,7 @@ unsafe impl ::windows::core::Abi for WIDTHRUN {
 }
 impl ::core::cmp::PartialEq for WIDTHRUN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIDTHRUN>()) == 0 }
+        self.wStartGlyph == other.wStartGlyph && self.wGlyphCount == other.wGlyphCount && self.loCharWidthOffset == other.loCharWidthOffset
     }
 }
 impl ::core::cmp::Eq for WIDTHRUN {}
@@ -21270,7 +21358,7 @@ unsafe impl ::windows::core::Abi for WIDTHTABLE {
 }
 impl ::core::cmp::PartialEq for WIDTHTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIDTHTABLE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwRunNum == other.dwRunNum && self.WidthRun == other.WidthRun
     }
 }
 impl ::core::cmp::Eq for WIDTHTABLE {}
@@ -21300,7 +21388,7 @@ unsafe impl ::windows::core::Abi for _SPLCLIENT_INFO_2_V3 {
 }
 impl ::core::cmp::PartialEq for _SPLCLIENT_INFO_2_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_SPLCLIENT_INFO_2_V3>()) == 0 }
+        self.hSplPrinter == other.hSplPrinter
     }
 }
 impl ::core::cmp::Eq for _SPLCLIENT_INFO_2_V3 {}

--- a/crates/libs/windows/src/Windows/Win32/Management/MobileDeviceManagementRegistration/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Management/MobileDeviceManagementRegistration/mod.rs
@@ -341,7 +341,7 @@ unsafe impl ::windows::core::Abi for MANAGEMENT_REGISTRATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MANAGEMENT_REGISTRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MANAGEMENT_REGISTRATION_INFO>()) == 0 }
+        self.fDeviceRegisteredWithManagement == other.fDeviceRegisteredWithManagement && self.dwDeviceRegistionKind == other.dwDeviceRegistionKind && self.pszUPN == other.pszUPN && self.pszMDMServiceUri == other.pszMDMServiceUri
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -374,7 +374,7 @@ unsafe impl ::windows::core::Abi for MANAGEMENT_SERVICE_INFO {
 }
 impl ::core::cmp::PartialEq for MANAGEMENT_SERVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MANAGEMENT_SERVICE_INFO>()) == 0 }
+        self.pszMDMServiceUri == other.pszMDMServiceUri && self.pszAuthenticationUri == other.pszAuthenticationUri
     }
 }
 impl ::core::cmp::Eq for MANAGEMENT_SERVICE_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -1129,7 +1129,7 @@ unsafe impl ::windows::core::Abi for APOInitBaseStruct {
 }
 impl ::core::cmp::PartialEq for APOInitBaseStruct {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APOInitBaseStruct>()) == 0 }
+        self.cbSize == other.cbSize && self.clsid == other.clsid
     }
 }
 impl ::core::cmp::Eq for APOInitBaseStruct {}
@@ -1366,7 +1366,7 @@ unsafe impl ::windows::core::Abi for APO_CONNECTION_PROPERTY {
 }
 impl ::core::cmp::PartialEq for APO_CONNECTION_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APO_CONNECTION_PROPERTY>()) == 0 }
+        self.pBuffer == other.pBuffer && self.u32ValidFrameCount == other.u32ValidFrameCount && self.u32BufferFlags == other.u32BufferFlags && self.u32Signature == other.u32Signature
     }
 }
 impl ::core::cmp::Eq for APO_CONNECTION_PROPERTY {}
@@ -1397,7 +1397,7 @@ unsafe impl ::windows::core::Abi for APO_CONNECTION_PROPERTY_V2 {
 }
 impl ::core::cmp::PartialEq for APO_CONNECTION_PROPERTY_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APO_CONNECTION_PROPERTY_V2>()) == 0 }
+        self.property == other.property && self.u64QPCTime == other.u64QPCTime
     }
 }
 impl ::core::cmp::Eq for APO_CONNECTION_PROPERTY_V2 {}
@@ -1424,14 +1424,6 @@ unsafe impl ::windows::core::Abi for APO_NOTIFICATION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::PartialEq for APO_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        self.r#type == other.r#type && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::Eq for APO_NOTIFICATION {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ::core::default::Default for APO_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1456,14 +1448,6 @@ unsafe impl ::windows::core::Abi for APO_NOTIFICATION_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::PartialEq for APO_NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APO_NOTIFICATION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::Eq for APO_NOTIFICATION_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ::core::default::Default for APO_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1483,12 +1467,6 @@ impl ::core::clone::Clone for APO_NOTIFICATION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for APO_NOTIFICATION_DESCRIPTOR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for APO_NOTIFICATION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        self.r#type == other.r#type && self.Anonymous == other.Anonymous
-    }
-}
-impl ::core::cmp::Eq for APO_NOTIFICATION_DESCRIPTOR {}
 impl ::core::default::Default for APO_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1509,12 +1487,6 @@ impl ::core::clone::Clone for APO_NOTIFICATION_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for APO_NOTIFICATION_DESCRIPTOR_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for APO_NOTIFICATION_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APO_NOTIFICATION_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for APO_NOTIFICATION_DESCRIPTOR_0 {}
 impl ::core::default::Default for APO_NOTIFICATION_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1567,7 +1539,7 @@ unsafe impl ::windows::core::Abi for APO_REG_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for APO_REG_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APO_REG_PROPERTIES>()) == 0 }
+        self.clsid == other.clsid && self.Flags == other.Flags && self.szFriendlyName == other.szFriendlyName && self.szCopyrightInfo == other.szCopyrightInfo && self.u32MajorVersion == other.u32MajorVersion && self.u32MinorVersion == other.u32MinorVersion && self.u32MinInputConnections == other.u32MinInputConnections && self.u32MaxInputConnections == other.u32MaxInputConnections && self.u32MinOutputConnections == other.u32MinOutputConnections && self.u32MaxOutputConnections == other.u32MaxOutputConnections && self.u32MaxInstances == other.u32MaxInstances && self.u32NumAPOInterfaces == other.u32NumAPOInterfaces && self.iidAPOInterfaceList == other.iidAPOInterfaceList
     }
 }
 impl ::core::cmp::Eq for APO_REG_PROPERTIES {}
@@ -1738,7 +1710,7 @@ unsafe impl ::windows::core::Abi for AUDIO_SYSTEMEFFECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUDIO_SYSTEMEFFECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIO_SYSTEMEFFECT>()) == 0 }
+        self.id == other.id && self.canSetState == other.canSetState && self.state == other.state
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1889,7 +1861,7 @@ unsafe impl ::windows::core::Abi for UNCOMPRESSEDAUDIOFORMAT {
 }
 impl ::core::cmp::PartialEq for UNCOMPRESSEDAUDIOFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNCOMPRESSEDAUDIOFORMAT>()) == 0 }
+        self.guidFormatType == other.guidFormatType && self.dwSamplesPerFrame == other.dwSamplesPerFrame && self.dwBytesPerSampleContainer == other.dwBytesPerSampleContainer && self.dwValidBitsPerSample == other.dwValidBitsPerSample && self.fFramesPerSecond == other.fFramesPerSecond && self.dwChannelMask == other.dwChannelMask
     }
 }
 impl ::core::cmp::Eq for UNCOMPRESSEDAUDIOFORMAT {}

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -1610,7 +1610,7 @@ unsafe impl ::windows::core::Abi for CONNECTION {
 }
 impl ::core::cmp::PartialEq for CONNECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTION>()) == 0 }
+        self.usSource == other.usSource && self.usControl == other.usControl && self.usDestination == other.usDestination && self.usTransform == other.usTransform && self.lScale == other.lScale
     }
 }
 impl ::core::cmp::Eq for CONNECTION {}
@@ -1641,7 +1641,7 @@ unsafe impl ::windows::core::Abi for CONNECTIONLIST {
 }
 impl ::core::cmp::PartialEq for CONNECTIONLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTIONLIST>()) == 0 }
+        self.cbSize == other.cbSize && self.cConnections == other.cConnections
     }
 }
 impl ::core::cmp::Eq for CONNECTIONLIST {}
@@ -1671,7 +1671,7 @@ unsafe impl ::windows::core::Abi for DLSHEADER {
 }
 impl ::core::cmp::PartialEq for DLSHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLSHEADER>()) == 0 }
+        self.cInstruments == other.cInstruments
     }
 }
 impl ::core::cmp::Eq for DLSHEADER {}
@@ -1704,7 +1704,7 @@ unsafe impl ::windows::core::Abi for DLSID {
 }
 impl ::core::cmp::PartialEq for DLSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLSID>()) == 0 }
+        self.ulData1 == other.ulData1 && self.usData2 == other.usData2 && self.usData3 == other.usData3 && self.abData4 == other.abData4
     }
 }
 impl ::core::cmp::Eq for DLSID {}
@@ -1735,7 +1735,7 @@ unsafe impl ::windows::core::Abi for DLSVERSION {
 }
 impl ::core::cmp::PartialEq for DLSVERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLSVERSION>()) == 0 }
+        self.dwVersionMS == other.dwVersionMS && self.dwVersionLS == other.dwVersionLS
     }
 }
 impl ::core::cmp::Eq for DLSVERSION {}
@@ -1768,7 +1768,7 @@ unsafe impl ::windows::core::Abi for DMUS_ARTICPARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_ARTICPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_ARTICPARAMS>()) == 0 }
+        self.LFO == other.LFO && self.VolEG == other.VolEG && self.PitchEG == other.PitchEG && self.Misc == other.Misc
     }
 }
 impl ::core::cmp::Eq for DMUS_ARTICPARAMS {}
@@ -1799,7 +1799,7 @@ unsafe impl ::windows::core::Abi for DMUS_ARTICULATION {
 }
 impl ::core::cmp::PartialEq for DMUS_ARTICULATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_ARTICULATION>()) == 0 }
+        self.ulArt1Idx == other.ulArt1Idx && self.ulFirstExtCkIdx == other.ulFirstExtCkIdx
     }
 }
 impl ::core::cmp::Eq for DMUS_ARTICULATION {}
@@ -1831,7 +1831,7 @@ unsafe impl ::windows::core::Abi for DMUS_ARTICULATION2 {
 }
 impl ::core::cmp::PartialEq for DMUS_ARTICULATION2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_ARTICULATION2>()) == 0 }
+        self.ulArtIdx == other.ulArtIdx && self.ulFirstExtCkIdx == other.ulFirstExtCkIdx && self.ulNextArtIdx == other.ulNextArtIdx
     }
 }
 impl ::core::cmp::Eq for DMUS_ARTICULATION2 {}
@@ -1864,7 +1864,7 @@ unsafe impl ::windows::core::Abi for DMUS_BUFFERDESC {
 }
 impl ::core::cmp::PartialEq for DMUS_BUFFERDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_BUFFERDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidBufferFormat == other.guidBufferFormat && self.cbBuffer == other.cbBuffer
     }
 }
 impl ::core::cmp::Eq for DMUS_BUFFERDESC {}
@@ -1897,7 +1897,7 @@ unsafe impl ::windows::core::Abi for DMUS_CLOCKINFO7 {
 }
 impl ::core::cmp::PartialEq for DMUS_CLOCKINFO7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_CLOCKINFO7>()) == 0 }
+        self.dwSize == other.dwSize && self.ctType == other.ctType && self.guidClock == other.guidClock && self.wszDescription == other.wszDescription
     }
 }
 impl ::core::cmp::Eq for DMUS_CLOCKINFO7 {}
@@ -1931,7 +1931,7 @@ unsafe impl ::windows::core::Abi for DMUS_CLOCKINFO8 {
 }
 impl ::core::cmp::PartialEq for DMUS_CLOCKINFO8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_CLOCKINFO8>()) == 0 }
+        self.dwSize == other.dwSize && self.ctType == other.ctType && self.guidClock == other.guidClock && self.wszDescription == other.wszDescription && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DMUS_CLOCKINFO8 {}
@@ -1962,7 +1962,7 @@ unsafe impl ::windows::core::Abi for DMUS_COPYRIGHT {
 }
 impl ::core::cmp::PartialEq for DMUS_COPYRIGHT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_COPYRIGHT>()) == 0 }
+        self.cbSize == other.cbSize && self.byCopyright == other.byCopyright
     }
 }
 impl ::core::cmp::Eq for DMUS_COPYRIGHT {}
@@ -1995,7 +1995,7 @@ unsafe impl ::windows::core::Abi for DMUS_DOWNLOADINFO {
 }
 impl ::core::cmp::PartialEq for DMUS_DOWNLOADINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_DOWNLOADINFO>()) == 0 }
+        self.dwDLType == other.dwDLType && self.dwDLId == other.dwDLId && self.dwNumOffsetTableEntries == other.dwNumOffsetTableEntries && self.cbSize == other.cbSize
     }
 }
 impl ::core::cmp::Eq for DMUS_DOWNLOADINFO {}
@@ -2021,12 +2021,6 @@ impl ::core::clone::Clone for DMUS_EVENTHEADER {
 unsafe impl ::windows::core::Abi for DMUS_EVENTHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DMUS_EVENTHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_EVENTHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DMUS_EVENTHEADER {}
 impl ::core::default::Default for DMUS_EVENTHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2056,7 +2050,7 @@ unsafe impl ::windows::core::Abi for DMUS_EXTENSIONCHUNK {
 }
 impl ::core::cmp::PartialEq for DMUS_EXTENSIONCHUNK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_EXTENSIONCHUNK>()) == 0 }
+        self.cbSize == other.cbSize && self.ulNextExtCkIdx == other.ulNextExtCkIdx && self.ExtCkID == other.ExtCkID && self.byExtCk == other.byExtCk
     }
 }
 impl ::core::cmp::Eq for DMUS_EXTENSIONCHUNK {}
@@ -2091,7 +2085,7 @@ unsafe impl ::windows::core::Abi for DMUS_INSTRUMENT {
 }
 impl ::core::cmp::PartialEq for DMUS_INSTRUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_INSTRUMENT>()) == 0 }
+        self.ulPatch == other.ulPatch && self.ulFirstRegionIdx == other.ulFirstRegionIdx && self.ulGlobalArtIdx == other.ulGlobalArtIdx && self.ulFirstExtCkIdx == other.ulFirstExtCkIdx && self.ulCopyrightIdx == other.ulCopyrightIdx && self.ulFlags == other.ulFlags
     }
 }
 impl ::core::cmp::Eq for DMUS_INSTRUMENT {}
@@ -2126,7 +2120,7 @@ unsafe impl ::windows::core::Abi for DMUS_LFOPARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_LFOPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_LFOPARAMS>()) == 0 }
+        self.pcFrequency == other.pcFrequency && self.tcDelay == other.tcDelay && self.gcVolumeScale == other.gcVolumeScale && self.pcPitchScale == other.pcPitchScale && self.gcMWToVolume == other.gcMWToVolume && self.pcMWToPitch == other.pcMWToPitch
     }
 }
 impl ::core::cmp::Eq for DMUS_LFOPARAMS {}
@@ -2156,7 +2150,7 @@ unsafe impl ::windows::core::Abi for DMUS_MSCPARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_MSCPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_MSCPARAMS>()) == 0 }
+        self.ptDefaultPan == other.ptDefaultPan
     }
 }
 impl ::core::cmp::Eq for DMUS_MSCPARAMS {}
@@ -2187,7 +2181,7 @@ unsafe impl ::windows::core::Abi for DMUS_NOTERANGE {
 }
 impl ::core::cmp::PartialEq for DMUS_NOTERANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_NOTERANGE>()) == 0 }
+        self.dwLowNote == other.dwLowNote && self.dwHighNote == other.dwHighNote
     }
 }
 impl ::core::cmp::Eq for DMUS_NOTERANGE {}
@@ -2217,7 +2211,7 @@ unsafe impl ::windows::core::Abi for DMUS_OFFSETTABLE {
 }
 impl ::core::cmp::PartialEq for DMUS_OFFSETTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_OFFSETTABLE>()) == 0 }
+        self.ulOffsetTable == other.ulOffsetTable
     }
 }
 impl ::core::cmp::Eq for DMUS_OFFSETTABLE {}
@@ -2253,7 +2247,7 @@ unsafe impl ::windows::core::Abi for DMUS_PEGPARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_PEGPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_PEGPARAMS>()) == 0 }
+        self.tcAttack == other.tcAttack && self.tcDecay == other.tcDecay && self.ptSustain == other.ptSustain && self.tcRelease == other.tcRelease && self.tcVel2Attack == other.tcVel2Attack && self.tcKey2Decay == other.tcKey2Decay && self.pcRange == other.pcRange
     }
 }
 impl ::core::cmp::Eq for DMUS_PEGPARAMS {}
@@ -2293,7 +2287,7 @@ unsafe impl ::windows::core::Abi for DMUS_PORTCAPS {
 }
 impl ::core::cmp::PartialEq for DMUS_PORTCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_PORTCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidPort == other.guidPort && self.dwClass == other.dwClass && self.dwType == other.dwType && self.dwMemorySize == other.dwMemorySize && self.dwMaxChannelGroups == other.dwMaxChannelGroups && self.dwMaxVoices == other.dwMaxVoices && self.dwMaxAudioChannels == other.dwMaxAudioChannels && self.dwEffectFlags == other.dwEffectFlags && self.wszDescription == other.wszDescription
     }
 }
 impl ::core::cmp::Eq for DMUS_PORTCAPS {}
@@ -2336,7 +2330,7 @@ unsafe impl ::windows::core::Abi for DMUS_PORTPARAMS7 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DMUS_PORTPARAMS7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_PORTPARAMS7>()) == 0 }
+        self.dwSize == other.dwSize && self.dwValidParams == other.dwValidParams && self.dwVoices == other.dwVoices && self.dwChannelGroups == other.dwChannelGroups && self.dwAudioChannels == other.dwAudioChannels && self.dwSampleRate == other.dwSampleRate && self.dwEffectFlags == other.dwEffectFlags && self.fShare == other.fShare
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2382,7 +2376,7 @@ unsafe impl ::windows::core::Abi for DMUS_PORTPARAMS8 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DMUS_PORTPARAMS8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_PORTPARAMS8>()) == 0 }
+        self.dwSize == other.dwSize && self.dwValidParams == other.dwValidParams && self.dwVoices == other.dwVoices && self.dwChannelGroups == other.dwChannelGroups && self.dwAudioChannels == other.dwAudioChannels && self.dwSampleRate == other.dwSampleRate && self.dwEffectFlags == other.dwEffectFlags && self.fShare == other.fShare && self.dwFeatures == other.dwFeatures
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2423,7 +2417,7 @@ unsafe impl ::windows::core::Abi for DMUS_REGION {
 }
 impl ::core::cmp::PartialEq for DMUS_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_REGION>()) == 0 }
+        self.RangeKey == other.RangeKey && self.RangeVelocity == other.RangeVelocity && self.fusOptions == other.fusOptions && self.usKeyGroup == other.usKeyGroup && self.ulRegionArtIdx == other.ulRegionArtIdx && self.ulNextRegionIdx == other.ulNextRegionIdx && self.ulFirstExtCkIdx == other.ulFirstExtCkIdx && self.WaveLink == other.WaveLink && self.WSMP == other.WSMP && self.WLOOP == other.WLOOP
     }
 }
 impl ::core::cmp::Eq for DMUS_REGION {}
@@ -2460,7 +2454,7 @@ unsafe impl ::windows::core::Abi for DMUS_SYNTHSTATS {
 }
 impl ::core::cmp::PartialEq for DMUS_SYNTHSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_SYNTHSTATS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwValidStats == other.dwValidStats && self.dwVoices == other.dwVoices && self.dwTotalCPU == other.dwTotalCPU && self.dwCPUPerVoice == other.dwCPUPerVoice && self.dwLostNotes == other.dwLostNotes && self.dwFreeMemory == other.dwFreeMemory && self.lPeakVolume == other.lPeakVolume
     }
 }
 impl ::core::cmp::Eq for DMUS_SYNTHSTATS {}
@@ -2498,7 +2492,7 @@ unsafe impl ::windows::core::Abi for DMUS_SYNTHSTATS8 {
 }
 impl ::core::cmp::PartialEq for DMUS_SYNTHSTATS8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_SYNTHSTATS8>()) == 0 }
+        self.dwSize == other.dwSize && self.dwValidStats == other.dwValidStats && self.dwVoices == other.dwVoices && self.dwTotalCPU == other.dwTotalCPU && self.dwCPUPerVoice == other.dwCPUPerVoice && self.dwLostNotes == other.dwLostNotes && self.dwFreeMemory == other.dwFreeMemory && self.lPeakVolume == other.lPeakVolume && self.dwSynthMemUse == other.dwSynthMemUse
     }
 }
 impl ::core::cmp::Eq for DMUS_SYNTHSTATS8 {}
@@ -2533,7 +2527,7 @@ unsafe impl ::windows::core::Abi for DMUS_VEGPARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_VEGPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_VEGPARAMS>()) == 0 }
+        self.tcAttack == other.tcAttack && self.tcDecay == other.tcDecay && self.ptSustain == other.ptSustain && self.tcRelease == other.tcRelease && self.tcVel2Attack == other.tcVel2Attack && self.tcKey2Decay == other.tcKey2Decay
     }
 }
 impl ::core::cmp::Eq for DMUS_VEGPARAMS {}
@@ -2570,7 +2564,7 @@ unsafe impl ::windows::core::Abi for DMUS_VOICE_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DMUS_VOICE_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_VOICE_STATE>()) == 0 }
+        self.bExists == other.bExists && self.spPosition == other.spPosition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2598,12 +2592,6 @@ impl ::core::clone::Clone for DMUS_WAVE {
 unsafe impl ::windows::core::Abi for DMUS_WAVE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DMUS_WAVE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_WAVE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DMUS_WAVE {}
 impl ::core::default::Default for DMUS_WAVE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2634,7 +2622,7 @@ unsafe impl ::windows::core::Abi for DMUS_WAVEARTDL {
 }
 impl ::core::cmp::PartialEq for DMUS_WAVEARTDL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_WAVEARTDL>()) == 0 }
+        self.ulDownloadIdIdx == other.ulDownloadIdIdx && self.ulBus == other.ulBus && self.ulBuffers == other.ulBuffers && self.ulMasterDLId == other.ulMasterDLId && self.usOptions == other.usOptions
     }
 }
 impl ::core::cmp::Eq for DMUS_WAVEARTDL {}
@@ -2665,7 +2653,7 @@ unsafe impl ::windows::core::Abi for DMUS_WAVEDATA {
 }
 impl ::core::cmp::PartialEq for DMUS_WAVEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_WAVEDATA>()) == 0 }
+        self.cbSize == other.cbSize && self.byData == other.byData
     }
 }
 impl ::core::cmp::Eq for DMUS_WAVEDATA {}
@@ -2695,7 +2683,7 @@ unsafe impl ::windows::core::Abi for DMUS_WAVEDL {
 }
 impl ::core::cmp::PartialEq for DMUS_WAVEDL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_WAVEDL>()) == 0 }
+        self.cbWaveData == other.cbWaveData
     }
 }
 impl ::core::cmp::Eq for DMUS_WAVEDL {}
@@ -2728,7 +2716,7 @@ unsafe impl ::windows::core::Abi for DMUS_WAVES_REVERB_PARAMS {
 }
 impl ::core::cmp::PartialEq for DMUS_WAVES_REVERB_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMUS_WAVES_REVERB_PARAMS>()) == 0 }
+        self.fInGain == other.fInGain && self.fReverbMix == other.fReverbMix && self.fReverbTime == other.fReverbTime && self.fHighFreqRTRatio == other.fHighFreqRTRatio
     }
 }
 impl ::core::cmp::Eq for DMUS_WAVES_REVERB_PARAMS {}
@@ -2772,7 +2760,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_DATA>()) == 0 }
+        self.DeviceId == other.DeviceId && self.DescriptionA == other.DescriptionA && self.DescriptionW == other.DescriptionW && self.ModuleA == other.ModuleA && self.ModuleW == other.ModuleW && self.Type == other.Type && self.DataFlow == other.DataFlow && self.WaveDeviceId == other.WaveDeviceId && self.Devnode == other.Devnode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2810,7 +2798,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_
 }
 impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA>()) == 0 }
+        self.Type == other.Type && self.DataFlow == other.DataFlow && self.DeviceId == other.DeviceId && self.Description == other.Description && self.Module == other.Module && self.Interface == other.Interface && self.WaveDeviceId == other.WaveDeviceId
     }
 }
 impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA {}
@@ -2846,7 +2834,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_
 }
 impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA>()) == 0 }
+        self.Type == other.Type && self.DataFlow == other.DataFlow && self.DeviceId == other.DeviceId && self.Description == other.Description && self.Module == other.Module && self.Interface == other.Interface && self.WaveDeviceId == other.WaveDeviceId
     }
 }
 impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA {}
@@ -2873,21 +2861,13 @@ impl ::core::clone::Clone for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA").field("Callback", &self.Callback.map(|f| f as usize)).field("Context", &self.Context).finish()
+        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA").field("Context", &self.Context).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
     fn default() -> Self {
@@ -2912,21 +2892,13 @@ impl ::core::clone::Clone for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA").field("Callback", &self.Callback.map(|f| f as usize)).field("Context", &self.Context).finish()
+        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA").field("Context", &self.Context).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
     fn default() -> Self {
@@ -2951,21 +2923,13 @@ impl ::core::clone::Clone for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA").field("Callback", &self.Callback.map(|f| f as usize)).field("Context", &self.Context).finish()
+        f.debug_struct("DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA").field("Context", &self.Context).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
     fn default() -> Self {
@@ -2995,7 +2959,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPP
 }
 impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A_DATA>()) == 0 }
+        self.DeviceName == other.DeviceName && self.DataFlow == other.DataFlow && self.DeviceId == other.DeviceId
     }
 }
 impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A_DATA {}
@@ -3027,7 +2991,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPP
 }
 impl ::core::cmp::PartialEq for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W_DATA>()) == 0 }
+        self.DeviceName == other.DeviceName && self.DataFlow == other.DataFlow && self.DeviceId == other.DeviceId
     }
 }
 impl ::core::cmp::Eq for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W_DATA {}
@@ -3063,7 +3027,7 @@ unsafe impl ::windows::core::Abi for DVAudInfo {
 }
 impl ::core::cmp::PartialEq for DVAudInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DVAudInfo>()) == 0 }
+        self.bAudStyle == other.bAudStyle && self.bAudQu == other.bAudQu && self.bNumAudPin == other.bNumAudPin && self.wAvgSamplesPerPinPerFrm == other.wAvgSamplesPerPinPerFrm && self.wBlkMode == other.wBlkMode && self.wDIFMode == other.wDIFMode && self.wBlkDiv == other.wBlkDiv
     }
 }
 impl ::core::cmp::Eq for DVAudInfo {}
@@ -3094,7 +3058,7 @@ unsafe impl ::windows::core::Abi for INSTHEADER {
 }
 impl ::core::cmp::PartialEq for INSTHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTHEADER>()) == 0 }
+        self.cRegions == other.cRegions && self.Locale == other.Locale
     }
 }
 impl ::core::cmp::Eq for INSTHEADER {}
@@ -3118,12 +3082,6 @@ impl ::core::clone::Clone for MDEVICECAPSEX {
 unsafe impl ::windows::core::Abi for MDEVICECAPSEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MDEVICECAPSEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDEVICECAPSEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MDEVICECAPSEX {}
 impl ::core::default::Default for MDEVICECAPSEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3151,7 +3109,7 @@ unsafe impl ::windows::core::Abi for MIDILOCALE {
 }
 impl ::core::cmp::PartialEq for MIDILOCALE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDILOCALE>()) == 0 }
+        self.ulBank == other.ulBank && self.ulInstrument == other.ulInstrument
     }
 }
 impl ::core::cmp::Eq for MIDILOCALE {}
@@ -3184,14 +3142,6 @@ unsafe impl ::windows::core::Abi for MIDIOPENDESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Multimedia")]
-impl ::core::cmp::PartialEq for MIDIOPENDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOPENDESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Multimedia")]
-impl ::core::cmp::Eq for MIDIOPENDESC {}
-#[cfg(feature = "Win32_Media_Multimedia")]
 impl ::core::default::Default for MIDIOPENDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3218,7 +3168,7 @@ unsafe impl ::windows::core::Abi for POOLCUE {
 }
 impl ::core::cmp::PartialEq for POOLCUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POOLCUE>()) == 0 }
+        self.ulOffset == other.ulOffset
     }
 }
 impl ::core::cmp::Eq for POOLCUE {}
@@ -3249,7 +3199,7 @@ unsafe impl ::windows::core::Abi for POOLTABLE {
 }
 impl ::core::cmp::PartialEq for POOLTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POOLTABLE>()) == 0 }
+        self.cbSize == other.cbSize && self.cCues == other.cCues
     }
 }
 impl ::core::cmp::Eq for POOLTABLE {}
@@ -3282,7 +3232,7 @@ unsafe impl ::windows::core::Abi for RGNHEADER {
 }
 impl ::core::cmp::PartialEq for RGNHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGNHEADER>()) == 0 }
+        self.RangeKey == other.RangeKey && self.RangeVelocity == other.RangeVelocity && self.fusOptions == other.fusOptions && self.usKeyGroup == other.usKeyGroup
     }
 }
 impl ::core::cmp::Eq for RGNHEADER {}
@@ -3313,7 +3263,7 @@ unsafe impl ::windows::core::Abi for RGNRANGE {
 }
 impl ::core::cmp::PartialEq for RGNRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGNRANGE>()) == 0 }
+        self.usLow == other.usLow && self.usHigh == other.usHigh
     }
 }
 impl ::core::cmp::Eq for RGNRANGE {}
@@ -3346,7 +3296,7 @@ unsafe impl ::windows::core::Abi for WAVELINK {
 }
 impl ::core::cmp::PartialEq for WAVELINK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVELINK>()) == 0 }
+        self.fusOptions == other.fusOptions && self.usPhaseGroup == other.usPhaseGroup && self.ulChannel == other.ulChannel && self.ulTableIndex == other.ulTableIndex
     }
 }
 impl ::core::cmp::Eq for WAVELINK {}
@@ -3379,7 +3329,7 @@ unsafe impl ::windows::core::Abi for WLOOP {
 }
 impl ::core::cmp::PartialEq for WLOOP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLOOP>()) == 0 }
+        self.cbSize == other.cbSize && self.ulType == other.ulType && self.ulStart == other.ulStart && self.ulLength == other.ulLength
     }
 }
 impl ::core::cmp::Eq for WLOOP {}
@@ -3414,7 +3364,7 @@ unsafe impl ::windows::core::Abi for WSMPL {
 }
 impl ::core::cmp::PartialEq for WSMPL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMPL>()) == 0 }
+        self.cbSize == other.cbSize && self.usUnityNote == other.usUnityNote && self.sFineTune == other.sFineTune && self.lAttenuation == other.lAttenuation && self.fulOptions == other.fulOptions && self.cSampleLoops == other.cSampleLoops
     }
 }
 impl ::core::cmp::Eq for WSMPL {}

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
@@ -2175,7 +2175,7 @@ unsafe impl ::windows::core::Abi for DS3DBUFFER {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for DS3DBUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DBUFFER>()) == 0 }
+        self.dwSize == other.dwSize && self.vPosition == other.vPosition && self.vVelocity == other.vVelocity && self.dwInsideConeAngle == other.dwInsideConeAngle && self.dwOutsideConeAngle == other.dwOutsideConeAngle && self.vConeOrientation == other.vConeOrientation && self.lConeOutsideVolume == other.lConeOutsideVolume && self.flMinDistance == other.flMinDistance && self.flMaxDistance == other.flMaxDistance && self.dwMode == other.dwMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -2220,7 +2220,7 @@ unsafe impl ::windows::core::Abi for DS3DLISTENER {
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ::core::cmp::PartialEq for DS3DLISTENER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DLISTENER>()) == 0 }
+        self.dwSize == other.dwSize && self.vPosition == other.vPosition && self.vVelocity == other.vVelocity && self.vOrientFront == other.vOrientFront && self.vOrientTop == other.vOrientTop && self.flDistanceFactor == other.flDistanceFactor && self.flRolloffFactor == other.flRolloffFactor && self.flDopplerFactor == other.flDopplerFactor
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -2256,7 +2256,7 @@ unsafe impl ::windows::core::Abi for DSBCAPS {
 }
 impl ::core::cmp::PartialEq for DSBCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwUnlockTransferRate == other.dwUnlockTransferRate && self.dwPlayCpuOverhead == other.dwPlayCpuOverhead
     }
 }
 impl ::core::cmp::Eq for DSBCAPS {}
@@ -2293,7 +2293,7 @@ unsafe impl ::windows::core::Abi for DSBPOSITIONNOTIFY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSBPOSITIONNOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBPOSITIONNOTIFY>()) == 0 }
+        self.dwOffset == other.dwOffset && self.hEventNotify == other.hEventNotify
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2330,7 +2330,7 @@ unsafe impl ::windows::core::Abi for DSBUFFERDESC {
 }
 impl ::core::cmp::PartialEq for DSBUFFERDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBUFFERDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwReserved == other.dwReserved && self.lpwfxFormat == other.lpwfxFormat && self.guid3DAlgorithm == other.guid3DAlgorithm
     }
 }
 impl ::core::cmp::Eq for DSBUFFERDESC {}
@@ -2364,7 +2364,7 @@ unsafe impl ::windows::core::Abi for DSBUFFERDESC1 {
 }
 impl ::core::cmp::PartialEq for DSBUFFERDESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBUFFERDESC1>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwReserved == other.dwReserved && self.lpwfxFormat == other.lpwfxFormat
     }
 }
 impl ::core::cmp::Eq for DSBUFFERDESC1 {}
@@ -2442,7 +2442,30 @@ unsafe impl ::windows::core::Abi for DSCAPS {
 }
 impl ::core::cmp::PartialEq for DSCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCAPS>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwFlags == other.dwFlags
+            && self.dwMinSecondarySampleRate == other.dwMinSecondarySampleRate
+            && self.dwMaxSecondarySampleRate == other.dwMaxSecondarySampleRate
+            && self.dwPrimaryBuffers == other.dwPrimaryBuffers
+            && self.dwMaxHwMixingAllBuffers == other.dwMaxHwMixingAllBuffers
+            && self.dwMaxHwMixingStaticBuffers == other.dwMaxHwMixingStaticBuffers
+            && self.dwMaxHwMixingStreamingBuffers == other.dwMaxHwMixingStreamingBuffers
+            && self.dwFreeHwMixingAllBuffers == other.dwFreeHwMixingAllBuffers
+            && self.dwFreeHwMixingStaticBuffers == other.dwFreeHwMixingStaticBuffers
+            && self.dwFreeHwMixingStreamingBuffers == other.dwFreeHwMixingStreamingBuffers
+            && self.dwMaxHw3DAllBuffers == other.dwMaxHw3DAllBuffers
+            && self.dwMaxHw3DStaticBuffers == other.dwMaxHw3DStaticBuffers
+            && self.dwMaxHw3DStreamingBuffers == other.dwMaxHw3DStreamingBuffers
+            && self.dwFreeHw3DAllBuffers == other.dwFreeHw3DAllBuffers
+            && self.dwFreeHw3DStaticBuffers == other.dwFreeHw3DStaticBuffers
+            && self.dwFreeHw3DStreamingBuffers == other.dwFreeHw3DStreamingBuffers
+            && self.dwTotalHwMemBytes == other.dwTotalHwMemBytes
+            && self.dwFreeHwMemBytes == other.dwFreeHwMemBytes
+            && self.dwMaxContigFreeHwMemBytes == other.dwMaxContigFreeHwMemBytes
+            && self.dwUnlockTransferRateHwBuffers == other.dwUnlockTransferRateHwBuffers
+            && self.dwPlayCpuOverheadSwBuffers == other.dwPlayCpuOverheadSwBuffers
+            && self.dwReserved1 == other.dwReserved1
+            && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for DSCAPS {}
@@ -2475,7 +2498,7 @@ unsafe impl ::windows::core::Abi for DSCBCAPS {
 }
 impl ::core::cmp::PartialEq for DSCBCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCBCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for DSCBCAPS {}
@@ -2511,7 +2534,7 @@ unsafe impl ::windows::core::Abi for DSCBUFFERDESC {
 }
 impl ::core::cmp::PartialEq for DSCBUFFERDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCBUFFERDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwReserved == other.dwReserved && self.lpwfxFormat == other.lpwfxFormat && self.dwFXCount == other.dwFXCount && self.lpDSCFXDesc == other.lpDSCFXDesc
     }
 }
 impl ::core::cmp::Eq for DSCBUFFERDESC {}
@@ -2545,7 +2568,7 @@ unsafe impl ::windows::core::Abi for DSCBUFFERDESC1 {
 }
 impl ::core::cmp::PartialEq for DSCBUFFERDESC1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCBUFFERDESC1>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwBufferBytes == other.dwBufferBytes && self.dwReserved == other.dwReserved && self.lpwfxFormat == other.lpwfxFormat
     }
 }
 impl ::core::cmp::Eq for DSCBUFFERDESC1 {}
@@ -2578,7 +2601,7 @@ unsafe impl ::windows::core::Abi for DSCCAPS {
 }
 impl ::core::cmp::PartialEq for DSCCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCCAPS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwFormats == other.dwFormats && self.dwChannels == other.dwChannels
     }
 }
 impl ::core::cmp::Eq for DSCCAPS {}
@@ -2613,7 +2636,7 @@ unsafe impl ::windows::core::Abi for DSCEFFECTDESC {
 }
 impl ::core::cmp::PartialEq for DSCEFFECTDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCEFFECTDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidDSCFXClass == other.guidDSCFXClass && self.guidDSCFXInstance == other.guidDSCFXInstance && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for DSCEFFECTDESC {}
@@ -2651,7 +2674,7 @@ unsafe impl ::windows::core::Abi for DSCFXAec {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSCFXAec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCFXAec>()) == 0 }
+        self.fEnable == other.fEnable && self.fNoiseFill == other.fNoiseFill && self.dwMode == other.dwMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2689,7 +2712,7 @@ unsafe impl ::windows::core::Abi for DSCFXNoiseSuppress {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSCFXNoiseSuppress {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCFXNoiseSuppress>()) == 0 }
+        self.fEnable == other.fEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2725,7 +2748,7 @@ unsafe impl ::windows::core::Abi for DSEFFECTDESC {
 }
 impl ::core::cmp::PartialEq for DSEFFECTDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSEFFECTDESC>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.guidDSFXClass == other.guidDSFXClass && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for DSEFFECTDESC {}
@@ -2761,7 +2784,7 @@ unsafe impl ::windows::core::Abi for DSFXChorus {
 }
 impl ::core::cmp::PartialEq for DSFXChorus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXChorus>()) == 0 }
+        self.fWetDryMix == other.fWetDryMix && self.fDepth == other.fDepth && self.fFeedback == other.fFeedback && self.fFrequency == other.fFrequency && self.lWaveform == other.lWaveform && self.fDelay == other.fDelay && self.lPhase == other.lPhase
     }
 }
 impl ::core::cmp::Eq for DSFXChorus {}
@@ -2796,7 +2819,7 @@ unsafe impl ::windows::core::Abi for DSFXCompressor {
 }
 impl ::core::cmp::PartialEq for DSFXCompressor {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXCompressor>()) == 0 }
+        self.fGain == other.fGain && self.fAttack == other.fAttack && self.fRelease == other.fRelease && self.fThreshold == other.fThreshold && self.fRatio == other.fRatio && self.fPredelay == other.fPredelay
     }
 }
 impl ::core::cmp::Eq for DSFXCompressor {}
@@ -2830,7 +2853,7 @@ unsafe impl ::windows::core::Abi for DSFXDistortion {
 }
 impl ::core::cmp::PartialEq for DSFXDistortion {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXDistortion>()) == 0 }
+        self.fGain == other.fGain && self.fEdge == other.fEdge && self.fPostEQCenterFrequency == other.fPostEQCenterFrequency && self.fPostEQBandwidth == other.fPostEQBandwidth && self.fPreLowpassCutoff == other.fPreLowpassCutoff
     }
 }
 impl ::core::cmp::Eq for DSFXDistortion {}
@@ -2864,7 +2887,7 @@ unsafe impl ::windows::core::Abi for DSFXEcho {
 }
 impl ::core::cmp::PartialEq for DSFXEcho {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXEcho>()) == 0 }
+        self.fWetDryMix == other.fWetDryMix && self.fFeedback == other.fFeedback && self.fLeftDelay == other.fLeftDelay && self.fRightDelay == other.fRightDelay && self.lPanDelay == other.lPanDelay
     }
 }
 impl ::core::cmp::Eq for DSFXEcho {}
@@ -2900,7 +2923,7 @@ unsafe impl ::windows::core::Abi for DSFXFlanger {
 }
 impl ::core::cmp::PartialEq for DSFXFlanger {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXFlanger>()) == 0 }
+        self.fWetDryMix == other.fWetDryMix && self.fDepth == other.fDepth && self.fFeedback == other.fFeedback && self.fFrequency == other.fFrequency && self.lWaveform == other.lWaveform && self.fDelay == other.fDelay && self.lPhase == other.lPhase
     }
 }
 impl ::core::cmp::Eq for DSFXFlanger {}
@@ -2931,7 +2954,7 @@ unsafe impl ::windows::core::Abi for DSFXGargle {
 }
 impl ::core::cmp::PartialEq for DSFXGargle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXGargle>()) == 0 }
+        self.dwRateHz == other.dwRateHz && self.dwWaveShape == other.dwWaveShape
     }
 }
 impl ::core::cmp::Eq for DSFXGargle {}
@@ -2985,7 +3008,7 @@ unsafe impl ::windows::core::Abi for DSFXI3DL2Reverb {
 }
 impl ::core::cmp::PartialEq for DSFXI3DL2Reverb {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXI3DL2Reverb>()) == 0 }
+        self.lRoom == other.lRoom && self.lRoomHF == other.lRoomHF && self.flRoomRolloffFactor == other.flRoomRolloffFactor && self.flDecayTime == other.flDecayTime && self.flDecayHFRatio == other.flDecayHFRatio && self.lReflections == other.lReflections && self.flReflectionsDelay == other.flReflectionsDelay && self.lReverb == other.lReverb && self.flReverbDelay == other.flReverbDelay && self.flDiffusion == other.flDiffusion && self.flDensity == other.flDensity && self.flHFReference == other.flHFReference
     }
 }
 impl ::core::cmp::Eq for DSFXI3DL2Reverb {}
@@ -3017,7 +3040,7 @@ unsafe impl ::windows::core::Abi for DSFXParamEq {
 }
 impl ::core::cmp::PartialEq for DSFXParamEq {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXParamEq>()) == 0 }
+        self.fCenter == other.fCenter && self.fBandwidth == other.fBandwidth && self.fGain == other.fGain
     }
 }
 impl ::core::cmp::Eq for DSFXParamEq {}
@@ -3050,7 +3073,7 @@ unsafe impl ::windows::core::Abi for DSFXWavesReverb {
 }
 impl ::core::cmp::PartialEq for DSFXWavesReverb {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSFXWavesReverb>()) == 0 }
+        self.fInGain == other.fInGain && self.fReverbMix == other.fReverbMix && self.fReverbTime == other.fReverbTime && self.fHighFreqRTRatio == other.fHighFreqRTRatio
     }
 }
 impl ::core::cmp::Eq for DSFXWavesReverb {}

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
@@ -764,12 +764,6 @@ impl ::core::clone::Clone for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
 unsafe impl ::windows::core::Abi for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIO_ENDPOINT_SHARED_CREATE_PARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {}
 impl ::core::default::Default for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -1544,12 +1544,6 @@ impl ::core::clone::Clone for FXECHO_INITDATA {
 unsafe impl ::windows::core::Abi for FXECHO_INITDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FXECHO_INITDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FXECHO_INITDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FXECHO_INITDATA {}
 impl ::core::default::Default for FXECHO_INITDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1571,12 +1565,6 @@ impl ::core::clone::Clone for FXECHO_PARAMETERS {
 unsafe impl ::windows::core::Abi for FXECHO_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FXECHO_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FXECHO_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FXECHO_PARAMETERS {}
 impl ::core::default::Default for FXECHO_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1607,12 +1595,6 @@ impl ::core::clone::Clone for FXEQ_PARAMETERS {
 unsafe impl ::windows::core::Abi for FXEQ_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FXEQ_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FXEQ_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FXEQ_PARAMETERS {}
 impl ::core::default::Default for FXEQ_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1633,12 +1615,6 @@ impl ::core::clone::Clone for FXMASTERINGLIMITER_PARAMETERS {
 unsafe impl ::windows::core::Abi for FXMASTERINGLIMITER_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FXMASTERINGLIMITER_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FXMASTERINGLIMITER_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FXMASTERINGLIMITER_PARAMETERS {}
 impl ::core::default::Default for FXMASTERINGLIMITER_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1659,12 +1635,6 @@ impl ::core::clone::Clone for FXREVERB_PARAMETERS {
 unsafe impl ::windows::core::Abi for FXREVERB_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FXREVERB_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FXREVERB_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FXREVERB_PARAMETERS {}
 impl ::core::default::Default for FXREVERB_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1692,7 +1662,7 @@ unsafe impl ::windows::core::Abi for HrtfApoInit {
 }
 impl ::core::cmp::PartialEq for HrtfApoInit {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfApoInit>()) == 0 }
+        self.distanceDecay == other.distanceDecay && self.directivity == other.directivity
     }
 }
 impl ::core::cmp::Eq for HrtfApoInit {}
@@ -1723,7 +1693,7 @@ unsafe impl ::windows::core::Abi for HrtfDirectivity {
 }
 impl ::core::cmp::PartialEq for HrtfDirectivity {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfDirectivity>()) == 0 }
+        self.r#type == other.r#type && self.scaling == other.scaling
     }
 }
 impl ::core::cmp::Eq for HrtfDirectivity {}
@@ -1754,7 +1724,7 @@ unsafe impl ::windows::core::Abi for HrtfDirectivityCardioid {
 }
 impl ::core::cmp::PartialEq for HrtfDirectivityCardioid {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfDirectivityCardioid>()) == 0 }
+        self.directivity == other.directivity && self.order == other.order
     }
 }
 impl ::core::cmp::Eq for HrtfDirectivityCardioid {}
@@ -1786,7 +1756,7 @@ unsafe impl ::windows::core::Abi for HrtfDirectivityCone {
 }
 impl ::core::cmp::PartialEq for HrtfDirectivityCone {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfDirectivityCone>()) == 0 }
+        self.directivity == other.directivity && self.innerAngle == other.innerAngle && self.outerAngle == other.outerAngle
     }
 }
 impl ::core::cmp::Eq for HrtfDirectivityCone {}
@@ -1820,7 +1790,7 @@ unsafe impl ::windows::core::Abi for HrtfDistanceDecay {
 }
 impl ::core::cmp::PartialEq for HrtfDistanceDecay {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfDistanceDecay>()) == 0 }
+        self.r#type == other.r#type && self.maxGain == other.maxGain && self.minGain == other.minGain && self.unityGainDistance == other.unityGainDistance && self.cutoffDistance == other.cutoffDistance
     }
 }
 impl ::core::cmp::Eq for HrtfDistanceDecay {}
@@ -1850,7 +1820,7 @@ unsafe impl ::windows::core::Abi for HrtfOrientation {
 }
 impl ::core::cmp::PartialEq for HrtfOrientation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfOrientation>()) == 0 }
+        self.element == other.element
     }
 }
 impl ::core::cmp::Eq for HrtfOrientation {}
@@ -1882,7 +1852,7 @@ unsafe impl ::windows::core::Abi for HrtfPosition {
 }
 impl ::core::cmp::PartialEq for HrtfPosition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HrtfPosition>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z
     }
 }
 impl ::core::cmp::Eq for HrtfPosition {}
@@ -1906,12 +1876,6 @@ impl ::core::clone::Clone for XAPO_LOCKFORPROCESS_PARAMETERS {
 unsafe impl ::windows::core::Abi for XAPO_LOCKFORPROCESS_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAPO_LOCKFORPROCESS_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAPO_LOCKFORPROCESS_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAPO_LOCKFORPROCESS_PARAMETERS {}
 impl ::core::default::Default for XAPO_LOCKFORPROCESS_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1933,12 +1897,6 @@ impl ::core::clone::Clone for XAPO_PROCESS_BUFFER_PARAMETERS {
 unsafe impl ::windows::core::Abi for XAPO_PROCESS_BUFFER_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAPO_PROCESS_BUFFER_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAPO_PROCESS_BUFFER_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAPO_PROCESS_BUFFER_PARAMETERS {}
 impl ::core::default::Default for XAPO_PROCESS_BUFFER_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1967,12 +1925,6 @@ impl ::core::clone::Clone for XAPO_REGISTRATION_PROPERTIES {
 unsafe impl ::windows::core::Abi for XAPO_REGISTRATION_PROPERTIES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAPO_REGISTRATION_PROPERTIES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAPO_REGISTRATION_PROPERTIES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAPO_REGISTRATION_PROPERTIES {}
 impl ::core::default::Default for XAPO_REGISTRATION_PROPERTIES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2004,12 +1956,6 @@ impl ::core::clone::Clone for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
 unsafe impl ::windows::core::Abi for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2FX_REVERB_I3DL2_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {}
 impl ::core::default::Default for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2057,14 +2003,6 @@ unsafe impl ::windows::core::Abi for XAUDIO2FX_REVERB_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for XAUDIO2FX_REVERB_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2FX_REVERB_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for XAUDIO2FX_REVERB_PARAMETERS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for XAUDIO2FX_REVERB_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2086,12 +2024,6 @@ impl ::core::clone::Clone for XAUDIO2FX_VOLUMEMETER_LEVELS {
 unsafe impl ::windows::core::Abi for XAUDIO2FX_VOLUMEMETER_LEVELS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2FX_VOLUMEMETER_LEVELS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2FX_VOLUMEMETER_LEVELS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2FX_VOLUMEMETER_LEVELS {}
 impl ::core::default::Default for XAUDIO2FX_VOLUMEMETER_LEVELS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2119,12 +2051,6 @@ impl ::core::clone::Clone for XAUDIO2_BUFFER {
 unsafe impl ::windows::core::Abi for XAUDIO2_BUFFER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_BUFFER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_BUFFER {}
 impl ::core::default::Default for XAUDIO2_BUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2145,12 +2071,6 @@ impl ::core::clone::Clone for XAUDIO2_BUFFER_WMA {
 unsafe impl ::windows::core::Abi for XAUDIO2_BUFFER_WMA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_BUFFER_WMA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_BUFFER_WMA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_BUFFER_WMA {}
 impl ::core::default::Default for XAUDIO2_BUFFER_WMA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2180,14 +2100,6 @@ unsafe impl ::windows::core::Abi for XAUDIO2_DEBUG_CONFIGURATION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for XAUDIO2_DEBUG_CONFIGURATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_DEBUG_CONFIGURATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for XAUDIO2_DEBUG_CONFIGURATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for XAUDIO2_DEBUG_CONFIGURATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2213,14 +2125,6 @@ unsafe impl ::windows::core::Abi for XAUDIO2_EFFECT_CHAIN {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for XAUDIO2_EFFECT_CHAIN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_EFFECT_CHAIN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for XAUDIO2_EFFECT_CHAIN {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for XAUDIO2_EFFECT_CHAIN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2238,14 +2142,6 @@ pub struct XAUDIO2_EFFECT_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for XAUDIO2_EFFECT_DESCRIPTOR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for XAUDIO2_EFFECT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_EFFECT_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for XAUDIO2_EFFECT_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for XAUDIO2_EFFECT_DESCRIPTOR {
     fn default() -> Self {
@@ -2268,12 +2164,6 @@ impl ::core::clone::Clone for XAUDIO2_FILTER_PARAMETERS {
 unsafe impl ::windows::core::Abi for XAUDIO2_FILTER_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_FILTER_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_FILTER_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_FILTER_PARAMETERS {}
 impl ::core::default::Default for XAUDIO2_FILTER_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2306,12 +2196,6 @@ impl ::core::clone::Clone for XAUDIO2_PERFORMANCE_DATA {
 unsafe impl ::windows::core::Abi for XAUDIO2_PERFORMANCE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_PERFORMANCE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_PERFORMANCE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_PERFORMANCE_DATA {}
 impl ::core::default::Default for XAUDIO2_PERFORMANCE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2326,12 +2210,6 @@ pub struct XAUDIO2_SEND_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for XAUDIO2_SEND_DESCRIPTOR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_SEND_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_SEND_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_SEND_DESCRIPTOR {}
 impl ::core::default::Default for XAUDIO2_SEND_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2354,12 +2232,6 @@ impl ::core::clone::Clone for XAUDIO2_VOICE_DETAILS {
 unsafe impl ::windows::core::Abi for XAUDIO2_VOICE_DETAILS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_VOICE_DETAILS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_VOICE_DETAILS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_VOICE_DETAILS {}
 impl ::core::default::Default for XAUDIO2_VOICE_DETAILS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2380,12 +2252,6 @@ impl ::core::clone::Clone for XAUDIO2_VOICE_SENDS {
 unsafe impl ::windows::core::Abi for XAUDIO2_VOICE_SENDS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_VOICE_SENDS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_VOICE_SENDS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_VOICE_SENDS {}
 impl ::core::default::Default for XAUDIO2_VOICE_SENDS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2407,12 +2273,6 @@ impl ::core::clone::Clone for XAUDIO2_VOICE_STATE {
 unsafe impl ::windows::core::Abi for XAUDIO2_VOICE_STATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XAUDIO2_VOICE_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XAUDIO2_VOICE_STATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XAUDIO2_VOICE_STATE {}
 impl ::core::default::Default for XAUDIO2_VOICE_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -7804,14 +7804,6 @@ unsafe impl ::windows::core::Abi for ACMDRIVERDETAILSA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for ACMDRIVERDETAILSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRIVERDETAILSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for ACMDRIVERDETAILSA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for ACMDRIVERDETAILSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7851,14 +7843,6 @@ unsafe impl ::windows::core::Abi for ACMDRIVERDETAILSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for ACMDRIVERDETAILSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRIVERDETAILSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for ACMDRIVERDETAILSW {}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for ACMDRIVERDETAILSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7883,12 +7867,6 @@ impl ::core::clone::Clone for ACMDRVFORMATSUGGEST {
 unsafe impl ::windows::core::Abi for ACMDRVFORMATSUGGEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVFORMATSUGGEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVFORMATSUGGEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVFORMATSUGGEST {}
 impl ::core::default::Default for ACMDRVFORMATSUGGEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7916,12 +7894,6 @@ impl ::core::clone::Clone for ACMDRVOPENDESCA {
 unsafe impl ::windows::core::Abi for ACMDRVOPENDESCA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVOPENDESCA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVOPENDESCA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVOPENDESCA {}
 impl ::core::default::Default for ACMDRVOPENDESCA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7949,12 +7921,6 @@ impl ::core::clone::Clone for ACMDRVOPENDESCW {
 unsafe impl ::windows::core::Abi for ACMDRVOPENDESCW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVOPENDESCW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVOPENDESCW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVOPENDESCW {}
 impl ::core::default::Default for ACMDRVOPENDESCW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7994,12 +7960,6 @@ impl ::core::clone::Clone for ACMDRVSTREAMHEADER {
 unsafe impl ::windows::core::Abi for ACMDRVSTREAMHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVSTREAMHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVSTREAMHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVSTREAMHEADER {}
 impl ::core::default::Default for ACMDRVSTREAMHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8028,12 +7988,6 @@ impl ::core::clone::Clone for ACMDRVSTREAMINSTANCE {
 unsafe impl ::windows::core::Abi for ACMDRVSTREAMINSTANCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVSTREAMINSTANCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVSTREAMINSTANCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVSTREAMINSTANCE {}
 impl ::core::default::Default for ACMDRVSTREAMINSTANCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8056,12 +8010,6 @@ impl ::core::clone::Clone for ACMDRVSTREAMSIZE {
 unsafe impl ::windows::core::Abi for ACMDRVSTREAMSIZE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMDRVSTREAMSIZE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMDRVSTREAMSIZE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMDRVSTREAMSIZE {}
 impl ::core::default::Default for ACMDRVSTREAMSIZE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8100,14 +8048,6 @@ impl ::core::clone::Clone for ACMFILTERCHOOSEA {
 unsafe impl ::windows::core::Abi for ACMFILTERCHOOSEA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFILTERCHOOSEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERCHOOSEA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFILTERCHOOSEA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFILTERCHOOSEA {
     fn default() -> Self {
@@ -8148,14 +8088,6 @@ unsafe impl ::windows::core::Abi for ACMFILTERCHOOSEW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFILTERCHOOSEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERCHOOSEW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFILTERCHOOSEW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFILTERCHOOSEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8186,14 +8118,6 @@ unsafe impl ::windows::core::Abi for ACMFILTERDETAILSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFILTERDETAILSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERDETAILSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFILTERDETAILSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFILTERDETAILSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8219,12 +8143,6 @@ impl ::core::clone::Clone for ACMFILTERDETAILSW {
 unsafe impl ::windows::core::Abi for ACMFILTERDETAILSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMFILTERDETAILSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERDETAILSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMFILTERDETAILSW {}
 impl ::core::default::Default for ACMFILTERDETAILSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8255,14 +8173,6 @@ unsafe impl ::windows::core::Abi for ACMFILTERTAGDETAILSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFILTERTAGDETAILSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERTAGDETAILSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFILTERTAGDETAILSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFILTERTAGDETAILSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8288,12 +8198,6 @@ impl ::core::clone::Clone for ACMFILTERTAGDETAILSW {
 unsafe impl ::windows::core::Abi for ACMFILTERTAGDETAILSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMFILTERTAGDETAILSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFILTERTAGDETAILSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMFILTERTAGDETAILSW {}
 impl ::core::default::Default for ACMFILTERTAGDETAILSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8332,14 +8236,6 @@ impl ::core::clone::Clone for ACMFORMATCHOOSEA {
 unsafe impl ::windows::core::Abi for ACMFORMATCHOOSEA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFORMATCHOOSEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFORMATCHOOSEA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFORMATCHOOSEA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFORMATCHOOSEA {
     fn default() -> Self {
@@ -8380,14 +8276,6 @@ unsafe impl ::windows::core::Abi for ACMFORMATCHOOSEW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFORMATCHOOSEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFORMATCHOOSEW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFORMATCHOOSEW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFORMATCHOOSEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8417,14 +8305,6 @@ impl ::core::clone::Clone for ACMFORMATDETAILSA {
 unsafe impl ::windows::core::Abi for ACMFORMATDETAILSA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFORMATDETAILSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFORMATDETAILSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFORMATDETAILSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFORMATDETAILSA {
     fn default() -> Self {
@@ -8456,14 +8336,6 @@ unsafe impl ::windows::core::Abi for ACMFORMATTAGDETAILSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACMFORMATTAGDETAILSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFORMATTAGDETAILSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACMFORMATTAGDETAILSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACMFORMATTAGDETAILSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8489,12 +8361,6 @@ impl ::core::clone::Clone for ACMFORMATTAGDETAILSW {
 unsafe impl ::windows::core::Abi for ACMFORMATTAGDETAILSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ACMFORMATTAGDETAILSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMFORMATTAGDETAILSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ACMFORMATTAGDETAILSW {}
 impl ::core::default::Default for ACMFORMATTAGDETAILSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8529,14 +8395,6 @@ impl ::core::clone::Clone for ACMSTREAMHEADER {
 unsafe impl ::windows::core::Abi for ACMSTREAMHEADER {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for ACMSTREAMHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMSTREAMHEADER>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for ACMSTREAMHEADER {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for ACMSTREAMHEADER {
     fn default() -> Self {
@@ -8573,14 +8431,6 @@ unsafe impl ::windows::core::Abi for ACMSTREAMHEADER {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for ACMSTREAMHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACMSTREAMHEADER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for ACMSTREAMHEADER {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for ACMSTREAMHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8614,7 +8464,7 @@ unsafe impl ::windows::core::Abi for AMBISONICS_PARAMS {
 }
 impl ::core::cmp::PartialEq for AMBISONICS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMBISONICS_PARAMS>()) == 0 }
+        self.u32Size == other.u32Size && self.u32Version == other.u32Version && self.u32Type == other.u32Type && self.u32ChannelOrdering == other.u32ChannelOrdering && self.u32Normalization == other.u32Normalization && self.u32Order == other.u32Order && self.u32NumChannels == other.u32NumChannels && self.pu32ChannelMap == other.pu32ChannelMap
     }
 }
 impl ::core::cmp::Eq for AMBISONICS_PARAMS {}
@@ -8638,12 +8488,6 @@ impl ::core::clone::Clone for AUDIOCLIENT_ACTIVATION_PARAMS {
 unsafe impl ::windows::core::Abi for AUDIOCLIENT_ACTIVATION_PARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIOCLIENT_ACTIVATION_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIOCLIENT_ACTIVATION_PARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIOCLIENT_ACTIVATION_PARAMS {}
 impl ::core::default::Default for AUDIOCLIENT_ACTIVATION_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8663,12 +8507,6 @@ impl ::core::clone::Clone for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
 unsafe impl ::windows::core::Abi for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIOCLIENT_ACTIVATION_PARAMS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIOCLIENT_ACTIVATION_PARAMS_0 {}
 impl ::core::default::Default for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8696,7 +8534,7 @@ unsafe impl ::windows::core::Abi for AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
 }
 impl ::core::cmp::PartialEq for AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS>()) == 0 }
+        self.TargetProcessId == other.TargetProcessId && self.ProcessLoopbackMode == other.ProcessLoopbackMode
     }
 }
 impl ::core::cmp::Eq for AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {}
@@ -8734,7 +8572,7 @@ unsafe impl ::windows::core::Abi for AUDIO_EFFECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUDIO_EFFECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIO_EFFECT>()) == 0 }
+        self.id == other.id && self.canSetState == other.canSetState && self.state == other.state
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8776,7 +8614,7 @@ unsafe impl ::windows::core::Abi for AUDIO_VOLUME_NOTIFICATION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUDIO_VOLUME_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIO_VOLUME_NOTIFICATION_DATA>()) == 0 }
+        self.guidEventContext == other.guidEventContext && self.bMuted == other.bMuted && self.fMasterVolume == other.fMasterVolume && self.nChannels == other.nChannels && self.afChannelVolumes == other.afChannelVolumes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8815,14 +8653,6 @@ unsafe impl ::windows::core::Abi for AUXCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AUXCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUXCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AUXCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AUXCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8851,12 +8681,6 @@ impl ::core::clone::Clone for AUXCAPS2W {
 unsafe impl ::windows::core::Abi for AUXCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUXCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUXCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUXCAPS2W {}
 impl ::core::default::Default for AUXCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8887,14 +8711,6 @@ unsafe impl ::windows::core::Abi for AUXCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AUXCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUXCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AUXCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AUXCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8920,12 +8736,6 @@ impl ::core::clone::Clone for AUXCAPSW {
 unsafe impl ::windows::core::Abi for AUXCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUXCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUXCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUXCAPSW {}
 impl ::core::default::Default for AUXCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8952,7 +8762,7 @@ unsafe impl ::windows::core::Abi for AudioClient3ActivationParams {
 }
 impl ::core::cmp::PartialEq for AudioClient3ActivationParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AudioClient3ActivationParams>()) == 0 }
+        self.tracingContextId == other.tracingContextId
     }
 }
 impl ::core::cmp::Eq for AudioClient3ActivationParams {}
@@ -8991,7 +8801,7 @@ unsafe impl ::windows::core::Abi for AudioClientProperties {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AudioClientProperties {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AudioClientProperties>()) == 0 }
+        self.cbSize == other.cbSize && self.bIsOffload == other.bIsOffload && self.eCategory == other.eCategory && self.Options == other.Options
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9069,7 +8879,7 @@ unsafe impl ::windows::core::Abi for DIRECTX_AUDIO_ACTIVATION_PARAMS {
 }
 impl ::core::cmp::PartialEq for DIRECTX_AUDIO_ACTIVATION_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIRECTX_AUDIO_ACTIVATION_PARAMS>()) == 0 }
+        self.cbDirectXAudioActivationParams == other.cbDirectXAudioActivationParams && self.guidAudioSession == other.guidAudioSession && self.dwAudioStreamFlags == other.dwAudioStreamFlags
     }
 }
 impl ::core::cmp::Eq for DIRECTX_AUDIO_ACTIVATION_PARAMS {}
@@ -9094,12 +8904,6 @@ impl ::core::clone::Clone for ECHOWAVEFILTER {
 unsafe impl ::windows::core::Abi for ECHOWAVEFILTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ECHOWAVEFILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ECHOWAVEFILTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ECHOWAVEFILTER {}
 impl ::core::default::Default for ECHOWAVEFILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9538,12 +9342,6 @@ impl ::core::clone::Clone for MIDIEVENT {
 unsafe impl ::windows::core::Abi for MIDIEVENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIEVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIEVENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIEVENT {}
 impl ::core::default::Default for MIDIEVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9571,12 +9369,6 @@ impl ::core::clone::Clone for MIDIHDR {
 unsafe impl ::windows::core::Abi for MIDIHDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIHDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIHDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIHDR {}
 impl ::core::default::Default for MIDIHDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9608,14 +9400,6 @@ unsafe impl ::windows::core::Abi for MIDIINCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIDIINCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIINCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIDIINCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIDIINCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9642,12 +9426,6 @@ impl ::core::clone::Clone for MIDIINCAPS2W {
 unsafe impl ::windows::core::Abi for MIDIINCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIINCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIINCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIINCAPS2W {}
 impl ::core::default::Default for MIDIINCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9676,14 +9454,6 @@ unsafe impl ::windows::core::Abi for MIDIINCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIDIINCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIINCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIDIINCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIDIINCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9707,12 +9477,6 @@ impl ::core::clone::Clone for MIDIINCAPSW {
 unsafe impl ::windows::core::Abi for MIDIINCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIINCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIINCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIINCAPSW {}
 impl ::core::default::Default for MIDIINCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9748,14 +9512,6 @@ unsafe impl ::windows::core::Abi for MIDIOUTCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIDIOUTCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOUTCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIDIOUTCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIDIOUTCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9786,12 +9542,6 @@ impl ::core::clone::Clone for MIDIOUTCAPS2W {
 unsafe impl ::windows::core::Abi for MIDIOUTCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIOUTCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOUTCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIOUTCAPS2W {}
 impl ::core::default::Default for MIDIOUTCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9824,14 +9574,6 @@ unsafe impl ::windows::core::Abi for MIDIOUTCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIDIOUTCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOUTCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIDIOUTCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIDIOUTCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9859,12 +9601,6 @@ impl ::core::clone::Clone for MIDIOUTCAPSW {
 unsafe impl ::windows::core::Abi for MIDIOUTCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIOUTCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOUTCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIOUTCAPSW {}
 impl ::core::default::Default for MIDIOUTCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9885,12 +9621,6 @@ impl ::core::clone::Clone for MIDIPROPTEMPO {
 unsafe impl ::windows::core::Abi for MIDIPROPTEMPO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIPROPTEMPO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIPROPTEMPO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIPROPTEMPO {}
 impl ::core::default::Default for MIDIPROPTEMPO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9911,12 +9641,6 @@ impl ::core::clone::Clone for MIDIPROPTIMEDIV {
 unsafe impl ::windows::core::Abi for MIDIPROPTIMEDIV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIPROPTIMEDIV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIPROPTIMEDIV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIPROPTIMEDIV {}
 impl ::core::default::Default for MIDIPROPTIMEDIV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9938,12 +9662,6 @@ impl ::core::clone::Clone for MIDISTRMBUFFVER {
 unsafe impl ::windows::core::Abi for MIDISTRMBUFFVER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDISTRMBUFFVER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDISTRMBUFFVER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDISTRMBUFFVER {}
 impl ::core::default::Default for MIDISTRMBUFFVER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9976,14 +9694,6 @@ unsafe impl ::windows::core::Abi for MIXERCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10011,12 +9721,6 @@ impl ::core::clone::Clone for MIXERCAPS2W {
 unsafe impl ::windows::core::Abi for MIXERCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCAPS2W {}
 impl ::core::default::Default for MIXERCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10046,14 +9750,6 @@ unsafe impl ::windows::core::Abi for MIXERCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10078,12 +9774,6 @@ impl ::core::clone::Clone for MIXERCAPSW {
 unsafe impl ::windows::core::Abi for MIXERCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCAPSW {}
 impl ::core::default::Default for MIXERCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10116,14 +9806,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10150,14 +9832,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10182,14 +9856,6 @@ impl ::core::clone::Clone for MIXERCONTROLA_0_0 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLA_0_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLA_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLA_0_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLA_0_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLA_0_0 {
     fn default() -> Self {
@@ -10216,14 +9882,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLA_0_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLA_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLA_0_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLA_0_1 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLA_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10249,14 +9907,6 @@ impl ::core::clone::Clone for MIXERCONTROLA_1 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLA_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLA_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLA_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLA_1 {
     fn default() -> Self {
@@ -10287,14 +9937,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLDETAILS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10320,14 +9962,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLDETAILS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10347,12 +9981,6 @@ impl ::core::clone::Clone for MIXERCONTROLDETAILS_BOOLEAN {
 unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_BOOLEAN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_BOOLEAN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_BOOLEAN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_BOOLEAN {}
 impl ::core::default::Default for MIXERCONTROLDETAILS_BOOLEAN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10379,14 +10007,6 @@ unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_LISTTEXTA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_LISTTEXTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_LISTTEXTA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_LISTTEXTA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERCONTROLDETAILS_LISTTEXTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10408,12 +10028,6 @@ impl ::core::clone::Clone for MIXERCONTROLDETAILS_LISTTEXTW {
 unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_LISTTEXTW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_LISTTEXTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_LISTTEXTW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_LISTTEXTW {}
 impl ::core::default::Default for MIXERCONTROLDETAILS_LISTTEXTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10433,12 +10047,6 @@ impl ::core::clone::Clone for MIXERCONTROLDETAILS_SIGNED {
 unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_SIGNED {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_SIGNED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_SIGNED>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_SIGNED {}
 impl ::core::default::Default for MIXERCONTROLDETAILS_SIGNED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10458,12 +10066,6 @@ impl ::core::clone::Clone for MIXERCONTROLDETAILS_UNSIGNED {
 unsafe impl ::windows::core::Abi for MIXERCONTROLDETAILS_UNSIGNED {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLDETAILS_UNSIGNED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLDETAILS_UNSIGNED>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLDETAILS_UNSIGNED {}
 impl ::core::default::Default for MIXERCONTROLDETAILS_UNSIGNED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10491,12 +10093,6 @@ impl ::core::clone::Clone for MIXERCONTROLW {
 unsafe impl ::windows::core::Abi for MIXERCONTROLW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLW {}
 impl ::core::default::Default for MIXERCONTROLW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10518,12 +10114,6 @@ impl ::core::clone::Clone for MIXERCONTROLW_0 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLW_0 {}
 impl ::core::default::Default for MIXERCONTROLW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10544,12 +10134,6 @@ impl ::core::clone::Clone for MIXERCONTROLW_0_0 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLW_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLW_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLW_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLW_0_0 {}
 impl ::core::default::Default for MIXERCONTROLW_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10570,12 +10154,6 @@ impl ::core::clone::Clone for MIXERCONTROLW_0_1 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLW_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLW_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLW_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLW_0_1 {}
 impl ::core::default::Default for MIXERCONTROLW_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10597,12 +10175,6 @@ impl ::core::clone::Clone for MIXERCONTROLW_1 {
 unsafe impl ::windows::core::Abi for MIXERCONTROLW_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERCONTROLW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERCONTROLW_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERCONTROLW_1 {}
 impl ::core::default::Default for MIXERCONTROLW_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10639,14 +10211,6 @@ unsafe impl ::windows::core::Abi for MIXERLINEA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERLINEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINEA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERLINEA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERLINEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10675,14 +10239,6 @@ impl ::core::clone::Clone for MIXERLINEA_0 {
 unsafe impl ::windows::core::Abi for MIXERLINEA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERLINEA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINEA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERLINEA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERLINEA_0 {
     fn default() -> Self {
@@ -10713,14 +10269,6 @@ unsafe impl ::windows::core::Abi for MIXERLINECONTROLSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERLINECONTROLSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINECONTROLSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERLINECONTROLSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERLINECONTROLSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10746,14 +10294,6 @@ unsafe impl ::windows::core::Abi for MIXERLINECONTROLSA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MIXERLINECONTROLSA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINECONTROLSA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MIXERLINECONTROLSA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MIXERLINECONTROLSA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10778,12 +10318,6 @@ impl ::core::clone::Clone for MIXERLINECONTROLSW {
 unsafe impl ::windows::core::Abi for MIXERLINECONTROLSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERLINECONTROLSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINECONTROLSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERLINECONTROLSW {}
 impl ::core::default::Default for MIXERLINECONTROLSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10804,12 +10338,6 @@ impl ::core::clone::Clone for MIXERLINECONTROLSW_0 {
 unsafe impl ::windows::core::Abi for MIXERLINECONTROLSW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERLINECONTROLSW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINECONTROLSW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERLINECONTROLSW_0 {}
 impl ::core::default::Default for MIXERLINECONTROLSW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10841,12 +10369,6 @@ impl ::core::clone::Clone for MIXERLINEW {
 unsafe impl ::windows::core::Abi for MIXERLINEW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERLINEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINEW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERLINEW {}
 impl ::core::default::Default for MIXERLINEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10871,12 +10393,6 @@ impl ::core::clone::Clone for MIXERLINEW_0 {
 unsafe impl ::windows::core::Abi for MIXERLINEW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIXERLINEW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXERLINEW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIXERLINEW_0 {}
 impl ::core::default::Default for MIXERLINEW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10897,12 +10413,6 @@ impl ::core::clone::Clone for PCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for PCMWAVEFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PCMWAVEFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PCMWAVEFORMAT {}
 impl ::core::default::Default for PCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10934,7 +10444,7 @@ unsafe impl ::windows::core::Abi for SpatialAudioClientActivationParams {
 }
 impl ::core::cmp::PartialEq for SpatialAudioClientActivationParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioClientActivationParams>()) == 0 }
+        self.tracingContextId == other.tracingContextId && self.appId == other.appId && self.majorVersion == other.majorVersion && self.minorVersion1 == other.minorVersion1 && self.minorVersion2 == other.minorVersion2 && self.minorVersion3 == other.minorVersion3
     }
 }
 impl ::core::cmp::Eq for SpatialAudioClientActivationParams {}
@@ -10964,14 +10474,6 @@ unsafe impl ::windows::core::Abi for SpatialAudioHrtfActivationParams {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SpatialAudioHrtfActivationParams {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfActivationParams>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SpatialAudioHrtfActivationParams {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SpatialAudioHrtfActivationParams {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10999,14 +10501,6 @@ unsafe impl ::windows::core::Abi for SpatialAudioHrtfActivationParams2 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SpatialAudioHrtfActivationParams2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfActivationParams2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SpatialAudioHrtfActivationParams2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SpatialAudioHrtfActivationParams2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11027,12 +10521,6 @@ impl ::core::clone::Clone for SpatialAudioHrtfDirectivity {
 unsafe impl ::windows::core::Abi for SpatialAudioHrtfDirectivity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioHrtfDirectivity {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfDirectivity>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioHrtfDirectivity {}
 impl ::core::default::Default for SpatialAudioHrtfDirectivity {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11053,12 +10541,6 @@ impl ::core::clone::Clone for SpatialAudioHrtfDirectivityCardioid {
 unsafe impl ::windows::core::Abi for SpatialAudioHrtfDirectivityCardioid {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioHrtfDirectivityCardioid {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfDirectivityCardioid>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioHrtfDirectivityCardioid {}
 impl ::core::default::Default for SpatialAudioHrtfDirectivityCardioid {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11080,12 +10562,6 @@ impl ::core::clone::Clone for SpatialAudioHrtfDirectivityCone {
 unsafe impl ::windows::core::Abi for SpatialAudioHrtfDirectivityCone {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioHrtfDirectivityCone {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfDirectivityCone>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioHrtfDirectivityCone {}
 impl ::core::default::Default for SpatialAudioHrtfDirectivityCone {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11107,12 +10583,6 @@ impl ::core::clone::Clone for SpatialAudioHrtfDirectivityUnion {
 unsafe impl ::windows::core::Abi for SpatialAudioHrtfDirectivityUnion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioHrtfDirectivityUnion {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfDirectivityUnion>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioHrtfDirectivityUnion {}
 impl ::core::default::Default for SpatialAudioHrtfDirectivityUnion {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11136,12 +10606,6 @@ impl ::core::clone::Clone for SpatialAudioHrtfDistanceDecay {
 unsafe impl ::windows::core::Abi for SpatialAudioHrtfDistanceDecay {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioHrtfDistanceDecay {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioHrtfDistanceDecay>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioHrtfDistanceDecay {}
 impl ::core::default::Default for SpatialAudioHrtfDistanceDecay {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11164,12 +10628,6 @@ impl ::core::clone::Clone for SpatialAudioMetadataItemsInfo {
 unsafe impl ::windows::core::Abi for SpatialAudioMetadataItemsInfo {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioMetadataItemsInfo {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioMetadataItemsInfo>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioMetadataItemsInfo {}
 impl ::core::default::Default for SpatialAudioMetadataItemsInfo {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11191,14 +10649,6 @@ pub struct SpatialAudioObjectRenderStreamActivationParams {
 unsafe impl ::windows::core::Abi for SpatialAudioObjectRenderStreamActivationParams {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SpatialAudioObjectRenderStreamActivationParams {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioObjectRenderStreamActivationParams>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SpatialAudioObjectRenderStreamActivationParams {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SpatialAudioObjectRenderStreamActivationParams {
     fn default() -> Self {
@@ -11222,14 +10672,6 @@ pub struct SpatialAudioObjectRenderStreamActivationParams2 {
 unsafe impl ::windows::core::Abi for SpatialAudioObjectRenderStreamActivationParams2 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SpatialAudioObjectRenderStreamActivationParams2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioObjectRenderStreamActivationParams2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SpatialAudioObjectRenderStreamActivationParams2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SpatialAudioObjectRenderStreamActivationParams2 {
     fn default() -> Self {
@@ -11255,14 +10697,6 @@ pub struct SpatialAudioObjectRenderStreamForMetadataActivationParams {
 unsafe impl ::windows::core::Abi for SpatialAudioObjectRenderStreamForMetadataActivationParams {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for SpatialAudioObjectRenderStreamForMetadataActivationParams {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioObjectRenderStreamForMetadataActivationParams>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for SpatialAudioObjectRenderStreamForMetadataActivationParams {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for SpatialAudioObjectRenderStreamForMetadataActivationParams {
     fn default() -> Self {
@@ -11290,14 +10724,6 @@ unsafe impl ::windows::core::Abi for SpatialAudioObjectRenderStreamForMetadataAc
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for SpatialAudioObjectRenderStreamForMetadataActivationParams2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SpatialAudioObjectRenderStreamForMetadataActivationParams2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for SpatialAudioObjectRenderStreamForMetadataActivationParams2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for SpatialAudioObjectRenderStreamForMetadataActivationParams2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11318,12 +10744,6 @@ impl ::core::clone::Clone for VOLUMEWAVEFILTER {
 unsafe impl ::windows::core::Abi for VOLUMEWAVEFILTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VOLUMEWAVEFILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUMEWAVEFILTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VOLUMEWAVEFILTER {}
 impl ::core::default::Default for VOLUMEWAVEFILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11346,12 +10766,6 @@ impl ::core::clone::Clone for WAVEFILTER {
 unsafe impl ::windows::core::Abi for WAVEFILTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEFILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEFILTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEFILTER {}
 impl ::core::default::Default for WAVEFILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11375,12 +10789,6 @@ impl ::core::clone::Clone for WAVEFORMAT {
 unsafe impl ::windows::core::Abi for WAVEFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEFORMAT {}
 impl ::core::default::Default for WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11406,12 +10814,6 @@ impl ::core::clone::Clone for WAVEFORMATEX {
 unsafe impl ::windows::core::Abi for WAVEFORMATEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEFORMATEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEFORMATEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEFORMATEX {}
 impl ::core::default::Default for WAVEFORMATEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11434,12 +10836,6 @@ impl ::core::clone::Clone for WAVEFORMATEXTENSIBLE {
 unsafe impl ::windows::core::Abi for WAVEFORMATEXTENSIBLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEFORMATEXTENSIBLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEFORMATEXTENSIBLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEFORMATEXTENSIBLE {}
 impl ::core::default::Default for WAVEFORMATEXTENSIBLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11461,12 +10857,6 @@ impl ::core::clone::Clone for WAVEFORMATEXTENSIBLE_0 {
 unsafe impl ::windows::core::Abi for WAVEFORMATEXTENSIBLE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEFORMATEXTENSIBLE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEFORMATEXTENSIBLE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEFORMATEXTENSIBLE_0 {}
 impl ::core::default::Default for WAVEFORMATEXTENSIBLE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11493,12 +10883,6 @@ impl ::core::clone::Clone for WAVEHDR {
 unsafe impl ::windows::core::Abi for WAVEHDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEHDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEHDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEHDR {}
 impl ::core::default::Default for WAVEHDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11532,14 +10916,6 @@ unsafe impl ::windows::core::Abi for WAVEINCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAVEINCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEINCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAVEINCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAVEINCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11568,12 +10944,6 @@ impl ::core::clone::Clone for WAVEINCAPS2W {
 unsafe impl ::windows::core::Abi for WAVEINCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEINCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEINCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEINCAPS2W {}
 impl ::core::default::Default for WAVEINCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11604,14 +10974,6 @@ unsafe impl ::windows::core::Abi for WAVEINCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAVEINCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEINCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAVEINCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAVEINCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11637,12 +10999,6 @@ impl ::core::clone::Clone for WAVEINCAPSW {
 unsafe impl ::windows::core::Abi for WAVEINCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEINCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEINCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEINCAPSW {}
 impl ::core::default::Default for WAVEINCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11677,14 +11033,6 @@ unsafe impl ::windows::core::Abi for WAVEOUTCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAVEOUTCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEOUTCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAVEOUTCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAVEOUTCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11714,12 +11062,6 @@ impl ::core::clone::Clone for WAVEOUTCAPS2W {
 unsafe impl ::windows::core::Abi for WAVEOUTCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEOUTCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEOUTCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEOUTCAPS2W {}
 impl ::core::default::Default for WAVEOUTCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11751,14 +11093,6 @@ unsafe impl ::windows::core::Abi for WAVEOUTCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAVEOUTCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEOUTCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAVEOUTCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAVEOUTCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11785,12 +11119,6 @@ impl ::core::clone::Clone for WAVEOUTCAPSW {
 unsafe impl ::windows::core::Abi for WAVEOUTCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WAVEOUTCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEOUTCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WAVEOUTCAPSW {}
 impl ::core::default::Default for WAVEOUTCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11816,12 +11144,6 @@ impl ::core::clone::Clone for tACMFORMATDETAILSW {
 unsafe impl ::windows::core::Abi for tACMFORMATDETAILSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for tACMFORMATDETAILSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<tACMFORMATDETAILSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for tACMFORMATDETAILSW {}
 impl ::core::default::Default for tACMFORMATDETAILSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
@@ -5210,7 +5210,7 @@ unsafe impl ::windows::core::Abi for MACINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MACINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MACINFO>()) == 0 }
+        self.fUsed == other.fUsed && self.abMacState == other.abMacState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5240,12 +5240,6 @@ impl ::core::clone::Clone for MTP_COMMAND_DATA_IN {
 unsafe impl ::windows::core::Abi for MTP_COMMAND_DATA_IN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MTP_COMMAND_DATA_IN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MTP_COMMAND_DATA_IN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MTP_COMMAND_DATA_IN {}
 impl ::core::default::Default for MTP_COMMAND_DATA_IN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5269,12 +5263,6 @@ impl ::core::clone::Clone for MTP_COMMAND_DATA_OUT {
 unsafe impl ::windows::core::Abi for MTP_COMMAND_DATA_OUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MTP_COMMAND_DATA_OUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MTP_COMMAND_DATA_OUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MTP_COMMAND_DATA_OUT {}
 impl ::core::default::Default for MTP_COMMAND_DATA_OUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5304,7 +5292,7 @@ unsafe impl ::windows::core::Abi for OPAQUECOMMAND {
 }
 impl ::core::cmp::PartialEq for OPAQUECOMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPAQUECOMMAND>()) == 0 }
+        self.guidCommand == other.guidCommand && self.dwDataLen == other.dwDataLen && self.pData == other.pData && self.abMAC == other.abMAC
     }
 }
 impl ::core::cmp::Eq for OPAQUECOMMAND {}
@@ -5339,7 +5327,7 @@ unsafe impl ::windows::core::Abi for WMDMDATETIME {
 }
 impl ::core::cmp::PartialEq for WMDMDATETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDMDATETIME>()) == 0 }
+        self.wYear == other.wYear && self.wMonth == other.wMonth && self.wDay == other.wDay && self.wHour == other.wHour && self.wMinute == other.wMinute && self.wSecond == other.wSecond
     }
 }
 impl ::core::cmp::Eq for WMDMDATETIME {}
@@ -5443,12 +5431,6 @@ impl ::core::clone::Clone for WMDMDetermineMaxPropStringLen {
 unsafe impl ::windows::core::Abi for WMDMDetermineMaxPropStringLen {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMDMDetermineMaxPropStringLen {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDMDetermineMaxPropStringLen>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMDMDetermineMaxPropStringLen {}
 impl ::core::default::Default for WMDMDetermineMaxPropStringLen {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5478,7 +5460,7 @@ unsafe impl ::windows::core::Abi for WMDMID {
 }
 impl ::core::cmp::PartialEq for WMDMID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDMID>()) == 0 }
+        self.cbSize == other.cbSize && self.dwVendorID == other.dwVendorID && self.pID == other.pID && self.SerialNumberLength == other.SerialNumberLength
     }
 }
 impl ::core::cmp::Eq for WMDMID {}
@@ -5510,7 +5492,7 @@ unsafe impl ::windows::core::Abi for WMDMMetadataView {
 }
 impl ::core::cmp::PartialEq for WMDMMetadataView {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDMMetadataView>()) == 0 }
+        self.pwszViewName == other.pwszViewName && self.nDepth == other.nDepth && self.ppwszTags == other.ppwszTags
     }
 }
 impl ::core::cmp::Eq for WMDMMetadataView {}
@@ -5546,7 +5528,7 @@ unsafe impl ::windows::core::Abi for WMDMRIGHTS {
 }
 impl ::core::cmp::PartialEq for WMDMRIGHTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDMRIGHTS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwContentType == other.dwContentType && self.fuFlags == other.fuFlags && self.fuRights == other.fuRights && self.dwAppSec == other.dwAppSec && self.dwPlaybackCount == other.dwPlaybackCount && self.ExpirationDate == other.ExpirationDate
     }
 }
 impl ::core::cmp::Eq for WMDMRIGHTS {}
@@ -5583,7 +5565,7 @@ unsafe impl ::windows::core::Abi for WMDM_FORMAT_CAPABILITY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for WMDM_FORMAT_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDM_FORMAT_CAPABILITY>()) == 0 }
+        self.nPropConfig == other.nPropConfig && self.pConfigs == other.pConfigs
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -5623,7 +5605,7 @@ unsafe impl ::windows::core::Abi for WMDM_PROP_CONFIG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for WMDM_PROP_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDM_PROP_CONFIG>()) == 0 }
+        self.nPreference == other.nPreference && self.nPropDesc == other.nPropDesc && self.pPropDesc == other.pPropDesc
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -5653,14 +5635,6 @@ unsafe impl ::windows::core::Abi for WMDM_PROP_DESC {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for WMDM_PROP_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        self.pwszPropName == other.pwszPropName && self.ValidValuesForm == other.ValidValuesForm && self.ValidValues == other.ValidValues
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for WMDM_PROP_DESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for WMDM_PROP_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5683,14 +5657,6 @@ impl ::core::clone::Clone for WMDM_PROP_DESC_0 {
 unsafe impl ::windows::core::Abi for WMDM_PROP_DESC_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for WMDM_PROP_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDM_PROP_DESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for WMDM_PROP_DESC_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for WMDM_PROP_DESC_0 {
     fn default() -> Self {
@@ -5725,7 +5691,7 @@ unsafe impl ::windows::core::Abi for WMDM_PROP_VALUES_ENUM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for WMDM_PROP_VALUES_ENUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDM_PROP_VALUES_ENUM>()) == 0 }
+        self.cEnumValues == other.cEnumValues && self.pValues == other.pValues
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -5755,14 +5721,6 @@ unsafe impl ::windows::core::Abi for WMDM_PROP_VALUES_RANGE {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for WMDM_PROP_VALUES_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        self.rangeMin == other.rangeMin && self.rangeMax == other.rangeMax && self.rangeStep == other.rangeStep
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for WMDM_PROP_VALUES_RANGE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for WMDM_PROP_VALUES_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5790,7 +5748,7 @@ unsafe impl ::windows::core::Abi for WMFILECAPABILITIES {
 }
 impl ::core::cmp::PartialEq for WMFILECAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMFILECAPABILITIES>()) == 0 }
+        self.pwszMimeType == other.pwszMimeType && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for WMFILECAPABILITIES {}

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -935,7 +935,7 @@ unsafe impl ::windows::core::Abi for DMO_PARTIAL_MEDIATYPE {
 }
 impl ::core::cmp::PartialEq for DMO_PARTIAL_MEDIATYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DMO_PARTIAL_MEDIATYPE>()) == 0 }
+        self.r#type == other.r#type && self.subtype == other.subtype
     }
 }
 impl ::core::cmp::Eq for DMO_PARTIAL_MEDIATYPE {}

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -7639,7 +7639,27 @@ unsafe impl ::windows::core::Abi for ALLOCATOR_PROPERTIES_EX {
 }
 impl ::core::cmp::PartialEq for ALLOCATOR_PROPERTIES_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ALLOCATOR_PROPERTIES_EX>()) == 0 }
+        self.cBuffers == other.cBuffers
+            && self.cbBuffer == other.cbBuffer
+            && self.cbAlign == other.cbAlign
+            && self.cbPrefix == other.cbPrefix
+            && self.MemoryType == other.MemoryType
+            && self.BusType == other.BusType
+            && self.State == other.State
+            && self.Input == other.Input
+            && self.Output == other.Output
+            && self.Strategy == other.Strategy
+            && self.Flags == other.Flags
+            && self.Weight == other.Weight
+            && self.LogicalMemoryType == other.LogicalMemoryType
+            && self.AllocatorPlace == other.AllocatorPlace
+            && self.Dimensions == other.Dimensions
+            && self.PhysicalRange == other.PhysicalRange
+            && self.PrevSegment == other.PrevSegment
+            && self.CountNextSegments == other.CountNextSegments
+            && self.NextSegments == other.NextSegments
+            && self.InsideFactors == other.InsideFactors
+            && self.NumberPins == other.NumberPins
     }
 }
 impl ::core::cmp::Eq for ALLOCATOR_PROPERTIES_EX {}
@@ -7676,7 +7696,7 @@ unsafe impl ::windows::core::Abi for AUDIORESOURCEMANAGEMENT_RESOURCEGROUP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUDIORESOURCEMANAGEMENT_RESOURCEGROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIORESOURCEMANAGEMENT_RESOURCEGROUP>()) == 0 }
+        self.ResourceGroupAcquired == other.ResourceGroupAcquired && self.ResourceGroupName == other.ResourceGroupName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7709,7 +7729,7 @@ unsafe impl ::windows::core::Abi for CC_BYTE_PAIR {
 }
 impl ::core::cmp::PartialEq for CC_BYTE_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CC_BYTE_PAIR>()) == 0 }
+        self.Decoded == other.Decoded && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for CC_BYTE_PAIR {}
@@ -7742,7 +7762,7 @@ unsafe impl ::windows::core::Abi for CC_HW_FIELD {
 }
 impl ::core::cmp::PartialEq for CC_HW_FIELD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CC_HW_FIELD>()) == 0 }
+        self.ScanlinesRequested == other.ScanlinesRequested && self.fieldFlags == other.fieldFlags && self.PictureNumber == other.PictureNumber && self.Lines == other.Lines
     }
 }
 impl ::core::cmp::Eq for CC_HW_FIELD {}
@@ -7818,7 +7838,29 @@ unsafe impl ::windows::core::Abi for DEVCAPS {
 }
 impl ::core::cmp::PartialEq for DEVCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVCAPS>()) == 0 }
+        self.CanRecord == other.CanRecord
+            && self.CanRecordStrobe == other.CanRecordStrobe
+            && self.HasAudio == other.HasAudio
+            && self.HasVideo == other.HasVideo
+            && self.UsesFiles == other.UsesFiles
+            && self.CanSave == other.CanSave
+            && self.DeviceType == other.DeviceType
+            && self.TCRead == other.TCRead
+            && self.TCWrite == other.TCWrite
+            && self.CTLRead == other.CTLRead
+            && self.IndexRead == other.IndexRead
+            && self.Preroll == other.Preroll
+            && self.Postroll == other.Postroll
+            && self.SyncAcc == other.SyncAcc
+            && self.NormRate == other.NormRate
+            && self.CanPreview == other.CanPreview
+            && self.CanMonitorSrc == other.CanMonitorSrc
+            && self.CanTest == other.CanTest
+            && self.VideoIn == other.VideoIn
+            && self.AudioIn == other.AudioIn
+            && self.Calibrate == other.Calibrate
+            && self.SeekType == other.SeekType
+            && self.SimulatedHardware == other.SimulatedHardware
     }
 }
 impl ::core::cmp::Eq for DEVCAPS {}
@@ -7843,12 +7885,6 @@ impl ::core::clone::Clone for DS3DVECTOR {
 unsafe impl ::windows::core::Abi for DS3DVECTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DS3DVECTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DVECTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DS3DVECTOR {}
 impl ::core::default::Default for DS3DVECTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7869,12 +7905,6 @@ impl ::core::clone::Clone for DS3DVECTOR_0 {
 unsafe impl ::windows::core::Abi for DS3DVECTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DS3DVECTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DVECTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DS3DVECTOR_0 {}
 impl ::core::default::Default for DS3DVECTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7895,12 +7925,6 @@ impl ::core::clone::Clone for DS3DVECTOR_1 {
 unsafe impl ::windows::core::Abi for DS3DVECTOR_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DS3DVECTOR_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DVECTOR_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DS3DVECTOR_1 {}
 impl ::core::default::Default for DS3DVECTOR_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7921,12 +7945,6 @@ impl ::core::clone::Clone for DS3DVECTOR_2 {
 unsafe impl ::windows::core::Abi for DS3DVECTOR_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DS3DVECTOR_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS3DVECTOR_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DS3DVECTOR_2 {}
 impl ::core::default::Default for DS3DVECTOR_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7965,7 +7983,7 @@ unsafe impl ::windows::core::Abi for INTERLEAVED_AUDIO_FORMAT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for INTERLEAVED_AUDIO_FORMAT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERLEAVED_AUDIO_FORMAT_INFORMATION>()) == 0 }
+        self.Size == other.Size && self.PrimaryChannelCount == other.PrimaryChannelCount && self.PrimaryChannelStartPosition == other.PrimaryChannelStartPosition && self.PrimaryChannelMask == other.PrimaryChannelMask && self.InterleavedChannelCount == other.InterleavedChannelCount && self.InterleavedChannelStartPosition == other.InterleavedChannelStartPosition && self.InterleavedChannelMask == other.InterleavedChannelMask
     }
 }
 impl ::core::cmp::Eq for INTERLEAVED_AUDIO_FORMAT_INFORMATION {}
@@ -8002,7 +8020,7 @@ unsafe impl ::windows::core::Abi for KSAC3_ALTERNATE_AUDIO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAC3_ALTERNATE_AUDIO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_ALTERNATE_AUDIO>()) == 0 }
+        self.fStereo == other.fStereo && self.DualMode == other.DualMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8034,7 +8052,7 @@ unsafe impl ::windows::core::Abi for KSAC3_BIT_STREAM_MODE {
 }
 impl ::core::cmp::PartialEq for KSAC3_BIT_STREAM_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_BIT_STREAM_MODE>()) == 0 }
+        self.BitStreamMode == other.BitStreamMode
     }
 }
 impl ::core::cmp::Eq for KSAC3_BIT_STREAM_MODE {}
@@ -8064,7 +8082,7 @@ unsafe impl ::windows::core::Abi for KSAC3_DIALOGUE_LEVEL {
 }
 impl ::core::cmp::PartialEq for KSAC3_DIALOGUE_LEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_DIALOGUE_LEVEL>()) == 0 }
+        self.DialogueLevel == other.DialogueLevel
     }
 }
 impl ::core::cmp::Eq for KSAC3_DIALOGUE_LEVEL {}
@@ -8101,7 +8119,7 @@ unsafe impl ::windows::core::Abi for KSAC3_DOWNMIX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAC3_DOWNMIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_DOWNMIX>()) == 0 }
+        self.fDownMix == other.fDownMix && self.fDolbySurround == other.fDolbySurround
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8140,7 +8158,7 @@ unsafe impl ::windows::core::Abi for KSAC3_ERROR_CONCEALMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAC3_ERROR_CONCEALMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_ERROR_CONCEALMENT>()) == 0 }
+        self.fRepeatPreviousBlock == other.fRepeatPreviousBlock && self.fErrorInCurrentBlock == other.fErrorInCurrentBlock
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8178,7 +8196,7 @@ unsafe impl ::windows::core::Abi for KSAC3_ROOM_TYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAC3_ROOM_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAC3_ROOM_TYPE>()) == 0 }
+        self.fLargeRoom == other.fLargeRoom
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8208,12 +8226,6 @@ impl ::core::clone::Clone for KSALLOCATOR_FRAMING {
 unsafe impl ::windows::core::Abi for KSALLOCATOR_FRAMING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSALLOCATOR_FRAMING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSALLOCATOR_FRAMING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSALLOCATOR_FRAMING {}
 impl ::core::default::Default for KSALLOCATOR_FRAMING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8234,12 +8246,6 @@ impl ::core::clone::Clone for KSALLOCATOR_FRAMING_0 {
 unsafe impl ::windows::core::Abi for KSALLOCATOR_FRAMING_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSALLOCATOR_FRAMING_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSALLOCATOR_FRAMING_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSALLOCATOR_FRAMING_0 {}
 impl ::core::default::Default for KSALLOCATOR_FRAMING_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8260,12 +8266,6 @@ impl ::core::clone::Clone for KSALLOCATOR_FRAMING_1 {
 unsafe impl ::windows::core::Abi for KSALLOCATOR_FRAMING_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSALLOCATOR_FRAMING_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSALLOCATOR_FRAMING_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSALLOCATOR_FRAMING_1 {}
 impl ::core::default::Default for KSALLOCATOR_FRAMING_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8289,12 +8289,6 @@ impl ::core::clone::Clone for KSALLOCATOR_FRAMING_EX {
 unsafe impl ::windows::core::Abi for KSALLOCATOR_FRAMING_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSALLOCATOR_FRAMING_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSALLOCATOR_FRAMING_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSALLOCATOR_FRAMING_EX {}
 impl ::core::default::Default for KSALLOCATOR_FRAMING_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8323,7 +8317,7 @@ unsafe impl ::windows::core::Abi for KSATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for KSATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSATTRIBUTE>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.Attribute == other.Attribute
     }
 }
 impl ::core::cmp::Eq for KSATTRIBUTE {}
@@ -8354,7 +8348,7 @@ unsafe impl ::windows::core::Abi for KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE {
 }
 impl ::core::cmp::PartialEq for KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE>()) == 0 }
+        self.AttributeHeader == other.AttributeHeader && self.SignalProcessingMode == other.SignalProcessingMode
     }
 }
 impl ::core::cmp::Eq for KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE {}
@@ -8385,7 +8379,7 @@ unsafe impl ::windows::core::Abi for KSAUDIOENGINE_BUFFER_SIZE_RANGE {
 }
 impl ::core::cmp::PartialEq for KSAUDIOENGINE_BUFFER_SIZE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOENGINE_BUFFER_SIZE_RANGE>()) == 0 }
+        self.MinBufferBytes == other.MinBufferBytes && self.MaxBufferBytes == other.MaxBufferBytes
     }
 }
 impl ::core::cmp::Eq for KSAUDIOENGINE_BUFFER_SIZE_RANGE {}
@@ -8417,7 +8411,7 @@ unsafe impl ::windows::core::Abi for KSAUDIOENGINE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for KSAUDIOENGINE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOENGINE_DESCRIPTOR>()) == 0 }
+        self.nHostPinId == other.nHostPinId && self.nOffloadPinId == other.nOffloadPinId && self.nLoopbackPinId == other.nLoopbackPinId
     }
 }
 impl ::core::cmp::Eq for KSAUDIOENGINE_DESCRIPTOR {}
@@ -8449,7 +8443,7 @@ unsafe impl ::windows::core::Abi for KSAUDIOENGINE_VOLUMELEVEL {
 }
 impl ::core::cmp::PartialEq for KSAUDIOENGINE_VOLUMELEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOENGINE_VOLUMELEVEL>()) == 0 }
+        self.TargetVolume == other.TargetVolume && self.CurveType == other.CurveType && self.CurveDuration == other.CurveDuration
     }
 }
 impl ::core::cmp::Eq for KSAUDIOENGINE_VOLUMELEVEL {}
@@ -8483,7 +8477,7 @@ unsafe impl ::windows::core::Abi for KSAUDIOMODULE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for KSAUDIOMODULE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOMODULE_DESCRIPTOR>()) == 0 }
+        self.ClassId == other.ClassId && self.InstanceId == other.InstanceId && self.VersionMajor == other.VersionMajor && self.VersionMinor == other.VersionMinor && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for KSAUDIOMODULE_DESCRIPTOR {}
@@ -8506,12 +8500,6 @@ impl ::core::clone::Clone for KSAUDIOMODULE_NOTIFICATION {
 unsafe impl ::windows::core::Abi for KSAUDIOMODULE_NOTIFICATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSAUDIOMODULE_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOMODULE_NOTIFICATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSAUDIOMODULE_NOTIFICATION {}
 impl ::core::default::Default for KSAUDIOMODULE_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8532,12 +8520,6 @@ impl ::core::clone::Clone for KSAUDIOMODULE_NOTIFICATION_0 {
 unsafe impl ::windows::core::Abi for KSAUDIOMODULE_NOTIFICATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSAUDIOMODULE_NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOMODULE_NOTIFICATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSAUDIOMODULE_NOTIFICATION_0 {}
 impl ::core::default::Default for KSAUDIOMODULE_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8567,7 +8549,7 @@ unsafe impl ::windows::core::Abi for KSAUDIOMODULE_NOTIFICATION_0_0 {
 }
 impl ::core::cmp::PartialEq for KSAUDIOMODULE_NOTIFICATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOMODULE_NOTIFICATION_0_0>()) == 0 }
+        self.DeviceId == other.DeviceId && self.ClassId == other.ClassId && self.InstanceId == other.InstanceId && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSAUDIOMODULE_NOTIFICATION_0_0 {}
@@ -8592,12 +8574,6 @@ impl ::core::clone::Clone for KSAUDIOMODULE_PROPERTY {
 unsafe impl ::windows::core::Abi for KSAUDIOMODULE_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSAUDIOMODULE_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIOMODULE_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSAUDIOMODULE_PROPERTY {}
 impl ::core::default::Default for KSAUDIOMODULE_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8624,7 +8600,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_CHANNEL_CONFIG {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_CHANNEL_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_CHANNEL_CONFIG>()) == 0 }
+        self.ActiveSpeakerPositions == other.ActiveSpeakerPositions
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_CHANNEL_CONFIG {}
@@ -8661,7 +8637,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_COPY_PROTECTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAUDIO_COPY_PROTECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_COPY_PROTECTION>()) == 0 }
+        self.fCopyrighted == other.fCopyrighted && self.fOriginal == other.fOriginal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8694,7 +8670,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_DYNAMIC_RANGE {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_DYNAMIC_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_DYNAMIC_RANGE>()) == 0 }
+        self.QuietCompression == other.QuietCompression && self.LoudCompression == other.LoudCompression
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_DYNAMIC_RANGE {}
@@ -8729,7 +8705,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_MICROPHONE_COORDINATES {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_MICROPHONE_COORDINATES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MICROPHONE_COORDINATES>()) == 0 }
+        self.usType == other.usType && self.wXCoord == other.wXCoord && self.wYCoord == other.wYCoord && self.wZCoord == other.wZCoord && self.wVerticalAngle == other.wVerticalAngle && self.wHorizontalAngle == other.wHorizontalAngle
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_MICROPHONE_COORDINATES {}
@@ -8779,7 +8755,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_MIC_ARRAY_GEOMETRY {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_MIC_ARRAY_GEOMETRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MIC_ARRAY_GEOMETRY>()) == 0 }
+        self.usVersion == other.usVersion && self.usMicArrayType == other.usMicArrayType && self.wVerticalAngleBegin == other.wVerticalAngleBegin && self.wVerticalAngleEnd == other.wVerticalAngleEnd && self.wHorizontalAngleBegin == other.wHorizontalAngleBegin && self.wHorizontalAngleEnd == other.wHorizontalAngleEnd && self.usFrequencyBandLo == other.usFrequencyBandLo && self.usFrequencyBandHi == other.usFrequencyBandHi && self.usNumberOfMicrophones == other.usNumberOfMicrophones && self.KsMicCoord == other.KsMicCoord
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_MIC_ARRAY_GEOMETRY {}
@@ -8808,14 +8784,6 @@ impl ::core::clone::Clone for KSAUDIO_MIXCAP_TABLE {
 unsafe impl ::windows::core::Abi for KSAUDIO_MIXCAP_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSAUDIO_MIXCAP_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MIXCAP_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSAUDIO_MIXCAP_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSAUDIO_MIXCAP_TABLE {
     fn default() -> Self {
@@ -8850,7 +8818,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_MIXLEVEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSAUDIO_MIXLEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MIXLEVEL>()) == 0 }
+        self.Mute == other.Mute && self.Level == other.Level
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8883,14 +8851,6 @@ unsafe impl ::windows::core::Abi for KSAUDIO_MIX_CAPS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSAUDIO_MIX_CAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MIX_CAPS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSAUDIO_MIX_CAPS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSAUDIO_MIX_CAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8915,14 +8875,6 @@ impl ::core::clone::Clone for KSAUDIO_MIX_CAPS_0 {
 unsafe impl ::windows::core::Abi for KSAUDIO_MIX_CAPS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSAUDIO_MIX_CAPS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_MIX_CAPS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSAUDIO_MIX_CAPS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSAUDIO_MIX_CAPS_0 {
     fn default() -> Self {
@@ -8954,7 +8906,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_PACKETSIZE_CONSTRAINTS {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_PACKETSIZE_CONSTRAINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_PACKETSIZE_CONSTRAINTS>()) == 0 }
+        self.MinPacketPeriodInHns == other.MinPacketPeriodInHns && self.PacketSizeFileAlignment == other.PacketSizeFileAlignment && self.Reserved == other.Reserved && self.NumProcessingModeConstraints == other.NumProcessingModeConstraints && self.ProcessingModeConstraints == other.ProcessingModeConstraints
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_PACKETSIZE_CONSTRAINTS {}
@@ -8988,7 +8940,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_PACKETSIZE_CONSTRAINTS2 {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_PACKETSIZE_CONSTRAINTS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_PACKETSIZE_CONSTRAINTS2>()) == 0 }
+        self.MinPacketPeriodInHns == other.MinPacketPeriodInHns && self.PacketSizeFileAlignment == other.PacketSizeFileAlignment && self.MaxPacketSizeInBytes == other.MaxPacketSizeInBytes && self.NumProcessingModeConstraints == other.NumProcessingModeConstraints && self.ProcessingModeConstraints == other.ProcessingModeConstraints
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_PACKETSIZE_CONSTRAINTS2 {}
@@ -9020,7 +8972,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAIN
 }
 impl ::core::cmp::PartialEq for KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT>()) == 0 }
+        self.ProcessingMode == other.ProcessingMode && self.SamplesPerProcessingPacket == other.SamplesPerProcessingPacket && self.ProcessingPacketDurationInHns == other.ProcessingPacketDurationInHns
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT {}
@@ -9051,7 +9003,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_POSITION {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_POSITION>()) == 0 }
+        self.PlayOffset == other.PlayOffset && self.WriteOffset == other.WriteOffset
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_POSITION {}
@@ -9084,7 +9036,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_POSITIONEX {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_POSITIONEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_POSITIONEX>()) == 0 }
+        self.TimerFrequency == other.TimerFrequency && self.TimeStamp1 == other.TimeStamp1 && self.Position == other.Position && self.TimeStamp2 == other.TimeStamp2
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_POSITIONEX {}
@@ -9115,7 +9067,7 @@ unsafe impl ::windows::core::Abi for KSAUDIO_PRESENTATION_POSITION {
 }
 impl ::core::cmp::PartialEq for KSAUDIO_PRESENTATION_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSAUDIO_PRESENTATION_POSITION>()) == 0 }
+        self.u64PositionInBlocks == other.u64PositionInBlocks && self.u64QPCPosition == other.u64QPCPosition
     }
 }
 impl ::core::cmp::Eq for KSAUDIO_PRESENTATION_POSITION {}
@@ -9154,7 +9106,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATIO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS>()) == 0 }
+        self.Resolution == other.Resolution && self.MaxFrameRate == other.MaxFrameRate && self.MaskResolution == other.MaskResolution && self.SubType == other.SubType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9193,7 +9145,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATIO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS_0>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9228,7 +9180,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_CAMERAOFFSET {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_CAMERAOFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_CAMERAOFFSET>()) == 0 }
+        self.PitchAngle == other.PitchAngle && self.YawAngle == other.YawAngle && self.Flag == other.Flag && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_CAMERAOFFSET {}
@@ -9278,7 +9230,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGC
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPS>()) == 0 }
+        self.ResolutionX == other.ResolutionX && self.ResolutionY == other.ResolutionY && self.PorchTop == other.PorchTop && self.PorchLeft == other.PorchLeft && self.PorchBottom == other.PorchBottom && self.PorchRight == other.PorchRight && self.NonUpscalingWindowSize == other.NonUpscalingWindowSize && self.MinWindowSize == other.MinWindowSize && self.MaxWindowSize == other.MaxWindowSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPS {}
@@ -9309,7 +9261,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGC
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER>()) == 0 }
+        self.Size == other.Size && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER {}
@@ -9342,7 +9294,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING>()) == 0 }
+        self.OriginX == other.OriginX && self.OriginY == other.OriginY && self.WindowSize == other.WindowSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING {}
@@ -9376,7 +9328,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_EVCOMPENSATION>()) == 0 }
+        self.Mode == other.Mode && self.Min == other.Min && self.Max == other.Max && self.Value == other.Value && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {}
@@ -9409,7 +9361,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_FIELDOFVIEW {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_FIELDOFVIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_FIELDOFVIEW>()) == 0 }
+        self.NormalizedFocalLengthX == other.NormalizedFocalLengthX && self.NormalizedFocalLengthY == other.NormalizedFocalLengthY && self.Flag == other.Flag && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_FIELDOFVIEW {}
@@ -9444,7 +9396,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_HEADER>()) == 0 }
+        self.Version == other.Version && self.PinId == other.PinId && self.Size == other.Size && self.Result == other.Result && self.Flags == other.Flags && self.Capability == other.Capability
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_HEADER {}
@@ -9475,7 +9427,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_METADATAINFO {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_METADATAINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_METADATAINFO>()) == 0 }
+        self.BufferAlignment == other.BufferAlignment && self.MaxMetadataBufferSize == other.MaxMetadataBufferSize
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_METADATAINFO {}
@@ -9508,7 +9460,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_PHOTOMODE {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_PHOTOMODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_PHOTOMODE>()) == 0 }
+        self.RequestedHistoryFrames == other.RequestedHistoryFrames && self.MaxHistoryFrames == other.MaxHistoryFrames && self.SubMode == other.SubMode && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_PHOTOMODE {}
@@ -9540,7 +9492,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_PROFILE {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_PROFILE>()) == 0 }
+        self.ProfileId == other.ProfileId && self.Index == other.Index && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_PROFILE {}
@@ -9572,7 +9524,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS>()) == 0 }
+        self.ControlId == other.ControlId && self.MaxNumberOfROIs == other.MaxNumberOfROIs && self.Capability == other.Capability
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS {}
@@ -9604,7 +9556,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER 
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER>()) == 0 }
+        self.Size == other.Size && self.ConfigCapCount == other.ConfigCapCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER {}
@@ -9641,7 +9593,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE>()) == 0 }
+        self.ROIInfo == other.ROIInfo && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9680,7 +9632,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_FOCUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_FOCUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_FOCUS>()) == 0 }
+        self.ROIInfo == other.ROIInfo && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9721,7 +9673,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_INFO>()) == 0 }
+        self.Region == other.Region && self.Flags == other.Flags && self.Weight == other.Weight && self.RegionOfInterestType == other.RegionOfInterestType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9756,7 +9708,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL>()) == 0 }
+        self.ControlId == other.ControlId && self.ROICount == other.ROICount && self.Result == other.Result && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {}
@@ -9788,7 +9740,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER 
 }
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER>()) == 0 }
+        self.Size == other.Size && self.ControlCount == other.ControlCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER {}
@@ -9825,7 +9777,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE>()) == 0 }
+        self.ROIInfo == other.ROIInfo && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9850,12 +9802,6 @@ impl ::core::clone::Clone for KSCAMERA_EXTENDEDPROP_VALUE {
 unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_VALUE {}
 impl ::core::default::Default for KSCAMERA_EXTENDEDPROP_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9880,12 +9826,6 @@ impl ::core::clone::Clone for KSCAMERA_EXTENDEDPROP_VALUE_0 {
 unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_VALUE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_VALUE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_VALUE_0 {}
 impl ::core::default::Default for KSCAMERA_EXTENDEDPROP_VALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9910,12 +9850,6 @@ impl ::core::clone::Clone for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
 unsafe impl ::windows::core::Abi for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {}
 impl ::core::default::Default for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9947,7 +9881,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_MAXVIDEOFPS_FORPHOTORES {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_MAXVIDEOFPS_FORPHOTORES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_MAXVIDEOFPS_FORPHOTORES>()) == 0 }
+        self.PhotoResWidth == other.PhotoResWidth && self.PhotoResHeight == other.PhotoResHeight && self.PreviewFPSNum == other.PreviewFPSNum && self.PreviewFPSDenom == other.PreviewFPSDenom && self.CaptureFPSNum == other.CaptureFPSNum && self.CaptureFPSDenom == other.CaptureFPSDenom
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_MAXVIDEOFPS_FORPHOTORES {}
@@ -9987,7 +9921,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMAS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMASK>()) == 0 }
+        self.Header == other.Header && self.MaskCoverageBoundingBox == other.MaskCoverageBoundingBox && self.MaskResolution == other.MaskResolution && self.ForegroundBoundingBox == other.ForegroundBoundingBox && self.MaskData == other.MaskData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10049,7 +9983,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_CAPTURESTATS {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_CAPTURESTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_CAPTURESTATS>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.Reserved == other.Reserved && self.ExposureTime == other.ExposureTime && self.ExposureCompensationFlags == other.ExposureCompensationFlags && self.ExposureCompensationValue == other.ExposureCompensationValue && self.IsoSpeed == other.IsoSpeed && self.FocusState == other.FocusState && self.LensPosition == other.LensPosition && self.WhiteBalance == other.WhiteBalance && self.Flash == other.Flash && self.FlashPower == other.FlashPower && self.ZoomFactor == other.ZoomFactor && self.SceneMode == other.SceneMode && self.SensorFramerate == other.SensorFramerate
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_METADATA_CAPTURESTATS {}
@@ -10080,7 +10014,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_DIGITALWINDOW {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_DIGITALWINDOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_DIGITALWINDOW>()) == 0 }
+        self.Header == other.Header && self.Window == other.Window
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_METADATA_DIGITALWINDOW {}
@@ -10112,7 +10046,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_FRAMEILLUMINATION {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_FRAMEILLUMINATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_FRAMEILLUMINATION>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_METADATA_FRAMEILLUMINATION {}
@@ -10143,7 +10077,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_ITEMHEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_ITEMHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_ITEMHEADER>()) == 0 }
+        self.MetadataId == other.MetadataId && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_METADATA_ITEMHEADER {}
@@ -10175,7 +10109,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_METADATA_PHOTOCONFIRMATION {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_METADATA_PHOTOCONFIRMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_METADATA_PHOTOCONFIRMATION>()) == 0 }
+        self.Header == other.Header && self.PhotoConfirmationIndex == other.PhotoConfirmationIndex && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_METADATA_PHOTOCONFIRMATION {}
@@ -10207,7 +10141,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_CAP_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_CAP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_CAP_HEADER>()) == 0 }
+        self.Size == other.Size && self.ItemCount == other.ItemCount && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_CAP_HEADER {}
@@ -10239,7 +10173,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER>()) == 0 }
+        self.Size == other.Size && self.Type == other.Type && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {}
@@ -10271,7 +10205,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM>()) == 0 }
+        self.Size == other.Size && self.Reserved == other.Reserved && self.Id == other.Id
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM {}
@@ -10304,7 +10238,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_FRAME_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_FRAME_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_FRAME_HEADER>()) == 0 }
+        self.Size == other.Size && self.Id == other.Id && self.ItemCount == other.ItemCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_FRAME_HEADER {}
@@ -10339,7 +10273,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_HEADER>()) == 0 }
+        self.Size == other.Size && self.FrameCount == other.FrameCount && self.Id == other.Id && self.Flags == other.Flags && self.LoopCount == other.LoopCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_HEADER {}
@@ -10371,7 +10305,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PERFRAMESETTING_ITEM_HEADER {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PERFRAMESETTING_ITEM_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PERFRAMESETTING_ITEM_HEADER>()) == 0 }
+        self.Size == other.Size && self.Type == other.Type && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PERFRAMESETTING_ITEM_HEADER {}
@@ -10404,7 +10338,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_CONCURRENCYINFO {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_CONCURRENCYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_CONCURRENCYINFO>()) == 0 }
+        self.ReferenceGuid == other.ReferenceGuid && self.Reserved == other.Reserved && self.ProfileCount == other.ProfileCount && self.Profiles == other.Profiles
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_CONCURRENCYINFO {}
@@ -10437,7 +10371,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_INFO {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_INFO>()) == 0 }
+        self.ProfileId == other.ProfileId && self.Index == other.Index && self.PinCount == other.PinCount && self.Pins == other.Pins
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_INFO {}
@@ -10473,7 +10407,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_MEDIAINFO {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_MEDIAINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_MEDIAINFO>()) == 0 }
+        self.Resolution == other.Resolution && self.MaxFrameRate == other.MaxFrameRate && self.Flags == other.Flags && self.Data0 == other.Data0 && self.Data1 == other.Data1 && self.Data2 == other.Data2 && self.Data3 == other.Data3
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_MEDIAINFO {}
@@ -10504,7 +10438,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_MEDIAINFO_0 {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_MEDIAINFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_MEDIAINFO_0>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_MEDIAINFO_0 {}
@@ -10535,7 +10469,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_MEDIAINFO_1 {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_MEDIAINFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_MEDIAINFO_1>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_MEDIAINFO_1 {}
@@ -10561,12 +10495,6 @@ impl ::core::clone::Clone for KSCAMERA_PROFILE_PININFO {
 unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_PININFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_PININFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_PININFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSCAMERA_PROFILE_PININFO {}
 impl ::core::default::Default for KSCAMERA_PROFILE_PININFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10587,12 +10515,6 @@ impl ::core::clone::Clone for KSCAMERA_PROFILE_PININFO_0 {
 unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_PININFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_PININFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_PININFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSCAMERA_PROFILE_PININFO_0 {}
 impl ::core::default::Default for KSCAMERA_PROFILE_PININFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10620,7 +10542,7 @@ unsafe impl ::windows::core::Abi for KSCAMERA_PROFILE_PININFO_0_0 {
 }
 impl ::core::cmp::PartialEq for KSCAMERA_PROFILE_PININFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCAMERA_PROFILE_PININFO_0_0>()) == 0 }
+        self.PinIndex == other.PinIndex && self.ProfileSensorType == other.ProfileSensorType
     }
 }
 impl ::core::cmp::Eq for KSCAMERA_PROFILE_PININFO_0_0 {}
@@ -10650,7 +10572,7 @@ unsafe impl ::windows::core::Abi for KSCLOCK_CREATE {
 }
 impl ::core::cmp::PartialEq for KSCLOCK_CREATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCLOCK_CREATE>()) == 0 }
+        self.CreateFlags == other.CreateFlags
     }
 }
 impl ::core::cmp::Eq for KSCLOCK_CREATE {}
@@ -10685,7 +10607,7 @@ unsafe impl ::windows::core::Abi for KSCOMPONENTID {
 }
 impl ::core::cmp::PartialEq for KSCOMPONENTID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCOMPONENTID>()) == 0 }
+        self.Manufacturer == other.Manufacturer && self.Product == other.Product && self.Component == other.Component && self.Name == other.Name && self.Version == other.Version && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for KSCOMPONENTID {}
@@ -10716,7 +10638,7 @@ unsafe impl ::windows::core::Abi for KSCORRELATED_TIME {
 }
 impl ::core::cmp::PartialEq for KSCORRELATED_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSCORRELATED_TIME>()) == 0 }
+        self.Time == other.Time && self.SystemTime == other.SystemTime
     }
 }
 impl ::core::cmp::Eq for KSCORRELATED_TIME {}
@@ -10740,12 +10662,6 @@ impl ::core::clone::Clone for KSDATAFORMAT {
 unsafe impl ::windows::core::Abi for KSDATAFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDATAFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDATAFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDATAFORMAT {}
 impl ::core::default::Default for KSDATAFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10778,7 +10694,7 @@ unsafe impl ::windows::core::Abi for KSDATAFORMAT_0 {
 }
 impl ::core::cmp::PartialEq for KSDATAFORMAT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDATAFORMAT_0>()) == 0 }
+        self.FormatSize == other.FormatSize && self.Flags == other.Flags && self.SampleSize == other.SampleSize && self.Reserved == other.Reserved && self.MajorFormat == other.MajorFormat && self.SubFormat == other.SubFormat && self.Specifier == other.Specifier
     }
 }
 impl ::core::cmp::Eq for KSDATAFORMAT_0 {}
@@ -10806,12 +10722,6 @@ impl ::core::clone::Clone for KSDATARANGE_AUDIO {
 unsafe impl ::windows::core::Abi for KSDATARANGE_AUDIO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDATARANGE_AUDIO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDATARANGE_AUDIO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDATARANGE_AUDIO {}
 impl ::core::default::Default for KSDATARANGE_AUDIO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10835,12 +10745,6 @@ impl ::core::clone::Clone for KSDATARANGE_MUSIC {
 unsafe impl ::windows::core::Abi for KSDATARANGE_MUSIC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDATARANGE_MUSIC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDATARANGE_MUSIC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDATARANGE_MUSIC {}
 impl ::core::default::Default for KSDATARANGE_MUSIC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10862,12 +10766,6 @@ impl ::core::clone::Clone for KSDEVICE_PROFILE_INFO {
 unsafe impl ::windows::core::Abi for KSDEVICE_PROFILE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDEVICE_PROFILE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDEVICE_PROFILE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDEVICE_PROFILE_INFO {}
 impl ::core::default::Default for KSDEVICE_PROFILE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10887,12 +10785,6 @@ impl ::core::clone::Clone for KSDEVICE_PROFILE_INFO_0 {
 unsafe impl ::windows::core::Abi for KSDEVICE_PROFILE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDEVICE_PROFILE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDEVICE_PROFILE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDEVICE_PROFILE_INFO_0 {}
 impl ::core::default::Default for KSDEVICE_PROFILE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10922,7 +10814,7 @@ unsafe impl ::windows::core::Abi for KSDEVICE_PROFILE_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for KSDEVICE_PROFILE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDEVICE_PROFILE_INFO_0_0>()) == 0 }
+        self.Info == other.Info && self.Reserved == other.Reserved && self.ConcurrencyCount == other.ConcurrencyCount && self.Concurrency == other.Concurrency
     }
 }
 impl ::core::cmp::Eq for KSDEVICE_PROFILE_INFO_0_0 {}
@@ -10955,7 +10847,7 @@ unsafe impl ::windows::core::Abi for KSDISPLAYCHANGE {
 }
 impl ::core::cmp::PartialEq for KSDISPLAYCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDISPLAYCHANGE>()) == 0 }
+        self.PelsWidth == other.PelsWidth && self.PelsHeight == other.PelsHeight && self.BitsPerPel == other.BitsPerPel && self.DeviceID == other.DeviceID
     }
 }
 impl ::core::cmp::Eq for KSDISPLAYCHANGE {}
@@ -10986,12 +10878,6 @@ impl ::core::clone::Clone for KSDS3D_BUFFER_ALL {
 unsafe impl ::windows::core::Abi for KSDS3D_BUFFER_ALL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDS3D_BUFFER_ALL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_BUFFER_ALL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDS3D_BUFFER_ALL {}
 impl ::core::default::Default for KSDS3D_BUFFER_ALL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11019,7 +10905,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_BUFFER_CONE_ANGLES {
 }
 impl ::core::cmp::PartialEq for KSDS3D_BUFFER_CONE_ANGLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_BUFFER_CONE_ANGLES>()) == 0 }
+        self.InsideConeAngle == other.InsideConeAngle && self.OutsideConeAngle == other.OutsideConeAngle
     }
 }
 impl ::core::cmp::Eq for KSDS3D_BUFFER_CONE_ANGLES {}
@@ -11052,7 +10938,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_HRTF_FILTER_FORMAT_MSG {
 }
 impl ::core::cmp::PartialEq for KSDS3D_HRTF_FILTER_FORMAT_MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_HRTF_FILTER_FORMAT_MSG>()) == 0 }
+        self.FilterMethod == other.FilterMethod && self.CoeffFormat == other.CoeffFormat && self.Version == other.Version && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSDS3D_HRTF_FILTER_FORMAT_MSG {}
@@ -11089,7 +10975,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_HRTF_INIT_MSG {
 }
 impl ::core::cmp::PartialEq for KSDS3D_HRTF_INIT_MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_HRTF_INIT_MSG>()) == 0 }
+        self.Size == other.Size && self.Quality == other.Quality && self.SampleRate == other.SampleRate && self.MaxFilterSize == other.MaxFilterSize && self.FilterTransientMuteLength == other.FilterTransientMuteLength && self.FilterOverlapBufferLength == other.FilterOverlapBufferLength && self.OutputOverlapBufferLength == other.OutputOverlapBufferLength && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSDS3D_HRTF_INIT_MSG {}
@@ -11130,7 +11016,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_HRTF_PARAMS_MSG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSDS3D_HRTF_PARAMS_MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_HRTF_PARAMS_MSG>()) == 0 }
+        self.Size == other.Size && self.Enabled == other.Enabled && self.SwapChannels == other.SwapChannels && self.ZeroAzimuth == other.ZeroAzimuth && self.CrossFadeOutput == other.CrossFadeOutput && self.FilterSize == other.FilterSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11167,7 +11053,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_ITD_PARAMS {
 }
 impl ::core::cmp::PartialEq for KSDS3D_ITD_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_ITD_PARAMS>()) == 0 }
+        self.Channel == other.Channel && self.VolSmoothScale == other.VolSmoothScale && self.TotalDryAttenuation == other.TotalDryAttenuation && self.TotalWetAttenuation == other.TotalWetAttenuation && self.SmoothFrequency == other.SmoothFrequency && self.Delay == other.Delay
     }
 }
 impl ::core::cmp::Eq for KSDS3D_ITD_PARAMS {}
@@ -11200,7 +11086,7 @@ unsafe impl ::windows::core::Abi for KSDS3D_ITD_PARAMS_MSG {
 }
 impl ::core::cmp::PartialEq for KSDS3D_ITD_PARAMS_MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_ITD_PARAMS_MSG>()) == 0 }
+        self.Enabled == other.Enabled && self.LeftParams == other.LeftParams && self.RightParams == other.RightParams && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSDS3D_ITD_PARAMS_MSG {}
@@ -11229,12 +11115,6 @@ impl ::core::clone::Clone for KSDS3D_LISTENER_ALL {
 unsafe impl ::windows::core::Abi for KSDS3D_LISTENER_ALL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDS3D_LISTENER_ALL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_LISTENER_ALL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDS3D_LISTENER_ALL {}
 impl ::core::default::Default for KSDS3D_LISTENER_ALL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11255,12 +11135,6 @@ impl ::core::clone::Clone for KSDS3D_LISTENER_ORIENTATION {
 unsafe impl ::windows::core::Abi for KSDS3D_LISTENER_ORIENTATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSDS3D_LISTENER_ORIENTATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSDS3D_LISTENER_ORIENTATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSDS3D_LISTENER_ORIENTATION {}
 impl ::core::default::Default for KSDS3D_LISTENER_ORIENTATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11288,7 +11162,7 @@ unsafe impl ::windows::core::Abi for KSERROR {
 }
 impl ::core::cmp::PartialEq for KSERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSERROR>()) == 0 }
+        self.Context == other.Context && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for KSERROR {}
@@ -11317,14 +11191,6 @@ unsafe impl ::windows::core::Abi for KSEVENTDATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSEVENTDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENTDATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSEVENTDATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSEVENTDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11350,14 +11216,6 @@ impl ::core::clone::Clone for KSEVENTDATA_0 {
 unsafe impl ::windows::core::Abi for KSEVENTDATA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSEVENTDATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENTDATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSEVENTDATA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSEVENTDATA_0 {
     fn default() -> Self {
@@ -11392,7 +11250,7 @@ unsafe impl ::windows::core::Abi for KSEVENTDATA_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSEVENTDATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENTDATA_0_0>()) == 0 }
+        self.Unused == other.Unused && self.Alignment == other.Alignment
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11431,7 +11289,7 @@ unsafe impl ::windows::core::Abi for KSEVENTDATA_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSEVENTDATA_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENTDATA_0_1>()) == 0 }
+        self.Event == other.Event && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11471,7 +11329,7 @@ unsafe impl ::windows::core::Abi for KSEVENTDATA_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSEVENTDATA_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENTDATA_0_2>()) == 0 }
+        self.Semaphore == other.Semaphore && self.Reserved == other.Reserved && self.Adjustment == other.Adjustment
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11503,14 +11361,6 @@ unsafe impl ::windows::core::Abi for KSEVENT_TIME_INTERVAL {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSEVENT_TIME_INTERVAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENT_TIME_INTERVAL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSEVENT_TIME_INTERVAL {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSEVENT_TIME_INTERVAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11535,14 +11385,6 @@ impl ::core::clone::Clone for KSEVENT_TIME_MARK {
 unsafe impl ::windows::core::Abi for KSEVENT_TIME_MARK {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSEVENT_TIME_MARK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENT_TIME_MARK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSEVENT_TIME_MARK {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSEVENT_TIME_MARK {
     fn default() -> Self {
@@ -11570,14 +11412,6 @@ unsafe impl ::windows::core::Abi for KSEVENT_TUNER_INITIATE_SCAN_S {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSEVENT_TUNER_INITIATE_SCAN_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEVENT_TUNER_INITIATE_SCAN_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSEVENT_TUNER_INITIATE_SCAN_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSEVENT_TUNER_INITIATE_SCAN_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11599,12 +11433,6 @@ impl ::core::clone::Clone for KSE_NODE {
 unsafe impl ::windows::core::Abi for KSE_NODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSE_NODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSE_NODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSE_NODE {}
 impl ::core::default::Default for KSE_NODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11626,12 +11454,6 @@ impl ::core::clone::Clone for KSE_PIN {
 unsafe impl ::windows::core::Abi for KSE_PIN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSE_PIN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSE_PIN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSE_PIN {}
 impl ::core::default::Default for KSE_PIN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11660,7 +11482,7 @@ unsafe impl ::windows::core::Abi for KSFRAMETIME {
 }
 impl ::core::cmp::PartialEq for KSFRAMETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSFRAMETIME>()) == 0 }
+        self.Duration == other.Duration && self.FrameFlags == other.FrameFlags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSFRAMETIME {}
@@ -11699,7 +11521,7 @@ unsafe impl ::windows::core::Abi for KSGOP_USERDATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSGOP_USERDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSGOP_USERDATA>()) == 0 }
+        self.sc == other.sc && self.reserved1 == other.reserved1 && self.cFields == other.cFields && self.l21Data == other.l21Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11724,12 +11546,6 @@ impl ::core::clone::Clone for KSIDENTIFIER {
 unsafe impl ::windows::core::Abi for KSIDENTIFIER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSIDENTIFIER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSIDENTIFIER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSIDENTIFIER {}
 impl ::core::default::Default for KSIDENTIFIER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11750,12 +11566,6 @@ impl ::core::clone::Clone for KSIDENTIFIER_0 {
 unsafe impl ::windows::core::Abi for KSIDENTIFIER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSIDENTIFIER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSIDENTIFIER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSIDENTIFIER_0 {}
 impl ::core::default::Default for KSIDENTIFIER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11784,7 +11594,7 @@ unsafe impl ::windows::core::Abi for KSIDENTIFIER_0_0 {
 }
 impl ::core::cmp::PartialEq for KSIDENTIFIER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSIDENTIFIER_0_0>()) == 0 }
+        self.Set == other.Set && self.Id == other.Id && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KSIDENTIFIER_0_0 {}
@@ -11815,7 +11625,7 @@ unsafe impl ::windows::core::Abi for KSINTERVAL {
 }
 impl ::core::cmp::PartialEq for KSINTERVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSINTERVAL>()) == 0 }
+        self.TimeBase == other.TimeBase && self.Interval == other.Interval
     }
 }
 impl ::core::cmp::Eq for KSINTERVAL {}
@@ -11857,7 +11667,7 @@ unsafe impl ::windows::core::Abi for KSJACK_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSJACK_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSJACK_DESCRIPTION>()) == 0 }
+        self.ChannelMapping == other.ChannelMapping && self.Color == other.Color && self.ConnectionType == other.ConnectionType && self.GeoLocation == other.GeoLocation && self.GenLocation == other.GenLocation && self.PortConnection == other.PortConnection && self.IsConnected == other.IsConnected
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11890,7 +11700,7 @@ unsafe impl ::windows::core::Abi for KSJACK_DESCRIPTION2 {
 }
 impl ::core::cmp::PartialEq for KSJACK_DESCRIPTION2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSJACK_DESCRIPTION2>()) == 0 }
+        self.DeviceStateInfo == other.DeviceStateInfo && self.JackCapabilities == other.JackCapabilities
     }
 }
 impl ::core::cmp::Eq for KSJACK_DESCRIPTION2 {}
@@ -11934,7 +11744,7 @@ unsafe impl ::windows::core::Abi for KSJACK_SINK_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSJACK_SINK_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSJACK_SINK_INFORMATION>()) == 0 }
+        self.ConnType == other.ConnType && self.ManufacturerId == other.ManufacturerId && self.ProductId == other.ProductId && self.AudioLatency == other.AudioLatency && self.HDCPCapable == other.HDCPCapable && self.AICapable == other.AICapable && self.SinkDescriptionLength == other.SinkDescriptionLength && self.SinkDescription == other.SinkDescription && self.PortId == other.PortId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11969,7 +11779,7 @@ unsafe impl ::windows::core::Abi for KSMPEGVID_RECT {
 }
 impl ::core::cmp::PartialEq for KSMPEGVID_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSMPEGVID_RECT>()) == 0 }
+        self.StartX == other.StartX && self.StartY == other.StartY && self.EndX == other.EndX && self.EndY == other.EndY
     }
 }
 impl ::core::cmp::Eq for KSMPEGVID_RECT {}
@@ -11993,12 +11803,6 @@ impl ::core::clone::Clone for KSMULTIPLE_DATA_PROP {
 unsafe impl ::windows::core::Abi for KSMULTIPLE_DATA_PROP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSMULTIPLE_DATA_PROP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSMULTIPLE_DATA_PROP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSMULTIPLE_DATA_PROP {}
 impl ::core::default::Default for KSMULTIPLE_DATA_PROP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12026,7 +11830,7 @@ unsafe impl ::windows::core::Abi for KSMULTIPLE_ITEM {
 }
 impl ::core::cmp::PartialEq for KSMULTIPLE_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSMULTIPLE_ITEM>()) == 0 }
+        self.Size == other.Size && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for KSMULTIPLE_ITEM {}
@@ -12057,7 +11861,7 @@ unsafe impl ::windows::core::Abi for KSMUSICFORMAT {
 }
 impl ::core::cmp::PartialEq for KSMUSICFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSMUSICFORMAT>()) == 0 }
+        self.TimeDeltaMs == other.TimeDeltaMs && self.ByteCount == other.ByteCount
     }
 }
 impl ::core::cmp::Eq for KSMUSICFORMAT {}
@@ -12082,12 +11886,6 @@ impl ::core::clone::Clone for KSM_NODE {
 unsafe impl ::windows::core::Abi for KSM_NODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSM_NODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSM_NODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSM_NODE {}
 impl ::core::default::Default for KSM_NODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12109,12 +11907,6 @@ impl ::core::clone::Clone for KSNODEPROPERTY {
 unsafe impl ::windows::core::Abi for KSNODEPROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSNODEPROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSNODEPROPERTY {}
 impl ::core::default::Default for KSNODEPROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12140,14 +11932,6 @@ unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_3D_LISTENER {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_3D_LISTENER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_3D_LISTENER>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_3D_LISTENER {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_3D_LISTENER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12174,14 +11958,6 @@ unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_3D_LISTENER {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_3D_LISTENER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_3D_LISTENER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_3D_LISTENER {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_3D_LISTENER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12203,12 +11979,6 @@ impl ::core::clone::Clone for KSNODEPROPERTY_AUDIO_CHANNEL {
 unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_CHANNEL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_CHANNEL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_CHANNEL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_CHANNEL {}
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_CHANNEL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12231,12 +12001,6 @@ impl ::core::clone::Clone for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
 unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_DEV_SPECIFIC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {}
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12262,14 +12026,6 @@ impl ::core::clone::Clone for KSNODEPROPERTY_AUDIO_PROPERTY {
 unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_PROPERTY {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_PROPERTY>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_PROPERTY {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_PROPERTY {
     fn default() -> Self {
@@ -12297,14 +12053,6 @@ impl ::core::clone::Clone for KSNODEPROPERTY_AUDIO_PROPERTY {
 unsafe impl ::windows::core::Abi for KSNODEPROPERTY_AUDIO_PROPERTY {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for KSNODEPROPERTY_AUDIO_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODEPROPERTY_AUDIO_PROPERTY>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for KSNODEPROPERTY_AUDIO_PROPERTY {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for KSNODEPROPERTY_AUDIO_PROPERTY {
     fn default() -> Self {
@@ -12333,7 +12081,7 @@ unsafe impl ::windows::core::Abi for KSNODE_CREATE {
 }
 impl ::core::cmp::PartialEq for KSNODE_CREATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSNODE_CREATE>()) == 0 }
+        self.CreateFlags == other.CreateFlags && self.Node == other.Node
     }
 }
 impl ::core::cmp::Eq for KSNODE_CREATE {}
@@ -12364,7 +12112,7 @@ unsafe impl ::windows::core::Abi for KSPIN_CINSTANCES {
 }
 impl ::core::cmp::PartialEq for KSPIN_CINSTANCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPIN_CINSTANCES>()) == 0 }
+        self.PossibleCount == other.PossibleCount && self.CurrentCount == other.CurrentCount
     }
 }
 impl ::core::cmp::Eq for KSPIN_CINSTANCES {}
@@ -12396,14 +12144,6 @@ unsafe impl ::windows::core::Abi for KSPIN_CONNECT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPIN_CONNECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPIN_CONNECT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPIN_CONNECT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPIN_CONNECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12431,7 +12171,7 @@ unsafe impl ::windows::core::Abi for KSPIN_MDL_CACHING_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for KSPIN_MDL_CACHING_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPIN_MDL_CACHING_NOTIFICATION>()) == 0 }
+        self.Event == other.Event && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for KSPIN_MDL_CACHING_NOTIFICATION {}
@@ -12462,7 +12202,7 @@ unsafe impl ::windows::core::Abi for KSPIN_MDL_CACHING_NOTIFICATION32 {
 }
 impl ::core::cmp::PartialEq for KSPIN_MDL_CACHING_NOTIFICATION32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPIN_MDL_CACHING_NOTIFICATION32>()) == 0 }
+        self.Event == other.Event && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for KSPIN_MDL_CACHING_NOTIFICATION32 {}
@@ -12494,7 +12234,7 @@ unsafe impl ::windows::core::Abi for KSPIN_PHYSICALCONNECTION {
 }
 impl ::core::cmp::PartialEq for KSPIN_PHYSICALCONNECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPIN_PHYSICALCONNECTION>()) == 0 }
+        self.Size == other.Size && self.Pin == other.Pin && self.SymbolicLinkName == other.SymbolicLinkName
     }
 }
 impl ::core::cmp::Eq for KSPIN_PHYSICALCONNECTION {}
@@ -12525,7 +12265,7 @@ unsafe impl ::windows::core::Abi for KSPRIORITY {
 }
 impl ::core::cmp::PartialEq for KSPRIORITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPRIORITY>()) == 0 }
+        self.PriorityClass == other.PriorityClass && self.PrioritySubClass == other.PrioritySubClass
     }
 }
 impl ::core::cmp::Eq for KSPRIORITY {}
@@ -12555,7 +12295,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S>()) == 0 }
+        self.InterleavedCapSupported == other.InterleavedCapSupported
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S {}
@@ -12585,7 +12325,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERL
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE_S>()) == 0 }
+        self.InterleavedCapPossible == other.InterleavedCapPossible
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE_S {}
@@ -12616,7 +12356,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S>()) == 0 }
+        self.CX == other.CX && self.CY == other.CY
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S {}
@@ -12640,12 +12380,6 @@ impl ::core::clone::Clone for KSPROPERTY_BOUNDS_LONG {
 unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONG {}
 impl ::core::default::Default for KSPROPERTY_BOUNDS_LONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12673,7 +12407,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONG_0 {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONG_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONG_0>()) == 0 }
+        self.SignedMinimum == other.SignedMinimum && self.SignedMaximum == other.SignedMaximum
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONG_0 {}
@@ -12704,7 +12438,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONG_1 {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONG_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONG_1>()) == 0 }
+        self.UnsignedMinimum == other.UnsignedMinimum && self.UnsignedMaximum == other.UnsignedMaximum
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONG_1 {}
@@ -12728,12 +12462,6 @@ impl ::core::clone::Clone for KSPROPERTY_BOUNDS_LONGLONG {
 unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONGLONG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONGLONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONGLONG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONGLONG {}
 impl ::core::default::Default for KSPROPERTY_BOUNDS_LONGLONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12761,7 +12489,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONGLONG_0 {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONGLONG_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONGLONG_0>()) == 0 }
+        self.SignedMinimum == other.SignedMinimum && self.SignedMaximum == other.SignedMaximum
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONGLONG_0 {}
@@ -12792,7 +12520,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_BOUNDS_LONGLONG_1 {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_BOUNDS_LONGLONG_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_BOUNDS_LONGLONG_1>()) == 0 }
+        self.UnsignedMinimum == other.UnsignedMinimum && self.UnsignedMaximum == other.UnsignedMaximum
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_BOUNDS_LONGLONG_1 {}
@@ -12823,7 +12551,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_FLASH_S {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_FLASH_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_FLASH_S>()) == 0 }
+        self.Flash == other.Flash && self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_FLASH_S {}
@@ -12849,12 +12577,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12882,7 +12604,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILI
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_S>()) == 0 }
+        self.Capabilities == other.Capabilities && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_S {}
@@ -12908,12 +12630,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12936,12 +12652,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_NODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_NODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_NODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_NODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_NODE_S {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_NODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12965,12 +12675,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_NODE_S2 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_NODE_S2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_NODE_S2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_NODE_S2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_NODE_S2 {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_NODE_S2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12999,14 +12703,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13032,14 +12728,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13062,12 +12750,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_S {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13091,12 +12773,6 @@ impl ::core::clone::Clone for KSPROPERTY_CAMERACONTROL_S2 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_S2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_S2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_S2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_S2 {}
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_S2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13125,14 +12801,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_S_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_S_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_S_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_S_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_CAMERACONTROL_S_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13160,7 +12828,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION_MODE_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION_MODE_S>()) == 0 }
+        self.VideoStabilizationMode == other.VideoStabilizationMode && self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION_MODE_S {}
@@ -13185,12 +12853,6 @@ impl ::core::clone::Clone for KSPROPERTY_CROSSBAR_ACTIVE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CROSSBAR_ACTIVE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CROSSBAR_ACTIVE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CROSSBAR_ACTIVE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CROSSBAR_ACTIVE_S {}
 impl ::core::default::Default for KSPROPERTY_CROSSBAR_ACTIVE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13212,12 +12874,6 @@ impl ::core::clone::Clone for KSPROPERTY_CROSSBAR_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CROSSBAR_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CROSSBAR_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CROSSBAR_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CROSSBAR_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_CROSSBAR_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13242,12 +12898,6 @@ impl ::core::clone::Clone for KSPROPERTY_CROSSBAR_PININFO_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CROSSBAR_PININFO_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CROSSBAR_PININFO_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CROSSBAR_PININFO_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CROSSBAR_PININFO_S {}
 impl ::core::default::Default for KSPROPERTY_CROSSBAR_PININFO_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13270,12 +12920,6 @@ impl ::core::clone::Clone for KSPROPERTY_CROSSBAR_ROUTE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_CROSSBAR_ROUTE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_CROSSBAR_ROUTE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_CROSSBAR_ROUTE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_CROSSBAR_ROUTE_S {}
 impl ::core::default::Default for KSPROPERTY_CROSSBAR_ROUTE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13299,12 +12943,6 @@ impl ::core::clone::Clone for KSPROPERTY_DESCRIPTION {
 unsafe impl ::windows::core::Abi for KSPROPERTY_DESCRIPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_DESCRIPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_DESCRIPTION {}
 impl ::core::default::Default for KSPROPERTY_DESCRIPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13327,12 +12965,6 @@ impl ::core::clone::Clone for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_DROPPEDFRAMES_CURRENT_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {}
 impl ::core::default::Default for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13353,12 +12985,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTDEVICE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTDEVICE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTDEVICE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTDEVICE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_EXTDEVICE_S {}
 impl ::core::default::Default for KSPROPERTY_EXTDEVICE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13382,12 +13008,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTDEVICE_S_0 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTDEVICE_S_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTDEVICE_S_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTDEVICE_S_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_EXTDEVICE_S_0 {}
 impl ::core::default::Default for KSPROPERTY_EXTDEVICE_S_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13412,14 +13032,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTXPORT_NODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_NODE_S {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_NODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_NODE_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_EXTXPORT_NODE_S {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_EXTXPORT_NODE_S {
     fn default() -> Self {
@@ -13452,14 +13064,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTXPORT_NODE_S_0 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_NODE_S_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_NODE_S_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_NODE_S_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_EXTXPORT_NODE_S_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_EXTXPORT_NODE_S_0 {
     fn default() -> Self {
@@ -13494,7 +13098,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_NODE_S_0_0>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.Payload == other.Payload
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13535,7 +13139,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_NODE_S_0_1>()) == 0 }
+        self.frame == other.frame && self.second == other.second && self.minute == other.minute && self.hour == other.hour
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13565,14 +13169,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTXPORT_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_S {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_EXTXPORT_S {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_EXTXPORT_S {
     fn default() -> Self {
@@ -13605,14 +13201,6 @@ impl ::core::clone::Clone for KSPROPERTY_EXTXPORT_S_0 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_S_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_S_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_S_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_EXTXPORT_S_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_EXTXPORT_S_0 {
     fn default() -> Self {
@@ -13647,7 +13235,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_S_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_S_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_S_0_0>()) == 0 }
+        self.PayloadSize == other.PayloadSize && self.Payload == other.Payload
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13688,7 +13276,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_EXTXPORT_S_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSPROPERTY_EXTXPORT_S_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_EXTXPORT_S_0_1>()) == 0 }
+        self.frame == other.frame && self.second == other.second && self.minute == other.minute && self.hour == other.hour
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13721,7 +13309,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_MEDIAAVAILABLE {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_MEDIAAVAILABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_MEDIAAVAILABLE>()) == 0 }
+        self.Earliest == other.Earliest && self.Latest == other.Latest
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_MEDIAAVAILABLE {}
@@ -13754,7 +13342,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_MEMBERSHEADER {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_MEMBERSHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_MEMBERSHEADER>()) == 0 }
+        self.MembersFlags == other.MembersFlags && self.MembersSize == other.MembersSize && self.MembersCount == other.MembersCount && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_MEMBERSHEADER {}
@@ -13785,7 +13373,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO 
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO>()) == 0 }
+        self.Header == other.Header && self.EventFilter == other.EventFilter
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO {}
@@ -13826,7 +13414,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_NETWORKCAMERACONTROL_METADATA_IN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSPROPERTY_NETWORKCAMERACONTROL_METADATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_NETWORKCAMERACONTROL_METADATA_INFO>()) == 0 }
+        self.MetadataItems == other.MetadataItems && self.Size == other.Size && self.PTZStatus == other.PTZStatus && self.Events == other.Events && self.Analytics == other.Analytics && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13859,7 +13447,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEA
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEADER>()) == 0 }
+        self.Size == other.Size && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEADER {}
@@ -13892,7 +13480,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_POSITIONS {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_POSITIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_POSITIONS>()) == 0 }
+        self.Current == other.Current && self.Stop == other.Stop && self.CurrentFlags == other.CurrentFlags && self.StopFlags == other.StopFlags
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_POSITIONS {}
@@ -13918,12 +13506,6 @@ impl ::core::clone::Clone for KSPROPERTY_SELECTOR_NODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_SELECTOR_NODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_SELECTOR_NODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SELECTOR_NODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_SELECTOR_NODE_S {}
 impl ::core::default::Default for KSPROPERTY_SELECTOR_NODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13946,12 +13528,6 @@ impl ::core::clone::Clone for KSPROPERTY_SELECTOR_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_SELECTOR_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_SELECTOR_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SELECTOR_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_SELECTOR_S {}
 impl ::core::default::Default for KSPROPERTY_SELECTOR_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13973,12 +13549,6 @@ impl ::core::clone::Clone for KSPROPERTY_SERIAL {
 unsafe impl ::windows::core::Abi for KSPROPERTY_SERIAL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_SERIAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SERIAL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_SERIAL {}
 impl ::core::default::Default for KSPROPERTY_SERIAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13999,12 +13569,6 @@ impl ::core::clone::Clone for KSPROPERTY_SERIALHDR {
 unsafe impl ::windows::core::Abi for KSPROPERTY_SERIALHDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_SERIALHDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SERIALHDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_SERIALHDR {}
 impl ::core::default::Default for KSPROPERTY_SERIALHDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14039,7 +13603,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_SPHLI {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_SPHLI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SPHLI>()) == 0 }
+        self.HLISS == other.HLISS && self.Reserved == other.Reserved && self.StartPTM == other.StartPTM && self.EndPTM == other.EndPTM && self.StartX == other.StartX && self.StartY == other.StartY && self.StopX == other.StopX && self.StopY == other.StopY && self.ColCon == other.ColCon
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_SPHLI {}
@@ -14069,7 +13633,7 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_SPPAL {
 }
 impl ::core::cmp::PartialEq for KSPROPERTY_SPPAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_SPPAL>()) == 0 }
+        self.sppal == other.sppal
     }
 }
 impl ::core::cmp::Eq for KSPROPERTY_SPPAL {}
@@ -14094,12 +13658,6 @@ impl ::core::clone::Clone for KSPROPERTY_STEPPING_LONG {
 unsafe impl ::windows::core::Abi for KSPROPERTY_STEPPING_LONG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_STEPPING_LONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_STEPPING_LONG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_STEPPING_LONG {}
 impl ::core::default::Default for KSPROPERTY_STEPPING_LONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14120,12 +13678,6 @@ impl ::core::clone::Clone for KSPROPERTY_STEPPING_LONGLONG {
 unsafe impl ::windows::core::Abi for KSPROPERTY_STEPPING_LONGLONG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_STEPPING_LONGLONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_STEPPING_LONGLONG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_STEPPING_LONGLONG {}
 impl ::core::default::Default for KSPROPERTY_STEPPING_LONGLONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14146,12 +13698,6 @@ impl ::core::clone::Clone for KSPROPERTY_TIMECODE_NODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TIMECODE_NODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TIMECODE_NODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TIMECODE_NODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TIMECODE_NODE_S {}
 impl ::core::default::Default for KSPROPERTY_TIMECODE_NODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14172,12 +13718,6 @@ impl ::core::clone::Clone for KSPROPERTY_TIMECODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TIMECODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TIMECODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TIMECODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TIMECODE_S {}
 impl ::core::default::Default for KSPROPERTY_TIMECODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14201,12 +13741,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14233,12 +13767,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_FREQUENCY_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_FREQUENCY_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_FREQUENCY_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_FREQUENCY_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_FREQUENCY_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_FREQUENCY_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14259,12 +13787,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_IF_MEDIUM_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_IF_MEDIUM_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_IF_MEDIUM_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_IF_MEDIUM_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_IF_MEDIUM_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_IF_MEDIUM_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14285,12 +13807,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_INPUT_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_INPUT_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_INPUT_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_INPUT_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_INPUT_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_INPUT_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14318,12 +13834,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_MODE_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_MODE_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_MODE_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_MODE_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_MODE_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_MODE_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14344,12 +13854,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_MODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_MODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_MODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_MODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_MODE_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_MODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14372,12 +13876,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14406,14 +13904,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_SCAN_CAPS_S {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_SCAN_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_SCAN_CAPS_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_SCAN_CAPS_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_TUNER_SCAN_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14435,12 +13925,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_SCAN_STATUS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_SCAN_STATUS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_SCAN_STATUS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_SCAN_STATUS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_SCAN_STATUS_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_SCAN_STATUS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14466,14 +13950,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_STANDARD_MODE_S {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_STANDARD_MODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_STANDARD_MODE_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_STANDARD_MODE_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_TUNER_STANDARD_MODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14494,12 +13970,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_STANDARD_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_STANDARD_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_STANDARD_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_STANDARD_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_STANDARD_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_STANDARD_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14523,12 +13993,6 @@ impl ::core::clone::Clone for KSPROPERTY_TUNER_STATUS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TUNER_STATUS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TUNER_STATUS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TUNER_STATUS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TUNER_STATUS_S {}
 impl ::core::default::Default for KSPROPERTY_TUNER_STATUS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14551,12 +14015,6 @@ impl ::core::clone::Clone for KSPROPERTY_TVAUDIO_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TVAUDIO_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TVAUDIO_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TVAUDIO_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TVAUDIO_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_TVAUDIO_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14577,12 +14035,6 @@ impl ::core::clone::Clone for KSPROPERTY_TVAUDIO_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_TVAUDIO_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_TVAUDIO_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_TVAUDIO_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_TVAUDIO_S {}
 impl ::core::default::Default for KSPROPERTY_TVAUDIO_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14603,12 +14055,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14629,12 +14075,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14655,12 +14095,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_SCANLINES_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14681,12 +14115,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14707,12 +14135,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14733,12 +14155,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14759,12 +14175,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14785,12 +14195,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14811,12 +14215,6 @@ impl ::core::clone::Clone for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {}
 impl ::core::default::Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14842,12 +14240,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14869,12 +14261,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOCOMPRESSION_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCOMPRESSION_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCOMPRESSION_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCOMPRESSION_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCOMPRESSION_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOCOMPRESSION_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14897,12 +14283,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOCOMPRESSION_S1 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCOMPRESSION_S1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCOMPRESSION_S1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCOMPRESSION_S1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCOMPRESSION_S1 {}
 impl ::core::default::Default for KSPROPERTY_VIDEOCOMPRESSION_S1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14932,14 +14312,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14961,12 +14333,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOCONTROL_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCONTROL_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCONTROL_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCONTROL_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCONTROL_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOCONTROL_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14994,14 +14360,6 @@ unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15023,12 +14381,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOCONTROL_MODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOCONTROL_MODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOCONTROL_MODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOCONTROL_MODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOCONTROL_MODE_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOCONTROL_MODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15052,12 +14404,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEODECODER_CAPS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEODECODER_CAPS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEODECODER_CAPS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEODECODER_CAPS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEODECODER_CAPS_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEODECODER_CAPS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15078,12 +14424,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEODECODER_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEODECODER_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEODECODER_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEODECODER_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEODECODER_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEODECODER_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15106,12 +14446,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEODECODER_STATUS2_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEODECODER_STATUS2_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEODECODER_STATUS2_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEODECODER_STATUS2_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEODECODER_STATUS2_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEODECODER_STATUS2_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15133,12 +14467,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEODECODER_STATUS_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEODECODER_STATUS_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEODECODER_STATUS_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEODECODER_STATUS_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEODECODER_STATUS_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEODECODER_STATUS_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15161,12 +14489,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOENCODER_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOENCODER_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOENCODER_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOENCODER_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOENCODER_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOENCODER_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15189,12 +14511,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOPROCAMP_NODE_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOPROCAMP_NODE_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOPROCAMP_NODE_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOPROCAMP_NODE_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOPROCAMP_NODE_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOPROCAMP_NODE_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15218,12 +14534,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOPROCAMP_NODE_S2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {}
 impl ::core::default::Default for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15246,12 +14556,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOPROCAMP_S {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOPROCAMP_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOPROCAMP_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOPROCAMP_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOPROCAMP_S {}
 impl ::core::default::Default for KSPROPERTY_VIDEOPROCAMP_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15275,12 +14579,6 @@ impl ::core::clone::Clone for KSPROPERTY_VIDEOPROCAMP_S2 {
 unsafe impl ::windows::core::Abi for KSPROPERTY_VIDEOPROCAMP_S2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSPROPERTY_VIDEOPROCAMP_S2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSPROPERTY_VIDEOPROCAMP_S2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSPROPERTY_VIDEOPROCAMP_S2 {}
 impl ::core::default::Default for KSPROPERTY_VIDEOPROCAMP_S2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15302,12 +14600,6 @@ impl ::core::clone::Clone for KSP_NODE {
 unsafe impl ::windows::core::Abi for KSP_NODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSP_NODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSP_NODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSP_NODE {}
 impl ::core::default::Default for KSP_NODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15329,12 +14621,6 @@ impl ::core::clone::Clone for KSP_PIN {
 unsafe impl ::windows::core::Abi for KSP_PIN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSP_PIN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSP_PIN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSP_PIN {}
 impl ::core::default::Default for KSP_PIN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15355,12 +14641,6 @@ impl ::core::clone::Clone for KSP_PIN_0 {
 unsafe impl ::windows::core::Abi for KSP_PIN_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSP_PIN_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSP_PIN_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSP_PIN_0 {}
 impl ::core::default::Default for KSP_PIN_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15383,12 +14663,6 @@ impl ::core::clone::Clone for KSP_TIMEFORMAT {
 unsafe impl ::windows::core::Abi for KSP_TIMEFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSP_TIMEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSP_TIMEFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSP_TIMEFORMAT {}
 impl ::core::default::Default for KSP_TIMEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15417,7 +14691,7 @@ unsafe impl ::windows::core::Abi for KSQUALITY {
 }
 impl ::core::cmp::PartialEq for KSQUALITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSQUALITY>()) == 0 }
+        self.Context == other.Context && self.Proportion == other.Proportion && self.DeltaTime == other.DeltaTime
     }
 }
 impl ::core::cmp::Eq for KSQUALITY {}
@@ -15454,7 +14728,7 @@ unsafe impl ::windows::core::Abi for KSQUALITY_MANAGER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSQUALITY_MANAGER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSQUALITY_MANAGER>()) == 0 }
+        self.QualityManager == other.QualityManager && self.Context == other.Context
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15486,14 +14760,6 @@ unsafe impl ::windows::core::Abi for KSQUERYBUFFER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSQUERYBUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSQUERYBUFFER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSQUERYBUFFER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSQUERYBUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15517,12 +14783,6 @@ impl ::core::clone::Clone for KSRATE {
 unsafe impl ::windows::core::Abi for KSRATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRATE {}
 impl ::core::default::Default for KSRATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15543,12 +14803,6 @@ impl ::core::clone::Clone for KSRATE_CAPABILITY {
 unsafe impl ::windows::core::Abi for KSRATE_CAPABILITY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRATE_CAPABILITY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRATE_CAPABILITY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRATE_CAPABILITY {}
 impl ::core::default::Default for KSRATE_CAPABILITY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15578,14 +14832,6 @@ unsafe impl ::windows::core::Abi for KSRELATIVEEVENT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSRELATIVEEVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRELATIVEEVENT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSRELATIVEEVENT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSRELATIVEEVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15610,14 +14856,6 @@ impl ::core::clone::Clone for KSRELATIVEEVENT_0 {
 unsafe impl ::windows::core::Abi for KSRELATIVEEVENT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSRELATIVEEVENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRELATIVEEVENT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSRELATIVEEVENT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSRELATIVEEVENT_0 {
     fn default() -> Self {
@@ -15646,7 +14884,7 @@ unsafe impl ::windows::core::Abi for KSRESOLUTION {
 }
 impl ::core::cmp::PartialEq for KSRESOLUTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRESOLUTION>()) == 0 }
+        self.Granularity == other.Granularity && self.Error == other.Error
     }
 }
 impl ::core::cmp::Eq for KSRESOLUTION {}
@@ -15684,7 +14922,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER>()) == 0 }
+        self.BufferAddress == other.BufferAddress && self.ActualBufferSize == other.ActualBufferSize && self.CallMemoryBarrier == other.CallMemoryBarrier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15724,7 +14962,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER32>()) == 0 }
+        self.BufferAddress == other.BufferAddress && self.ActualBufferSize == other.ActualBufferSize && self.CallMemoryBarrier == other.CallMemoryBarrier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15751,12 +14989,6 @@ impl ::core::clone::Clone for KSRTAUDIO_BUFFER_PROPERTY {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_BUFFER_PROPERTY {}
 impl ::core::default::Default for KSRTAUDIO_BUFFER_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15778,12 +15010,6 @@ impl ::core::clone::Clone for KSRTAUDIO_BUFFER_PROPERTY32 {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER_PROPERTY32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER_PROPERTY32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER_PROPERTY32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_BUFFER_PROPERTY32 {}
 impl ::core::default::Default for KSRTAUDIO_BUFFER_PROPERTY32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15806,12 +15032,6 @@ impl ::core::clone::Clone for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {}
 impl ::core::default::Default for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15834,12 +15054,6 @@ impl ::core::clone::Clone for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {}
 impl ::core::default::Default for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15875,7 +15089,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_GETREADPACKET_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KSRTAUDIO_GETREADPACKET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_GETREADPACKET_INFO>()) == 0 }
+        self.PacketNumber == other.PacketNumber && self.Flags == other.Flags && self.PerformanceCounterValue == other.PerformanceCounterValue && self.MoreData == other.MoreData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15909,7 +15123,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_HWLATENCY {
 }
 impl ::core::cmp::PartialEq for KSRTAUDIO_HWLATENCY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_HWLATENCY>()) == 0 }
+        self.FifoSize == other.FifoSize && self.ChipsetDelay == other.ChipsetDelay && self.CodecDelay == other.CodecDelay
     }
 }
 impl ::core::cmp::Eq for KSRTAUDIO_HWLATENCY {}
@@ -15943,7 +15157,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_HWREGISTER {
 }
 impl ::core::cmp::PartialEq for KSRTAUDIO_HWREGISTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_HWREGISTER>()) == 0 }
+        self.Register == other.Register && self.Width == other.Width && self.Numerator == other.Numerator && self.Denominator == other.Denominator && self.Accuracy == other.Accuracy
     }
 }
 impl ::core::cmp::Eq for KSRTAUDIO_HWREGISTER {}
@@ -15977,7 +15191,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_HWREGISTER32 {
 }
 impl ::core::cmp::PartialEq for KSRTAUDIO_HWREGISTER32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_HWREGISTER32>()) == 0 }
+        self.Register == other.Register && self.Width == other.Width && self.Numerator == other.Numerator && self.Denominator == other.Denominator && self.Accuracy == other.Accuracy
     }
 }
 impl ::core::cmp::Eq for KSRTAUDIO_HWREGISTER32 {}
@@ -16001,12 +15215,6 @@ impl ::core::clone::Clone for KSRTAUDIO_HWREGISTER_PROPERTY {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_HWREGISTER_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_HWREGISTER_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_HWREGISTER_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_HWREGISTER_PROPERTY {}
 impl ::core::default::Default for KSRTAUDIO_HWREGISTER_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16027,12 +15235,6 @@ impl ::core::clone::Clone for KSRTAUDIO_HWREGISTER_PROPERTY32 {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_HWREGISTER_PROPERTY32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_HWREGISTER_PROPERTY32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_HWREGISTER_PROPERTY32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_HWREGISTER_PROPERTY32 {}
 impl ::core::default::Default for KSRTAUDIO_HWREGISTER_PROPERTY32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16058,14 +15260,6 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16086,12 +15280,6 @@ impl ::core::clone::Clone for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {}
 impl ::core::default::Default for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16120,7 +15308,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_PACKETVREGISTER {
 }
 impl ::core::cmp::PartialEq for KSRTAUDIO_PACKETVREGISTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_PACKETVREGISTER>()) == 0 }
+        self.CompletedPacketCount == other.CompletedPacketCount && self.CompletedPacketQPC == other.CompletedPacketQPC && self.CompletedPacketHash == other.CompletedPacketHash
     }
 }
 impl ::core::cmp::Eq for KSRTAUDIO_PACKETVREGISTER {}
@@ -16144,12 +15332,6 @@ impl ::core::clone::Clone for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
 unsafe impl ::windows::core::Abi for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_PACKETVREGISTER_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSRTAUDIO_PACKETVREGISTER_PROPERTY {}
 impl ::core::default::Default for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16178,7 +15360,7 @@ unsafe impl ::windows::core::Abi for KSRTAUDIO_SETWRITEPACKET_INFO {
 }
 impl ::core::cmp::PartialEq for KSRTAUDIO_SETWRITEPACKET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSRTAUDIO_SETWRITEPACKET_INFO>()) == 0 }
+        self.PacketNumber == other.PacketNumber && self.Flags == other.Flags && self.EosPacketLength == other.EosPacketLength
     }
 }
 impl ::core::cmp::Eq for KSRTAUDIO_SETWRITEPACKET_INFO {}
@@ -16202,12 +15384,6 @@ impl ::core::clone::Clone for KSSOUNDDETECTORPROPERTY {
 unsafe impl ::windows::core::Abi for KSSOUNDDETECTORPROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSOUNDDETECTORPROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSOUNDDETECTORPROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSOUNDDETECTORPROPERTY {}
 impl ::core::default::Default for KSSOUNDDETECTORPROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16229,12 +15405,6 @@ impl ::core::clone::Clone for KSSTREAMALLOCATOR_STATUS {
 unsafe impl ::windows::core::Abi for KSSTREAMALLOCATOR_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSTREAMALLOCATOR_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAMALLOCATOR_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSTREAMALLOCATOR_STATUS {}
 impl ::core::default::Default for KSSTREAMALLOCATOR_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16256,12 +15426,6 @@ impl ::core::clone::Clone for KSSTREAMALLOCATOR_STATUS_EX {
 unsafe impl ::windows::core::Abi for KSSTREAMALLOCATOR_STATUS_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSTREAMALLOCATOR_STATUS_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAMALLOCATOR_STATUS_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSTREAMALLOCATOR_STATUS_EX {}
 impl ::core::default::Default for KSSTREAMALLOCATOR_STATUS_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16302,7 +15466,7 @@ unsafe impl ::windows::core::Abi for KSSTREAM_HEADER {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for KSSTREAM_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_HEADER>()) == 0 }
+        self.Size == other.Size && self.TypeSpecificFlags == other.TypeSpecificFlags && self.PresentationTime == other.PresentationTime && self.Duration == other.Duration && self.FrameExtent == other.FrameExtent && self.DataUsed == other.DataUsed && self.Data == other.Data && self.OptionsFlags == other.OptionsFlags && self.Reserved == other.Reserved
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -16347,7 +15511,7 @@ unsafe impl ::windows::core::Abi for KSSTREAM_HEADER {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for KSSTREAM_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_HEADER>()) == 0 }
+        self.Size == other.Size && self.TypeSpecificFlags == other.TypeSpecificFlags && self.PresentationTime == other.PresentationTime && self.Duration == other.Duration && self.FrameExtent == other.FrameExtent && self.DataUsed == other.DataUsed && self.Data == other.Data && self.OptionsFlags == other.OptionsFlags
     }
 }
 #[cfg(target_arch = "x86")]
@@ -16384,7 +15548,7 @@ unsafe impl ::windows::core::Abi for KSSTREAM_METADATA_INFO {
 }
 impl ::core::cmp::PartialEq for KSSTREAM_METADATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_METADATA_INFO>()) == 0 }
+        self.BufferSize == other.BufferSize && self.UsedSize == other.UsedSize && self.Data == other.Data && self.SystemVa == other.SystemVa && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSSTREAM_METADATA_INFO {}
@@ -16408,12 +15572,6 @@ impl ::core::clone::Clone for KSSTREAM_UVC_METADATA {
 unsafe impl ::windows::core::Abi for KSSTREAM_UVC_METADATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSTREAM_UVC_METADATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_UVC_METADATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSTREAM_UVC_METADATA {}
 impl ::core::default::Default for KSSTREAM_UVC_METADATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16437,12 +15595,6 @@ impl ::core::clone::Clone for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
 unsafe impl ::windows::core::Abi for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_UVC_METADATATYPE_TIMESTAMP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {}
 impl ::core::default::Default for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16463,12 +15615,6 @@ impl ::core::clone::Clone for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
 unsafe impl ::windows::core::Abi for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {}
 impl ::core::default::Default for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16495,7 +15641,7 @@ unsafe impl ::windows::core::Abi for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {
 }
 impl ::core::cmp::PartialEq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {}
@@ -16526,7 +15672,7 @@ unsafe impl ::windows::core::Abi for KSTELEPHONY_CALLCONTROL {
 }
 impl ::core::cmp::PartialEq for KSTELEPHONY_CALLCONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTELEPHONY_CALLCONTROL>()) == 0 }
+        self.CallType == other.CallType && self.CallControlOp == other.CallControlOp
     }
 }
 impl ::core::cmp::Eq for KSTELEPHONY_CALLCONTROL {}
@@ -16557,7 +15703,7 @@ unsafe impl ::windows::core::Abi for KSTELEPHONY_CALLINFO {
 }
 impl ::core::cmp::PartialEq for KSTELEPHONY_CALLINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTELEPHONY_CALLINFO>()) == 0 }
+        self.CallType == other.CallType && self.CallState == other.CallState
     }
 }
 impl ::core::cmp::Eq for KSTELEPHONY_CALLINFO {}
@@ -16588,7 +15734,7 @@ unsafe impl ::windows::core::Abi for KSTELEPHONY_PROVIDERCHANGE {
 }
 impl ::core::cmp::PartialEq for KSTELEPHONY_PROVIDERCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTELEPHONY_PROVIDERCHANGE>()) == 0 }
+        self.CallType == other.CallType && self.ProviderChangeOp == other.ProviderChangeOp
     }
 }
 impl ::core::cmp::Eq for KSTELEPHONY_PROVIDERCHANGE {}
@@ -16620,7 +15766,7 @@ unsafe impl ::windows::core::Abi for KSTIME {
 }
 impl ::core::cmp::PartialEq for KSTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTIME>()) == 0 }
+        self.Time == other.Time && self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for KSTIME {}
@@ -16657,7 +15803,7 @@ unsafe impl ::windows::core::Abi for KSTOPOLOGY {
 }
 impl ::core::cmp::PartialEq for KSTOPOLOGY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTOPOLOGY>()) == 0 }
+        self.CategoriesCount == other.CategoriesCount && self.Categories == other.Categories && self.TopologyNodesCount == other.TopologyNodesCount && self.TopologyNodes == other.TopologyNodes && self.TopologyConnectionsCount == other.TopologyConnectionsCount && self.TopologyConnections == other.TopologyConnections && self.TopologyNodesNames == other.TopologyNodesNames && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSTOPOLOGY {}
@@ -16690,7 +15836,7 @@ unsafe impl ::windows::core::Abi for KSTOPOLOGY_CONNECTION {
 }
 impl ::core::cmp::PartialEq for KSTOPOLOGY_CONNECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTOPOLOGY_CONNECTION>()) == 0 }
+        self.FromNode == other.FromNode && self.FromNodePin == other.FromNodePin && self.ToNode == other.ToNode && self.ToNodePin == other.ToNodePin
     }
 }
 impl ::core::cmp::Eq for KSTOPOLOGY_CONNECTION {}
@@ -16721,7 +15867,7 @@ unsafe impl ::windows::core::Abi for KSTOPOLOGY_ENDPOINTID {
 }
 impl ::core::cmp::PartialEq for KSTOPOLOGY_ENDPOINTID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTOPOLOGY_ENDPOINTID>()) == 0 }
+        self.TopologyName == other.TopologyName && self.PinId == other.PinId
     }
 }
 impl ::core::cmp::Eq for KSTOPOLOGY_ENDPOINTID {}
@@ -16752,7 +15898,7 @@ unsafe impl ::windows::core::Abi for KSTOPOLOGY_ENDPOINTIDPAIR {
 }
 impl ::core::cmp::PartialEq for KSTOPOLOGY_ENDPOINTIDPAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSTOPOLOGY_ENDPOINTIDPAIR>()) == 0 }
+        self.RenderEndpoint == other.RenderEndpoint && self.CaptureEndpoint == other.CaptureEndpoint
     }
 }
 impl ::core::cmp::Eq for KSTOPOLOGY_ENDPOINTIDPAIR {}
@@ -16784,7 +15930,7 @@ unsafe impl ::windows::core::Abi for KSVPMAXPIXELRATE {
 }
 impl ::core::cmp::PartialEq for KSVPMAXPIXELRATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSVPMAXPIXELRATE>()) == 0 }
+        self.Size == other.Size && self.MaxPixelsPerSecond == other.MaxPixelsPerSecond && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KSVPMAXPIXELRATE {}
@@ -16808,12 +15954,6 @@ impl ::core::clone::Clone for KSVPSIZE_PROP {
 unsafe impl ::windows::core::Abi for KSVPSIZE_PROP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KSVPSIZE_PROP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSVPSIZE_PROP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KSVPSIZE_PROP {}
 impl ::core::default::Default for KSVPSIZE_PROP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16842,7 +15982,7 @@ unsafe impl ::windows::core::Abi for KSVPSURFACEPARAMS {
 }
 impl ::core::cmp::PartialEq for KSVPSURFACEPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSVPSURFACEPARAMS>()) == 0 }
+        self.dwPitch == other.dwPitch && self.dwXOrigin == other.dwXOrigin && self.dwYOrigin == other.dwYOrigin
     }
 }
 impl ::core::cmp::Eq for KSVPSURFACEPARAMS {}
@@ -16875,14 +16015,6 @@ unsafe impl ::windows::core::Abi for KSWAVETABLE_WAVE_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KSWAVETABLE_WAVE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVETABLE_WAVE_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KSWAVETABLE_WAVE_DESC {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KSWAVETABLE_WAVE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16911,7 +16043,7 @@ unsafe impl ::windows::core::Abi for KSWAVE_BUFFER {
 }
 impl ::core::cmp::PartialEq for KSWAVE_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVE_BUFFER>()) == 0 }
+        self.Attributes == other.Attributes && self.BufferSize == other.BufferSize && self.BufferAddress == other.BufferAddress
     }
 }
 impl ::core::cmp::Eq for KSWAVE_BUFFER {}
@@ -16941,7 +16073,7 @@ unsafe impl ::windows::core::Abi for KSWAVE_COMPATCAPS {
 }
 impl ::core::cmp::PartialEq for KSWAVE_COMPATCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVE_COMPATCAPS>()) == 0 }
+        self.ulDeviceType == other.ulDeviceType
     }
 }
 impl ::core::cmp::Eq for KSWAVE_COMPATCAPS {}
@@ -16977,7 +16109,7 @@ unsafe impl ::windows::core::Abi for KSWAVE_INPUT_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for KSWAVE_INPUT_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVE_INPUT_CAPABILITIES>()) == 0 }
+        self.MaximumChannelsPerConnection == other.MaximumChannelsPerConnection && self.MinimumBitsPerSample == other.MinimumBitsPerSample && self.MaximumBitsPerSample == other.MaximumBitsPerSample && self.MinimumSampleFrequency == other.MinimumSampleFrequency && self.MaximumSampleFrequency == other.MaximumSampleFrequency && self.TotalConnections == other.TotalConnections && self.ActiveConnections == other.ActiveConnections
     }
 }
 impl ::core::cmp::Eq for KSWAVE_INPUT_CAPABILITIES {}
@@ -17047,7 +16179,26 @@ unsafe impl ::windows::core::Abi for KSWAVE_OUTPUT_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for KSWAVE_OUTPUT_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVE_OUTPUT_CAPABILITIES>()) == 0 }
+        self.MaximumChannelsPerConnection == other.MaximumChannelsPerConnection
+            && self.MinimumBitsPerSample == other.MinimumBitsPerSample
+            && self.MaximumBitsPerSample == other.MaximumBitsPerSample
+            && self.MinimumSampleFrequency == other.MinimumSampleFrequency
+            && self.MaximumSampleFrequency == other.MaximumSampleFrequency
+            && self.TotalConnections == other.TotalConnections
+            && self.StaticConnections == other.StaticConnections
+            && self.StreamingConnections == other.StreamingConnections
+            && self.ActiveConnections == other.ActiveConnections
+            && self.ActiveStaticConnections == other.ActiveStaticConnections
+            && self.ActiveStreamingConnections == other.ActiveStreamingConnections
+            && self.Total3DConnections == other.Total3DConnections
+            && self.Static3DConnections == other.Static3DConnections
+            && self.Streaming3DConnections == other.Streaming3DConnections
+            && self.Active3DConnections == other.Active3DConnections
+            && self.ActiveStatic3DConnections == other.ActiveStatic3DConnections
+            && self.ActiveStreaming3DConnections == other.ActiveStreaming3DConnections
+            && self.TotalSampleMemory == other.TotalSampleMemory
+            && self.FreeSampleMemory == other.FreeSampleMemory
+            && self.LargestFreeContiguousSampleMemory == other.LargestFreeContiguousSampleMemory
     }
 }
 impl ::core::cmp::Eq for KSWAVE_OUTPUT_CAPABILITIES {}
@@ -17078,7 +16229,7 @@ unsafe impl ::windows::core::Abi for KSWAVE_VOLUME {
 }
 impl ::core::cmp::PartialEq for KSWAVE_VOLUME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSWAVE_VOLUME>()) == 0 }
+        self.LeftAttenuation == other.LeftAttenuation && self.RightAttenuation == other.RightAttenuation
     }
 }
 impl ::core::cmp::Eq for KSWAVE_VOLUME {}
@@ -17140,7 +16291,7 @@ unsafe impl ::windows::core::Abi for KS_AMVPDATAINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_AMVPDATAINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_AMVPDATAINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMicrosecondsPerField == other.dwMicrosecondsPerField && self.amvpDimInfo == other.amvpDimInfo && self.dwPictAspectRatioX == other.dwPictAspectRatioX && self.dwPictAspectRatioY == other.dwPictAspectRatioY && self.bEnableDoubleClock == other.bEnableDoubleClock && self.bEnableVACT == other.bEnableVACT && self.bDataIsInterlaced == other.bDataIsInterlaced && self.lHalfLinesOdd == other.lHalfLinesOdd && self.bFieldPolarityInverted == other.bFieldPolarityInverted && self.dwNumLinesInVREF == other.dwNumLinesInVREF && self.lHalfLinesEven == other.lHalfLinesEven && self.dwReserved1 == other.dwReserved1
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17182,7 +16333,7 @@ unsafe impl ::windows::core::Abi for KS_AMVPDIMINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_AMVPDIMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_AMVPDIMINFO>()) == 0 }
+        self.dwFieldWidth == other.dwFieldWidth && self.dwFieldHeight == other.dwFieldHeight && self.dwVBIWidth == other.dwVBIWidth && self.dwVBIHeight == other.dwVBIHeight && self.rcValidRegion == other.rcValidRegion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17215,7 +16366,7 @@ unsafe impl ::windows::core::Abi for KS_AMVPSIZE {
 }
 impl ::core::cmp::PartialEq for KS_AMVPSIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_AMVPSIZE>()) == 0 }
+        self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight
     }
 }
 impl ::core::cmp::Eq for KS_AMVPSIZE {}
@@ -17246,7 +16397,7 @@ unsafe impl ::windows::core::Abi for KS_AM_ExactRateChange {
 }
 impl ::core::cmp::PartialEq for KS_AM_ExactRateChange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_AM_ExactRateChange>()) == 0 }
+        self.OutputZeroTime == other.OutputZeroTime && self.Rate == other.Rate
     }
 }
 impl ::core::cmp::Eq for KS_AM_ExactRateChange {}
@@ -17277,7 +16428,7 @@ unsafe impl ::windows::core::Abi for KS_AM_SimpleRateChange {
 }
 impl ::core::cmp::PartialEq for KS_AM_SimpleRateChange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_AM_SimpleRateChange>()) == 0 }
+        self.StartTime == other.StartTime && self.Rate == other.Rate
     }
 }
 impl ::core::cmp::Eq for KS_AM_SimpleRateChange {}
@@ -17317,7 +16468,7 @@ unsafe impl ::windows::core::Abi for KS_ANALOGVIDEOINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_ANALOGVIDEOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_ANALOGVIDEOINFO>()) == 0 }
+        self.rcSource == other.rcSource && self.rcTarget == other.rcTarget && self.dwActiveWidth == other.dwActiveWidth && self.dwActiveHeight == other.dwActiveHeight && self.AvgTimePerFrame == other.AvgTimePerFrame
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17359,7 +16510,7 @@ unsafe impl ::windows::core::Abi for KS_BITMAPINFOHEADER {
 }
 impl ::core::cmp::PartialEq for KS_BITMAPINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_BITMAPINFOHEADER>()) == 0 }
+        self.biSize == other.biSize && self.biWidth == other.biWidth && self.biHeight == other.biHeight && self.biPlanes == other.biPlanes && self.biBitCount == other.biBitCount && self.biCompression == other.biCompression && self.biSizeImage == other.biSizeImage && self.biXPelsPerMeter == other.biXPelsPerMeter && self.biYPelsPerMeter == other.biYPelsPerMeter && self.biClrUsed == other.biClrUsed && self.biClrImportant == other.biClrImportant
     }
 }
 impl ::core::cmp::Eq for KS_BITMAPINFOHEADER {}
@@ -17392,7 +16543,7 @@ unsafe impl ::windows::core::Abi for KS_COLCON {
 }
 impl ::core::cmp::PartialEq for KS_COLCON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_COLCON>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2 && self._bitfield3 == other._bitfield3 && self._bitfield4 == other._bitfield4
     }
 }
 impl ::core::cmp::Eq for KS_COLCON {}
@@ -17424,7 +16575,7 @@ unsafe impl ::windows::core::Abi for KS_COMPRESSION {
 }
 impl ::core::cmp::PartialEq for KS_COMPRESSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_COMPRESSION>()) == 0 }
+        self.RatioNumerator == other.RatioNumerator && self.RatioDenominator == other.RatioDenominator && self.RatioConstantMargin == other.RatioConstantMargin
     }
 }
 impl ::core::cmp::Eq for KS_COMPRESSION {}
@@ -17454,7 +16605,7 @@ unsafe impl ::windows::core::Abi for KS_COPY_MACROVISION {
 }
 impl ::core::cmp::PartialEq for KS_COPY_MACROVISION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_COPY_MACROVISION>()) == 0 }
+        self.MACROVISIONLevel == other.MACROVISIONLevel
     }
 }
 impl ::core::cmp::Eq for KS_COPY_MACROVISION {}
@@ -17478,12 +16629,6 @@ impl ::core::clone::Clone for KS_DATAFORMAT_H264VIDEOINFO {
 unsafe impl ::windows::core::Abi for KS_DATAFORMAT_H264VIDEOINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_H264VIDEOINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_H264VIDEOINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KS_DATAFORMAT_H264VIDEOINFO {}
 impl ::core::default::Default for KS_DATAFORMAT_H264VIDEOINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17504,12 +16649,6 @@ impl ::core::clone::Clone for KS_DATAFORMAT_IMAGEINFO {
 unsafe impl ::windows::core::Abi for KS_DATAFORMAT_IMAGEINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_IMAGEINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_IMAGEINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KS_DATAFORMAT_IMAGEINFO {}
 impl ::core::default::Default for KS_DATAFORMAT_IMAGEINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17535,14 +16674,6 @@ unsafe impl ::windows::core::Abi for KS_DATAFORMAT_MPEGVIDEOINFO2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_MPEGVIDEOINFO2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_MPEGVIDEOINFO2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATAFORMAT_MPEGVIDEOINFO2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATAFORMAT_MPEGVIDEOINFO2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17563,12 +16694,6 @@ impl ::core::clone::Clone for KS_DATAFORMAT_VBIINFOHEADER {
 unsafe impl ::windows::core::Abi for KS_DATAFORMAT_VBIINFOHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_VBIINFOHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_VBIINFOHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KS_DATAFORMAT_VBIINFOHEADER {}
 impl ::core::default::Default for KS_DATAFORMAT_VBIINFOHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17593,14 +16718,6 @@ impl ::core::clone::Clone for KS_DATAFORMAT_VIDEOINFOHEADER {
 unsafe impl ::windows::core::Abi for KS_DATAFORMAT_VIDEOINFOHEADER {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_VIDEOINFOHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_VIDEOINFOHEADER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATAFORMAT_VIDEOINFOHEADER {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATAFORMAT_VIDEOINFOHEADER {
     fn default() -> Self {
@@ -17627,14 +16744,6 @@ unsafe impl ::windows::core::Abi for KS_DATAFORMAT_VIDEOINFOHEADER2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_VIDEOINFOHEADER2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_VIDEOINFOHEADER2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATAFORMAT_VIDEOINFOHEADER2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATAFORMAT_VIDEOINFOHEADER2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17660,14 +16769,6 @@ unsafe impl ::windows::core::Abi for KS_DATAFORMAT_VIDEOINFO_PALETTE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATAFORMAT_VIDEOINFO_PALETTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATAFORMAT_VIDEOINFO_PALETTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATAFORMAT_VIDEOINFO_PALETTE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATAFORMAT_VIDEOINFO_PALETTE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17692,14 +16793,6 @@ impl ::core::clone::Clone for KS_DATARANGE_ANALOGVIDEO {
 unsafe impl ::windows::core::Abi for KS_DATARANGE_ANALOGVIDEO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_ANALOGVIDEO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_ANALOGVIDEO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_ANALOGVIDEO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_ANALOGVIDEO {
     fn default() -> Self {
@@ -17731,14 +16824,6 @@ unsafe impl ::windows::core::Abi for KS_DATARANGE_H264_VIDEO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_H264_VIDEO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_H264_VIDEO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_H264_VIDEO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_H264_VIDEO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17764,14 +16849,6 @@ impl ::core::clone::Clone for KS_DATARANGE_IMAGE {
 unsafe impl ::windows::core::Abi for KS_DATARANGE_IMAGE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_IMAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_IMAGE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_IMAGE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_IMAGE {
     fn default() -> Self {
@@ -17803,14 +16880,6 @@ unsafe impl ::windows::core::Abi for KS_DATARANGE_MPEG1_VIDEO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_MPEG1_VIDEO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_MPEG1_VIDEO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_MPEG1_VIDEO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_MPEG1_VIDEO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17840,14 +16909,6 @@ impl ::core::clone::Clone for KS_DATARANGE_MPEG2_VIDEO {
 unsafe impl ::windows::core::Abi for KS_DATARANGE_MPEG2_VIDEO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_MPEG2_VIDEO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_MPEG2_VIDEO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_MPEG2_VIDEO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_MPEG2_VIDEO {
     fn default() -> Self {
@@ -17879,14 +16940,6 @@ unsafe impl ::windows::core::Abi for KS_DATARANGE_VIDEO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_VIDEO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_VIDEO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_VIDEO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_VIDEO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17916,14 +16969,6 @@ impl ::core::clone::Clone for KS_DATARANGE_VIDEO2 {
 unsafe impl ::windows::core::Abi for KS_DATARANGE_VIDEO2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_VIDEO2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_VIDEO2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_VIDEO2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_VIDEO2 {
     fn default() -> Self {
@@ -17955,14 +17000,6 @@ unsafe impl ::windows::core::Abi for KS_DATARANGE_VIDEO_PALETTE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_VIDEO_PALETTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_VIDEO_PALETTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_VIDEO_PALETTE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_VIDEO_PALETTE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17993,14 +17030,6 @@ unsafe impl ::windows::core::Abi for KS_DATARANGE_VIDEO_VBI {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_DATARANGE_VIDEO_VBI {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DATARANGE_VIDEO_VBI>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_DATARANGE_VIDEO_VBI {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_DATARANGE_VIDEO_VBI {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18028,7 +17057,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_BUSKEY {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_BUSKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_BUSKEY>()) == 0 }
+        self.BusKey == other.BusKey && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_BUSKEY {}
@@ -18059,7 +17088,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_CHLGKEY {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_CHLGKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_CHLGKEY>()) == 0 }
+        self.ChlgKey == other.ChlgKey && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_CHLGKEY {}
@@ -18089,7 +17118,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_DISCKEY {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_DISCKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_DISCKEY>()) == 0 }
+        self.DiscKey == other.DiscKey
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_DISCKEY {}
@@ -18121,7 +17150,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_REGION {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_REGION>()) == 0 }
+        self.Reserved == other.Reserved && self.RegionData == other.RegionData && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_REGION {}
@@ -18151,7 +17180,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_SET_COPY_STATE {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_SET_COPY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_SET_COPY_STATE>()) == 0 }
+        self.DVDCopyState == other.DVDCopyState
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_SET_COPY_STATE {}
@@ -18184,7 +17213,7 @@ unsafe impl ::windows::core::Abi for KS_DVDCOPY_TITLEKEY {
 }
 impl ::core::cmp::PartialEq for KS_DVDCOPY_TITLEKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVDCOPY_TITLEKEY>()) == 0 }
+        self.KeyFlags == other.KeyFlags && self.ReservedNT == other.ReservedNT && self.TitleKey == other.TitleKey && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for KS_DVDCOPY_TITLEKEY {}
@@ -18217,7 +17246,7 @@ unsafe impl ::windows::core::Abi for KS_DVD_YCrCb {
 }
 impl ::core::cmp::PartialEq for KS_DVD_YCrCb {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVD_YCrCb>()) == 0 }
+        self.Reserved == other.Reserved && self.Y == other.Y && self.Cr == other.Cr && self.Cb == other.Cb
     }
 }
 impl ::core::cmp::Eq for KS_DVD_YCrCb {}
@@ -18250,7 +17279,7 @@ unsafe impl ::windows::core::Abi for KS_DVD_YUV {
 }
 impl ::core::cmp::PartialEq for KS_DVD_YUV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_DVD_YUV>()) == 0 }
+        self.Reserved == other.Reserved && self.Y == other.Y && self.V == other.V && self.U == other.U
     }
 }
 impl ::core::cmp::Eq for KS_DVD_YUV {}
@@ -18287,14 +17316,6 @@ unsafe impl ::windows::core::Abi for KS_FRAME_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_FRAME_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAME_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_FRAME_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_FRAME_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18320,14 +17341,6 @@ unsafe impl ::windows::core::Abi for KS_FRAME_INFO_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_FRAME_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAME_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_FRAME_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_FRAME_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18352,14 +17365,6 @@ impl ::core::clone::Clone for KS_FRAME_INFO_1 {
 unsafe impl ::windows::core::Abi for KS_FRAME_INFO_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_FRAME_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAME_INFO_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_FRAME_INFO_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_FRAME_INFO_1 {
     fn default() -> Self {
@@ -18394,7 +17399,7 @@ unsafe impl ::windows::core::Abi for KS_FRAME_INFO_1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_FRAME_INFO_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAME_INFO_1_0>()) == 0 }
+        self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18428,12 +17433,6 @@ impl ::core::clone::Clone for KS_FRAMING_ITEM {
 unsafe impl ::windows::core::Abi for KS_FRAMING_ITEM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KS_FRAMING_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAMING_ITEM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KS_FRAMING_ITEM {}
 impl ::core::default::Default for KS_FRAMING_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18454,12 +17453,6 @@ impl ::core::clone::Clone for KS_FRAMING_ITEM_0 {
 unsafe impl ::windows::core::Abi for KS_FRAMING_ITEM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KS_FRAMING_ITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAMING_ITEM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KS_FRAMING_ITEM_0 {}
 impl ::core::default::Default for KS_FRAMING_ITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18488,7 +17481,7 @@ unsafe impl ::windows::core::Abi for KS_FRAMING_RANGE {
 }
 impl ::core::cmp::PartialEq for KS_FRAMING_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAMING_RANGE>()) == 0 }
+        self.MinFrameSize == other.MinFrameSize && self.MaxFrameSize == other.MaxFrameSize && self.Stepping == other.Stepping
     }
 }
 impl ::core::cmp::Eq for KS_FRAMING_RANGE {}
@@ -18520,7 +17513,7 @@ unsafe impl ::windows::core::Abi for KS_FRAMING_RANGE_WEIGHTED {
 }
 impl ::core::cmp::PartialEq for KS_FRAMING_RANGE_WEIGHTED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_FRAMING_RANGE_WEIGHTED>()) == 0 }
+        self.Range == other.Range && self.InPlaceWeight == other.InPlaceWeight && self.NotInPlaceWeight == other.NotInPlaceWeight
     }
 }
 impl ::core::cmp::Eq for KS_FRAMING_RANGE_WEIGHTED {}
@@ -18626,7 +17619,44 @@ unsafe impl ::windows::core::Abi for KS_H264VIDEOINFO {
 }
 impl ::core::cmp::PartialEq for KS_H264VIDEOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_H264VIDEOINFO>()) == 0 }
+        self.wWidth == other.wWidth
+            && self.wHeight == other.wHeight
+            && self.wSARwidth == other.wSARwidth
+            && self.wSARheight == other.wSARheight
+            && self.wProfile == other.wProfile
+            && self.bLevelIDC == other.bLevelIDC
+            && self.wConstrainedToolset == other.wConstrainedToolset
+            && self.bmSupportedUsages == other.bmSupportedUsages
+            && self.bmCapabilities == other.bmCapabilities
+            && self.bmSVCCapabilities == other.bmSVCCapabilities
+            && self.bmMVCCapabilities == other.bmMVCCapabilities
+            && self.dwFrameInterval == other.dwFrameInterval
+            && self.bMaxCodecConfigDelay == other.bMaxCodecConfigDelay
+            && self.bmSupportedSliceModes == other.bmSupportedSliceModes
+            && self.bmSupportedSyncFrameTypes == other.bmSupportedSyncFrameTypes
+            && self.bResolutionScaling == other.bResolutionScaling
+            && self.bSimulcastSupport == other.bSimulcastSupport
+            && self.bmSupportedRateControlModes == other.bmSupportedRateControlModes
+            && self.wMaxMBperSecOneResolutionNoScalability == other.wMaxMBperSecOneResolutionNoScalability
+            && self.wMaxMBperSecTwoResolutionsNoScalability == other.wMaxMBperSecTwoResolutionsNoScalability
+            && self.wMaxMBperSecThreeResolutionsNoScalability == other.wMaxMBperSecThreeResolutionsNoScalability
+            && self.wMaxMBperSecFourResolutionsNoScalability == other.wMaxMBperSecFourResolutionsNoScalability
+            && self.wMaxMBperSecOneResolutionTemporalScalability == other.wMaxMBperSecOneResolutionTemporalScalability
+            && self.wMaxMBperSecTwoResolutionsTemporalScalablility == other.wMaxMBperSecTwoResolutionsTemporalScalablility
+            && self.wMaxMBperSecThreeResolutionsTemporalScalability == other.wMaxMBperSecThreeResolutionsTemporalScalability
+            && self.wMaxMBperSecFourResolutionsTemporalScalability == other.wMaxMBperSecFourResolutionsTemporalScalability
+            && self.wMaxMBperSecOneResolutionTemporalQualityScalability == other.wMaxMBperSecOneResolutionTemporalQualityScalability
+            && self.wMaxMBperSecTwoResolutionsTemporalQualityScalability == other.wMaxMBperSecTwoResolutionsTemporalQualityScalability
+            && self.wMaxMBperSecThreeResolutionsTemporalQualityScalablity == other.wMaxMBperSecThreeResolutionsTemporalQualityScalablity
+            && self.wMaxMBperSecFourResolutionsTemporalQualityScalability == other.wMaxMBperSecFourResolutionsTemporalQualityScalability
+            && self.wMaxMBperSecOneResolutionTemporalSpatialScalability == other.wMaxMBperSecOneResolutionTemporalSpatialScalability
+            && self.wMaxMBperSecTwoResolutionsTemporalSpatialScalability == other.wMaxMBperSecTwoResolutionsTemporalSpatialScalability
+            && self.wMaxMBperSecThreeResolutionsTemporalSpatialScalablity == other.wMaxMBperSecThreeResolutionsTemporalSpatialScalablity
+            && self.wMaxMBperSecFourResolutionsTemporalSpatialScalability == other.wMaxMBperSecFourResolutionsTemporalSpatialScalability
+            && self.wMaxMBperSecOneResolutionFullScalability == other.wMaxMBperSecOneResolutionFullScalability
+            && self.wMaxMBperSecTwoResolutionsFullScalability == other.wMaxMBperSecTwoResolutionsFullScalability
+            && self.wMaxMBperSecThreeResolutionsFullScalability == other.wMaxMBperSecThreeResolutionsFullScalability
+            && self.wMaxMBperSecFourResolutionsFullScalability == other.wMaxMBperSecFourResolutionsFullScalability
     }
 }
 impl ::core::cmp::Eq for KS_H264VIDEOINFO {}
@@ -18665,7 +17695,7 @@ unsafe impl ::windows::core::Abi for KS_MPEG1VIDEOINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_MPEG1VIDEOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_MPEG1VIDEOINFO>()) == 0 }
+        self.hdr == other.hdr && self.dwStartTimeCode == other.dwStartTimeCode && self.cbSequenceHeader == other.cbSequenceHeader && self.bSequenceHeader == other.bSequenceHeader
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18700,7 +17730,7 @@ unsafe impl ::windows::core::Abi for KS_MPEGAUDIOINFO {
 }
 impl ::core::cmp::PartialEq for KS_MPEGAUDIOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_MPEGAUDIOINFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3
     }
 }
 impl ::core::cmp::Eq for KS_MPEGAUDIOINFO {}
@@ -18734,14 +17764,6 @@ unsafe impl ::windows::core::Abi for KS_MPEGVIDEOINFO2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_MPEGVIDEOINFO2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_MPEGVIDEOINFO2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_MPEGVIDEOINFO2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_MPEGVIDEOINFO2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18771,7 +17793,7 @@ unsafe impl ::windows::core::Abi for KS_RGBQUAD {
 }
 impl ::core::cmp::PartialEq for KS_RGBQUAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_RGBQUAD>()) == 0 }
+        self.rgbBlue == other.rgbBlue && self.rgbGreen == other.rgbGreen && self.rgbRed == other.rgbRed && self.rgbReserved == other.rgbReserved
     }
 }
 impl ::core::cmp::Eq for KS_RGBQUAD {}
@@ -18802,7 +17824,7 @@ unsafe impl ::windows::core::Abi for KS_TRUECOLORINFO {
 }
 impl ::core::cmp::PartialEq for KS_TRUECOLORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_TRUECOLORINFO>()) == 0 }
+        self.dwBitMasks == other.dwBitMasks && self.bmiColors == other.bmiColors
     }
 }
 impl ::core::cmp::Eq for KS_TRUECOLORINFO {}
@@ -18835,7 +17857,7 @@ unsafe impl ::windows::core::Abi for KS_TVTUNER_CHANGE_INFO {
 }
 impl ::core::cmp::PartialEq for KS_TVTUNER_CHANGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_TVTUNER_CHANGE_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwCountryCode == other.dwCountryCode && self.dwAnalogVideoStandard == other.dwAnalogVideoStandard && self.dwChannel == other.dwChannel
     }
 }
 impl ::core::cmp::Eq for KS_TVTUNER_CHANGE_INFO {}
@@ -18887,7 +17909,7 @@ unsafe impl ::windows::core::Abi for KS_VBIINFOHEADER {
 }
 impl ::core::cmp::PartialEq for KS_VBIINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VBIINFOHEADER>()) == 0 }
+        self.StartLine == other.StartLine && self.EndLine == other.EndLine && self.SamplingFrequency == other.SamplingFrequency && self.MinLineStartTime == other.MinLineStartTime && self.MaxLineStartTime == other.MaxLineStartTime && self.ActualLineStartTime == other.ActualLineStartTime && self.ActualLineEndTime == other.ActualLineEndTime && self.VideoStandard == other.VideoStandard && self.SamplesPerLine == other.SamplesPerLine && self.StrideInBytes == other.StrideInBytes && self.BufferSize == other.BufferSize
     }
 }
 impl ::core::cmp::Eq for KS_VBIINFOHEADER {}
@@ -18923,7 +17945,7 @@ unsafe impl ::windows::core::Abi for KS_VBI_FRAME_INFO {
 }
 impl ::core::cmp::PartialEq for KS_VBI_FRAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VBI_FRAME_INFO>()) == 0 }
+        self.ExtendedHeaderSize == other.ExtendedHeaderSize && self.dwFrameFlags == other.dwFrameFlags && self.PictureNumber == other.PictureNumber && self.DropCount == other.DropCount && self.dwSamplingFrequency == other.dwSamplingFrequency && self.TvTunerChangeInfo == other.TvTunerChangeInfo && self.VBIInfoHeader == other.VBIInfoHeader
     }
 }
 impl ::core::cmp::Eq for KS_VBI_FRAME_INFO {}
@@ -18957,14 +17979,6 @@ unsafe impl ::windows::core::Abi for KS_VIDEOINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_VIDEOINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEOINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_VIDEOINFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_VIDEOINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18990,14 +18004,6 @@ impl ::core::clone::Clone for KS_VIDEOINFO_0 {
 unsafe impl ::windows::core::Abi for KS_VIDEOINFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_VIDEOINFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEOINFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_VIDEOINFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_VIDEOINFO_0 {
     fn default() -> Self {
@@ -19036,7 +18042,7 @@ unsafe impl ::windows::core::Abi for KS_VIDEOINFOHEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_VIDEOINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEOINFOHEADER>()) == 0 }
+        self.rcSource == other.rcSource && self.rcTarget == other.rcTarget && self.dwBitRate == other.dwBitRate && self.dwBitErrorRate == other.dwBitErrorRate && self.AvgTimePerFrame == other.AvgTimePerFrame && self.bmiHeader == other.bmiHeader
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19077,14 +18083,6 @@ unsafe impl ::windows::core::Abi for KS_VIDEOINFOHEADER2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_VIDEOINFOHEADER2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEOINFOHEADER2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_VIDEOINFOHEADER2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_VIDEOINFOHEADER2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19109,14 +18107,6 @@ impl ::core::clone::Clone for KS_VIDEOINFOHEADER2_0 {
 unsafe impl ::windows::core::Abi for KS_VIDEOINFOHEADER2_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KS_VIDEOINFOHEADER2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEOINFOHEADER2_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KS_VIDEOINFOHEADER2_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KS_VIDEOINFOHEADER2_0 {
     fn default() -> Self {
@@ -19192,7 +18182,27 @@ unsafe impl ::windows::core::Abi for KS_VIDEO_STREAM_CONFIG_CAPS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KS_VIDEO_STREAM_CONFIG_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KS_VIDEO_STREAM_CONFIG_CAPS>()) == 0 }
+        self.guid == other.guid
+            && self.VideoStandard == other.VideoStandard
+            && self.InputSize == other.InputSize
+            && self.MinCroppingSize == other.MinCroppingSize
+            && self.MaxCroppingSize == other.MaxCroppingSize
+            && self.CropGranularityX == other.CropGranularityX
+            && self.CropGranularityY == other.CropGranularityY
+            && self.CropAlignX == other.CropAlignX
+            && self.CropAlignY == other.CropAlignY
+            && self.MinOutputSize == other.MinOutputSize
+            && self.MaxOutputSize == other.MaxOutputSize
+            && self.OutputGranularityX == other.OutputGranularityX
+            && self.OutputGranularityY == other.OutputGranularityY
+            && self.StretchTapsX == other.StretchTapsX
+            && self.StretchTapsY == other.StretchTapsY
+            && self.ShrinkTapsX == other.ShrinkTapsX
+            && self.ShrinkTapsY == other.ShrinkTapsY
+            && self.MinFrameInterval == other.MinFrameInterval
+            && self.MaxFrameInterval == other.MaxFrameInterval
+            && self.MinBitsPerSecond == other.MinBitsPerSecond
+            && self.MaxBitsPerSecond == other.MaxBitsPerSecond
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19222,14 +18232,6 @@ impl ::core::clone::Clone for LOOPEDSTREAMING_POSITION_EVENT_DATA {
 unsafe impl ::windows::core::Abi for LOOPEDSTREAMING_POSITION_EVENT_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LOOPEDSTREAMING_POSITION_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOOPEDSTREAMING_POSITION_EVENT_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LOOPEDSTREAMING_POSITION_EVENT_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LOOPEDSTREAMING_POSITION_EVENT_DATA {
     fn default() -> Self {
@@ -19265,7 +18267,7 @@ unsafe impl ::windows::core::Abi for MEDIUM_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MEDIUM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEDIUM_INFO>()) == 0 }
+        self.MediaPresent == other.MediaPresent && self.MediaType == other.MediaType && self.RecordInhibit == other.RecordInhibit
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19291,12 +18293,6 @@ impl ::core::clone::Clone for MF_MDL_SHARED_PAYLOAD_KEY {
 unsafe impl ::windows::core::Abi for MF_MDL_SHARED_PAYLOAD_KEY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MF_MDL_SHARED_PAYLOAD_KEY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_MDL_SHARED_PAYLOAD_KEY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MF_MDL_SHARED_PAYLOAD_KEY {}
 impl ::core::default::Default for MF_MDL_SHARED_PAYLOAD_KEY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19325,7 +18321,7 @@ unsafe impl ::windows::core::Abi for MF_MDL_SHARED_PAYLOAD_KEY_0 {
 }
 impl ::core::cmp::PartialEq for MF_MDL_SHARED_PAYLOAD_KEY_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_MDL_SHARED_PAYLOAD_KEY_0>()) == 0 }
+        self.pHandle == other.pHandle && self.fHandle == other.fHandle && self.uPayload == other.uPayload
     }
 }
 impl ::core::cmp::Eq for MF_MDL_SHARED_PAYLOAD_KEY_0 {}
@@ -19358,7 +18354,7 @@ unsafe impl ::windows::core::Abi for NABTSFEC_BUFFER {
 }
 impl ::core::cmp::PartialEq for NABTSFEC_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NABTSFEC_BUFFER>()) == 0 }
+        self.dataSize == other.dataSize && self.groupID == other.groupID && self.Reserved == other.Reserved && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for NABTSFEC_BUFFER {}
@@ -19383,12 +18379,6 @@ impl ::core::clone::Clone for NABTS_BUFFER {
 unsafe impl ::windows::core::Abi for NABTS_BUFFER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NABTS_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NABTS_BUFFER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NABTS_BUFFER {}
 impl ::core::default::Default for NABTS_BUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19416,7 +18406,7 @@ unsafe impl ::windows::core::Abi for NABTS_BUFFER_LINE {
 }
 impl ::core::cmp::PartialEq for NABTS_BUFFER_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NABTS_BUFFER_LINE>()) == 0 }
+        self.Confidence == other.Confidence && self.Bytes == other.Bytes
     }
 }
 impl ::core::cmp::Eq for NABTS_BUFFER_LINE {}
@@ -19448,7 +18438,7 @@ unsafe impl ::windows::core::Abi for OPTIMAL_WEIGHT_TOTALS {
 }
 impl ::core::cmp::PartialEq for OPTIMAL_WEIGHT_TOTALS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPTIMAL_WEIGHT_TOTALS>()) == 0 }
+        self.MinTotalNominator == other.MinTotalNominator && self.MaxTotalNominator == other.MaxTotalNominator && self.TotalDenominator == other.TotalDenominator
     }
 }
 impl ::core::cmp::Eq for OPTIMAL_WEIGHT_TOTALS {}
@@ -19480,7 +18470,7 @@ unsafe impl ::windows::core::Abi for PIPE_DIMENSIONS {
 }
 impl ::core::cmp::PartialEq for PIPE_DIMENSIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PIPE_DIMENSIONS>()) == 0 }
+        self.AllocatorPin == other.AllocatorPin && self.MaxExpansionPin == other.MaxExpansionPin && self.EndPin == other.EndPin
     }
 }
 impl ::core::cmp::Eq for PIPE_DIMENSIONS {}
@@ -19515,7 +18505,7 @@ unsafe impl ::windows::core::Abi for PIPE_TERMINATION {
 }
 impl ::core::cmp::PartialEq for PIPE_TERMINATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PIPE_TERMINATION>()) == 0 }
+        self.Flags == other.Flags && self.OutsideFactors == other.OutsideFactors && self.Weigth == other.Weigth && self.PhysicalRange == other.PhysicalRange && self.OptimalRange == other.OptimalRange && self.Compression == other.Compression
     }
 }
 impl ::core::cmp::Eq for PIPE_TERMINATION {}
@@ -19548,7 +18538,7 @@ unsafe impl ::windows::core::Abi for SECURE_BUFFER_INFO {
 }
 impl ::core::cmp::PartialEq for SECURE_BUFFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURE_BUFFER_INFO>()) == 0 }
+        self.guidBufferIdentifier == other.guidBufferIdentifier && self.cbBufferSize == other.cbBufferSize && self.cbCaptured == other.cbCaptured && self.ullReserved == other.ullReserved
     }
 }
 impl ::core::cmp::Eq for SECURE_BUFFER_INFO {}
@@ -19579,7 +18569,7 @@ unsafe impl ::windows::core::Abi for SOUNDDETECTOR_PATTERNHEADER {
 }
 impl ::core::cmp::PartialEq for SOUNDDETECTOR_PATTERNHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOUNDDETECTOR_PATTERNHEADER>()) == 0 }
+        self.Size == other.Size && self.PatternType == other.PatternType
     }
 }
 impl ::core::cmp::Eq for SOUNDDETECTOR_PATTERNHEADER {}
@@ -19613,7 +18603,7 @@ unsafe impl ::windows::core::Abi for TRANSPORTAUDIOPARMS {
 }
 impl ::core::cmp::PartialEq for TRANSPORTAUDIOPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORTAUDIOPARMS>()) == 0 }
+        self.EnableOutput == other.EnableOutput && self.EnableRecord == other.EnableRecord && self.EnableSelsync == other.EnableSelsync && self.Input == other.Input && self.MonitorSource == other.MonitorSource
     }
 }
 impl ::core::cmp::Eq for TRANSPORTAUDIOPARMS {}
@@ -19703,7 +18693,36 @@ unsafe impl ::windows::core::Abi for TRANSPORTBASICPARMS {
 }
 impl ::core::cmp::PartialEq for TRANSPORTBASICPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORTBASICPARMS>()) == 0 }
+        self.TimeFormat == other.TimeFormat
+            && self.TimeReference == other.TimeReference
+            && self.Superimpose == other.Superimpose
+            && self.EndStopAction == other.EndStopAction
+            && self.RecordFormat == other.RecordFormat
+            && self.StepFrames == other.StepFrames
+            && self.SetpField == other.SetpField
+            && self.Preroll == other.Preroll
+            && self.RecPreroll == other.RecPreroll
+            && self.Postroll == other.Postroll
+            && self.EditDelay == other.EditDelay
+            && self.PlayTCDelay == other.PlayTCDelay
+            && self.RecTCDelay == other.RecTCDelay
+            && self.EditField == other.EditField
+            && self.FrameServo == other.FrameServo
+            && self.ColorFrameServo == other.ColorFrameServo
+            && self.ServoRef == other.ServoRef
+            && self.WarnGenlock == other.WarnGenlock
+            && self.SetTracking == other.SetTracking
+            && self.VolumeName == other.VolumeName
+            && self.Ballistic == other.Ballistic
+            && self.Speed == other.Speed
+            && self.CounterFormat == other.CounterFormat
+            && self.TunerChannel == other.TunerChannel
+            && self.TunerNumber == other.TunerNumber
+            && self.TimerEvent == other.TimerEvent
+            && self.TimerStartDay == other.TimerStartDay
+            && self.TimerStartTime == other.TimerStartTime
+            && self.TimerStopDay == other.TimerStopDay
+            && self.TimerStopTime == other.TimerStopTime
     }
 }
 impl ::core::cmp::Eq for TRANSPORTBASICPARMS {}
@@ -19759,7 +18778,7 @@ unsafe impl ::windows::core::Abi for TRANSPORTSTATUS {
 }
 impl ::core::cmp::PartialEq for TRANSPORTSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORTSTATUS>()) == 0 }
+        self.Mode == other.Mode && self.LastError == other.LastError && self.RecordInhibit == other.RecordInhibit && self.ServoLock == other.ServoLock && self.MediaPresent == other.MediaPresent && self.MediaLength == other.MediaLength && self.MediaSize == other.MediaSize && self.MediaTrackCount == other.MediaTrackCount && self.MediaTrackLength == other.MediaTrackLength && self.MediaTrackSide == other.MediaTrackSide && self.MediaType == other.MediaType && self.LinkMode == other.LinkMode && self.NotifyOn == other.NotifyOn
     }
 }
 impl ::core::cmp::Eq for TRANSPORTSTATUS {}
@@ -19790,7 +18809,7 @@ unsafe impl ::windows::core::Abi for TRANSPORTVIDEOPARMS {
 }
 impl ::core::cmp::PartialEq for TRANSPORTVIDEOPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORTVIDEOPARMS>()) == 0 }
+        self.OutputMode == other.OutputMode && self.Input == other.Input
     }
 }
 impl ::core::cmp::Eq for TRANSPORTVIDEOPARMS {}
@@ -19821,7 +18840,7 @@ unsafe impl ::windows::core::Abi for TRANSPORT_STATE {
 }
 impl ::core::cmp::PartialEq for TRANSPORT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORT_STATE>()) == 0 }
+        self.Mode == other.Mode && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for TRANSPORT_STATE {}
@@ -19858,7 +18877,7 @@ unsafe impl ::windows::core::Abi for TUNER_ANALOG_CAPS_S {
 }
 impl ::core::cmp::PartialEq for TUNER_ANALOG_CAPS_S {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TUNER_ANALOG_CAPS_S>()) == 0 }
+        self.Mode == other.Mode && self.StandardsSupported == other.StandardsSupported && self.MinFrequency == other.MinFrequency && self.MaxFrequency == other.MaxFrequency && self.TuningGranularity == other.TuningGranularity && self.SettlingTime == other.SettlingTime && self.ScanSensingRange == other.ScanSensingRange && self.FineTuneSensingRange == other.FineTuneSensingRange
     }
 }
 impl ::core::cmp::Eq for TUNER_ANALOG_CAPS_S {}
@@ -19883,12 +18902,6 @@ impl ::core::clone::Clone for VBICAP_PROPERTIES_PROTECTION_S {
 unsafe impl ::windows::core::Abi for VBICAP_PROPERTIES_PROTECTION_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBICAP_PROPERTIES_PROTECTION_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICAP_PROPERTIES_PROTECTION_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBICAP_PROPERTIES_PROTECTION_S {}
 impl ::core::default::Default for VBICAP_PROPERTIES_PROTECTION_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19915,7 +18928,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_CC_SUBSTREAMS {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_CC_SUBSTREAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_CC_SUBSTREAMS>()) == 0 }
+        self.SubstreamMask == other.SubstreamMask
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_CC_SUBSTREAMS {}
@@ -19945,7 +18958,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_NABTS_SUBSTREAMS {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_NABTS_SUBSTREAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_NABTS_SUBSTREAMS>()) == 0 }
+        self.SubstreamMask == other.SubstreamMask
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_NABTS_SUBSTREAMS {}
@@ -19975,7 +18988,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_SCANLINES {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_SCANLINES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_SCANLINES>()) == 0 }
+        self.DwordBitArray == other.DwordBitArray
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_SCANLINES {}
@@ -20005,7 +19018,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_CC {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_CC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_CC>()) == 0 }
+        self.Common == other.Common
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_CC {}
@@ -20035,7 +19048,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_CC_PIN {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_CC_PIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_CC_PIN>()) == 0 }
+        self.Common == other.Common
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_CC_PIN {}
@@ -20093,7 +19106,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_COMMON {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_COMMON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_COMMON>()) == 0 }
+        self.InputSRBsProcessed == other.InputSRBsProcessed && self.OutputSRBsProcessed == other.OutputSRBsProcessed && self.SRBsIgnored == other.SRBsIgnored && self.InputSRBsMissing == other.InputSRBsMissing && self.OutputSRBsMissing == other.OutputSRBsMissing && self.OutputFailures == other.OutputFailures && self.InternalErrors == other.InternalErrors && self.ExternalErrors == other.ExternalErrors && self.InputDiscontinuities == other.InputDiscontinuities && self.DSPFailures == other.DSPFailures && self.TvTunerChanges == other.TvTunerChanges && self.VBIHeaderChanges == other.VBIHeaderChanges && self.LineConfidenceAvg == other.LineConfidenceAvg && self.BytesOutput == other.BytesOutput
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_COMMON {}
@@ -20130,7 +19143,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_COMMON_PIN {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_COMMON_PIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_COMMON_PIN>()) == 0 }
+        self.SRBsProcessed == other.SRBsProcessed && self.SRBsIgnored == other.SRBsIgnored && self.SRBsMissing == other.SRBsMissing && self.InternalErrors == other.InternalErrors && self.ExternalErrors == other.ExternalErrors && self.Discontinuities == other.Discontinuities && self.LineConfidenceAvg == other.LineConfidenceAvg && self.BytesOutput == other.BytesOutput
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_COMMON_PIN {}
@@ -20167,7 +19180,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_NABTS {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_NABTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_NABTS>()) == 0 }
+        self.Common == other.Common && self.FECBundleBadLines == other.FECBundleBadLines && self.FECQueueOverflows == other.FECQueueOverflows && self.FECCorrectedLines == other.FECCorrectedLines && self.FECUncorrectableLines == other.FECUncorrectableLines && self.BundlesProcessed == other.BundlesProcessed && self.BundlesSent2IP == other.BundlesSent2IP && self.FilteredLines == other.FilteredLines
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_NABTS {}
@@ -20197,7 +19210,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_NABTS_PIN {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_NABTS_PIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_NABTS_PIN>()) == 0 }
+        self.Common == other.Common
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_NABTS_PIN {}
@@ -20227,7 +19240,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_TELETEXT {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_TELETEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_TELETEXT>()) == 0 }
+        self.Common == other.Common
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_TELETEXT {}
@@ -20257,7 +19270,7 @@ unsafe impl ::windows::core::Abi for VBICODECFILTERING_STATISTICS_TELETEXT_PIN {
 }
 impl ::core::cmp::PartialEq for VBICODECFILTERING_STATISTICS_TELETEXT_PIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBICODECFILTERING_STATISTICS_TELETEXT_PIN>()) == 0 }
+        self.Common == other.Common
     }
 }
 impl ::core::cmp::Eq for VBICODECFILTERING_STATISTICS_TELETEXT_PIN {}
@@ -20294,7 +19307,7 @@ unsafe impl ::windows::core::Abi for VRAM_SURFACE_INFO {
 }
 impl ::core::cmp::PartialEq for VRAM_SURFACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VRAM_SURFACE_INFO>()) == 0 }
+        self.hSurface == other.hSurface && self.VramPhysicalAddress == other.VramPhysicalAddress && self.cbCaptured == other.cbCaptured && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.dwLinearSize == other.dwLinearSize && self.lPitch == other.lPitch && self.ullReserved == other.ullReserved
     }
 }
 impl ::core::cmp::Eq for VRAM_SURFACE_INFO {}
@@ -20318,12 +19331,6 @@ impl ::core::clone::Clone for VRAM_SURFACE_INFO_PROPERTY_S {
 unsafe impl ::windows::core::Abi for VRAM_SURFACE_INFO_PROPERTY_S {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VRAM_SURFACE_INFO_PROPERTY_S {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VRAM_SURFACE_INFO_PROPERTY_S>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VRAM_SURFACE_INFO_PROPERTY_S {}
 impl ::core::default::Default for VRAM_SURFACE_INFO_PROPERTY_S {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20353,7 +19360,7 @@ unsafe impl ::windows::core::Abi for WNF_KSCAMERA_STREAMSTATE_INFO {
 }
 impl ::core::cmp::PartialEq for WNF_KSCAMERA_STREAMSTATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNF_KSCAMERA_STREAMSTATE_INFO>()) == 0 }
+        self.ProcessId == other.ProcessId && self.SessionId == other.SessionId && self.StreamState == other.StreamState && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WNF_KSCAMERA_STREAMSTATE_INFO {}
@@ -20384,7 +19391,7 @@ unsafe impl ::windows::core::Abi for WST_BUFFER {
 }
 impl ::core::cmp::PartialEq for WST_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WST_BUFFER>()) == 0 }
+        self.ScanlinesRequested == other.ScanlinesRequested && self.WstLines == other.WstLines
     }
 }
 impl ::core::cmp::Eq for WST_BUFFER {}
@@ -20415,7 +19422,7 @@ unsafe impl ::windows::core::Abi for WST_BUFFER_LINE {
 }
 impl ::core::cmp::PartialEq for WST_BUFFER_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WST_BUFFER_LINE>()) == 0 }
+        self.Confidence == other.Confidence && self.Bytes == other.Bytes
     }
 }
 impl ::core::cmp::Eq for WST_BUFFER_LINE {}

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -46574,12 +46574,6 @@ impl ::core::clone::Clone for ASF_FLAT_PICTURE {
 unsafe impl ::windows::core::Abi for ASF_FLAT_PICTURE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ASF_FLAT_PICTURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASF_FLAT_PICTURE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ASF_FLAT_PICTURE {}
 impl ::core::default::Default for ASF_FLAT_PICTURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -46601,12 +46595,6 @@ impl ::core::clone::Clone for ASF_FLAT_SYNCHRONISED_LYRICS {
 unsafe impl ::windows::core::Abi for ASF_FLAT_SYNCHRONISED_LYRICS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ASF_FLAT_SYNCHRONISED_LYRICS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASF_FLAT_SYNCHRONISED_LYRICS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ASF_FLAT_SYNCHRONISED_LYRICS {}
 impl ::core::default::Default for ASF_FLAT_SYNCHRONISED_LYRICS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -46636,7 +46624,7 @@ unsafe impl ::windows::core::Abi for ASF_INDEX_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for ASF_INDEX_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASF_INDEX_DESCRIPTOR>()) == 0 }
+        self.Identifier == other.Identifier && self.cPerEntryBytes == other.cPerEntryBytes && self.szDescription == other.szDescription && self.dwInterval == other.dwInterval
     }
 }
 impl ::core::cmp::Eq for ASF_INDEX_DESCRIPTOR {}
@@ -46667,7 +46655,7 @@ unsafe impl ::windows::core::Abi for ASF_INDEX_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for ASF_INDEX_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASF_INDEX_IDENTIFIER>()) == 0 }
+        self.guidIndexType == other.guidIndexType && self.wStreamNumber == other.wStreamNumber
     }
 }
 impl ::core::cmp::Eq for ASF_INDEX_IDENTIFIER {}
@@ -46698,7 +46686,7 @@ unsafe impl ::windows::core::Abi for ASF_MUX_STATISTICS {
 }
 impl ::core::cmp::PartialEq for ASF_MUX_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASF_MUX_STATISTICS>()) == 0 }
+        self.cFramesWritten == other.cFramesWritten && self.cFramesDropped == other.cFramesDropped
     }
 }
 impl ::core::cmp::Eq for ASF_MUX_STATISTICS {}
@@ -46766,7 +46754,25 @@ unsafe impl ::windows::core::Abi for AecQualityMetrics_Struct {
 }
 impl ::core::cmp::PartialEq for AecQualityMetrics_Struct {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AecQualityMetrics_Struct>()) == 0 }
+        self.i64Timestamp == other.i64Timestamp
+            && self.ConvergenceFlag == other.ConvergenceFlag
+            && self.MicClippedFlag == other.MicClippedFlag
+            && self.MicSilenceFlag == other.MicSilenceFlag
+            && self.PstvFeadbackFlag == other.PstvFeadbackFlag
+            && self.SpkClippedFlag == other.SpkClippedFlag
+            && self.SpkMuteFlag == other.SpkMuteFlag
+            && self.GlitchFlag == other.GlitchFlag
+            && self.DoubleTalkFlag == other.DoubleTalkFlag
+            && self.uGlitchCount == other.uGlitchCount
+            && self.uMicClipCount == other.uMicClipCount
+            && self.fDuration == other.fDuration
+            && self.fTSVariance == other.fTSVariance
+            && self.fTSDriftRate == other.fTSDriftRate
+            && self.fVoiceLevel == other.fVoiceLevel
+            && self.fNoiseLevel == other.fNoiseLevel
+            && self.fERLE == other.fERLE
+            && self.fAvgERLE == other.fAvgERLE
+            && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for AecQualityMetrics_Struct {}
@@ -46798,7 +46804,7 @@ unsafe impl ::windows::core::Abi for CodecAPIEventData {
 }
 impl ::core::cmp::PartialEq for CodecAPIEventData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CodecAPIEventData>()) == 0 }
+        self.guid == other.guid && self.dataLength == other.dataLength && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for CodecAPIEventData {}
@@ -46834,7 +46840,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ARCHITECTURE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ARCHITECTURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ARCHITECTURE>()) == 0 }
+        self.IOCoherent == other.IOCoherent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46874,7 +46880,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE 
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE>()) == 0 }
+        self.VideoDecoderHeapDesc == other.VideoDecoderHeapDesc && self.MemoryPoolL0Size == other.MemoryPoolL0Size && self.MemoryPoolL1Size == other.MemoryPoolL1Size
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -46915,7 +46921,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1>()) == 0 }
+        self.VideoDecoderHeapDesc == other.VideoDecoderHeapDesc && self.Protected == other.Protected && self.MemoryPoolL0Size == other.MemoryPoolL0Size && self.MemoryPoolL1Size == other.MemoryPoolL1Size
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -46960,7 +46966,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Configuration == other.Configuration && self.DecodeSample == other.DecodeSample && self.OutputFormat == other.OutputFormat && self.FrameRate == other.FrameRate && self.BitRate == other.BitRate && self.SupportFlags == other.SupportFlags && self.ScaleSupport == other.ScaleSupport
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -47001,7 +47007,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMATS {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_FORMATS>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Configuration == other.Configuration && self.FormatCount == other.FormatCount && self.pOutputFormats == other.pOutputFormats
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -47035,7 +47041,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUN
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Configuration == other.Configuration && self.FormatCount == other.FormatCount
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT {}
@@ -47078,7 +47084,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAM {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAM>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.DecodeProfile == other.DecodeProfile && self.Width == other.Width && self.Height == other.Height && self.DecodeFormat == other.DecodeFormat && self.Components == other.Components && self.BinCount == other.BinCount && self.CounterBitDepth == other.CounterBitDepth
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -47112,7 +47118,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.ProfileCount == other.ProfileCount && self.pProfiles == other.pProfiles
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {}
@@ -47143,7 +47149,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COU
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.ProfileCount == other.ProfileCount
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT {}
@@ -47175,7 +47181,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_R
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCES>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Configuration == other.Configuration && self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCES {}
@@ -47220,7 +47226,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Configuration == other.Configuration && self.Width == other.Width && self.Height == other.Height && self.DecodeFormat == other.DecodeFormat && self.FrameRate == other.FrameRate && self.BitRate == other.BitRate && self.SupportFlags == other.SupportFlags && self.ConfigurationFlags == other.ConfigurationFlags && self.DecodeTier == other.DecodeTier
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -47260,7 +47266,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Codec == other.Codec && self.IsSupported == other.IsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -47294,14 +47300,6 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONF
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47329,14 +47327,6 @@ impl ::core::clone::Clone for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CON
 unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
     fn default() -> Self {
@@ -47367,14 +47357,6 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBR
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47401,14 +47383,6 @@ impl ::core::clone::Clone for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
 unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
     fn default() -> Self {
@@ -47438,14 +47412,6 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORM
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47474,14 +47440,6 @@ impl ::core::clone::Clone for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MOD
 unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
     fn default() -> Self {
@@ -47533,7 +47491,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RES
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Codec == other.Codec && self.ResolutionRatiosCount == other.ResolutionRatiosCount && self.IsSupported == other.IsSupported && self.MinResolutionSupported == other.MinResolutionSupported && self.MaxResolutionSupported == other.MaxResolutionSupported && self.ResolutionWidthMultipleRequirement == other.ResolutionWidthMultipleRequirement && self.ResolutionHeightMultipleRequirement == other.ResolutionHeightMultipleRequirement && self.pResolutionRatios == other.pResolutionRatios
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -47567,7 +47525,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RES
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Codec == other.Codec && self.ResolutionRatiosCount == other.ResolutionRatiosCount
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT {}
@@ -47599,14 +47557,6 @@ impl ::core::clone::Clone for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
 unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
     fn default() -> Self {
@@ -47643,7 +47593,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTROL_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTROL_MODE>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.Codec == other.Codec && self.RateControlMode == other.RateControlMode && self.IsSupported == other.IsSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -47678,7 +47628,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS>()) == 0 }
+        self.MaxSubregionsNumber == other.MaxSubregionsNumber && self.MaxIntraRefreshFrameDuration == other.MaxIntraRefreshFrameDuration && self.SubregionBlockPixelsSize == other.SubregionBlockPixelsSize && self.QPMapRegionPixelsSize == other.QPMapRegionPixelsSize
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS {}
@@ -47713,14 +47663,6 @@ impl ::core::clone::Clone for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREM
 unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {
     fn default() -> Self {
@@ -47761,14 +47703,6 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47803,7 +47737,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMANDS
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMANDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMANDS>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.CommandCount == other.CommandCount && self.pCommandInfos == other.pCommandInfos
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -47836,7 +47770,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.CommandCount == other.CommandCount
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT {}
@@ -47869,7 +47803,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETERS>()) == 0 }
+        self.CommandId == other.CommandId && self.Stage == other.Stage && self.ParameterCount == other.ParameterCount && self.pParameterInfos == other.pParameterInfos
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETERS {}
@@ -47902,7 +47836,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT>()) == 0 }
+        self.CommandId == other.CommandId && self.Stage == other.Stage && self.ParameterCount == other.ParameterCount && self.ParameterPacking == other.ParameterPacking
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT {}
@@ -47937,7 +47871,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SIZE>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.CommandId == other.CommandId && self.pCreationParameters == other.pCreationParameters && self.CreationParametersSizeInBytes == other.CreationParametersSizeInBytes && self.MemoryPoolL0Size == other.MemoryPoolL0Size && self.MemoryPoolL1Size == other.MemoryPoolL1Size
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SIZE {}
@@ -47972,7 +47906,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.CommandId == other.CommandId && self.pInputData == other.pInputData && self.InputDataSizeInBytes == other.InputDataSizeInBytes && self.pOutputData == other.pOutputData && self.OutputDataSizeInBytes == other.OutputDataSizeInBytes
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT {}
@@ -48011,7 +47945,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.VideoDecodeSupport == other.VideoDecodeSupport && self.VideoProcessSupport == other.VideoProcessSupport && self.VideoEncodeSupport == other.VideoEncodeSupport
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -48053,7 +47987,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.InputFormat == other.InputFormat && self.BlockSizeFlags == other.BlockSizeFlags && self.PrecisionFlags == other.PrecisionFlags && self.SizeRange == other.SizeRange
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -48086,7 +48020,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_P
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES {}
@@ -48142,7 +48076,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_S
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZE>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.InputFormat == other.InputFormat && self.BlockSize == other.BlockSize && self.Precision == other.Precision && self.SizeRange == other.SizeRange && self.Protected == other.Protected && self.MotionVectorHeapMemoryPoolL0Size == other.MotionVectorHeapMemoryPoolL0Size && self.MotionVectorHeapMemoryPoolL1Size == other.MotionVectorHeapMemoryPoolL1Size && self.MotionEstimatorMemoryPoolL0Size == other.MotionEstimatorMemoryPoolL0Size && self.MotionEstimatorMemoryPoolL1Size == other.MotionEstimatorMemoryPoolL1Size
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -48185,7 +48119,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE>()) == 0 }
+        self.NodeMask == other.NodeMask && self.pOutputStreamDesc == other.pOutputStreamDesc && self.NumInputStreamDescs == other.NumInputStreamDescs && self.pInputStreamDescs == other.pInputStreamDescs && self.MemoryPoolL0Size == other.MemoryPoolL0Size && self.MemoryPoolL1Size == other.MemoryPoolL1Size
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -48229,7 +48163,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE1>()) == 0 }
+        self.NodeMask == other.NodeMask && self.pOutputStreamDesc == other.pOutputStreamDesc && self.NumInputStreamDescs == other.NumInputStreamDescs && self.pInputStreamDescs == other.pInputStreamDescs && self.Protected == other.Protected && self.MemoryPoolL0Size == other.MemoryPoolL0Size && self.MemoryPoolL1Size == other.MemoryPoolL1Size
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -48262,7 +48196,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.MaxInputStreams == other.MaxInputStreams
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS {}
@@ -48293,7 +48227,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_
 }
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES {}
@@ -48337,7 +48271,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFO>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.DeinterlaceMode == other.DeinterlaceMode && self.Filters == other.Filters && self.FeatureSupport == other.FeatureSupport && self.InputFrameRate == other.InputFrameRate && self.OutputFrameRate == other.OutputFrameRate && self.EnableAutoProcessing == other.EnableAutoProcessing && self.PastFrames == other.PastFrames && self.FutureFrames == other.FutureFrames
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -48405,7 +48339,7 @@ unsafe impl ::windows::core::Abi for D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORT>()) == 0 }
+        self.NodeIndex == other.NodeIndex && self.InputSample == other.InputSample && self.InputFieldType == other.InputFieldType && self.InputStereoFormat == other.InputStereoFormat && self.InputFrameRate == other.InputFrameRate && self.OutputFormat == other.OutputFormat && self.OutputStereoFormat == other.OutputStereoFormat && self.OutputFrameRate == other.OutputFrameRate && self.SupportFlags == other.SupportFlags && self.ScaleSupport == other.ScaleSupport && self.FeatureSupport == other.FeatureSupport && self.DeinterlaceSupport == other.DeinterlaceSupport && self.AutoProcessingSupport == other.AutoProcessingSupport && self.FilterSupport == other.FilterSupport && self.FilterRangeSupport == other.FilterRangeSupport
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -48446,7 +48380,7 @@ unsafe impl ::windows::core::Abi for D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICS {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICS>()) == 0 }
+        self.Status == other.Status && self.NumMacroblocksAffected == other.NumMacroblocksAffected && self.FrameRate == other.FrameRate && self.BitRate == other.BitRate
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -48556,7 +48490,7 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_COORDINATE {
 }
 impl ::core::cmp::PartialEq for D3D12_RESOURCE_COORDINATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_RESOURCE_COORDINATE>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z && self.SubresourceIndex == other.SubresourceIndex
     }
 }
 impl ::core::cmp::Eq for D3D12_RESOURCE_COORDINATE {}
@@ -48587,7 +48521,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODER_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_DECODER_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_DECODER_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.Configuration == other.Configuration
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_DECODER_DESC {}
@@ -48630,7 +48564,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODER_HEAP_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_DECODER_HEAP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_DECODER_HEAP_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.Configuration == other.Configuration && self.DecodeWidth == other.DecodeWidth && self.DecodeHeight == other.DecodeHeight && self.Format == other.Format && self.FrameRate == other.FrameRate && self.BitRate == other.BitRate && self.MaxDecodePictureBufferCount == other.MaxDecodePictureBufferCount
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -48702,7 +48636,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODE_CONFIGURATION {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_DECODE_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_DECODE_CONFIGURATION>()) == 0 }
+        self.DecodeProfile == other.DecodeProfile && self.BitstreamEncryption == other.BitstreamEncryption && self.InterlaceType == other.InterlaceType
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_DECODE_CONFIGURATION {}
@@ -48830,7 +48764,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODE_FRAME_ARGUMENT {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_DECODE_FRAME_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_DECODE_FRAME_ARGUMENT>()) == 0 }
+        self.Type == other.Type && self.Size == other.Size && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_DECODE_FRAME_ARGUMENT {}
@@ -49038,7 +48972,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODE_REFERENCE_FRAMES {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_DECODE_REFERENCE_FRAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_DECODE_REFERENCE_FRAMES>()) == 0 }
+        self.NumTexture2Ds == other.NumTexture2Ds && self.ppTexture2Ds == other.ppTexture2Ds && self.pSubresources == other.pSubresources && self.ppHeaps == other.ppHeaps
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -49064,12 +48998,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49090,12 +49018,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49124,7 +49046,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H26
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264>()) == 0 }
+        self.ConfigurationFlags == other.ConfigurationFlags && self.DirectModeConfig == other.DirectModeConfig && self.DisableDeblockingFilterConfig == other.DisableDeblockingFilterConfig
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264 {}
@@ -49168,7 +49090,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEV
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC>()) == 0 }
+        self.ConfigurationFlags == other.ConfigurationFlags && self.MinLumaCodingUnitSize == other.MinLumaCodingUnitSize && self.MaxLumaCodingUnitSize == other.MaxLumaCodingUnitSize && self.MinLumaTransformUnitSize == other.MinLumaTransformUnitSize && self.MaxLumaTransformUnitSize == other.MaxLumaTransformUnitSize && self.max_transform_hierarchy_depth_inter == other.max_transform_hierarchy_depth_inter && self.max_transform_hierarchy_depth_intra == other.max_transform_hierarchy_depth_intra
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC {}
@@ -49192,12 +49114,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49218,12 +49134,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49251,7 +49161,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUP
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264>()) == 0 }
+        self.SupportFlags == other.SupportFlags && self.DisableDeblockingFilterSupportedModes == other.DisableDeblockingFilterSupportedModes
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264 {}
@@ -49295,7 +49205,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUP
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC>()) == 0 }
+        self.SupportFlags == other.SupportFlags && self.MinLumaCodingUnitSize == other.MinLumaCodingUnitSize && self.MaxLumaCodingUnitSize == other.MaxLumaCodingUnitSize && self.MinLumaTransformUnitSize == other.MinLumaTransformUnitSize && self.MaxLumaTransformUnitSize == other.MaxLumaTransformUnitSize && self.max_transform_hierarchy_depth_inter == other.max_transform_hierarchy_depth_inter && self.max_transform_hierarchy_depth_intra == other.max_transform_hierarchy_depth_intra
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC {}
@@ -49319,12 +49229,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT 
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49345,12 +49249,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49381,7 +49279,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_S
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_H264>()) == 0 }
+        self.MaxL0ReferencesForP == other.MaxL0ReferencesForP && self.MaxL0ReferencesForB == other.MaxL0ReferencesForB && self.MaxL1ReferencesForB == other.MaxL1ReferencesForB && self.MaxLongTermReferences == other.MaxLongTermReferences && self.MaxDPBCapacity == other.MaxDPBCapacity
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_H264 {}
@@ -49415,7 +49313,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_S
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC>()) == 0 }
+        self.MaxL0ReferencesForP == other.MaxL0ReferencesForP && self.MaxL0ReferencesForB == other.MaxL0ReferencesForB && self.MaxL1ReferencesForB == other.MaxL1ReferencesForB && self.MaxLongTermReferences == other.MaxLongTermReferences && self.MaxDPBCapacity == other.MaxDPBCapacity
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC {}
@@ -49486,14 +49384,6 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49525,14 +49415,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
-    fn eq(&self, other: &Self) -> bool {
-        self.SequenceControlDesc == other.SequenceControlDesc && self.PictureControlDesc == other.PictureControlDesc && self.pInputFrame == other.pInputFrame && self.InputFrameSubresource == other.InputFrameSubresource && self.CurrentFrameBitstreamMetadataSize == other.CurrentFrameBitstreamMetadataSize
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
     fn default() -> Self {
@@ -49641,7 +49523,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADAT
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADATA>()) == 0 }
+        self.bSize == other.bSize && self.bStartOffset == other.bStartOffset && self.bHeaderSize == other.bHeaderSize
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADATA {}
@@ -49670,12 +49552,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_HEAP_DESC {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_HEAP_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_HEAP_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_HEAP_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_HEAP_DESC {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_HEAP_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49703,7 +49579,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_INTRA_REFRESH {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_INTRA_REFRESH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_INTRA_REFRESH>()) == 0 }
+        self.Mode == other.Mode && self.IntraRefreshDuration == other.IntraRefreshDuration
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_INTRA_REFRESH {}
@@ -49727,12 +49603,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_LEVEL_SETTING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_LEVEL_SETTING {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49753,12 +49623,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_LEVEL_SETTING_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49786,7 +49650,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC>()) == 0 }
+        self.Level == other.Level && self.Tier == other.Tier
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC {}
@@ -49819,7 +49683,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_OUTPUT_METADATA {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_OUTPUT_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_OUTPUT_METADATA>()) == 0 }
+        self.EncodeErrorFlags == other.EncodeErrorFlags && self.EncodeStats == other.EncodeStats && self.EncodedBitstreamWrittenBytesCount == other.EncodedBitstreamWrittenBytesCount && self.WrittenSubregionsCount == other.WrittenSubregionsCount
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_OUTPUT_METADATA {}
@@ -49854,7 +49718,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATIST
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS>()) == 0 }
+        self.AverageQP == other.AverageQP && self.IntraCodingUnitsCount == other.IntraCodingUnitsCount && self.InterCodingUnitsCount == other.InterCodingUnitsCount && self.SkipCodingUnitsCount == other.SkipCodingUnitsCount && self.AverageMotionEstimationXDirection == other.AverageMotionEstimationXDirection && self.AverageMotionEstimationYDirection == other.AverageMotionEstimationYDirection
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS {}
@@ -49883,14 +49747,6 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_D
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49915,14 +49771,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
     fn default() -> Self {
@@ -50000,7 +49848,28 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_D
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264>()) == 0 }
+        self.Flags == other.Flags
+            && self.FrameType == other.FrameType
+            && self.pic_parameter_set_id == other.pic_parameter_set_id
+            && self.idr_pic_id == other.idr_pic_id
+            && self.PictureOrderCountNumber == other.PictureOrderCountNumber
+            && self.FrameDecodingOrderNumber == other.FrameDecodingOrderNumber
+            && self.TemporalLayerIndex == other.TemporalLayerIndex
+            && self.List0ReferenceFramesCount == other.List0ReferenceFramesCount
+            && self.pList0ReferenceFrames == other.pList0ReferenceFrames
+            && self.List1ReferenceFramesCount == other.List1ReferenceFramesCount
+            && self.pList1ReferenceFrames == other.pList1ReferenceFrames
+            && self.ReferenceFramesReconPictureDescriptorsCount == other.ReferenceFramesReconPictureDescriptorsCount
+            && self.pReferenceFramesReconPictureDescriptors == other.pReferenceFramesReconPictureDescriptors
+            && self.adaptive_ref_pic_marking_mode_flag == other.adaptive_ref_pic_marking_mode_flag
+            && self.RefPicMarkingOperationsCommandsCount == other.RefPicMarkingOperationsCommandsCount
+            && self.pRefPicMarkingOperationsCommands == other.pRefPicMarkingOperationsCommands
+            && self.List0RefPicModificationsCount == other.List0RefPicModificationsCount
+            && self.pList0RefPicModifications == other.pList0RefPicModifications
+            && self.List1RefPicModificationsCount == other.List1RefPicModificationsCount
+            && self.pList1RefPicModifications == other.pList1RefPicModifications
+            && self.QPMapValuesCount == other.QPMapValuesCount
+            && self.pRateControlQPMap == other.pRateControlQPMap
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -50034,7 +49903,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_D
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_LIST_MODIFICATION_OPERATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_LIST_MODIFICATION_OPERATION>()) == 0 }
+        self.modification_of_pic_nums_idc == other.modification_of_pic_nums_idc && self.abs_diff_pic_num_minus1 == other.abs_diff_pic_num_minus1 && self.long_term_pic_num == other.long_term_pic_num
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_LIST_MODIFICATION_OPERATION {}
@@ -50068,7 +49937,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_D
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_MARKING_OPERATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_MARKING_OPERATION>()) == 0 }
+        self.memory_management_control_operation == other.memory_management_control_operation && self.difference_of_pic_nums_minus1 == other.difference_of_pic_nums_minus1 && self.long_term_pic_num == other.long_term_pic_num && self.long_term_frame_idx == other.long_term_frame_idx && self.max_long_term_frame_idx_plus1 == other.max_long_term_frame_idx_plus1
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_MARKING_OPERATION {}
@@ -50138,7 +50007,23 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_D
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC>()) == 0 }
+        self.Flags == other.Flags
+            && self.FrameType == other.FrameType
+            && self.slice_pic_parameter_set_id == other.slice_pic_parameter_set_id
+            && self.PictureOrderCountNumber == other.PictureOrderCountNumber
+            && self.TemporalLayerIndex == other.TemporalLayerIndex
+            && self.List0ReferenceFramesCount == other.List0ReferenceFramesCount
+            && self.pList0ReferenceFrames == other.pList0ReferenceFrames
+            && self.List1ReferenceFramesCount == other.List1ReferenceFramesCount
+            && self.pList1ReferenceFrames == other.pList1ReferenceFrames
+            && self.ReferenceFramesReconPictureDescriptorsCount == other.ReferenceFramesReconPictureDescriptorsCount
+            && self.pReferenceFramesReconPictureDescriptors == other.pReferenceFramesReconPictureDescriptors
+            && self.List0RefPicModificationsCount == other.List0RefPicModificationsCount
+            && self.pList0RefPicModifications == other.pList0RefPicModifications
+            && self.List1RefPicModificationsCount == other.List1RefPicModificationsCount
+            && self.pList1RefPicModifications == other.pList1RefPicModifications
+            && self.QPMapValuesCount == other.QPMapValuesCount
+            && self.pRateControlQPMap == other.pRateControlQPMap
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -50171,14 +50056,6 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50199,12 +50076,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAY
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50225,12 +50096,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAY
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50250,12 +50115,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAY
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50278,12 +50137,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAY
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50311,7 +50164,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC {}
@@ -50342,7 +50195,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATI
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATIO_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATIO_DESC>()) == 0 }
+        self.WidthRatio == other.WidthRatio && self.HeightRatio == other.HeightRatio
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATIO_DESC {}
@@ -50366,12 +50219,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PROFILE_DESC {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PROFILE_DESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PROFILE_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PROFILE_DESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PROFILE_DESC {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PROFILE_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50392,12 +50239,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_PROFILE_DESC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50424,14 +50265,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_RATE_CONTROL {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_RATE_CONTROL {
     fn default() -> Self {
@@ -50465,7 +50298,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR>()) == 0 }
+        self.InitialQP == other.InitialQP && self.MinQP == other.MinQP && self.MaxQP == other.MaxQP && self.MaxFrameBitSize == other.MaxFrameBitSize && self.TargetBitRate == other.TargetBitRate && self.VBVCapacity == other.VBVCapacity && self.InitialVBVFullness == other.InitialVBVFullness
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR {}
@@ -50489,12 +50322,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PAR
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50517,12 +50344,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PAR
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50551,7 +50372,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP>()) == 0 }
+        self.ConstantQP_FullIntracodedFrame == other.ConstantQP_FullIntracodedFrame && self.ConstantQP_InterPredictedFrame_PrevRefOnly == other.ConstantQP_InterPredictedFrame_PrevRefOnly && self.ConstantQP_InterPredictedFrame_BiDirectionalRef == other.ConstantQP_InterPredictedFrame_BiDirectionalRef
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {}
@@ -50587,7 +50408,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR>()) == 0 }
+        self.InitialQP == other.InitialQP && self.MinQP == other.MinQP && self.MaxQP == other.MaxQP && self.MaxFrameBitSize == other.MaxFrameBitSize && self.TargetAvgBitRate == other.TargetAvgBitRate && self.PeakBitRate == other.PeakBitRate && self.ConstantQualityTarget == other.ConstantQualityTarget
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR {}
@@ -50624,7 +50445,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR>()) == 0 }
+        self.InitialQP == other.InitialQP && self.MinQP == other.MinQP && self.MaxQP == other.MaxQP && self.MaxFrameBitSize == other.MaxFrameBitSize && self.TargetAvgBitRate == other.TargetAvgBitRate && self.PeakBitRate == other.PeakBitRate && self.VBVCapacity == other.VBVCapacity && self.InitialVBVFullness == other.InitialVBVFullness
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {}
@@ -50702,7 +50523,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_H264>()) == 0 }
+        self.ReconstructedPictureResourceIndex == other.ReconstructedPictureResourceIndex && self.IsLongTermReference == other.IsLongTermReference && self.LongTermPictureIdx == other.LongTermPictureIdx && self.PictureOrderCountNumber == other.PictureOrderCountNumber && self.FrameDecodingOrderNumber == other.FrameDecodingOrderNumber && self.TemporalLayerIndex == other.TemporalLayerIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -50744,7 +50565,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_HEVC>()) == 0 }
+        self.ReconstructedPictureResourceIndex == other.ReconstructedPictureResourceIndex && self.IsRefUsedByCurrentPic == other.IsRefUsedByCurrentPic && self.IsLongTermReference == other.IsLongTermReference && self.PictureOrderCountNumber == other.PictureOrderCountNumber && self.TemporalLayerIndex == other.TemporalLayerIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -50781,14 +50602,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMEN
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {
-    fn eq(&self, other: &Self) -> bool {
-        self.EncoderCodec == other.EncoderCodec && self.EncoderProfile == other.EncoderProfile && self.EncoderInputFormat == other.EncoderInputFormat && self.EncodedPictureEffectiveResolution == other.EncodedPictureEffectiveResolution && self.HWLayoutMetadata == other.HWLayoutMetadata
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {
     fn default() -> Self {
@@ -50856,14 +50669,6 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50884,12 +50689,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50910,12 +50709,6 @@ impl ::core::clone::Clone for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
 unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {}
 impl ::core::default::Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50946,7 +50739,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_H264 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_H264>()) == 0 }
+        self.GOPLength == other.GOPLength && self.PPicturePeriod == other.PPicturePeriod && self.pic_order_cnt_type == other.pic_order_cnt_type && self.log2_max_frame_num_minus4 == other.log2_max_frame_num_minus4 && self.log2_max_pic_order_cnt_lsb_minus4 == other.log2_max_pic_order_cnt_lsb_minus4
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_H264 {}
@@ -50978,7 +50771,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC>()) == 0 }
+        self.GOPLength == other.GOPLength && self.PPicturePeriod == other.PPicturePeriod && self.log2_max_pic_order_cnt_lsb_minus4 == other.log2_max_pic_order_cnt_lsb_minus4
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC {}
@@ -51016,7 +50809,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODE_REFERENCE_FRAMES {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_ENCODE_REFERENCE_FRAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_ENCODE_REFERENCE_FRAMES>()) == 0 }
+        self.NumTexture2Ds == other.NumTexture2Ds && self.ppTexture2Ds == other.ppTexture2Ds && self.pSubresources == other.pSubresources
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -51049,7 +50842,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_EXTENSION_COMMAND_DESC {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_EXTENSION_COMMAND_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_EXTENSION_COMMAND_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.CommandId == other.CommandId
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_EXTENSION_COMMAND_DESC {}
@@ -51087,7 +50880,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_EXTENSION_COMMAND_INFO {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_EXTENSION_COMMAND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_EXTENSION_COMMAND_INFO>()) == 0 }
+        self.CommandId == other.CommandId && self.Name == other.Name && self.CommandListSupportFlags == other.CommandListSupportFlags
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -51121,7 +50914,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INF
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INFO>()) == 0 }
+        self.Name == other.Name && self.Type == other.Type && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INFO {}
@@ -51158,7 +50951,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_FORMAT {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_FORMAT>()) == 0 }
+        self.Format == other.Format && self.ColorSpace == other.ColorSpace
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -51200,7 +50993,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_MOTION_ESTIMATOR_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_MOTION_ESTIMATOR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_MOTION_ESTIMATOR_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.InputFormat == other.InputFormat && self.BlockSize == other.BlockSize && self.Precision == other.Precision && self.SizeRange == other.SizeRange
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -51324,7 +51117,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC>()) == 0 }
+        self.NodeMask == other.NodeMask && self.InputFormat == other.InputFormat && self.BlockSize == other.BlockSize && self.Precision == other.Precision && self.SizeRange == other.SizeRange
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -51363,7 +51156,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_ALPHA_BLENDING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_ALPHA_BLENDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_ALPHA_BLENDING>()) == 0 }
+        self.Enable == other.Enable && self.Alpha == other.Alpha
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -51398,7 +51191,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_FILTER_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_FILTER_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_FILTER_RANGE>()) == 0 }
+        self.Minimum == other.Minimum && self.Maximum == other.Maximum && self.Default == other.Default && self.Multiplier == other.Multiplier
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_PROCESS_FILTER_RANGE {}
@@ -51604,7 +51397,23 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC>()) == 0 }
+        self.Format == other.Format
+            && self.ColorSpace == other.ColorSpace
+            && self.SourceAspectRatio == other.SourceAspectRatio
+            && self.DestinationAspectRatio == other.DestinationAspectRatio
+            && self.FrameRate == other.FrameRate
+            && self.SourceSizeRange == other.SourceSizeRange
+            && self.DestinationSizeRange == other.DestinationSizeRange
+            && self.EnableOrientation == other.EnableOrientation
+            && self.FilterFlags == other.FilterFlags
+            && self.StereoFormat == other.StereoFormat
+            && self.FieldType == other.FieldType
+            && self.DeinterlaceMode == other.DeinterlaceMode
+            && self.EnableAlphaBlending == other.EnableAlphaBlending
+            && self.LumaKey == other.LumaKey
+            && self.NumPastFrames == other.NumPastFrames
+            && self.NumFutureFrames == other.NumFutureFrames
+            && self.EnableAutoProcessing == other.EnableAutoProcessing
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -51637,7 +51446,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE>()) == 0 }
+        self.OutputIndex == other.OutputIndex && self.InputFrameOrField == other.InputFrameOrField
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE {}
@@ -51675,7 +51484,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_LUMA_KEY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_LUMA_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_LUMA_KEY>()) == 0 }
+        self.Enable == other.Enable && self.Lower == other.Lower && self.Upper == other.Upper
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -51793,7 +51602,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC>()) == 0 }
+        self.Format == other.Format && self.ColorSpace == other.ColorSpace && self.AlphaFillMode == other.AlphaFillMode && self.AlphaFillModeSourceStreamIndex == other.AlphaFillModeSourceStreamIndex && self.BackgroundColor == other.BackgroundColor && self.FrameRate == other.FrameRate && self.EnableStereo == other.EnableStereo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -51836,7 +51645,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_REFERENCE_SET {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_REFERENCE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_REFERENCE_SET>()) == 0 }
+        self.NumPastFrames == other.NumPastFrames && self.ppPastFrames == other.ppPastFrames && self.pPastSubresources == other.pPastSubresources && self.NumFutureFrames == other.NumFutureFrames && self.ppFutureFrames == other.ppFutureFrames && self.pFutureSubresources == other.pFutureSubresources
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -51876,7 +51685,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_TRANSFORM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_PROCESS_TRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_PROCESS_TRANSFORM>()) == 0 }
+        self.SourceRectangle == other.SourceRectangle && self.DestinationRectangle == other.DestinationRectangle && self.Orientation == other.Orientation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -51916,7 +51725,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_SAMPLE {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for D3D12_VIDEO_SAMPLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_SAMPLE>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -51949,7 +51758,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_SCALE_SUPPORT {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_SCALE_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_SCALE_SUPPORT>()) == 0 }
+        self.OutputSizeRange == other.OutputSizeRange && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_SCALE_SUPPORT {}
@@ -51982,7 +51791,7 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_SIZE_RANGE {
 }
 impl ::core::cmp::PartialEq for D3D12_VIDEO_SIZE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3D12_VIDEO_SIZE_RANGE>()) == 0 }
+        self.MaxWidth == other.MaxWidth && self.MaxHeight == other.MaxHeight && self.MinWidth == other.MinWidth && self.MinHeight == other.MinHeight
     }
 }
 impl ::core::cmp::Eq for D3D12_VIDEO_SIZE_RANGE {}
@@ -52014,14 +51823,6 @@ unsafe impl ::windows::core::Abi for D3DCONTENTPROTECTIONCAPS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for D3DCONTENTPROTECTIONCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCONTENTPROTECTIONCAPS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for D3DCONTENTPROTECTIONCAPS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for D3DCONTENTPROTECTIONCAPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52049,14 +51850,6 @@ impl ::core::clone::Clone for D3DCONTENTPROTECTIONCAPS {
 unsafe impl ::windows::core::Abi for D3DCONTENTPROTECTIONCAPS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for D3DCONTENTPROTECTIONCAPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DCONTENTPROTECTIONCAPS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for D3DCONTENTPROTECTIONCAPS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for D3DCONTENTPROTECTIONCAPS {
     fn default() -> Self {
@@ -52086,7 +51879,7 @@ unsafe impl ::windows::core::Abi for D3DOVERLAYCAPS {
 }
 impl ::core::cmp::PartialEq for D3DOVERLAYCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<D3DOVERLAYCAPS>()) == 0 }
+        self.Caps == other.Caps && self.MaxOverlayDisplayWidth == other.MaxOverlayDisplayWidth && self.MaxOverlayDisplayHeight == other.MaxOverlayDisplayHeight
     }
 }
 impl ::core::cmp::Eq for D3DOVERLAYCAPS {}
@@ -52163,7 +51956,7 @@ unsafe impl ::windows::core::Abi for DIRTYRECT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIRTYRECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIRTYRECT_INFO>()) == 0 }
+        self.FrameNumber == other.FrameNumber && self.NumDirtyRects == other.NumDirtyRects && self.DirtyRects == other.DirtyRects
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -52196,7 +51989,7 @@ unsafe impl ::windows::core::Abi for DXVA2_AES_CTR_IV {
 }
 impl ::core::cmp::PartialEq for DXVA2_AES_CTR_IV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_AES_CTR_IV>()) == 0 }
+        self.IV == other.IV && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for DXVA2_AES_CTR_IV {}
@@ -52229,7 +52022,7 @@ unsafe impl ::windows::core::Abi for DXVA2_AYUVSample16 {
 }
 impl ::core::cmp::PartialEq for DXVA2_AYUVSample16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_AYUVSample16>()) == 0 }
+        self.Cr == other.Cr && self.Cb == other.Cb && self.Y == other.Y && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DXVA2_AYUVSample16 {}
@@ -52262,7 +52055,7 @@ unsafe impl ::windows::core::Abi for DXVA2_AYUVSample8 {
 }
 impl ::core::cmp::PartialEq for DXVA2_AYUVSample8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_AYUVSample8>()) == 0 }
+        self.Cr == other.Cr && self.Cb == other.Cb && self.Y == other.Y && self.Alpha == other.Alpha
     }
 }
 impl ::core::cmp::Eq for DXVA2_AYUVSample8 {}
@@ -52326,7 +52119,23 @@ unsafe impl ::windows::core::Abi for DXVA2_ConfigPictureDecode {
 }
 impl ::core::cmp::PartialEq for DXVA2_ConfigPictureDecode {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ConfigPictureDecode>()) == 0 }
+        self.guidConfigBitstreamEncryption == other.guidConfigBitstreamEncryption
+            && self.guidConfigMBcontrolEncryption == other.guidConfigMBcontrolEncryption
+            && self.guidConfigResidDiffEncryption == other.guidConfigResidDiffEncryption
+            && self.ConfigBitstreamRaw == other.ConfigBitstreamRaw
+            && self.ConfigMBcontrolRasterOrder == other.ConfigMBcontrolRasterOrder
+            && self.ConfigResidDiffHost == other.ConfigResidDiffHost
+            && self.ConfigSpatialResid8 == other.ConfigSpatialResid8
+            && self.ConfigResid8Subtraction == other.ConfigResid8Subtraction
+            && self.ConfigSpatialHost8or9Clipping == other.ConfigSpatialHost8or9Clipping
+            && self.ConfigSpatialResidInterleaved == other.ConfigSpatialResidInterleaved
+            && self.ConfigIntraResidUnsigned == other.ConfigIntraResidUnsigned
+            && self.ConfigResidDiffAccelerator == other.ConfigResidDiffAccelerator
+            && self.ConfigHostInverseScan == other.ConfigHostInverseScan
+            && self.ConfigSpecificIDCT == other.ConfigSpecificIDCT
+            && self.Config4GroupedCoefs == other.Config4GroupedCoefs
+            && self.ConfigMinRenderTargetBuffCount == other.ConfigMinRenderTargetBuffCount
+            && self.ConfigDecoderSpecific == other.ConfigDecoderSpecific
     }
 }
 impl ::core::cmp::Eq for DXVA2_ConfigPictureDecode {}
@@ -52366,7 +52175,7 @@ unsafe impl ::windows::core::Abi for DXVA2_DecodeBufferDesc {
 }
 impl ::core::cmp::PartialEq for DXVA2_DecodeBufferDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_DecodeBufferDesc>()) == 0 }
+        self.CompressedBufferType == other.CompressedBufferType && self.BufferIndex == other.BufferIndex && self.DataOffset == other.DataOffset && self.DataSize == other.DataSize && self.FirstMBaddress == other.FirstMBaddress && self.NumMBsInBuffer == other.NumMBsInBuffer && self.Width == other.Width && self.Height == other.Height && self.Stride == other.Stride && self.ReservedBits == other.ReservedBits && self.pvPVPState == other.pvPVPState
     }
 }
 impl ::core::cmp::Eq for DXVA2_DecodeBufferDesc {}
@@ -52398,7 +52207,7 @@ unsafe impl ::windows::core::Abi for DXVA2_DecodeExecuteParams {
 }
 impl ::core::cmp::PartialEq for DXVA2_DecodeExecuteParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_DecodeExecuteParams>()) == 0 }
+        self.NumCompBuffers == other.NumCompBuffers && self.pCompressedBuffers == other.pCompressedBuffers && self.pExtensionData == other.pExtensionData
     }
 }
 impl ::core::cmp::Eq for DXVA2_DecodeExecuteParams {}
@@ -52432,7 +52241,7 @@ unsafe impl ::windows::core::Abi for DXVA2_DecodeExtensionData {
 }
 impl ::core::cmp::PartialEq for DXVA2_DecodeExtensionData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_DecodeExtensionData>()) == 0 }
+        self.Function == other.Function && self.pPrivateInputData == other.pPrivateInputData && self.PrivateInputDataSize == other.PrivateInputDataSize && self.pPrivateOutputData == other.pPrivateOutputData && self.PrivateOutputDataSize == other.PrivateOutputDataSize
     }
 }
 impl ::core::cmp::Eq for DXVA2_DecodeExtensionData {}
@@ -52455,12 +52264,6 @@ impl ::core::clone::Clone for DXVA2_ExtendedFormat {
 unsafe impl ::windows::core::Abi for DXVA2_ExtendedFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_ExtendedFormat {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ExtendedFormat>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_ExtendedFormat {}
 impl ::core::default::Default for DXVA2_ExtendedFormat {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52481,12 +52284,6 @@ impl ::core::clone::Clone for DXVA2_ExtendedFormat_0 {
 unsafe impl ::windows::core::Abi for DXVA2_ExtendedFormat_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_ExtendedFormat_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ExtendedFormat_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_ExtendedFormat_0 {}
 impl ::core::default::Default for DXVA2_ExtendedFormat_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52513,7 +52310,7 @@ unsafe impl ::windows::core::Abi for DXVA2_ExtendedFormat_0_0 {
 }
 impl ::core::cmp::PartialEq for DXVA2_ExtendedFormat_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ExtendedFormat_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DXVA2_ExtendedFormat_0_0 {}
@@ -52538,12 +52335,6 @@ impl ::core::clone::Clone for DXVA2_FilterValues {
 unsafe impl ::windows::core::Abi for DXVA2_FilterValues {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_FilterValues {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_FilterValues>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_FilterValues {}
 impl ::core::default::Default for DXVA2_FilterValues {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52563,12 +52354,6 @@ impl ::core::clone::Clone for DXVA2_Fixed32 {
 unsafe impl ::windows::core::Abi for DXVA2_Fixed32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_Fixed32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_Fixed32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_Fixed32 {}
 impl ::core::default::Default for DXVA2_Fixed32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52589,12 +52374,6 @@ impl ::core::clone::Clone for DXVA2_Fixed32_0 {
 unsafe impl ::windows::core::Abi for DXVA2_Fixed32_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_Fixed32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_Fixed32_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_Fixed32_0 {}
 impl ::core::default::Default for DXVA2_Fixed32_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52622,7 +52401,7 @@ unsafe impl ::windows::core::Abi for DXVA2_Fixed32_0_0 {
 }
 impl ::core::cmp::PartialEq for DXVA2_Fixed32_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_Fixed32_0_0>()) == 0 }
+        self.Fraction == other.Fraction && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DXVA2_Fixed32_0_0 {}
@@ -52653,7 +52432,7 @@ unsafe impl ::windows::core::Abi for DXVA2_Frequency {
 }
 impl ::core::cmp::PartialEq for DXVA2_Frequency {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_Frequency>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for DXVA2_Frequency {}
@@ -52679,12 +52458,6 @@ impl ::core::clone::Clone for DXVA2_ProcAmpValues {
 unsafe impl ::windows::core::Abi for DXVA2_ProcAmpValues {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_ProcAmpValues {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ProcAmpValues>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_ProcAmpValues {}
 impl ::core::default::Default for DXVA2_ProcAmpValues {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52707,12 +52480,6 @@ impl ::core::clone::Clone for DXVA2_ValueRange {
 unsafe impl ::windows::core::Abi for DXVA2_ValueRange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA2_ValueRange {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_ValueRange>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA2_ValueRange {}
 impl ::core::default::Default for DXVA2_ValueRange {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52743,14 +52510,6 @@ impl ::core::clone::Clone for DXVA2_VideoDesc {
 unsafe impl ::windows::core::Abi for DXVA2_VideoDesc {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl ::core::cmp::PartialEq for DXVA2_VideoDesc {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_VideoDesc>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl ::core::cmp::Eq for DXVA2_VideoDesc {}
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::default::Default for DXVA2_VideoDesc {
     fn default() -> Self {
@@ -52787,14 +52546,6 @@ impl ::core::clone::Clone for DXVA2_VideoProcessBltParams {
 unsafe impl ::windows::core::Abi for DXVA2_VideoProcessBltParams {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DXVA2_VideoProcessBltParams {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_VideoProcessBltParams>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DXVA2_VideoProcessBltParams {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DXVA2_VideoProcessBltParams {
     fn default() -> Self {
@@ -52848,7 +52599,7 @@ unsafe impl ::windows::core::Abi for DXVA2_VideoProcessorCaps {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA2_VideoProcessorCaps {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA2_VideoProcessorCaps>()) == 0 }
+        self.DeviceCaps == other.DeviceCaps && self.InputPool == other.InputPool && self.NumForwardRefSamples == other.NumForwardRefSamples && self.NumBackwardRefSamples == other.NumBackwardRefSamples && self.Reserved == other.Reserved && self.DeinterlaceTechnology == other.DeinterlaceTechnology && self.ProcAmpControlCaps == other.ProcAmpControlCaps && self.VideoProcessorOperations == other.VideoProcessorOperations && self.NoiseFilterTechnology == other.NoiseFilterTechnology && self.DetailFilterTechnology == other.DetailFilterTechnology
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -52894,14 +52645,6 @@ unsafe impl ::windows::core::Abi for DXVA2_VideoSample {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
-impl ::core::cmp::PartialEq for DXVA2_VideoSample {
-    fn eq(&self, other: &Self) -> bool {
-        self.Start == other.Start && self.End == other.End && self.SampleFormat == other.SampleFormat && self.SrcSurface == other.SrcSurface && self.SrcRect == other.SrcRect && self.DstRect == other.DstRect && self.Pal == other.Pal && self.PlanarAlpha == other.PlanarAlpha && self.SampleData == other.SampleData
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
-impl ::core::cmp::Eq for DXVA2_VideoSample {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl ::core::default::Default for DXVA2_VideoSample {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52930,7 +52673,7 @@ unsafe impl ::windows::core::Abi for DXVABufferInfo {
 }
 impl ::core::cmp::PartialEq for DXVABufferInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVABufferInfo>()) == 0 }
+        self.pCompSurface == other.pCompSurface && self.DataOffset == other.DataOffset && self.DataSize == other.DataSize
     }
 }
 impl ::core::cmp::Eq for DXVABufferInfo {}
@@ -52972,7 +52715,7 @@ unsafe impl ::windows::core::Abi for DXVACompBufferInfo {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVACompBufferInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVACompBufferInfo>()) == 0 }
+        self.NumCompBuffers == other.NumCompBuffers && self.WidthToCreate == other.WidthToCreate && self.HeightToCreate == other.HeightToCreate && self.BytesToAllocate == other.BytesToAllocate && self.Usage == other.Usage && self.Pool == other.Pool && self.Format == other.Format
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -53006,7 +52749,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_CREATEVIDEOPROCESSOR {
 }
 impl ::core::cmp::PartialEq for DXVAHDETW_CREATEVIDEOPROCESSOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_CREATEVIDEOPROCESSOR>()) == 0 }
+        self.pObject == other.pObject && self.pD3D9Ex == other.pD3D9Ex && self.VPGuid == other.VPGuid
     }
 }
 impl ::core::cmp::Eq for DXVAHDETW_CREATEVIDEOPROCESSOR {}
@@ -53036,7 +52779,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_DESTROYVIDEOPROCESSOR {
 }
 impl ::core::cmp::PartialEq for DXVAHDETW_DESTROYVIDEOPROCESSOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_DESTROYVIDEOPROCESSOR>()) == 0 }
+        self.pObject == other.pObject
     }
 }
 impl ::core::cmp::Eq for DXVAHDETW_DESTROYVIDEOPROCESSOR {}
@@ -53079,7 +52822,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_VIDEOPROCESSBLTHD {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl ::core::cmp::PartialEq for DXVAHDETW_VIDEOPROCESSBLTHD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_VIDEOPROCESSBLTHD>()) == 0 }
+        self.pObject == other.pObject && self.pOutputSurface == other.pOutputSurface && self.TargetRect == other.TargetRect && self.OutputFormat == other.OutputFormat && self.ColorSpace == other.ColorSpace && self.OutputFrame == other.OutputFrame && self.StreamCount == other.StreamCount && self.Enter == other.Enter
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
@@ -53141,7 +52884,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_VIDEOPROCESSBLTHD_STREAM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl ::core::cmp::PartialEq for DXVAHDETW_VIDEOPROCESSBLTHD_STREAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_VIDEOPROCESSBLTHD_STREAM>()) == 0 }
+        self.pObject == other.pObject && self.pInputSurface == other.pInputSurface && self.SourceRect == other.SourceRect && self.DestinationRect == other.DestinationRect && self.InputFormat == other.InputFormat && self.FrameFormat == other.FrameFormat && self.ColorSpace == other.ColorSpace && self.StreamNumber == other.StreamNumber && self.OutputIndex == other.OutputIndex && self.InputFrameOrField == other.InputFrameOrField && self.PastFrames == other.PastFrames && self.FutureFrames == other.FutureFrames
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
@@ -53182,7 +52925,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_VIDEOPROCESSBLTSTATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHDETW_VIDEOPROCESSBLTSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_VIDEOPROCESSBLTSTATE>()) == 0 }
+        self.pObject == other.pObject && self.State == other.State && self.DataSize == other.DataSize && self.SetState == other.SetState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53224,7 +52967,7 @@ unsafe impl ::windows::core::Abi for DXVAHDETW_VIDEOPROCESSSTREAMSTATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHDETW_VIDEOPROCESSSTREAMSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDETW_VIDEOPROCESSSTREAMSTATE>()) == 0 }
+        self.pObject == other.pObject && self.StreamNumber == other.StreamNumber && self.State == other.State && self.DataSize == other.DataSize && self.SetState == other.SetState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53267,38 +53010,13 @@ impl ::core::clone::Clone for DXVAHDSW_CALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl ::core::fmt::Debug for DXVAHDSW_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DXVAHDSW_CALLBACKS")
-            .field("CreateDevice", &self.CreateDevice.map(|f| f as usize))
-            .field("ProposeVideoPrivateFormat", &self.ProposeVideoPrivateFormat.map(|f| f as usize))
-            .field("GetVideoProcessorDeviceCaps", &self.GetVideoProcessorDeviceCaps.map(|f| f as usize))
-            .field("GetVideoProcessorOutputFormats", &self.GetVideoProcessorOutputFormats.map(|f| f as usize))
-            .field("GetVideoProcessorInputFormats", &self.GetVideoProcessorInputFormats.map(|f| f as usize))
-            .field("GetVideoProcessorCaps", &self.GetVideoProcessorCaps.map(|f| f as usize))
-            .field("GetVideoProcessorCustomRates", &self.GetVideoProcessorCustomRates.map(|f| f as usize))
-            .field("GetVideoProcessorFilterRange", &self.GetVideoProcessorFilterRange.map(|f| f as usize))
-            .field("DestroyDevice", &self.DestroyDevice.map(|f| f as usize))
-            .field("CreateVideoProcessor", &self.CreateVideoProcessor.map(|f| f as usize))
-            .field("SetVideoProcessBltState", &self.SetVideoProcessBltState.map(|f| f as usize))
-            .field("GetVideoProcessBltStatePrivate", &self.GetVideoProcessBltStatePrivate.map(|f| f as usize))
-            .field("SetVideoProcessStreamState", &self.SetVideoProcessStreamState.map(|f| f as usize))
-            .field("GetVideoProcessStreamStatePrivate", &self.GetVideoProcessStreamStatePrivate.map(|f| f as usize))
-            .field("VideoProcessBltHD", &self.VideoProcessBltHD.map(|f| f as usize))
-            .field("DestroyVideoProcessor", &self.DestroyVideoProcessor.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DXVAHDSW_CALLBACKS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 unsafe impl ::windows::core::Abi for DXVAHDSW_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
-impl ::core::cmp::PartialEq for DXVAHDSW_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHDSW_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
-impl ::core::cmp::Eq for DXVAHDSW_CALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl ::core::default::Default for DXVAHDSW_CALLBACKS {
     fn default() -> Self {
@@ -53327,7 +53045,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_ALPHA_FILL_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_ALPHA_FILL_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_ALPHA_FILL_DATA>()) == 0 }
+        self.Mode == other.Mode && self.StreamNumber == other.StreamNumber
     }
 }
 impl ::core::cmp::Eq for DXVAHD_BLT_STATE_ALPHA_FILL_DATA {}
@@ -53355,14 +53073,6 @@ impl ::core::clone::Clone for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
 unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
     fn default() -> Self {
@@ -53397,7 +53107,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_CONSTRICTION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_CONSTRICTION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_CONSTRICTION_DATA>()) == 0 }
+        self.Enable == other.Enable && self.Size == other.Size
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53422,12 +53132,6 @@ impl ::core::clone::Clone for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
 unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {}
 impl ::core::default::Default for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53448,12 +53152,6 @@ impl ::core::clone::Clone for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
 unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {}
 impl ::core::default::Default for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53480,7 +53178,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_
 }
 impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0 {}
@@ -53512,7 +53210,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_PRIVATE_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_PRIVATE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_PRIVATE_DATA>()) == 0 }
+        self.Guid == other.Guid && self.DataSize == other.DataSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for DXVAHD_BLT_STATE_PRIVATE_DATA {}
@@ -53549,7 +53247,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_BLT_STATE_TARGET_RECT_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_BLT_STATE_TARGET_RECT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_BLT_STATE_TARGET_RECT_DATA>()) == 0 }
+        self.Enable == other.Enable && self.TargetRect == other.TargetRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53575,12 +53273,6 @@ impl ::core::clone::Clone for DXVAHD_COLOR {
 unsafe impl ::windows::core::Abi for DXVAHD_COLOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVAHD_COLOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_COLOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVAHD_COLOR {}
 impl ::core::default::Default for DXVAHD_COLOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53610,7 +53302,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_COLOR_RGBA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_COLOR_RGBA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_COLOR_RGBA>()) == 0 }
+        self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A
     }
 }
 impl ::core::cmp::Eq for DXVAHD_COLOR_RGBA {}
@@ -53643,7 +53335,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_COLOR_YCbCrA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_COLOR_YCbCrA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_COLOR_YCbCrA>()) == 0 }
+        self.Y == other.Y && self.Cb == other.Cb && self.Cr == other.Cr && self.A == other.A
     }
 }
 impl ::core::cmp::Eq for DXVAHD_COLOR_YCbCrA {}
@@ -53679,7 +53371,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_CONTENT_DESC {
 }
 impl ::core::cmp::PartialEq for DXVAHD_CONTENT_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_CONTENT_DESC>()) == 0 }
+        self.InputFrameFormat == other.InputFrameFormat && self.InputFrameRate == other.InputFrameRate && self.InputWidth == other.InputWidth && self.InputHeight == other.InputHeight && self.OutputFrameRate == other.OutputFrameRate && self.OutputWidth == other.OutputWidth && self.OutputHeight == other.OutputHeight
     }
 }
 impl ::core::cmp::Eq for DXVAHD_CONTENT_DESC {}
@@ -53718,7 +53410,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_CUSTOM_RATE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_CUSTOM_RATE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_CUSTOM_RATE_DATA>()) == 0 }
+        self.CustomRate == other.CustomRate && self.OutputFrames == other.OutputFrames && self.InputInterlaced == other.InputInterlaced && self.InputFramesOrFields == other.InputFramesOrFields
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53753,7 +53445,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_FILTER_RANGE_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_FILTER_RANGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_FILTER_RANGE_DATA>()) == 0 }
+        self.Minimum == other.Minimum && self.Maximum == other.Maximum && self.Default == other.Default && self.Multiplier == other.Multiplier
     }
 }
 impl ::core::cmp::Eq for DXVAHD_FILTER_RANGE_DATA {}
@@ -53784,7 +53476,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_RATIONAL {
 }
 impl ::core::cmp::PartialEq for DXVAHD_RATIONAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_RATIONAL>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for DXVAHD_RATIONAL {}
@@ -53873,7 +53565,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_ALPHA_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_ALPHA_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_ALPHA_DATA>()) == 0 }
+        self.Enable == other.Enable && self.Alpha == other.Alpha
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53913,7 +53605,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_ASPECT_RATIO_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_ASPECT_RATIO_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_ASPECT_RATIO_DATA>()) == 0 }
+        self.Enable == other.Enable && self.SourceAspectRatio == other.SourceAspectRatio && self.DestinationAspectRatio == other.DestinationAspectRatio
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53951,7 +53643,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_D3DFORMAT_DATA {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_D3DFORMAT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_D3DFORMAT_DATA>()) == 0 }
+        self.Format == other.Format
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -53990,7 +53682,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_DESTINATION_RECT_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_DESTINATION_RECT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_DESTINATION_RECT_DATA>()) == 0 }
+        self.Enable == other.Enable && self.DestinationRect == other.DestinationRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54029,7 +53721,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_FILTER_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_FILTER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_FILTER_DATA>()) == 0 }
+        self.Enable == other.Enable && self.Level == other.Level
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54061,7 +53753,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA>()) == 0 }
+        self.FrameFormat == other.FrameFormat
     }
 }
 impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA {}
@@ -54084,12 +53776,6 @@ impl ::core::clone::Clone for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
 unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {}
 impl ::core::default::Default for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54110,12 +53796,6 @@ impl ::core::clone::Clone for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
 unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {}
 impl ::core::default::Default for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54142,7 +53822,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_
 }
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0 {}
@@ -54180,7 +53860,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_LUMA_KEY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_LUMA_KEY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_LUMA_KEY_DATA>()) == 0 }
+        self.Enable == other.Enable && self.Lower == other.Lower && self.Upper == other.Upper
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54220,7 +53900,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_OUTPUT_RATE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_OUTPUT_RATE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_OUTPUT_RATE_DATA>()) == 0 }
+        self.RepeatFrame == other.RepeatFrame && self.OutputRate == other.OutputRate && self.CustomRate == other.CustomRate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54253,7 +53933,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_PALETTE_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_PALETTE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_PALETTE_DATA>()) == 0 }
+        self.Count == other.Count && self.pEntries == other.pEntries
     }
 }
 impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_PALETTE_DATA {}
@@ -54285,7 +53965,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_PRIVATE_DATA {
 }
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_PRIVATE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_PRIVATE_DATA>()) == 0 }
+        self.Guid == other.Guid && self.DataSize == other.DataSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for DXVAHD_STREAM_STATE_PRIVATE_DATA {}
@@ -54324,7 +54004,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_PRIVATE_IVTC_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_PRIVATE_IVTC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_PRIVATE_IVTC_DATA>()) == 0 }
+        self.Enable == other.Enable && self.ITelecineFlags == other.ITelecineFlags && self.Frames == other.Frames && self.InputField == other.InputField
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54363,7 +54043,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_STREAM_STATE_SOURCE_RECT_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVAHD_STREAM_STATE_SOURCE_RECT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_STREAM_STATE_SOURCE_RECT_DATA>()) == 0 }
+        self.Enable == other.Enable && self.SourceRect == other.SourceRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54400,7 +54080,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_VPCAPS {
 }
 impl ::core::cmp::PartialEq for DXVAHD_VPCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_VPCAPS>()) == 0 }
+        self.VPGuid == other.VPGuid && self.PastFrames == other.PastFrames && self.FutureFrames == other.FutureFrames && self.ProcessorCaps == other.ProcessorCaps && self.ITelecineCaps == other.ITelecineCaps && self.CustomRateCount == other.CustomRateCount
     }
 }
 impl ::core::cmp::Eq for DXVAHD_VPCAPS {}
@@ -54458,7 +54138,7 @@ unsafe impl ::windows::core::Abi for DXVAHD_VPDEVCAPS {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVAHD_VPDEVCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAHD_VPDEVCAPS>()) == 0 }
+        self.DeviceType == other.DeviceType && self.DeviceCaps == other.DeviceCaps && self.FeatureCaps == other.FeatureCaps && self.FilterCaps == other.FilterCaps && self.InputFormatCaps == other.InputFormatCaps && self.InputPool == other.InputPool && self.OutputFormatCount == other.OutputFormatCount && self.InputFormatCount == other.InputFormatCount && self.VideoProcessorCount == other.VideoProcessorCount && self.MaxInputStreams == other.MaxInputStreams && self.MaxStreamStates == other.MaxStreamStates
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -54498,7 +54178,7 @@ unsafe impl ::windows::core::Abi for DXVAUncompDataInfo {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVAUncompDataInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVAUncompDataInfo>()) == 0 }
+        self.UncompWidth == other.UncompWidth && self.UncompHeight == other.UncompHeight && self.UncompFormat == other.UncompFormat
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -54533,7 +54213,7 @@ unsafe impl ::windows::core::Abi for DXVA_AYUVsample2 {
 }
 impl ::core::cmp::PartialEq for DXVA_AYUVsample2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_AYUVsample2>()) == 0 }
+        self.bCrValue == other.bCrValue && self.bCbValue == other.bCbValue && self.bY_Value == other.bY_Value && self.bSampleAlpha8 == other.bSampleAlpha8
     }
 }
 impl ::core::cmp::Eq for DXVA_AYUVsample2 {}
@@ -54565,12 +54245,6 @@ impl ::core::clone::Clone for DXVA_BufferDescription {
 unsafe impl ::windows::core::Abi for DXVA_BufferDescription {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA_BufferDescription {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_BufferDescription>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA_BufferDescription {}
 impl ::core::default::Default for DXVA_BufferDescription {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54601,7 +54275,7 @@ unsafe impl ::windows::core::Abi for DXVA_COPPCommand {
 }
 impl ::core::cmp::PartialEq for DXVA_COPPCommand {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_COPPCommand>()) == 0 }
+        self.macKDI == other.macKDI && self.guidCommandID == other.guidCommandID && self.dwSequence == other.dwSequence && self.cbSizeData == other.cbSizeData && self.CommandData == other.CommandData
     }
 }
 impl ::core::cmp::Eq for DXVA_COPPCommand {}
@@ -54631,7 +54305,7 @@ unsafe impl ::windows::core::Abi for DXVA_COPPSignature {
 }
 impl ::core::cmp::PartialEq for DXVA_COPPSignature {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_COPPSignature>()) == 0 }
+        self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for DXVA_COPPSignature {}
@@ -54665,7 +54339,7 @@ unsafe impl ::windows::core::Abi for DXVA_COPPStatusInput {
 }
 impl ::core::cmp::PartialEq for DXVA_COPPStatusInput {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_COPPStatusInput>()) == 0 }
+        self.rApp == other.rApp && self.guidStatusRequestID == other.guidStatusRequestID && self.dwSequence == other.dwSequence && self.cbSizeData == other.cbSizeData && self.StatusData == other.StatusData
     }
 }
 impl ::core::cmp::Eq for DXVA_COPPStatusInput {}
@@ -54697,7 +54371,7 @@ unsafe impl ::windows::core::Abi for DXVA_COPPStatusOutput {
 }
 impl ::core::cmp::PartialEq for DXVA_COPPStatusOutput {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_COPPStatusOutput>()) == 0 }
+        self.macKDI == other.macKDI && self.cbSizeData == other.cbSizeData && self.COPPStatus == other.COPPStatus
     }
 }
 impl ::core::cmp::Eq for DXVA_COPPStatusOutput {}
@@ -54736,12 +54410,6 @@ impl ::core::clone::Clone for DXVA_ConfigPictureDecode {
 unsafe impl ::windows::core::Abi for DXVA_ConfigPictureDecode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA_ConfigPictureDecode {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_ConfigPictureDecode>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA_ConfigPictureDecode {}
 impl ::core::default::Default for DXVA_ConfigPictureDecode {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54781,7 +54449,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceBlt {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceBlt {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceBlt>()) == 0 }
+        self.Size == other.Size && self.Reserved == other.Reserved && self.rtTarget == other.rtTarget && self.DstRect == other.DstRect && self.SrcRect == other.SrcRect && self.NumSourceSurfaces == other.NumSourceSurfaces && self.Alpha == other.Alpha && self.Source == other.Source
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54827,7 +54495,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceBltEx {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceBltEx {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceBltEx>()) == 0 }
+        self.Size == other.Size && self.BackgroundColor == other.BackgroundColor && self.rcTarget == other.rcTarget && self.rtTarget == other.rtTarget && self.NumSourceSurfaces == other.NumSourceSurfaces && self.Alpha == other.Alpha && self.Source == other.Source && self.DestinationFormat == other.DestinationFormat && self.DestinationFlags == other.DestinationFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54879,7 +54547,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceBltEx32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceBltEx32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceBltEx32>()) == 0 }
+        self.Size == other.Size && self.BackgroundColor == other.BackgroundColor && self.rcTarget == other.rcTarget && self.rtTarget == other.rtTarget && self.NumSourceSurfaces == other.NumSourceSurfaces && self.Alpha == other.Alpha && self.Source == other.Source && self.DestinationFormat == other.DestinationFormat && self.DestinationFlags == other.DestinationFlags
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -54926,7 +54594,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceCaps {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceCaps {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceCaps>()) == 0 }
+        self.Size == other.Size && self.NumPreviousOutputFrames == other.NumPreviousOutputFrames && self.InputPool == other.InputPool && self.NumForwardRefSamples == other.NumForwardRefSamples && self.NumBackwardRefSamples == other.NumBackwardRefSamples && self.d3dOutputFormat == other.d3dOutputFormat && self.VideoProcessingCaps == other.VideoProcessingCaps && self.DeinterlaceTechnology == other.DeinterlaceTechnology
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -54960,7 +54628,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceQueryAvailableModes {
 }
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceQueryAvailableModes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceQueryAvailableModes>()) == 0 }
+        self.Size == other.Size && self.NumGuids == other.NumGuids && self.Guids == other.Guids
     }
 }
 impl ::core::cmp::Eq for DXVA_DeinterlaceQueryAvailableModes {}
@@ -54998,7 +54666,7 @@ unsafe impl ::windows::core::Abi for DXVA_DeinterlaceQueryModeCaps {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA_DeinterlaceQueryModeCaps {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_DeinterlaceQueryModeCaps>()) == 0 }
+        self.Size == other.Size && self.Guid == other.Guid && self.VideoDesc == other.VideoDesc
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -55030,7 +54698,7 @@ unsafe impl ::windows::core::Abi for DXVA_ExtendedFormat {
 }
 impl ::core::cmp::PartialEq for DXVA_ExtendedFormat {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_ExtendedFormat>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DXVA_ExtendedFormat {}
@@ -55061,7 +54729,7 @@ unsafe impl ::windows::core::Abi for DXVA_Frequency {
 }
 impl ::core::cmp::PartialEq for DXVA_Frequency {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_Frequency>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for DXVA_Frequency {}
@@ -55119,12 +54787,6 @@ impl ::core::clone::Clone for DXVA_PictureParameters {
 unsafe impl ::windows::core::Abi for DXVA_PictureParameters {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DXVA_PictureParameters {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_PictureParameters>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DXVA_PictureParameters {}
 impl ::core::default::Default for DXVA_PictureParameters {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55164,7 +54826,7 @@ unsafe impl ::windows::core::Abi for DXVA_ProcAmpControlBlt {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_ProcAmpControlBlt {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_ProcAmpControlBlt>()) == 0 }
+        self.Size == other.Size && self.DstRect == other.DstRect && self.SrcRect == other.SrcRect && self.Alpha == other.Alpha && self.Brightness == other.Brightness && self.Contrast == other.Contrast && self.Hue == other.Hue && self.Saturation == other.Saturation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -55206,7 +54868,7 @@ unsafe impl ::windows::core::Abi for DXVA_ProcAmpControlCaps {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA_ProcAmpControlCaps {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_ProcAmpControlCaps>()) == 0 }
+        self.Size == other.Size && self.InputPool == other.InputPool && self.d3dOutputFormat == other.d3dOutputFormat && self.ProcAmpControlProps == other.ProcAmpControlProps && self.VideoProcessingCaps == other.VideoProcessingCaps
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -55246,7 +54908,7 @@ unsafe impl ::windows::core::Abi for DXVA_ProcAmpControlQueryRange {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA_ProcAmpControlQueryRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_ProcAmpControlQueryRange>()) == 0 }
+        self.Size == other.Size && self.ProcAmpControlProp == other.ProcAmpControlProp && self.VideoDesc == other.VideoDesc
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -55290,7 +54952,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoDesc {
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::cmp::PartialEq for DXVA_VideoDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoDesc>()) == 0 }
+        self.Size == other.Size && self.SampleWidth == other.SampleWidth && self.SampleHeight == other.SampleHeight && self.SampleFormat == other.SampleFormat && self.d3dFormat == other.d3dFormat && self.InputSampleFreq == other.InputSampleFreq && self.OutputFrameFreq == other.OutputFrameFreq
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -55325,7 +54987,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoPropertyRange {
 }
 impl ::core::cmp::PartialEq for DXVA_VideoPropertyRange {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoPropertyRange>()) == 0 }
+        self.MinValue == other.MinValue && self.MaxValue == other.MaxValue && self.DefaultValue == other.DefaultValue && self.StepSize == other.StepSize
     }
 }
 impl ::core::cmp::Eq for DXVA_VideoPropertyRange {}
@@ -55358,7 +55020,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoSample {
 }
 impl ::core::cmp::PartialEq for DXVA_VideoSample {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoSample>()) == 0 }
+        self.rtStart == other.rtStart && self.rtEnd == other.rtEnd && self.SampleFormat == other.SampleFormat && self.lpDDSSrcSurface == other.lpDDSSrcSurface
     }
 }
 impl ::core::cmp::Eq for DXVA_VideoSample {}
@@ -55409,7 +55071,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoSample2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_VideoSample2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoSample2>()) == 0 }
+        self.Size == other.Size && self.Reserved == other.Reserved && self.rtStart == other.rtStart && self.rtEnd == other.rtEnd && self.SampleFormat == other.SampleFormat && self.SampleFlags == other.SampleFlags && self.lpDDSSrcSurface == other.lpDDSSrcSurface && self.rcSrc == other.rcSrc && self.rcDst == other.rcDst && self.Palette == other.Palette
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -55462,7 +55124,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoSample2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_VideoSample2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoSample2>()) == 0 }
+        self.rtStart == other.rtStart && self.rtEnd == other.rtEnd && self.SampleFormat == other.SampleFormat && self.SampleFlags == other.SampleFlags && self.lpDDSSrcSurface == other.lpDDSSrcSurface && self.rcSrc == other.rcSrc && self.rcDst == other.rcDst && self.Palette == other.Palette
     }
 }
 #[cfg(target_arch = "x86")]
@@ -55515,7 +55177,7 @@ unsafe impl ::windows::core::Abi for DXVA_VideoSample32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DXVA_VideoSample32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DXVA_VideoSample32>()) == 0 }
+        self.rtStart == other.rtStart && self.rtEnd == other.rtEnd && self.SampleFormat == other.SampleFormat && self.SampleFlags == other.SampleFlags && self.lpDDSSrcSurface == other.lpDDSSrcSurface && self.rcSrc == other.rcSrc && self.rcDst == other.rcDst && self.Palette == other.Palette
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -55551,7 +55213,7 @@ unsafe impl ::windows::core::Abi for DigitalWindowSetting {
 }
 impl ::core::cmp::PartialEq for DigitalWindowSetting {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DigitalWindowSetting>()) == 0 }
+        self.OriginX == other.OriginX && self.OriginY == other.OriginY && self.WindowSize == other.WindowSize
     }
 }
 impl ::core::cmp::Eq for DigitalWindowSetting {}
@@ -55584,7 +55246,7 @@ unsafe impl ::windows::core::Abi for MACROBLOCK_DATA {
 }
 impl ::core::cmp::PartialEq for MACROBLOCK_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MACROBLOCK_DATA>()) == 0 }
+        self.flags == other.flags && self.motionVectorX == other.motionVectorX && self.motionVectorY == other.motionVectorY && self.QPDelta == other.QPDelta
     }
 }
 impl ::core::cmp::Eq for MACROBLOCK_DATA {}
@@ -55617,7 +55279,7 @@ unsafe impl ::windows::core::Abi for MFARGB {
 }
 impl ::core::cmp::PartialEq for MFARGB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFARGB>()) == 0 }
+        self.rgbBlue == other.rgbBlue && self.rgbGreen == other.rgbGreen && self.rgbRed == other.rgbRed && self.rgbAlpha == other.rgbAlpha
     }
 }
 impl ::core::cmp::Eq for MFARGB {}
@@ -55650,7 +55312,7 @@ unsafe impl ::windows::core::Abi for MFAYUVSample {
 }
 impl ::core::cmp::PartialEq for MFAYUVSample {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFAYUVSample>()) == 0 }
+        self.bCrValue == other.bCrValue && self.bCbValue == other.bCbValue && self.bYValue == other.bYValue && self.bSampleAlpha8 == other.bSampleAlpha8
     }
 }
 impl ::core::cmp::Eq for MFAYUVSample {}
@@ -55681,7 +55343,7 @@ unsafe impl ::windows::core::Abi for MFAudioDecoderDegradationInfo {
 }
 impl ::core::cmp::PartialEq for MFAudioDecoderDegradationInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFAudioDecoderDegradationInfo>()) == 0 }
+        self.eDegradationReason == other.eDegradationReason && self.eType == other.eType
     }
 }
 impl ::core::cmp::Eq for MFAudioDecoderDegradationInfo {}
@@ -55718,7 +55380,7 @@ unsafe impl ::windows::core::Abi for MFBYTESTREAM_BUFFERING_PARAMS {
 }
 impl ::core::cmp::PartialEq for MFBYTESTREAM_BUFFERING_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFBYTESTREAM_BUFFERING_PARAMS>()) == 0 }
+        self.cbTotalFileSize == other.cbTotalFileSize && self.cbPlayableDataSize == other.cbPlayableDataSize && self.prgBuckets == other.prgBuckets && self.cBuckets == other.cBuckets && self.qwNetBufferingTime == other.qwNetBufferingTime && self.qwExtraBufferingTimeDuringSeek == other.qwExtraBufferingTimeDuringSeek && self.qwPlayDuration == other.qwPlayDuration && self.dRate == other.dRate
     }
 }
 impl ::core::cmp::Eq for MFBYTESTREAM_BUFFERING_PARAMS {}
@@ -55753,7 +55415,7 @@ unsafe impl ::windows::core::Abi for MFCLOCK_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for MFCLOCK_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCLOCK_PROPERTIES>()) == 0 }
+        self.qwCorrelationRate == other.qwCorrelationRate && self.guidClockId == other.guidClockId && self.dwClockFlags == other.dwClockFlags && self.qwClockFrequency == other.qwClockFrequency && self.dwClockTolerance == other.dwClockTolerance && self.dwClockJitter == other.dwClockJitter
     }
 }
 impl ::core::cmp::Eq for MFCLOCK_PROPERTIES {}
@@ -55787,7 +55449,7 @@ unsafe impl ::windows::core::Abi for MFCONTENTPROTECTIONDEVICE_INPUT_DATA {
 }
 impl ::core::cmp::PartialEq for MFCONTENTPROTECTIONDEVICE_INPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCONTENTPROTECTIONDEVICE_INPUT_DATA>()) == 0 }
+        self.HWProtectionFunctionID == other.HWProtectionFunctionID && self.PrivateDataByteCount == other.PrivateDataByteCount && self.HWProtectionDataByteCount == other.HWProtectionDataByteCount && self.Reserved == other.Reserved && self.InputData == other.InputData
     }
 }
 impl ::core::cmp::Eq for MFCONTENTPROTECTIONDEVICE_INPUT_DATA {}
@@ -55831,7 +55493,7 @@ unsafe impl ::windows::core::Abi for MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {
 }
 impl ::core::cmp::PartialEq for MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA>()) == 0 }
+        self.PrivateDataByteCount == other.PrivateDataByteCount && self.MaxHWProtectionDataByteCount == other.MaxHWProtectionDataByteCount && self.HWProtectionDataByteCount == other.HWProtectionDataByteCount && self.Status == other.Status && self.TransportTimeInHundredsOfNanoseconds == other.TransportTimeInHundredsOfNanoseconds && self.ExecutionTimeInHundredsOfNanoseconds == other.ExecutionTimeInHundredsOfNanoseconds && self.OutputData == other.OutputData
     }
 }
 impl ::core::cmp::Eq for MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {}
@@ -55863,7 +55525,7 @@ unsafe impl ::windows::core::Abi for MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DA
 }
 impl ::core::cmp::PartialEq for MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA>()) == 0 }
+        self.TaskIndex == other.TaskIndex && self.ClassName == other.ClassName && self.BasePriority == other.BasePriority
     }
 }
 impl ::core::cmp::Eq for MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA {}
@@ -55895,7 +55557,7 @@ unsafe impl ::windows::core::Abi for MFCameraExtrinsic_CalibratedTransform {
 }
 impl ::core::cmp::PartialEq for MFCameraExtrinsic_CalibratedTransform {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraExtrinsic_CalibratedTransform>()) == 0 }
+        self.CalibrationId == other.CalibrationId && self.Position == other.Position && self.Orientation == other.Orientation
     }
 }
 impl ::core::cmp::Eq for MFCameraExtrinsic_CalibratedTransform {}
@@ -55926,7 +55588,7 @@ unsafe impl ::windows::core::Abi for MFCameraExtrinsics {
 }
 impl ::core::cmp::PartialEq for MFCameraExtrinsics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraExtrinsics>()) == 0 }
+        self.TransformCount == other.TransformCount && self.CalibratedTransforms == other.CalibratedTransforms
     }
 }
 impl ::core::cmp::Eq for MFCameraExtrinsics {}
@@ -55959,7 +55621,7 @@ unsafe impl ::windows::core::Abi for MFCameraIntrinsic_CameraModel {
 }
 impl ::core::cmp::PartialEq for MFCameraIntrinsic_CameraModel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraIntrinsic_CameraModel>()) == 0 }
+        self.FocalLength_x == other.FocalLength_x && self.FocalLength_y == other.FocalLength_y && self.PrincipalPoint_x == other.PrincipalPoint_x && self.PrincipalPoint_y == other.PrincipalPoint_y
     }
 }
 impl ::core::cmp::Eq for MFCameraIntrinsic_CameraModel {}
@@ -55993,7 +55655,7 @@ unsafe impl ::windows::core::Abi for MFCameraIntrinsic_DistortionModel {
 }
 impl ::core::cmp::PartialEq for MFCameraIntrinsic_DistortionModel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraIntrinsic_DistortionModel>()) == 0 }
+        self.Radial_k1 == other.Radial_k1 && self.Radial_k2 == other.Radial_k2 && self.Radial_k3 == other.Radial_k3 && self.Tangential_p1 == other.Tangential_p1 && self.Tangential_p2 == other.Tangential_p2
     }
 }
 impl ::core::cmp::Eq for MFCameraIntrinsic_DistortionModel {}
@@ -56030,7 +55692,7 @@ unsafe impl ::windows::core::Abi for MFCameraIntrinsic_DistortionModel6KT {
 }
 impl ::core::cmp::PartialEq for MFCameraIntrinsic_DistortionModel6KT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraIntrinsic_DistortionModel6KT>()) == 0 }
+        self.Radial_k1 == other.Radial_k1 && self.Radial_k2 == other.Radial_k2 && self.Radial_k3 == other.Radial_k3 && self.Radial_k4 == other.Radial_k4 && self.Radial_k5 == other.Radial_k5 && self.Radial_k6 == other.Radial_k6 && self.Tangential_p1 == other.Tangential_p1 && self.Tangential_p2 == other.Tangential_p2
     }
 }
 impl ::core::cmp::Eq for MFCameraIntrinsic_DistortionModel6KT {}
@@ -56064,7 +55726,7 @@ unsafe impl ::windows::core::Abi for MFCameraIntrinsic_DistortionModelArcTan {
 }
 impl ::core::cmp::PartialEq for MFCameraIntrinsic_DistortionModelArcTan {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraIntrinsic_DistortionModelArcTan>()) == 0 }
+        self.Radial_k0 == other.Radial_k0 && self.DistortionCenter_x == other.DistortionCenter_x && self.DistortionCenter_y == other.DistortionCenter_y && self.Tangential_x == other.Tangential_x && self.Tangential_y == other.Tangential_y
     }
 }
 impl ::core::cmp::Eq for MFCameraIntrinsic_DistortionModelArcTan {}
@@ -56095,7 +55757,7 @@ unsafe impl ::windows::core::Abi for MFCameraIntrinsic_PinholeCameraModel {
 }
 impl ::core::cmp::PartialEq for MFCameraIntrinsic_PinholeCameraModel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFCameraIntrinsic_PinholeCameraModel>()) == 0 }
+        self.FocalLength == other.FocalLength && self.PrincipalPoint == other.PrincipalPoint
     }
 }
 impl ::core::cmp::Eq for MFCameraIntrinsic_PinholeCameraModel {}
@@ -56128,7 +55790,7 @@ unsafe impl ::windows::core::Abi for MFExtendedCameraIntrinsic_IntrinsicModel {
 }
 impl ::core::cmp::PartialEq for MFExtendedCameraIntrinsic_IntrinsicModel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFExtendedCameraIntrinsic_IntrinsicModel>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.SplitFrameId == other.SplitFrameId && self.CameraModel == other.CameraModel
     }
 }
 impl ::core::cmp::Eq for MFExtendedCameraIntrinsic_IntrinsicModel {}
@@ -56162,7 +55824,7 @@ unsafe impl ::windows::core::Abi for MFFOLDDOWN_MATRIX {
 }
 impl ::core::cmp::PartialEq for MFFOLDDOWN_MATRIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFFOLDDOWN_MATRIX>()) == 0 }
+        self.cbSize == other.cbSize && self.cSrcChannels == other.cSrcChannels && self.cDstChannels == other.cDstChannels && self.dwChannelMask == other.dwChannelMask && self.Coeff == other.Coeff
     }
 }
 impl ::core::cmp::Eq for MFFOLDDOWN_MATRIX {}
@@ -56194,7 +55856,7 @@ unsafe impl ::windows::core::Abi for MFINPUTTRUSTAUTHORITY_ACCESS_ACTION {
 }
 impl ::core::cmp::PartialEq for MFINPUTTRUSTAUTHORITY_ACCESS_ACTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFINPUTTRUSTAUTHORITY_ACCESS_ACTION>()) == 0 }
+        self.Action == other.Action && self.pbTicket == other.pbTicket && self.cbTicket == other.cbTicket
     }
 }
 impl ::core::cmp::Eq for MFINPUTTRUSTAUTHORITY_ACCESS_ACTION {}
@@ -56231,7 +55893,7 @@ unsafe impl ::windows::core::Abi for MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {
 }
 impl ::core::cmp::PartialEq for MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVer == other.dwVer && self.cbSignatureOffset == other.cbSignatureOffset && self.cbSignatureSize == other.cbSignatureSize && self.cbExtensionOffset == other.cbExtensionOffset && self.cbExtensionSize == other.cbExtensionSize && self.cActions == other.cActions && self.rgOutputActions == other.rgOutputActions
     }
 }
 impl ::core::cmp::Eq for MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {}
@@ -56295,7 +55957,7 @@ unsafe impl ::windows::core::Abi for MFMPEG2DLNASINKSTATS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MFMPEG2DLNASINKSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFMPEG2DLNASINKSTATS>()) == 0 }
+        self.cBytesWritten == other.cBytesWritten && self.fPAL == other.fPAL && self.fccVideo == other.fccVideo && self.dwVideoWidth == other.dwVideoWidth && self.dwVideoHeight == other.dwVideoHeight && self.cVideoFramesReceived == other.cVideoFramesReceived && self.cVideoFramesEncoded == other.cVideoFramesEncoded && self.cVideoFramesSkipped == other.cVideoFramesSkipped && self.cBlackVideoFramesEncoded == other.cBlackVideoFramesEncoded && self.cVideoFramesDuplicated == other.cVideoFramesDuplicated && self.cAudioSamplesPerSec == other.cAudioSamplesPerSec && self.cAudioChannels == other.cAudioChannels && self.cAudioBytesReceived == other.cAudioBytesReceived && self.cAudioFramesEncoded == other.cAudioFramesEncoded
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -56329,7 +55991,7 @@ unsafe impl ::windows::core::Abi for MFMediaKeyStatus {
 }
 impl ::core::cmp::PartialEq for MFMediaKeyStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFMediaKeyStatus>()) == 0 }
+        self.pbKeyId == other.pbKeyId && self.cbKeyId == other.cbKeyId && self.eMediaKeyStatus == other.eMediaKeyStatus
     }
 }
 impl ::core::cmp::Eq for MFMediaKeyStatus {}
@@ -56372,7 +56034,7 @@ unsafe impl ::windows::core::Abi for MFNetCredentialManagerGetParam {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MFNetCredentialManagerGetParam {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFNetCredentialManagerGetParam>()) == 0 }
+        self.hrOp == other.hrOp && self.fAllowLoggedOnUser == other.fAllowLoggedOnUser && self.fClearTextPackage == other.fClearTextPackage && self.pszUrl == other.pszUrl && self.pszSite == other.pszSite && self.pszRealm == other.pszRealm && self.pszPackage == other.pszPackage && self.nRetries == other.nRetries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -56405,7 +56067,7 @@ unsafe impl ::windows::core::Abi for MFOffset {
 }
 impl ::core::cmp::PartialEq for MFOffset {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFOffset>()) == 0 }
+        self.fract == other.fract && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for MFOffset {}
@@ -56992,12 +56654,6 @@ impl ::core::clone::Clone for MFPaletteEntry {
 unsafe impl ::windows::core::Abi for MFPaletteEntry {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFPaletteEntry {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFPaletteEntry>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFPaletteEntry {}
 impl ::core::default::Default for MFPaletteEntry {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57027,7 +56683,7 @@ unsafe impl ::windows::core::Abi for MFPinholeCameraIntrinsic_IntrinsicModel {
 }
 impl ::core::cmp::PartialEq for MFPinholeCameraIntrinsic_IntrinsicModel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFPinholeCameraIntrinsic_IntrinsicModel>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.CameraModel == other.CameraModel && self.DistortionModel == other.DistortionModel
     }
 }
 impl ::core::cmp::Eq for MFPinholeCameraIntrinsic_IntrinsicModel {}
@@ -57058,7 +56714,7 @@ unsafe impl ::windows::core::Abi for MFPinholeCameraIntrinsics {
 }
 impl ::core::cmp::PartialEq for MFPinholeCameraIntrinsics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFPinholeCameraIntrinsics>()) == 0 }
+        self.IntrinsicModelCount == other.IntrinsicModelCount && self.IntrinsicModels == other.IntrinsicModels
     }
 }
 impl ::core::cmp::Eq for MFPinholeCameraIntrinsics {}
@@ -57090,7 +56746,7 @@ unsafe impl ::windows::core::Abi for MFRR_COMPONENTS {
 }
 impl ::core::cmp::PartialEq for MFRR_COMPONENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFRR_COMPONENTS>()) == 0 }
+        self.dwRRInfoVersion == other.dwRRInfoVersion && self.dwRRComponents == other.dwRRComponents && self.pRRComponents == other.pRRComponents
     }
 }
 impl ::core::cmp::Eq for MFRR_COMPONENTS {}
@@ -57123,7 +56779,7 @@ unsafe impl ::windows::core::Abi for MFRR_COMPONENT_HASH_INFO {
 }
 impl ::core::cmp::PartialEq for MFRR_COMPONENT_HASH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFRR_COMPONENT_HASH_INFO>()) == 0 }
+        self.ulReason == other.ulReason && self.rgHeaderHash == other.rgHeaderHash && self.rgPublicKeyHash == other.rgPublicKeyHash && self.wszName == other.wszName
     }
 }
 impl ::core::cmp::Eq for MFRR_COMPONENT_HASH_INFO {}
@@ -57154,7 +56810,7 @@ unsafe impl ::windows::core::Abi for MFRatio {
 }
 impl ::core::cmp::PartialEq for MFRatio {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFRatio>()) == 0 }
+        self.Numerator == other.Numerator && self.Denominator == other.Denominator
     }
 }
 impl ::core::cmp::Eq for MFRatio {}
@@ -57180,12 +56836,6 @@ impl ::core::clone::Clone for MFTOPONODE_ATTRIBUTE_UPDATE {
 unsafe impl ::windows::core::Abi for MFTOPONODE_ATTRIBUTE_UPDATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFTOPONODE_ATTRIBUTE_UPDATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFTOPONODE_ATTRIBUTE_UPDATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFTOPONODE_ATTRIBUTE_UPDATE {}
 impl ::core::default::Default for MFTOPONODE_ATTRIBUTE_UPDATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57207,12 +56857,6 @@ impl ::core::clone::Clone for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
 unsafe impl ::windows::core::Abi for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFTOPONODE_ATTRIBUTE_UPDATE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFTOPONODE_ATTRIBUTE_UPDATE_0 {}
 impl ::core::default::Default for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57243,7 +56887,7 @@ unsafe impl ::windows::core::Abi for MFT_INPUT_STREAM_INFO {
 }
 impl ::core::cmp::PartialEq for MFT_INPUT_STREAM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_INPUT_STREAM_INFO>()) == 0 }
+        self.hnsMaxLatency == other.hnsMaxLatency && self.dwFlags == other.dwFlags && self.cbSize == other.cbSize && self.cbMaxLookahead == other.cbMaxLookahead && self.cbAlignment == other.cbAlignment
     }
 }
 impl ::core::cmp::Eq for MFT_INPUT_STREAM_INFO {}
@@ -57307,7 +56951,7 @@ unsafe impl ::windows::core::Abi for MFT_OUTPUT_STREAM_INFO {
 }
 impl ::core::cmp::PartialEq for MFT_OUTPUT_STREAM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_OUTPUT_STREAM_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cbSize == other.cbSize && self.cbAlignment == other.cbAlignment
     }
 }
 impl ::core::cmp::Eq for MFT_OUTPUT_STREAM_INFO {}
@@ -57338,7 +56982,7 @@ unsafe impl ::windows::core::Abi for MFT_REGISTER_TYPE_INFO {
 }
 impl ::core::cmp::PartialEq for MFT_REGISTER_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_REGISTER_TYPE_INFO>()) == 0 }
+        self.guidMajorType == other.guidMajorType && self.guidSubtype == other.guidSubtype
     }
 }
 impl ::core::cmp::Eq for MFT_REGISTER_TYPE_INFO {}
@@ -57375,7 +57019,7 @@ unsafe impl ::windows::core::Abi for MFT_REGISTRATION_INFO {
 }
 impl ::core::cmp::PartialEq for MFT_REGISTRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_REGISTRATION_INFO>()) == 0 }
+        self.clsid == other.clsid && self.guidCategory == other.guidCategory && self.uiFlags == other.uiFlags && self.pszName == other.pszName && self.cInTypes == other.cInTypes && self.pInTypes == other.pInTypes && self.cOutTypes == other.cOutTypes && self.pOutTypes == other.pOutTypes
     }
 }
 impl ::core::cmp::Eq for MFT_REGISTRATION_INFO {}
@@ -57406,7 +57050,7 @@ unsafe impl ::windows::core::Abi for MFT_STREAM_STATE_PARAM {
 }
 impl ::core::cmp::PartialEq for MFT_STREAM_STATE_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_STREAM_STATE_PARAM>()) == 0 }
+        self.StreamId == other.StreamId && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for MFT_STREAM_STATE_PARAM {}
@@ -57438,14 +57082,6 @@ unsafe impl ::windows::core::Abi for MFVIDEOFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MFVIDEOFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVIDEOFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MFVIDEOFORMAT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MFVIDEOFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57470,14 +57106,6 @@ unsafe impl ::windows::core::Abi for MFVideoAlphaBitmap {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for MFVideoAlphaBitmap {
-    fn eq(&self, other: &Self) -> bool {
-        self.GetBitmapFromDC == other.GetBitmapFromDC && self.bitmap == other.bitmap && self.params == other.params
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for MFVideoAlphaBitmap {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for MFVideoAlphaBitmap {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57500,14 +57128,6 @@ impl ::core::clone::Clone for MFVideoAlphaBitmap_0 {
 unsafe impl ::windows::core::Abi for MFVideoAlphaBitmap_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for MFVideoAlphaBitmap_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoAlphaBitmap_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for MFVideoAlphaBitmap_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for MFVideoAlphaBitmap_0 {
     fn default() -> Self {
@@ -57546,7 +57166,7 @@ unsafe impl ::windows::core::Abi for MFVideoAlphaBitmapParams {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MFVideoAlphaBitmapParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoAlphaBitmapParams>()) == 0 }
+        self.dwFlags == other.dwFlags && self.clrSrcKey == other.clrSrcKey && self.rcSrc == other.rcSrc && self.nrcDest == other.nrcDest && self.fAlpha == other.fAlpha && self.dwFilterMode == other.dwFilterMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -57586,7 +57206,7 @@ unsafe impl ::windows::core::Abi for MFVideoArea {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MFVideoArea {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoArea>()) == 0 }
+        self.OffsetX == other.OffsetX && self.OffsetY == other.OffsetY && self.Area == other.Area
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -57620,7 +57240,7 @@ unsafe impl ::windows::core::Abi for MFVideoCompressedInfo {
 }
 impl ::core::cmp::PartialEq for MFVideoCompressedInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoCompressedInfo>()) == 0 }
+        self.AvgBitrate == other.AvgBitrate && self.AvgBitErrorRate == other.AvgBitErrorRate && self.MaxKeyFrameSpacing == other.MaxKeyFrameSpacing
     }
 }
 impl ::core::cmp::Eq for MFVideoCompressedInfo {}
@@ -57686,7 +57306,7 @@ unsafe impl ::windows::core::Abi for MFVideoInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MFVideoInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoInfo>()) == 0 }
+        self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.PixelAspectRatio == other.PixelAspectRatio && self.SourceChromaSubsampling == other.SourceChromaSubsampling && self.InterlaceMode == other.InterlaceMode && self.TransferFunction == other.TransferFunction && self.ColorPrimaries == other.ColorPrimaries && self.TransferMatrix == other.TransferMatrix && self.SourceLighting == other.SourceLighting && self.FramesPerSecond == other.FramesPerSecond && self.NominalRange == other.NominalRange && self.GeometricAperture == other.GeometricAperture && self.MinimumDisplayAperture == other.MinimumDisplayAperture && self.PanScanAperture == other.PanScanAperture && self.VideoFlags == other.VideoFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -57721,7 +57341,7 @@ unsafe impl ::windows::core::Abi for MFVideoNormalizedRect {
 }
 impl ::core::cmp::PartialEq for MFVideoNormalizedRect {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoNormalizedRect>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for MFVideoNormalizedRect {}
@@ -57746,12 +57366,6 @@ impl ::core::clone::Clone for MFVideoSurfaceInfo {
 unsafe impl ::windows::core::Abi for MFVideoSurfaceInfo {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MFVideoSurfaceInfo {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFVideoSurfaceInfo>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MFVideoSurfaceInfo {}
 impl ::core::default::Default for MFVideoSurfaceInfo {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57779,7 +57393,7 @@ unsafe impl ::windows::core::Abi for MF_BYTE_STREAM_CACHE_RANGE {
 }
 impl ::core::cmp::PartialEq for MF_BYTE_STREAM_CACHE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_BYTE_STREAM_CACHE_RANGE>()) == 0 }
+        self.qwStartOffset == other.qwStartOffset && self.qwEndOffset == other.qwEndOffset
     }
 }
 impl ::core::cmp::Eq for MF_BYTE_STREAM_CACHE_RANGE {}
@@ -57810,7 +57424,7 @@ unsafe impl ::windows::core::Abi for MF_FLOAT2 {
 }
 impl ::core::cmp::PartialEq for MF_FLOAT2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_FLOAT2>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for MF_FLOAT2 {}
@@ -57842,7 +57456,7 @@ unsafe impl ::windows::core::Abi for MF_FLOAT3 {
 }
 impl ::core::cmp::PartialEq for MF_FLOAT3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_FLOAT3>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z
     }
 }
 impl ::core::cmp::Eq for MF_FLOAT3 {}
@@ -57873,7 +57487,7 @@ unsafe impl ::windows::core::Abi for MF_LEAKY_BUCKET_PAIR {
 }
 impl ::core::cmp::PartialEq for MF_LEAKY_BUCKET_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_LEAKY_BUCKET_PAIR>()) == 0 }
+        self.dwBitrate == other.dwBitrate && self.msBufferWindow == other.msBufferWindow
     }
 }
 impl ::core::cmp::Eq for MF_LEAKY_BUCKET_PAIR {}
@@ -57906,7 +57520,7 @@ unsafe impl ::windows::core::Abi for MF_QUATERNION {
 }
 impl ::core::cmp::PartialEq for MF_QUATERNION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_QUATERNION>()) == 0 }
+        self.x == other.x && self.y == other.y && self.z == other.z && self.w == other.w
     }
 }
 impl ::core::cmp::Eq for MF_QUATERNION {}
@@ -57968,7 +57582,22 @@ unsafe impl ::windows::core::Abi for MF_SINK_WRITER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for MF_SINK_WRITER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_SINK_WRITER_STATISTICS>()) == 0 }
+        self.cb == other.cb
+            && self.llLastTimestampReceived == other.llLastTimestampReceived
+            && self.llLastTimestampEncoded == other.llLastTimestampEncoded
+            && self.llLastTimestampProcessed == other.llLastTimestampProcessed
+            && self.llLastStreamTickReceived == other.llLastStreamTickReceived
+            && self.llLastSinkSampleRequest == other.llLastSinkSampleRequest
+            && self.qwNumSamplesReceived == other.qwNumSamplesReceived
+            && self.qwNumSamplesEncoded == other.qwNumSamplesEncoded
+            && self.qwNumSamplesProcessed == other.qwNumSamplesProcessed
+            && self.qwNumStreamTicksReceived == other.qwNumStreamTicksReceived
+            && self.dwByteCountQueued == other.dwByteCountQueued
+            && self.qwByteCountProcessed == other.qwByteCountProcessed
+            && self.dwNumOutstandingSinkSampleRequests == other.dwNumOutstandingSinkSampleRequests
+            && self.dwAverageSampleRateReceived == other.dwAverageSampleRateReceived
+            && self.dwAverageSampleRateEncoded == other.dwAverageSampleRateEncoded
+            && self.dwAverageSampleRateProcessed == other.dwAverageSampleRateProcessed
     }
 }
 impl ::core::cmp::Eq for MF_SINK_WRITER_STATISTICS {}
@@ -58037,7 +57666,7 @@ unsafe impl ::windows::core::Abi for MF_VIDEO_SPHERICAL_VIEWDIRECTION {
 }
 impl ::core::cmp::PartialEq for MF_VIDEO_SPHERICAL_VIEWDIRECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MF_VIDEO_SPHERICAL_VIEWDIRECTION>()) == 0 }
+        self.iHeading == other.iHeading && self.iPitch == other.iPitch && self.iRoll == other.iRoll
     }
 }
 impl ::core::cmp::Eq for MF_VIDEO_SPHERICAL_VIEWDIRECTION {}
@@ -58075,7 +57704,7 @@ unsafe impl ::windows::core::Abi for MOVEREGION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOVEREGION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOVEREGION_INFO>()) == 0 }
+        self.FrameNumber == other.FrameNumber && self.NumMoveRegions == other.NumMoveRegions && self.MoveRegions == other.MoveRegions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58114,7 +57743,7 @@ unsafe impl ::windows::core::Abi for MOVE_RECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOVE_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOVE_RECT>()) == 0 }
+        self.SourcePoint == other.SourcePoint && self.DestRect == other.DestRect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58155,7 +57784,7 @@ unsafe impl ::windows::core::Abi for MPEG1VIDEOINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for MPEG1VIDEOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPEG1VIDEOINFO>()) == 0 }
+        self.hdr == other.hdr && self.dwStartTimeCode == other.dwStartTimeCode && self.cbSequenceHeader == other.cbSequenceHeader && self.bSequenceHeader == other.bSequenceHeader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -58190,14 +57819,6 @@ impl ::core::clone::Clone for MPEG2VIDEOINFO {
 unsafe impl ::windows::core::Abi for MPEG2VIDEOINFO {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for MPEG2VIDEOINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPEG2VIDEOINFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for MPEG2VIDEOINFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for MPEG2VIDEOINFO {
     fn default() -> Self {
@@ -58236,7 +57857,7 @@ unsafe impl ::windows::core::Abi for MT_ARBITRARY_HEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MT_ARBITRARY_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MT_ARBITRARY_HEADER>()) == 0 }
+        self.majortype == other.majortype && self.subtype == other.subtype && self.bFixedSizeSamples == other.bFixedSizeSamples && self.bTemporalCompression == other.bTemporalCompression && self.lSampleSize == other.lSampleSize && self.formattype == other.formattype
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58275,7 +57896,7 @@ unsafe impl ::windows::core::Abi for MT_CUSTOM_VIDEO_PRIMARIES {
 }
 impl ::core::cmp::PartialEq for MT_CUSTOM_VIDEO_PRIMARIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MT_CUSTOM_VIDEO_PRIMARIES>()) == 0 }
+        self.fRx == other.fRx && self.fRy == other.fRy && self.fGx == other.fGx && self.fGy == other.fGy && self.fBx == other.fBx && self.fBy == other.fBy && self.fWx == other.fWx && self.fWy == other.fWy
     }
 }
 impl ::core::cmp::Eq for MT_CUSTOM_VIDEO_PRIMARIES {}
@@ -58310,12 +57931,6 @@ impl ::core::clone::Clone for OPM_ACP_AND_CGMSA_SIGNALING {
 unsafe impl ::windows::core::Abi for OPM_ACP_AND_CGMSA_SIGNALING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_ACP_AND_CGMSA_SIGNALING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_ACP_AND_CGMSA_SIGNALING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_ACP_AND_CGMSA_SIGNALING {}
 impl ::core::default::Default for OPM_ACP_AND_CGMSA_SIGNALING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58347,14 +57962,6 @@ unsafe impl ::windows::core::Abi for OPM_ACTUAL_OUTPUT_FORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl ::core::cmp::PartialEq for OPM_ACTUAL_OUTPUT_FORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_ACTUAL_OUTPUT_FORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl ::core::cmp::Eq for OPM_ACTUAL_OUTPUT_FORMAT {}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl ::core::default::Default for OPM_ACTUAL_OUTPUT_FORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58378,12 +57985,6 @@ impl ::core::clone::Clone for OPM_CONFIGURE_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_CONFIGURE_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_CONFIGURE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_CONFIGURE_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_CONFIGURE_PARAMETERS {}
 impl ::core::default::Default for OPM_CONFIGURE_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58409,12 +58010,6 @@ impl ::core::clone::Clone for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
 unsafe impl ::windows::core::Abi for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_CONNECTED_HDCP_DEVICE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {}
 impl ::core::default::Default for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58438,12 +58033,6 @@ impl ::core::clone::Clone for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {}
 impl ::core::default::Default for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58470,7 +58059,7 @@ unsafe impl ::windows::core::Abi for OPM_ENCRYPTED_INITIALIZATION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for OPM_ENCRYPTED_INITIALIZATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_ENCRYPTED_INITIALIZATION_PARAMETERS>()) == 0 }
+        self.abEncryptedInitializationParameters == other.abEncryptedInitializationParameters
     }
 }
 impl ::core::cmp::Eq for OPM_ENCRYPTED_INITIALIZATION_PARAMETERS {}
@@ -58494,12 +58083,6 @@ impl ::core::clone::Clone for OPM_GET_CODEC_INFO_INFORMATION {
 unsafe impl ::windows::core::Abi for OPM_GET_CODEC_INFO_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_GET_CODEC_INFO_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_GET_CODEC_INFO_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_GET_CODEC_INFO_INFORMATION {}
 impl ::core::default::Default for OPM_GET_CODEC_INFO_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58520,12 +58103,6 @@ impl ::core::clone::Clone for OPM_GET_CODEC_INFO_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_GET_CODEC_INFO_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_GET_CODEC_INFO_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_GET_CODEC_INFO_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_GET_CODEC_INFO_PARAMETERS {}
 impl ::core::default::Default for OPM_GET_CODEC_INFO_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58550,12 +58127,6 @@ impl ::core::clone::Clone for OPM_GET_INFO_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_GET_INFO_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_GET_INFO_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_GET_INFO_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_GET_INFO_PARAMETERS {}
 impl ::core::default::Default for OPM_GET_INFO_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58582,7 +58153,7 @@ unsafe impl ::windows::core::Abi for OPM_HDCP_KEY_SELECTION_VECTOR {
 }
 impl ::core::cmp::PartialEq for OPM_HDCP_KEY_SELECTION_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_HDCP_KEY_SELECTION_VECTOR>()) == 0 }
+        self.abKeySelectionVector == other.abKeySelectionVector
     }
 }
 impl ::core::cmp::Eq for OPM_HDCP_KEY_SELECTION_VECTOR {}
@@ -58612,7 +58183,7 @@ unsafe impl ::windows::core::Abi for OPM_OMAC {
 }
 impl ::core::cmp::PartialEq for OPM_OMAC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_OMAC>()) == 0 }
+        self.abOMAC == other.abOMAC
     }
 }
 impl ::core::cmp::Eq for OPM_OMAC {}
@@ -58637,12 +58208,6 @@ impl ::core::clone::Clone for OPM_OUTPUT_ID_DATA {
 unsafe impl ::windows::core::Abi for OPM_OUTPUT_ID_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_OUTPUT_ID_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_OUTPUT_ID_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_OUTPUT_ID_DATA {}
 impl ::core::default::Default for OPM_OUTPUT_ID_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58669,7 +58234,7 @@ unsafe impl ::windows::core::Abi for OPM_RANDOM_NUMBER {
 }
 impl ::core::cmp::PartialEq for OPM_RANDOM_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_RANDOM_NUMBER>()) == 0 }
+        self.abRandomNumber == other.abRandomNumber
     }
 }
 impl ::core::cmp::Eq for OPM_RANDOM_NUMBER {}
@@ -58694,12 +58259,6 @@ impl ::core::clone::Clone for OPM_REQUESTED_INFORMATION {
 unsafe impl ::windows::core::Abi for OPM_REQUESTED_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_REQUESTED_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_REQUESTED_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_REQUESTED_INFORMATION {}
 impl ::core::default::Default for OPM_REQUESTED_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58728,12 +58287,6 @@ impl ::core::clone::Clone for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {}
 impl ::core::default::Default for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58753,12 +58306,6 @@ impl ::core::clone::Clone for OPM_SET_HDCP_SRM_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_SET_HDCP_SRM_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_SET_HDCP_SRM_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_SET_HDCP_SRM_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_SET_HDCP_SRM_PARAMETERS {}
 impl ::core::default::Default for OPM_SET_HDCP_SRM_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58781,12 +58328,6 @@ impl ::core::clone::Clone for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
 unsafe impl ::windows::core::Abi for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_SET_PROTECTION_LEVEL_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_SET_PROTECTION_LEVEL_PARAMETERS {}
 impl ::core::default::Default for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58810,12 +58351,6 @@ impl ::core::clone::Clone for OPM_STANDARD_INFORMATION {
 unsafe impl ::windows::core::Abi for OPM_STANDARD_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OPM_STANDARD_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPM_STANDARD_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for OPM_STANDARD_INFORMATION {}
 impl ::core::default::Default for OPM_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58849,7 +58384,7 @@ unsafe impl ::windows::core::Abi for ROI_AREA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ROI_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROI_AREA>()) == 0 }
+        self.rect == other.rect && self.QPDelta == other.QPDelta
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58883,7 +58418,7 @@ unsafe impl ::windows::core::Abi for SENSORPROFILEID {
 }
 impl ::core::cmp::PartialEq for SENSORPROFILEID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENSORPROFILEID>()) == 0 }
+        self.Type == other.Type && self.Index == other.Index && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for SENSORPROFILEID {}
@@ -58914,7 +58449,7 @@ unsafe impl ::windows::core::Abi for STREAM_MEDIUM {
 }
 impl ::core::cmp::PartialEq for STREAM_MEDIUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_MEDIUM>()) == 0 }
+        self.gidMedium == other.gidMedium && self.unMediumInstance == other.unMediumInstance
     }
 }
 impl ::core::cmp::Eq for STREAM_MEDIUM {}
@@ -58947,7 +58482,7 @@ unsafe impl ::windows::core::Abi for TOC_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for TOC_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOC_DESCRIPTOR>()) == 0 }
+        self.guidID == other.guidID && self.wStreamNumber == other.wStreamNumber && self.guidType == other.guidType && self.wLanguageIndex == other.wLanguageIndex
     }
 }
 impl ::core::cmp::Eq for TOC_DESCRIPTOR {}
@@ -58981,7 +58516,7 @@ unsafe impl ::windows::core::Abi for TOC_ENTRY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for TOC_ENTRY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOC_ENTRY_DESCRIPTOR>()) == 0 }
+        self.qwStartTime == other.qwStartTime && self.qwEndTime == other.qwEndTime && self.qwStartPacketOffset == other.qwStartPacketOffset && self.qwEndPacketOffset == other.qwEndPacketOffset && self.qwRepresentativeFrameTime == other.qwRepresentativeFrameTime
     }
 }
 impl ::core::cmp::Eq for TOC_ENTRY_DESCRIPTOR {}
@@ -59022,7 +58557,7 @@ unsafe impl ::windows::core::Abi for VIDEOINFOHEADER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for VIDEOINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOINFOHEADER>()) == 0 }
+        self.rcSource == other.rcSource && self.rcTarget == other.rcTarget && self.dwBitRate == other.dwBitRate && self.dwBitErrorRate == other.dwBitErrorRate && self.AvgTimePerFrame == other.AvgTimePerFrame && self.bmiHeader == other.bmiHeader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -59063,14 +58598,6 @@ unsafe impl ::windows::core::Abi for VIDEOINFOHEADER2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for VIDEOINFOHEADER2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOINFOHEADER2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for VIDEOINFOHEADER2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for VIDEOINFOHEADER2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59095,14 +58622,6 @@ impl ::core::clone::Clone for VIDEOINFOHEADER2_0 {
 unsafe impl ::windows::core::Abi for VIDEOINFOHEADER2_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for VIDEOINFOHEADER2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOINFOHEADER2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for VIDEOINFOHEADER2_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for VIDEOINFOHEADER2_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
@@ -14387,7 +14387,7 @@ unsafe impl ::windows::core::Abi for TimedLevel {
 }
 impl ::core::cmp::PartialEq for TimedLevel {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TimedLevel>()) == 0 }
+        self.frequency == other.frequency && self.waveform == other.waveform && self.state == other.state && self.timeStamp == other.timeStamp
     }
 }
 impl ::core::cmp::Eq for TimedLevel {}
@@ -14446,12 +14446,6 @@ impl ::core::clone::Clone for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
 unsafe impl ::windows::core::Abi for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {}
 impl ::core::default::Default for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14472,12 +14466,6 @@ impl ::core::clone::Clone for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
 unsafe impl ::windows::core::Abi for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {}
 impl ::core::default::Default for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -11188,12 +11188,6 @@ impl ::core::clone::Clone for ADPCMCOEFSET {
 unsafe impl ::windows::core::Abi for ADPCMCOEFSET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ADPCMCOEFSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADPCMCOEFSET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ADPCMCOEFSET {}
 impl ::core::default::Default for ADPCMCOEFSET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11218,14 +11212,6 @@ impl ::core::clone::Clone for ADPCMEWAVEFORMAT {
 unsafe impl ::windows::core::Abi for ADPCMEWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for ADPCMEWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADPCMEWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for ADPCMEWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for ADPCMEWAVEFORMAT {
     fn default() -> Self {
@@ -11254,14 +11240,6 @@ unsafe impl ::windows::core::Abi for ADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for ADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for ADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for ADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11285,14 +11263,6 @@ impl ::core::clone::Clone for APTXWAVEFORMAT {
 unsafe impl ::windows::core::Abi for APTXWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for APTXWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APTXWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for APTXWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for APTXWAVEFORMAT {
     fn default() -> Self {
@@ -11318,14 +11288,6 @@ unsafe impl ::windows::core::Abi for AUDIOFILE_AF10WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for AUDIOFILE_AF10WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIOFILE_AF10WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for AUDIOFILE_AF10WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for AUDIOFILE_AF10WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11349,14 +11311,6 @@ impl ::core::clone::Clone for AUDIOFILE_AF36WAVEFORMAT {
 unsafe impl ::windows::core::Abi for AUDIOFILE_AF36WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for AUDIOFILE_AF36WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIOFILE_AF36WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for AUDIOFILE_AF36WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for AUDIOFILE_AF36WAVEFORMAT {
     fn default() -> Self {
@@ -11394,7 +11348,7 @@ unsafe impl ::windows::core::Abi for AVICOMPRESSOPTIONS {
 }
 impl ::core::cmp::PartialEq for AVICOMPRESSOPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVICOMPRESSOPTIONS>()) == 0 }
+        self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.dwKeyFrameEvery == other.dwKeyFrameEvery && self.dwQuality == other.dwQuality && self.dwBytesPerSecond == other.dwBytesPerSecond && self.dwFlags == other.dwFlags && self.lpFormat == other.lpFormat && self.cbFormat == other.cbFormat && self.lpParms == other.lpParms && self.cbParms == other.cbParms && self.dwInterleaveEvery == other.dwInterleaveEvery
     }
 }
 impl ::core::cmp::Eq for AVICOMPRESSOPTIONS {}
@@ -11454,7 +11408,7 @@ unsafe impl ::windows::core::Abi for AVIFILEINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AVIFILEINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVIFILEINFOA>()) == 0 }
+        self.dwMaxBytesPerSec == other.dwMaxBytesPerSec && self.dwFlags == other.dwFlags && self.dwCaps == other.dwCaps && self.dwStreams == other.dwStreams && self.dwSuggestedBufferSize == other.dwSuggestedBufferSize && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.dwScale == other.dwScale && self.dwRate == other.dwRate && self.dwLength == other.dwLength && self.dwEditCount == other.dwEditCount && self.szFileType == other.szFileType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11510,7 +11464,7 @@ unsafe impl ::windows::core::Abi for AVIFILEINFOW {
 }
 impl ::core::cmp::PartialEq for AVIFILEINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVIFILEINFOW>()) == 0 }
+        self.dwMaxBytesPerSec == other.dwMaxBytesPerSec && self.dwFlags == other.dwFlags && self.dwCaps == other.dwCaps && self.dwStreams == other.dwStreams && self.dwSuggestedBufferSize == other.dwSuggestedBufferSize && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.dwScale == other.dwScale && self.dwRate == other.dwRate && self.dwLength == other.dwLength && self.dwEditCount == other.dwEditCount && self.szFileType == other.szFileType
     }
 }
 impl ::core::cmp::Eq for AVIFILEINFOW {}
@@ -11582,7 +11536,7 @@ unsafe impl ::windows::core::Abi for AVISTREAMINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AVISTREAMINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVISTREAMINFOA>()) == 0 }
+        self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.dwFlags == other.dwFlags && self.dwCaps == other.dwCaps && self.wPriority == other.wPriority && self.wLanguage == other.wLanguage && self.dwScale == other.dwScale && self.dwRate == other.dwRate && self.dwStart == other.dwStart && self.dwLength == other.dwLength && self.dwInitialFrames == other.dwInitialFrames && self.dwSuggestedBufferSize == other.dwSuggestedBufferSize && self.dwQuality == other.dwQuality && self.dwSampleSize == other.dwSampleSize && self.rcFrame == other.rcFrame && self.dwEditCount == other.dwEditCount && self.dwFormatChangeCount == other.dwFormatChangeCount && self.szName == other.szName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11656,7 +11610,7 @@ unsafe impl ::windows::core::Abi for AVISTREAMINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AVISTREAMINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVISTREAMINFOW>()) == 0 }
+        self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.dwFlags == other.dwFlags && self.dwCaps == other.dwCaps && self.wPriority == other.wPriority && self.wLanguage == other.wLanguage && self.dwScale == other.dwScale && self.dwRate == other.dwRate && self.dwStart == other.dwStart && self.dwLength == other.dwLength && self.dwInitialFrames == other.dwInitialFrames && self.dwSuggestedBufferSize == other.dwSuggestedBufferSize && self.dwQuality == other.dwQuality && self.dwSampleSize == other.dwSampleSize && self.rcFrame == other.rcFrame && self.dwEditCount == other.dwEditCount && self.dwFormatChangeCount == other.dwFormatChangeCount && self.szName == other.szName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11716,7 +11670,7 @@ unsafe impl ::windows::core::Abi for CAPDRIVERCAPS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CAPDRIVERCAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAPDRIVERCAPS>()) == 0 }
+        self.wDeviceIndex == other.wDeviceIndex && self.fHasOverlay == other.fHasOverlay && self.fHasDlgVideoSource == other.fHasDlgVideoSource && self.fHasDlgVideoFormat == other.fHasDlgVideoFormat && self.fHasDlgVideoDisplay == other.fHasDlgVideoDisplay && self.fCaptureInitialized == other.fCaptureInitialized && self.fDriverSuppliesPalettes == other.fDriverSuppliesPalettes && self.hVideoIn == other.hVideoIn && self.hVideoOut == other.hVideoOut && self.hVideoExtIn == other.hVideoExtIn && self.hVideoExtOut == other.hVideoExtOut
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11750,7 +11704,7 @@ unsafe impl ::windows::core::Abi for CAPINFOCHUNK {
 }
 impl ::core::cmp::PartialEq for CAPINFOCHUNK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAPINFOCHUNK>()) == 0 }
+        self.fccInfoID == other.fccInfoID && self.lpData == other.lpData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for CAPINFOCHUNK {}
@@ -11822,7 +11776,24 @@ unsafe impl ::windows::core::Abi for CAPSTATUS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for CAPSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAPSTATUS>()) == 0 }
+        self.uiImageWidth == other.uiImageWidth
+            && self.uiImageHeight == other.uiImageHeight
+            && self.fLiveWindow == other.fLiveWindow
+            && self.fOverlayWindow == other.fOverlayWindow
+            && self.fScale == other.fScale
+            && self.ptScroll == other.ptScroll
+            && self.fUsingDefaultPalette == other.fUsingDefaultPalette
+            && self.fAudioHardware == other.fAudioHardware
+            && self.fCapFileExists == other.fCapFileExists
+            && self.dwCurrentVideoFrame == other.dwCurrentVideoFrame
+            && self.dwCurrentVideoFramesDropped == other.dwCurrentVideoFramesDropped
+            && self.dwCurrentWaveSamples == other.dwCurrentWaveSamples
+            && self.dwCurrentTimeElapsedMS == other.dwCurrentTimeElapsedMS
+            && self.hPalCurrent == other.hPalCurrent
+            && self.fCapturingNow == other.fCapturingNow
+            && self.dwReturn == other.dwReturn
+            && self.wNumVideoAllocated == other.wNumVideoAllocated
+            && self.wNumAudioAllocated == other.wNumAudioAllocated
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11908,7 +11879,30 @@ unsafe impl ::windows::core::Abi for CAPTUREPARMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CAPTUREPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAPTUREPARMS>()) == 0 }
+        self.dwRequestMicroSecPerFrame == other.dwRequestMicroSecPerFrame
+            && self.fMakeUserHitOKToCapture == other.fMakeUserHitOKToCapture
+            && self.wPercentDropForError == other.wPercentDropForError
+            && self.fYield == other.fYield
+            && self.dwIndexSize == other.dwIndexSize
+            && self.wChunkGranularity == other.wChunkGranularity
+            && self.fUsingDOSMemory == other.fUsingDOSMemory
+            && self.wNumVideoRequested == other.wNumVideoRequested
+            && self.fCaptureAudio == other.fCaptureAudio
+            && self.wNumAudioRequested == other.wNumAudioRequested
+            && self.vKeyAbort == other.vKeyAbort
+            && self.fAbortLeftMouse == other.fAbortLeftMouse
+            && self.fAbortRightMouse == other.fAbortRightMouse
+            && self.fLimitEnabled == other.fLimitEnabled
+            && self.wTimeLimit == other.wTimeLimit
+            && self.fMCIControl == other.fMCIControl
+            && self.fStepMCIDevice == other.fStepMCIDevice
+            && self.dwMCIStartTime == other.dwMCIStartTime
+            && self.dwMCIStopTime == other.dwMCIStopTime
+            && self.fStepCaptureAt2x == other.fStepCaptureAt2x
+            && self.wStepCaptureAverageFrames == other.wStepCaptureAverageFrames
+            && self.dwAudioBufferSize == other.dwAudioBufferSize
+            && self.fDisableWriteCache == other.fDisableWriteCache
+            && self.AVStreamMaster == other.AVStreamMaster
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11948,7 +11942,7 @@ unsafe impl ::windows::core::Abi for CHANNEL_CAPS {
 }
 impl ::core::cmp::PartialEq for CHANNEL_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANNEL_CAPS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwSrcRectXMod == other.dwSrcRectXMod && self.dwSrcRectYMod == other.dwSrcRectYMod && self.dwSrcRectWidthMod == other.dwSrcRectWidthMod && self.dwSrcRectHeightMod == other.dwSrcRectHeightMod && self.dwDstRectXMod == other.dwDstRectXMod && self.dwDstRectYMod == other.dwDstRectYMod && self.dwDstRectWidthMod == other.dwDstRectWidthMod && self.dwDstRectHeightMod == other.dwDstRectHeightMod
     }
 }
 impl ::core::cmp::Eq for CHANNEL_CAPS {}
@@ -12016,7 +12010,7 @@ unsafe impl ::windows::core::Abi for COMPVARS {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for COMPVARS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPVARS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.hic == other.hic && self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.lpbiIn == other.lpbiIn && self.lpbiOut == other.lpbiOut && self.lpBitsOut == other.lpBitsOut && self.lpBitsPrev == other.lpBitsPrev && self.lFrame == other.lFrame && self.lKey == other.lKey && self.lDataRate == other.lDataRate && self.lQ == other.lQ && self.lKeyCount == other.lKeyCount && self.lpState == other.lpState && self.cbState == other.cbState
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12047,14 +12041,6 @@ unsafe impl ::windows::core::Abi for CONTRESCR10WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CONTRESCR10WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTRESCR10WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CONTRESCR10WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CONTRESCR10WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12079,14 +12065,6 @@ impl ::core::clone::Clone for CONTRESVQLPCWAVEFORMAT {
 unsafe impl ::windows::core::Abi for CONTRESVQLPCWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CONTRESVQLPCWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTRESVQLPCWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CONTRESVQLPCWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CONTRESVQLPCWAVEFORMAT {
     fn default() -> Self {
@@ -12113,14 +12091,6 @@ unsafe impl ::windows::core::Abi for CREATIVEADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CREATIVEADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATIVEADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CREATIVEADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CREATIVEADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12145,14 +12115,6 @@ impl ::core::clone::Clone for CREATIVEFASTSPEECH10WAVEFORMAT {
 unsafe impl ::windows::core::Abi for CREATIVEFASTSPEECH10WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CREATIVEFASTSPEECH10WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATIVEFASTSPEECH10WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CREATIVEFASTSPEECH10WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CREATIVEFASTSPEECH10WAVEFORMAT {
     fn default() -> Self {
@@ -12179,14 +12141,6 @@ unsafe impl ::windows::core::Abi for CREATIVEFASTSPEECH8WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CREATIVEFASTSPEECH8WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATIVEFASTSPEECH8WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CREATIVEFASTSPEECH8WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CREATIVEFASTSPEECH8WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12211,14 +12165,6 @@ unsafe impl ::windows::core::Abi for CSIMAADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for CSIMAADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSIMAADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for CSIMAADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for CSIMAADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12242,14 +12188,6 @@ impl ::core::clone::Clone for DIALOGICOKIADPCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for DIALOGICOKIADPCMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DIALOGICOKIADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIALOGICOKIADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DIALOGICOKIADPCMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DIALOGICOKIADPCMWAVEFORMAT {
     fn default() -> Self {
@@ -12276,14 +12214,6 @@ unsafe impl ::windows::core::Abi for DIGIADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DIGIADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIGIADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DIGIADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DIGIADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12307,14 +12237,6 @@ impl ::core::clone::Clone for DIGIFIXWAVEFORMAT {
 unsafe impl ::windows::core::Abi for DIGIFIXWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DIGIFIXWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIGIFIXWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DIGIFIXWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DIGIFIXWAVEFORMAT {
     fn default() -> Self {
@@ -12341,14 +12263,6 @@ unsafe impl ::windows::core::Abi for DIGIREALWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DIGIREALWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIGIREALWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DIGIREALWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DIGIREALWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12372,14 +12286,6 @@ impl ::core::clone::Clone for DIGISTDWAVEFORMAT {
 unsafe impl ::windows::core::Abi for DIGISTDWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DIGISTDWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIGISTDWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DIGISTDWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DIGISTDWAVEFORMAT {
     fn default() -> Self {
@@ -12405,14 +12311,6 @@ impl ::core::clone::Clone for DOLBYAC2WAVEFORMAT {
 unsafe impl ::windows::core::Abi for DOLBYAC2WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DOLBYAC2WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOLBYAC2WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DOLBYAC2WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DOLBYAC2WAVEFORMAT {
     fn default() -> Self {
@@ -12446,7 +12344,7 @@ unsafe impl ::windows::core::Abi for DRAWDIBTIME {
 }
 impl ::core::cmp::PartialEq for DRAWDIBTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAWDIBTIME>()) == 0 }
+        self.timeCount == other.timeCount && self.timeDraw == other.timeDraw && self.timeDecompress == other.timeDecompress && self.timeDither == other.timeDither && self.timeStretch == other.timeStretch && self.timeBlt == other.timeBlt && self.timeSetDIBits == other.timeSetDIBits
     }
 }
 impl ::core::cmp::Eq for DRAWDIBTIME {}
@@ -12477,14 +12375,6 @@ unsafe impl ::windows::core::Abi for DRMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DRMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DRMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DRMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12506,12 +12396,6 @@ impl ::core::clone::Clone for DRVCONFIGINFO {
 unsafe impl ::windows::core::Abi for DRVCONFIGINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DRVCONFIGINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRVCONFIGINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DRVCONFIGINFO {}
 impl ::core::default::Default for DRVCONFIGINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12534,12 +12418,6 @@ impl ::core::clone::Clone for DRVCONFIGINFOEX {
 unsafe impl ::windows::core::Abi for DRVCONFIGINFOEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DRVCONFIGINFOEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRVCONFIGINFOEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DRVCONFIGINFOEX {}
 impl ::core::default::Default for DRVCONFIGINFOEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12560,12 +12438,6 @@ impl ::core::clone::Clone for DRVM_IOCTL_DATA {
 unsafe impl ::windows::core::Abi for DRVM_IOCTL_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DRVM_IOCTL_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRVM_IOCTL_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DRVM_IOCTL_DATA {}
 impl ::core::default::Default for DRVM_IOCTL_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12591,14 +12463,6 @@ unsafe impl ::windows::core::Abi for DVIADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for DVIADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DVIADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for DVIADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for DVIADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12622,14 +12486,6 @@ impl ::core::clone::Clone for ECHOSC1WAVEFORMAT {
 unsafe impl ::windows::core::Abi for ECHOSC1WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for ECHOSC1WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ECHOSC1WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for ECHOSC1WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for ECHOSC1WAVEFORMAT {
     fn default() -> Self {
@@ -12656,14 +12512,6 @@ unsafe impl ::windows::core::Abi for EXBMINFOHEADER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::PartialEq for EXBMINFOHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXBMINFOHEADER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::Eq for EXBMINFOHEADER {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::default::Default for EXBMINFOHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12689,14 +12537,6 @@ unsafe impl ::windows::core::Abi for FMTOWNS_SND_WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for FMTOWNS_SND_WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FMTOWNS_SND_WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for FMTOWNS_SND_WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for FMTOWNS_SND_WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12721,14 +12561,6 @@ impl ::core::clone::Clone for G721_ADPCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for G721_ADPCMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for G721_ADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<G721_ADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for G721_ADPCMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for G721_ADPCMWAVEFORMAT {
     fn default() -> Self {
@@ -12756,14 +12588,6 @@ unsafe impl ::windows::core::Abi for G723_ADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for G723_ADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<G723_ADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for G723_ADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for G723_ADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12788,14 +12612,6 @@ impl ::core::clone::Clone for GSM610WAVEFORMAT {
 unsafe impl ::windows::core::Abi for GSM610WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for GSM610WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GSM610WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for GSM610WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for GSM610WAVEFORMAT {
     fn default() -> Self {
@@ -12968,7 +12784,7 @@ unsafe impl ::windows::core::Abi for ICCOMPRESS {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICCOMPRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICCOMPRESS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpbiOutput == other.lpbiOutput && self.lpOutput == other.lpOutput && self.lpbiInput == other.lpbiInput && self.lpInput == other.lpInput && self.lpckid == other.lpckid && self.lpdwFlags == other.lpdwFlags && self.lFrameNum == other.lFrameNum && self.dwFrameSize == other.dwFrameSize && self.dwQuality == other.dwQuality && self.lpbiPrev == other.lpbiPrev && self.lpPrev == other.lpPrev
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13038,7 +12854,7 @@ unsafe impl ::windows::core::Abi for ICCOMPRESSFRAMES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICCOMPRESSFRAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICCOMPRESSFRAMES>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpbiOutput == other.lpbiOutput && self.lOutput == other.lOutput && self.lpbiInput == other.lpbiInput && self.lInput == other.lInput && self.lStartFrame == other.lStartFrame && self.lFrameCount == other.lFrameCount && self.lQuality == other.lQuality && self.lDataRate == other.lDataRate && self.lKeyRate == other.lKeyRate && self.dwRate == other.dwRate && self.dwScale == other.dwScale && self.dwOverheadPerFrame == other.dwOverheadPerFrame && self.dwReserved2 == other.dwReserved2 && self.GetData == other.GetData && self.PutData == other.PutData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13081,7 +12897,7 @@ unsafe impl ::windows::core::Abi for ICDECOMPRESS {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICDECOMPRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICDECOMPRESS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpbiInput == other.lpbiInput && self.lpInput == other.lpInput && self.lpbiOutput == other.lpbiOutput && self.lpOutput == other.lpOutput && self.ckid == other.ckid
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13131,7 +12947,7 @@ unsafe impl ::windows::core::Abi for ICDECOMPRESSEX {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICDECOMPRESSEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICDECOMPRESSEX>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpbiSrc == other.lpbiSrc && self.lpSrc == other.lpSrc && self.lpbiDst == other.lpbiDst && self.lpDst == other.lpDst && self.xDst == other.xDst && self.yDst == other.yDst && self.dxDst == other.dxDst && self.dyDst == other.dyDst && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.dxSrc == other.dxSrc && self.dySrc == other.dySrc
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13167,7 +12983,7 @@ unsafe impl ::windows::core::Abi for ICDRAW {
 }
 impl ::core::cmp::PartialEq for ICDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICDRAW>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lpFormat == other.lpFormat && self.lpData == other.lpData && self.cbData == other.cbData && self.lTime == other.lTime
     }
 }
 impl ::core::cmp::Eq for ICDRAW {}
@@ -13217,7 +13033,7 @@ unsafe impl ::windows::core::Abi for ICDRAWBEGIN {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICDRAWBEGIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICDRAWBEGIN>()) == 0 }
+        self.dwFlags == other.dwFlags && self.hpal == other.hpal && self.hwnd == other.hwnd && self.hdc == other.hdc && self.xDst == other.xDst && self.yDst == other.yDst && self.dxDst == other.dxDst && self.dyDst == other.dyDst && self.lpbi == other.lpbi && self.xSrc == other.xSrc && self.ySrc == other.ySrc && self.dxSrc == other.dxSrc && self.dySrc == other.dySrc && self.dwRate == other.dwRate && self.dwScale == other.dwScale
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13261,7 +13077,7 @@ unsafe impl ::windows::core::Abi for ICDRAWSUGGEST {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICDRAWSUGGEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICDRAWSUGGEST>()) == 0 }
+        self.lpbiIn == other.lpbiIn && self.lpbiSuggest == other.lpbiSuggest && self.dxSrc == other.dxSrc && self.dySrc == other.dySrc && self.dxDst == other.dxDst && self.dyDst == other.dyDst && self.hicDecompressor == other.hicDecompressor
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13301,7 +13117,7 @@ unsafe impl ::windows::core::Abi for ICINFO {
 }
 impl ::core::cmp::PartialEq for ICINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.dwFlags == other.dwFlags && self.dwVersion == other.dwVersion && self.dwVersionICM == other.dwVersionICM && self.szName == other.szName && self.szDescription == other.szDescription && self.szDriver == other.szDriver
     }
 }
 impl ::core::cmp::Eq for ICINFO {}
@@ -13345,7 +13161,7 @@ unsafe impl ::windows::core::Abi for ICOPEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ICOPEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICOPEN>()) == 0 }
+        self.dwSize == other.dwSize && self.fccType == other.fccType && self.fccHandler == other.fccHandler && self.dwVersion == other.dwVersion && self.dwFlags == other.dwFlags && self.dwError == other.dwError && self.pV1Reserved == other.pV1Reserved && self.pV2Reserved == other.pV2Reserved && self.dnDevNode == other.dnDevNode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13386,7 +13202,7 @@ unsafe impl ::windows::core::Abi for ICPALETTE {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICPALETTE>()) == 0 }
+        self.dwFlags == other.dwFlags && self.iStart == other.iStart && self.iLen == other.iLen && self.lppe == other.lppe
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13426,7 +13242,7 @@ unsafe impl ::windows::core::Abi for ICSETSTATUSPROC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ICSETSTATUSPROC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICSETSTATUSPROC>()) == 0 }
+        self.dwFlags == other.dwFlags && self.lParam == other.lParam && self.Status == other.Status
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13456,14 +13272,6 @@ impl ::core::clone::Clone for IMAADPCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for IMAADPCMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for IMAADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for IMAADPCMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for IMAADPCMWAVEFORMAT {
     fn default() -> Self {
@@ -13515,14 +13323,6 @@ unsafe impl ::windows::core::Abi for JOYCAPS2A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JOYCAPS2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYCAPS2A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JOYCAPS2A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JOYCAPS2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13568,12 +13368,6 @@ impl ::core::clone::Clone for JOYCAPS2W {
 unsafe impl ::windows::core::Abi for JOYCAPS2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOYCAPS2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYCAPS2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOYCAPS2W {}
 impl ::core::default::Default for JOYCAPS2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13621,14 +13415,6 @@ unsafe impl ::windows::core::Abi for JOYCAPSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JOYCAPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYCAPSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JOYCAPSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JOYCAPSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13671,12 +13457,6 @@ impl ::core::clone::Clone for JOYCAPSW {
 unsafe impl ::windows::core::Abi for JOYCAPSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOYCAPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYCAPSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOYCAPSW {}
 impl ::core::default::Default for JOYCAPSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13699,12 +13479,6 @@ impl ::core::clone::Clone for JOYINFO {
 unsafe impl ::windows::core::Abi for JOYINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOYINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOYINFO {}
 impl ::core::default::Default for JOYINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13736,12 +13510,6 @@ impl ::core::clone::Clone for JOYINFOEX {
 unsafe impl ::windows::core::Abi for JOYINFOEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOYINFOEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOYINFOEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOYINFOEX {}
 impl ::core::default::Default for JOYINFOEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13766,12 +13534,6 @@ impl ::core::clone::Clone for JPEGINFOHEADER {
 unsafe impl ::windows::core::Abi for JPEGINFOHEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JPEGINFOHEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JPEGINFOHEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JPEGINFOHEADER {}
 impl ::core::default::Default for JPEGINFOHEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13801,14 +13563,6 @@ impl ::core::clone::Clone for MCI_ANIM_OPEN_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_ANIM_OPEN_PARMSA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_ANIM_OPEN_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_OPEN_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_ANIM_OPEN_PARMSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_ANIM_OPEN_PARMSA {
     fn default() -> Self {
@@ -13840,14 +13594,6 @@ unsafe impl ::windows::core::Abi for MCI_ANIM_OPEN_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_ANIM_OPEN_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_OPEN_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_ANIM_OPEN_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_ANIM_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13870,12 +13616,6 @@ impl ::core::clone::Clone for MCI_ANIM_PLAY_PARMS {
 unsafe impl ::windows::core::Abi for MCI_ANIM_PLAY_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_ANIM_PLAY_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_PLAY_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_ANIM_PLAY_PARMS {}
 impl ::core::default::Default for MCI_ANIM_PLAY_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13901,14 +13641,6 @@ unsafe impl ::windows::core::Abi for MCI_ANIM_RECT_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_ANIM_RECT_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_RECT_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_ANIM_RECT_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_ANIM_RECT_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13929,12 +13661,6 @@ impl ::core::clone::Clone for MCI_ANIM_STEP_PARMS {
 unsafe impl ::windows::core::Abi for MCI_ANIM_STEP_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_ANIM_STEP_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_STEP_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_ANIM_STEP_PARMS {}
 impl ::core::default::Default for MCI_ANIM_STEP_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13960,14 +13686,6 @@ impl ::core::clone::Clone for MCI_ANIM_UPDATE_PARMS {
 unsafe impl ::windows::core::Abi for MCI_ANIM_UPDATE_PARMS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for MCI_ANIM_UPDATE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_UPDATE_PARMS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for MCI_ANIM_UPDATE_PARMS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for MCI_ANIM_UPDATE_PARMS {
     fn default() -> Self {
@@ -13996,14 +13714,6 @@ unsafe impl ::windows::core::Abi for MCI_ANIM_WINDOW_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_ANIM_WINDOW_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_WINDOW_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_ANIM_WINDOW_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_ANIM_WINDOW_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14031,14 +13741,6 @@ unsafe impl ::windows::core::Abi for MCI_ANIM_WINDOW_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_ANIM_WINDOW_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_ANIM_WINDOW_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_ANIM_WINDOW_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_ANIM_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14064,14 +13766,6 @@ impl ::core::clone::Clone for MCI_BREAK_PARMS {
 unsafe impl ::windows::core::Abi for MCI_BREAK_PARMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_BREAK_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_BREAK_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_BREAK_PARMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_BREAK_PARMS {
     fn default() -> Self {
@@ -14099,14 +13793,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_CAPTURE_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_CAPTURE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_CAPTURE_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_CAPTURE_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_CAPTURE_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14132,14 +13818,6 @@ impl ::core::clone::Clone for MCI_DGV_CAPTURE_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_CAPTURE_PARMSW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_CAPTURE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_CAPTURE_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_CAPTURE_PARMSW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_CAPTURE_PARMSW {
     fn default() -> Self {
@@ -14170,14 +13848,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_COPY_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_COPY_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_COPY_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_COPY_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_COPY_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14198,12 +13868,6 @@ impl ::core::clone::Clone for MCI_DGV_CUE_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_CUE_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_CUE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_CUE_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_CUE_PARMS {}
 impl ::core::default::Default for MCI_DGV_CUE_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14232,14 +13896,6 @@ impl ::core::clone::Clone for MCI_DGV_CUT_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_CUT_PARMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_CUT_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_CUT_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_CUT_PARMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_CUT_PARMS {
     fn default() -> Self {
@@ -14270,14 +13926,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_DELETE_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_DELETE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_DELETE_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_DELETE_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_DELETE_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14300,12 +13948,6 @@ impl ::core::clone::Clone for MCI_DGV_INFO_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_INFO_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_INFO_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_INFO_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_INFO_PARMSA {}
 impl ::core::default::Default for MCI_DGV_INFO_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14328,12 +13970,6 @@ impl ::core::clone::Clone for MCI_DGV_INFO_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_INFO_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_INFO_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_INFO_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_INFO_PARMSW {}
 impl ::core::default::Default for MCI_DGV_INFO_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14358,12 +13994,6 @@ impl ::core::clone::Clone for MCI_DGV_LIST_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_LIST_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_LIST_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_LIST_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_LIST_PARMSA {}
 impl ::core::default::Default for MCI_DGV_LIST_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14388,12 +14018,6 @@ impl ::core::clone::Clone for MCI_DGV_LIST_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_LIST_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_LIST_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_LIST_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_LIST_PARMSW {}
 impl ::core::default::Default for MCI_DGV_LIST_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14415,12 +14039,6 @@ impl ::core::clone::Clone for MCI_DGV_MONITOR_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_MONITOR_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_MONITOR_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_MONITOR_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_MONITOR_PARMS {}
 impl ::core::default::Default for MCI_DGV_MONITOR_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14450,14 +14068,6 @@ impl ::core::clone::Clone for MCI_DGV_OPEN_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_OPEN_PARMSA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_OPEN_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_OPEN_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_OPEN_PARMSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_OPEN_PARMSA {
     fn default() -> Self {
@@ -14489,14 +14099,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_OPEN_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_OPEN_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_OPEN_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_OPEN_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14525,14 +14127,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_PASTE_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_PASTE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_PASTE_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_PASTE_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_PASTE_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14556,12 +14150,6 @@ impl ::core::clone::Clone for MCI_DGV_QUALITY_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_QUALITY_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_QUALITY_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_QUALITY_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_QUALITY_PARMSA {}
 impl ::core::default::Default for MCI_DGV_QUALITY_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14585,12 +14173,6 @@ impl ::core::clone::Clone for MCI_DGV_QUALITY_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_QUALITY_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_QUALITY_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_QUALITY_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_QUALITY_PARMSW {}
 impl ::core::default::Default for MCI_DGV_QUALITY_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14620,14 +14202,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_RECORD_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_RECORD_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RECORD_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_RECORD_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_RECORD_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14653,14 +14227,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_RECT_PARMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_RECT_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RECT_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_RECT_PARMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_RECT_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14682,12 +14248,6 @@ impl ::core::clone::Clone for MCI_DGV_RESERVE_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_RESERVE_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_RESERVE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RESERVE_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_RESERVE_PARMSA {}
 impl ::core::default::Default for MCI_DGV_RESERVE_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14709,12 +14269,6 @@ impl ::core::clone::Clone for MCI_DGV_RESERVE_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_RESERVE_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_RESERVE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RESERVE_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_RESERVE_PARMSW {}
 impl ::core::default::Default for MCI_DGV_RESERVE_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14740,14 +14294,6 @@ impl ::core::clone::Clone for MCI_DGV_RESTORE_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_RESTORE_PARMSA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_RESTORE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RESTORE_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_RESTORE_PARMSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_RESTORE_PARMSA {
     fn default() -> Self {
@@ -14775,14 +14321,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_RESTORE_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_RESTORE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_RESTORE_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_RESTORE_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_RESTORE_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14808,14 +14346,6 @@ impl ::core::clone::Clone for MCI_DGV_SAVE_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_SAVE_PARMSA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_SAVE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SAVE_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_SAVE_PARMSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_SAVE_PARMSA {
     fn default() -> Self {
@@ -14843,14 +14373,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_SAVE_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_SAVE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SAVE_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_SAVE_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_SAVE_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14875,12 +14397,6 @@ impl ::core::clone::Clone for MCI_DGV_SETAUDIO_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_SETAUDIO_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SETAUDIO_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SETAUDIO_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SETAUDIO_PARMSA {}
 impl ::core::default::Default for MCI_DGV_SETAUDIO_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14905,12 +14421,6 @@ impl ::core::clone::Clone for MCI_DGV_SETAUDIO_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_SETAUDIO_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SETAUDIO_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SETAUDIO_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SETAUDIO_PARMSW {}
 impl ::core::default::Default for MCI_DGV_SETAUDIO_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14936,12 +14446,6 @@ impl ::core::clone::Clone for MCI_DGV_SETVIDEO_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_SETVIDEO_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SETVIDEO_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SETVIDEO_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SETVIDEO_PARMSA {}
 impl ::core::default::Default for MCI_DGV_SETVIDEO_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14967,12 +14471,6 @@ impl ::core::clone::Clone for MCI_DGV_SETVIDEO_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_SETVIDEO_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SETVIDEO_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SETVIDEO_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SETVIDEO_PARMSW {}
 impl ::core::default::Default for MCI_DGV_SETVIDEO_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14996,12 +14494,6 @@ impl ::core::clone::Clone for MCI_DGV_SET_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_SET_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SET_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SET_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SET_PARMS {}
 impl ::core::default::Default for MCI_DGV_SET_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15024,12 +14516,6 @@ impl ::core::clone::Clone for MCI_DGV_SIGNAL_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_SIGNAL_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_SIGNAL_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_SIGNAL_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_SIGNAL_PARMS {}
 impl ::core::default::Default for MCI_DGV_SIGNAL_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15054,12 +14540,6 @@ impl ::core::clone::Clone for MCI_DGV_STATUS_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_DGV_STATUS_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_STATUS_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_STATUS_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_STATUS_PARMSA {}
 impl ::core::default::Default for MCI_DGV_STATUS_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15084,12 +14564,6 @@ impl ::core::clone::Clone for MCI_DGV_STATUS_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_DGV_STATUS_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_STATUS_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_STATUS_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_STATUS_PARMSW {}
 impl ::core::default::Default for MCI_DGV_STATUS_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15110,12 +14584,6 @@ impl ::core::clone::Clone for MCI_DGV_STEP_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_STEP_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_DGV_STEP_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_STEP_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_DGV_STEP_PARMS {}
 impl ::core::default::Default for MCI_DGV_STEP_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15141,14 +14609,6 @@ impl ::core::clone::Clone for MCI_DGV_UPDATE_PARMS {
 unsafe impl ::windows::core::Abi for MCI_DGV_UPDATE_PARMS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for MCI_DGV_UPDATE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_UPDATE_PARMS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for MCI_DGV_UPDATE_PARMS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for MCI_DGV_UPDATE_PARMS {
     fn default() -> Self {
@@ -15177,14 +14637,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_WINDOW_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_WINDOW_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_WINDOW_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_WINDOW_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_WINDOW_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15212,14 +14664,6 @@ unsafe impl ::windows::core::Abi for MCI_DGV_WINDOW_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_DGV_WINDOW_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_DGV_WINDOW_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_DGV_WINDOW_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_DGV_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15239,12 +14683,6 @@ impl ::core::clone::Clone for MCI_GENERIC_PARMS {
 unsafe impl ::windows::core::Abi for MCI_GENERIC_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_GENERIC_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_GENERIC_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_GENERIC_PARMS {}
 impl ::core::default::Default for MCI_GENERIC_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15266,12 +14704,6 @@ impl ::core::clone::Clone for MCI_GETDEVCAPS_PARMS {
 unsafe impl ::windows::core::Abi for MCI_GETDEVCAPS_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_GETDEVCAPS_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_GETDEVCAPS_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_GETDEVCAPS_PARMS {}
 impl ::core::default::Default for MCI_GETDEVCAPS_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15293,12 +14725,6 @@ impl ::core::clone::Clone for MCI_INFO_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_INFO_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_INFO_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_INFO_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_INFO_PARMSA {}
 impl ::core::default::Default for MCI_INFO_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15320,12 +14746,6 @@ impl ::core::clone::Clone for MCI_INFO_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_INFO_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_INFO_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_INFO_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_INFO_PARMSW {}
 impl ::core::default::Default for MCI_INFO_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15346,12 +14766,6 @@ impl ::core::clone::Clone for MCI_LOAD_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_LOAD_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_LOAD_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_LOAD_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_LOAD_PARMSA {}
 impl ::core::default::Default for MCI_LOAD_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15372,12 +14786,6 @@ impl ::core::clone::Clone for MCI_LOAD_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_LOAD_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_LOAD_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_LOAD_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_LOAD_PARMSW {}
 impl ::core::default::Default for MCI_LOAD_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15400,12 +14808,6 @@ impl ::core::clone::Clone for MCI_OPEN_DRIVER_PARMS {
 unsafe impl ::windows::core::Abi for MCI_OPEN_DRIVER_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_OPEN_DRIVER_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OPEN_DRIVER_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_OPEN_DRIVER_PARMS {}
 impl ::core::default::Default for MCI_OPEN_DRIVER_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15429,12 +14831,6 @@ impl ::core::clone::Clone for MCI_OPEN_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_OPEN_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_OPEN_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OPEN_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_OPEN_PARMSA {}
 impl ::core::default::Default for MCI_OPEN_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15458,12 +14854,6 @@ impl ::core::clone::Clone for MCI_OPEN_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_OPEN_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_OPEN_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OPEN_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_OPEN_PARMSW {}
 impl ::core::default::Default for MCI_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15490,14 +14880,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_LOAD_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_LOAD_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_LOAD_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_LOAD_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_LOAD_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15523,14 +14905,6 @@ impl ::core::clone::Clone for MCI_OVLY_LOAD_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_OVLY_LOAD_PARMSW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_LOAD_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_LOAD_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_LOAD_PARMSW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_LOAD_PARMSW {
     fn default() -> Self {
@@ -15562,14 +14936,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_OPEN_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_OPEN_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_OPEN_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_OPEN_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_OPEN_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15600,14 +14966,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_OPEN_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_OPEN_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_OPEN_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_OPEN_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15632,14 +14990,6 @@ impl ::core::clone::Clone for MCI_OVLY_RECT_PARMS {
 unsafe impl ::windows::core::Abi for MCI_OVLY_RECT_PARMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_RECT_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_RECT_PARMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_RECT_PARMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_RECT_PARMS {
     fn default() -> Self {
@@ -15667,14 +15017,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_SAVE_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_SAVE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_SAVE_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_SAVE_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_SAVE_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15700,14 +15042,6 @@ impl ::core::clone::Clone for MCI_OVLY_SAVE_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_OVLY_SAVE_PARMSW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_SAVE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_SAVE_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_SAVE_PARMSW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_SAVE_PARMSW {
     fn default() -> Self {
@@ -15736,14 +15070,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_WINDOW_PARMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_WINDOW_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_WINDOW_PARMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_WINDOW_PARMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_WINDOW_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15771,14 +15097,6 @@ unsafe impl ::windows::core::Abi for MCI_OVLY_WINDOW_PARMSW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCI_OVLY_WINDOW_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_OVLY_WINDOW_PARMSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCI_OVLY_WINDOW_PARMSW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCI_OVLY_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15800,12 +15118,6 @@ impl ::core::clone::Clone for MCI_PLAY_PARMS {
 unsafe impl ::windows::core::Abi for MCI_PLAY_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_PLAY_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_PLAY_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_PLAY_PARMS {}
 impl ::core::default::Default for MCI_PLAY_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15827,12 +15139,6 @@ impl ::core::clone::Clone for MCI_RECORD_PARMS {
 unsafe impl ::windows::core::Abi for MCI_RECORD_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_RECORD_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_RECORD_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_RECORD_PARMS {}
 impl ::core::default::Default for MCI_RECORD_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15853,12 +15159,6 @@ impl ::core::clone::Clone for MCI_SAVE_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_SAVE_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SAVE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SAVE_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SAVE_PARMSA {}
 impl ::core::default::Default for MCI_SAVE_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15879,12 +15179,6 @@ impl ::core::clone::Clone for MCI_SAVE_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_SAVE_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SAVE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SAVE_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SAVE_PARMSW {}
 impl ::core::default::Default for MCI_SAVE_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15905,12 +15199,6 @@ impl ::core::clone::Clone for MCI_SEEK_PARMS {
 unsafe impl ::windows::core::Abi for MCI_SEEK_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SEEK_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SEEK_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SEEK_PARMS {}
 impl ::core::default::Default for MCI_SEEK_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15937,12 +15225,6 @@ impl ::core::clone::Clone for MCI_SEQ_SET_PARMS {
 unsafe impl ::windows::core::Abi for MCI_SEQ_SET_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SEQ_SET_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SEQ_SET_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SEQ_SET_PARMS {}
 impl ::core::default::Default for MCI_SEQ_SET_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15964,12 +15246,6 @@ impl ::core::clone::Clone for MCI_SET_PARMS {
 unsafe impl ::windows::core::Abi for MCI_SET_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SET_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SET_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SET_PARMS {}
 impl ::core::default::Default for MCI_SET_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15992,12 +15268,6 @@ impl ::core::clone::Clone for MCI_STATUS_PARMS {
 unsafe impl ::windows::core::Abi for MCI_STATUS_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_STATUS_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_STATUS_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_STATUS_PARMS {}
 impl ::core::default::Default for MCI_STATUS_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16021,12 +15291,6 @@ impl ::core::clone::Clone for MCI_SYSINFO_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_SYSINFO_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SYSINFO_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SYSINFO_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SYSINFO_PARMSA {}
 impl ::core::default::Default for MCI_SYSINFO_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16050,12 +15314,6 @@ impl ::core::clone::Clone for MCI_SYSINFO_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_SYSINFO_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_SYSINFO_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_SYSINFO_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_SYSINFO_PARMSW {}
 impl ::core::default::Default for MCI_SYSINFO_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16076,12 +15334,6 @@ impl ::core::clone::Clone for MCI_VD_ESCAPE_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_VD_ESCAPE_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_VD_ESCAPE_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_VD_ESCAPE_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_VD_ESCAPE_PARMSA {}
 impl ::core::default::Default for MCI_VD_ESCAPE_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16102,12 +15354,6 @@ impl ::core::clone::Clone for MCI_VD_ESCAPE_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_VD_ESCAPE_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_VD_ESCAPE_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_VD_ESCAPE_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_VD_ESCAPE_PARMSW {}
 impl ::core::default::Default for MCI_VD_ESCAPE_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16130,12 +15376,6 @@ impl ::core::clone::Clone for MCI_VD_PLAY_PARMS {
 unsafe impl ::windows::core::Abi for MCI_VD_PLAY_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_VD_PLAY_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_VD_PLAY_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_VD_PLAY_PARMS {}
 impl ::core::default::Default for MCI_VD_PLAY_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16156,12 +15396,6 @@ impl ::core::clone::Clone for MCI_VD_STEP_PARMS {
 unsafe impl ::windows::core::Abi for MCI_VD_STEP_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_VD_STEP_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_VD_STEP_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_VD_STEP_PARMS {}
 impl ::core::default::Default for MCI_VD_STEP_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16183,12 +15417,6 @@ impl ::core::clone::Clone for MCI_WAVE_DELETE_PARMS {
 unsafe impl ::windows::core::Abi for MCI_WAVE_DELETE_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_WAVE_DELETE_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_WAVE_DELETE_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_WAVE_DELETE_PARMS {}
 impl ::core::default::Default for MCI_WAVE_DELETE_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16213,12 +15441,6 @@ impl ::core::clone::Clone for MCI_WAVE_OPEN_PARMSA {
 unsafe impl ::windows::core::Abi for MCI_WAVE_OPEN_PARMSA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_WAVE_OPEN_PARMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_WAVE_OPEN_PARMSA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_WAVE_OPEN_PARMSA {}
 impl ::core::default::Default for MCI_WAVE_OPEN_PARMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16243,12 +15465,6 @@ impl ::core::clone::Clone for MCI_WAVE_OPEN_PARMSW {
 unsafe impl ::windows::core::Abi for MCI_WAVE_OPEN_PARMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_WAVE_OPEN_PARMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_WAVE_OPEN_PARMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_WAVE_OPEN_PARMSW {}
 impl ::core::default::Default for MCI_WAVE_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16282,12 +15498,6 @@ impl ::core::clone::Clone for MCI_WAVE_SET_PARMS {
 unsafe impl ::windows::core::Abi for MCI_WAVE_SET_PARMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCI_WAVE_SET_PARMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCI_WAVE_SET_PARMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCI_WAVE_SET_PARMS {}
 impl ::core::default::Default for MCI_WAVE_SET_PARMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16313,14 +15523,6 @@ unsafe impl ::windows::core::Abi for MEDIASPACEADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for MEDIASPACEADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEDIASPACEADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for MEDIASPACEADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for MEDIASPACEADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16341,12 +15543,6 @@ impl ::core::clone::Clone for MIDIOPENSTRMID {
 unsafe impl ::windows::core::Abi for MIDIOPENSTRMID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIDIOPENSTRMID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDIOPENSTRMID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIDIOPENSTRMID {}
 impl ::core::default::Default for MIDIOPENSTRMID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16375,14 +15571,6 @@ unsafe impl ::windows::core::Abi for MIXEROPENDESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for MIXEROPENDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIXEROPENDESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for MIXEROPENDESC {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for MIXEROPENDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16406,12 +15594,6 @@ impl ::core::clone::Clone for MMCKINFO {
 unsafe impl ::windows::core::Abi for MMCKINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMCKINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMCKINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMCKINFO {}
 impl ::core::default::Default for MMCKINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16451,14 +15633,6 @@ unsafe impl ::windows::core::Abi for MMIOINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MMIOINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMIOINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MMIOINFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MMIOINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16485,14 +15659,6 @@ unsafe impl ::windows::core::Abi for MSAUDIO1WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for MSAUDIO1WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSAUDIO1WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for MSAUDIO1WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for MSAUDIO1WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16518,14 +15684,6 @@ unsafe impl ::windows::core::Abi for NMS_VBXADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for NMS_VBXADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMS_VBXADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for NMS_VBXADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for NMS_VBXADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16549,14 +15707,6 @@ impl ::core::clone::Clone for OLIADPCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for OLIADPCMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for OLIADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLIADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for OLIADPCMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for OLIADPCMWAVEFORMAT {
     fn default() -> Self {
@@ -16582,14 +15732,6 @@ unsafe impl ::windows::core::Abi for OLICELPWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for OLICELPWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLICELPWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for OLICELPWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for OLICELPWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16613,14 +15755,6 @@ impl ::core::clone::Clone for OLIGSMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for OLIGSMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for OLIGSMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLIGSMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for OLIGSMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for OLIGSMWAVEFORMAT {
     fn default() -> Self {
@@ -16646,14 +15780,6 @@ unsafe impl ::windows::core::Abi for OLIOPRWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for OLIOPRWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLIOPRWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for OLIOPRWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for OLIOPRWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16677,14 +15803,6 @@ impl ::core::clone::Clone for OLISBCWAVEFORMAT {
 unsafe impl ::windows::core::Abi for OLISBCWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for OLISBCWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLISBCWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for OLISBCWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for OLISBCWAVEFORMAT {
     fn default() -> Self {
@@ -16711,14 +15829,6 @@ unsafe impl ::windows::core::Abi for SIERRAADPCMWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for SIERRAADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIERRAADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for SIERRAADPCMWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for SIERRAADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16744,14 +15854,6 @@ unsafe impl ::windows::core::Abi for SONARCWAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for SONARCWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SONARCWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for SONARCWAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for SONARCWAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16776,12 +15878,6 @@ impl ::core::clone::Clone for TIMEREVENT {
 unsafe impl ::windows::core::Abi for TIMEREVENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TIMEREVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMEREVENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TIMEREVENT {}
 impl ::core::default::Default for TIMEREVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16808,14 +15904,6 @@ impl ::core::clone::Clone for TRUESPEECHWAVEFORMAT {
 unsafe impl ::windows::core::Abi for TRUESPEECHWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for TRUESPEECHWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUESPEECHWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for TRUESPEECHWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for TRUESPEECHWAVEFORMAT {
     fn default() -> Self {
@@ -16849,7 +15937,7 @@ unsafe impl ::windows::core::Abi for VIDEOHDR {
 }
 impl ::core::cmp::PartialEq for VIDEOHDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIDEOHDR>()) == 0 }
+        self.lpData == other.lpData && self.dwBufferLength == other.dwBufferLength && self.dwBytesUsed == other.dwBytesUsed && self.dwTimeCaptured == other.dwTimeCaptured && self.dwUser == other.dwUser && self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for VIDEOHDR {}
@@ -16882,14 +15970,6 @@ unsafe impl ::windows::core::Abi for WAVEOPENDESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for WAVEOPENDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAVEOPENDESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for WAVEOPENDESC {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for WAVEOPENDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16916,14 +15996,6 @@ impl ::core::clone::Clone for WMAUDIO2WAVEFORMAT {
 unsafe impl ::windows::core::Abi for WMAUDIO2WAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for WMAUDIO2WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMAUDIO2WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for WMAUDIO2WAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for WMAUDIO2WAVEFORMAT {
     fn default() -> Self {
@@ -16955,14 +16027,6 @@ unsafe impl ::windows::core::Abi for WMAUDIO3WAVEFORMAT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for WMAUDIO3WAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMAUDIO3WAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for WMAUDIO3WAVEFORMAT {}
-#[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for WMAUDIO3WAVEFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16986,14 +16050,6 @@ impl ::core::clone::Clone for YAMAHA_ADPCMWAVEFORMAT {
 unsafe impl ::windows::core::Abi for YAMAHA_ADPCMWAVEFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::PartialEq for YAMAHA_ADPCMWAVEFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<YAMAHA_ADPCMWAVEFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl ::core::cmp::Eq for YAMAHA_ADPCMWAVEFORMAT {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl ::core::default::Default for YAMAHA_ADPCMWAVEFORMAT {
     fn default() -> Self {
@@ -17033,7 +16089,7 @@ unsafe impl ::windows::core::Abi for s_RIFFWAVE_inst {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for s_RIFFWAVE_inst {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<s_RIFFWAVE_inst>()) == 0 }
+        self.bUnshiftedNote == other.bUnshiftedNote && self.chFineTune == other.chFineTune && self.chGain == other.chGain && self.bLowNote == other.bLowNote && self.bHighNote == other.bHighNote && self.bLowVelocity == other.bLowVelocity && self.bHighVelocity == other.bHighVelocity
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -14886,7 +14886,7 @@ unsafe impl ::windows::core::Abi for SPAUDIOBUFFERINFO {
 }
 impl ::core::cmp::PartialEq for SPAUDIOBUFFERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPAUDIOBUFFERINFO>()) == 0 }
+        self.ulMsMinNotification == other.ulMsMinNotification && self.ulMsBufferSize == other.ulMsBufferSize && self.ulMsEventBias == other.ulMsEventBias
     }
 }
 impl ::core::cmp::Eq for SPAUDIOBUFFERINFO {}
@@ -14922,7 +14922,7 @@ unsafe impl ::windows::core::Abi for SPAUDIOSTATUS {
 }
 impl ::core::cmp::PartialEq for SPAUDIOSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPAUDIOSTATUS>()) == 0 }
+        self.cbFreeBuffSpace == other.cbFreeBuffSpace && self.cbNonBlockingIO == other.cbNonBlockingIO && self.State == other.State && self.CurSeekPos == other.CurSeekPos && self.CurDevicePos == other.CurDevicePos && self.dwAudioLevel == other.dwAudioLevel && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for SPAUDIOSTATUS {}
@@ -14952,7 +14952,7 @@ unsafe impl ::windows::core::Abi for SPBINARYGRAMMAR {
 }
 impl ::core::cmp::PartialEq for SPBINARYGRAMMAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPBINARYGRAMMAR>()) == 0 }
+        self.ulTotalSerializedSize == other.ulTotalSerializedSize
     }
 }
 impl ::core::cmp::Eq for SPBINARYGRAMMAR {}
@@ -14983,7 +14983,7 @@ unsafe impl ::windows::core::Abi for SPDISPLAYPHRASE {
 }
 impl ::core::cmp::PartialEq for SPDISPLAYPHRASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPDISPLAYPHRASE>()) == 0 }
+        self.ulNumTokens == other.ulNumTokens && self.pTokens == other.pTokens
     }
 }
 impl ::core::cmp::Eq for SPDISPLAYPHRASE {}
@@ -15015,7 +15015,7 @@ unsafe impl ::windows::core::Abi for SPDISPLAYTOKEN {
 }
 impl ::core::cmp::PartialEq for SPDISPLAYTOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPDISPLAYTOKEN>()) == 0 }
+        self.pszLexical == other.pszLexical && self.pszDisplay == other.pszDisplay && self.bDisplayAttributes == other.bDisplayAttributes
     }
 }
 impl ::core::cmp::Eq for SPDISPLAYTOKEN {}
@@ -15055,7 +15055,7 @@ unsafe impl ::windows::core::Abi for SPEVENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SPEVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPEVENT>()) == 0 }
+        self._bitfield == other._bitfield && self.ulStreamNum == other.ulStreamNum && self.ullAudioStreamOffset == other.ullAudioStreamOffset && self.wParam == other.wParam && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15098,7 +15098,7 @@ unsafe impl ::windows::core::Abi for SPEVENTEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SPEVENTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPEVENTEX>()) == 0 }
+        self._bitfield == other._bitfield && self.ulStreamNum == other.ulStreamNum && self.ullAudioStreamOffset == other.ullAudioStreamOffset && self.wParam == other.wParam && self.lParam == other.lParam && self.ullAudioTimeOffset == other.ullAudioTimeOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15132,7 +15132,7 @@ unsafe impl ::windows::core::Abi for SPEVENTSOURCEINFO {
 }
 impl ::core::cmp::PartialEq for SPEVENTSOURCEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPEVENTSOURCEINFO>()) == 0 }
+        self.ullEventInterest == other.ullEventInterest && self.ullQueuedInterest == other.ullQueuedInterest && self.ulCount == other.ulCount
     }
 }
 impl ::core::cmp::Eq for SPEVENTSOURCEINFO {}
@@ -15163,7 +15163,7 @@ unsafe impl ::windows::core::Abi for SPNORMALIZATIONLIST {
 }
 impl ::core::cmp::PartialEq for SPNORMALIZATIONLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPNORMALIZATIONLIST>()) == 0 }
+        self.ulSize == other.ulSize && self.ppszzNormalizedList == other.ppszzNormalizedList
     }
 }
 impl ::core::cmp::Eq for SPNORMALIZATIONLIST {}
@@ -15201,7 +15201,7 @@ unsafe impl ::windows::core::Abi for SPPHRASE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for SPPHRASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASE>()) == 0 }
+        self.Base == other.Base && self.pSML == other.pSML && self.pSemanticErrorInfo == other.pSemanticErrorInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -15261,7 +15261,7 @@ unsafe impl ::windows::core::Abi for SPPHRASEELEMENT {
 }
 impl ::core::cmp::PartialEq for SPPHRASEELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASEELEMENT>()) == 0 }
+        self.ulAudioTimeOffset == other.ulAudioTimeOffset && self.ulAudioSizeTime == other.ulAudioSizeTime && self.ulAudioStreamOffset == other.ulAudioStreamOffset && self.ulAudioSizeBytes == other.ulAudioSizeBytes && self.ulRetainedStreamOffset == other.ulRetainedStreamOffset && self.ulRetainedSizeBytes == other.ulRetainedSizeBytes && self.pszDisplayText == other.pszDisplayText && self.pszLexicalForm == other.pszLexicalForm && self.pszPronunciation == other.pszPronunciation && self.bDisplayAttributes == other.bDisplayAttributes && self.RequiredConfidence == other.RequiredConfidence && self.ActualConfidence == other.ActualConfidence && self.Reserved == other.Reserved && self.SREngineConfidence == other.SREngineConfidence
     }
 }
 impl ::core::cmp::Eq for SPPHRASEELEMENT {}
@@ -15307,14 +15307,6 @@ unsafe impl ::windows::core::Abi for SPPHRASEPROPERTY {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for SPPHRASEPROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        self.pszName == other.pszName && self.Anonymous == other.Anonymous && self.pszValue == other.pszValue && self.vValue == other.vValue && self.ulFirstElement == other.ulFirstElement && self.ulCountOfElements == other.ulCountOfElements && self.pNextSibling == other.pNextSibling && self.pFirstChild == other.pFirstChild && self.SREngineConfidence == other.SREngineConfidence && self.Confidence == other.Confidence
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for SPPHRASEPROPERTY {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for SPPHRASEPROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15339,14 +15331,6 @@ impl ::core::clone::Clone for SPPHRASEPROPERTY_0 {
 unsafe impl ::windows::core::Abi for SPPHRASEPROPERTY_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for SPPHRASEPROPERTY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASEPROPERTY_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for SPPHRASEPROPERTY_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for SPPHRASEPROPERTY_0 {
     fn default() -> Self {
@@ -15382,7 +15366,7 @@ unsafe impl ::windows::core::Abi for SPPHRASEPROPERTY_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for SPPHRASEPROPERTY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASEPROPERTY_0_0>()) == 0 }
+        self.bType == other.bType && self.bReserved == other.bReserved && self.usArrayIndex == other.usArrayIndex
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -15417,7 +15401,7 @@ unsafe impl ::windows::core::Abi for SPPHRASEREPLACEMENT {
 }
 impl ::core::cmp::PartialEq for SPPHRASEREPLACEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASEREPLACEMENT>()) == 0 }
+        self.bDisplayAttributes == other.bDisplayAttributes && self.pszReplacementText == other.pszReplacementText && self.ulFirstElement == other.ulFirstElement && self.ulCountOfElements == other.ulCountOfElements
     }
 }
 impl ::core::cmp::Eq for SPPHRASEREPLACEMENT {}
@@ -15454,7 +15438,7 @@ unsafe impl ::windows::core::Abi for SPPHRASERULE {
 }
 impl ::core::cmp::PartialEq for SPPHRASERULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASERULE>()) == 0 }
+        self.pszName == other.pszName && self.ulId == other.ulId && self.ulFirstElement == other.ulFirstElement && self.ulCountOfElements == other.ulCountOfElements && self.pNextSibling == other.pNextSibling && self.pFirstChild == other.pFirstChild && self.SREngineConfidence == other.SREngineConfidence && self.Confidence == other.Confidence
     }
 }
 impl ::core::cmp::Eq for SPPHRASERULE {}
@@ -15524,7 +15508,7 @@ unsafe impl ::windows::core::Abi for SPPHRASE_50 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for SPPHRASE_50 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPPHRASE_50>()) == 0 }
+        self.cbSize == other.cbSize && self.LangID == other.LangID && self.wHomophoneGroupId == other.wHomophoneGroupId && self.ullGrammarID == other.ullGrammarID && self.ftStartTime == other.ftStartTime && self.ullAudioStreamPosition == other.ullAudioStreamPosition && self.ulAudioSizeBytes == other.ulAudioSizeBytes && self.ulRetainedSizeBytes == other.ulRetainedSizeBytes && self.ulAudioSizeTime == other.ulAudioSizeTime && self.Rule == other.Rule && self.pProperties == other.pProperties && self.pElements == other.pElements && self.cReplacements == other.cReplacements && self.pReplacements == other.pReplacements && self.SREngineID == other.SREngineID && self.ulSREnginePrivateDataSize == other.ulSREnginePrivateDataSize && self.pSREnginePrivateData == other.pSREnginePrivateData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -15555,14 +15539,6 @@ unsafe impl ::windows::core::Abi for SPPROPERTYINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for SPPROPERTYINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.pszName == other.pszName && self.ulId == other.ulId && self.pszValue == other.pszValue && self.vValue == other.vValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for SPPROPERTYINFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for SPPROPERTYINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15592,7 +15568,7 @@ unsafe impl ::windows::core::Abi for SPRECOCONTEXTSTATUS {
 }
 impl ::core::cmp::PartialEq for SPRECOCONTEXTSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPRECOCONTEXTSTATUS>()) == 0 }
+        self.eInterference == other.eInterference && self.szRequestTypeOfUI == other.szRequestTypeOfUI && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for SPRECOCONTEXTSTATUS {}
@@ -15629,7 +15605,7 @@ unsafe impl ::windows::core::Abi for SPRECOGNIZERSTATUS {
 }
 impl ::core::cmp::PartialEq for SPRECOGNIZERSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPRECOGNIZERSTATUS>()) == 0 }
+        self.AudioStatus == other.AudioStatus && self.ullRecognitionStreamPos == other.ullRecognitionStreamPos && self.ulStreamNumber == other.ulStreamNumber && self.ulNumActive == other.ulNumActive && self.clsidEngine == other.clsidEngine && self.cLangIDs == other.cLangIDs && self.aLangID == other.aLangID && self.ullRecognitionStreamTime == other.ullRecognitionStreamTime
     }
 }
 impl ::core::cmp::Eq for SPRECOGNIZERSTATUS {}
@@ -15668,7 +15644,7 @@ unsafe impl ::windows::core::Abi for SPRECORESULTTIMES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SPRECORESULTTIMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPRECORESULTTIMES>()) == 0 }
+        self.ftStreamTime == other.ftStreamTime && self.ullLength == other.ullLength && self.dwTickCount == other.dwTickCount && self.ullStart == other.ullStart
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15702,7 +15678,7 @@ unsafe impl ::windows::core::Abi for SPRULE {
 }
 impl ::core::cmp::PartialEq for SPRULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPRULE>()) == 0 }
+        self.pszRuleName == other.pszRuleName && self.ulRuleId == other.ulRuleId && self.dwAttributes == other.dwAttributes
     }
 }
 impl ::core::cmp::Eq for SPRULE {}
@@ -15736,7 +15712,7 @@ unsafe impl ::windows::core::Abi for SPSEMANTICERRORINFO {
 }
 impl ::core::cmp::PartialEq for SPSEMANTICERRORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSEMANTICERRORINFO>()) == 0 }
+        self.ulLineNumber == other.ulLineNumber && self.pszScriptLine == other.pszScriptLine && self.pszSource == other.pszSource && self.pszDescription == other.pszDescription && self.hrResultCode == other.hrResultCode
     }
 }
 impl ::core::cmp::Eq for SPSEMANTICERRORINFO {}
@@ -15770,7 +15746,7 @@ unsafe impl ::windows::core::Abi for SPSERIALIZEDEVENT {
 }
 impl ::core::cmp::PartialEq for SPSERIALIZEDEVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSERIALIZEDEVENT>()) == 0 }
+        self._bitfield == other._bitfield && self.ulStreamNum == other.ulStreamNum && self.ullAudioStreamOffset == other.ullAudioStreamOffset && self.SerializedwParam == other.SerializedwParam && self.SerializedlParam == other.SerializedlParam
     }
 }
 impl ::core::cmp::Eq for SPSERIALIZEDEVENT {}
@@ -15804,7 +15780,7 @@ unsafe impl ::windows::core::Abi for SPSERIALIZEDEVENT64 {
 }
 impl ::core::cmp::PartialEq for SPSERIALIZEDEVENT64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSERIALIZEDEVENT64>()) == 0 }
+        self._bitfield == other._bitfield && self.ulStreamNum == other.ulStreamNum && self.ullAudioStreamOffset == other.ullAudioStreamOffset && self.SerializedwParam == other.SerializedwParam && self.SerializedlParam == other.SerializedlParam
     }
 }
 impl ::core::cmp::Eq for SPSERIALIZEDEVENT64 {}
@@ -15834,7 +15810,7 @@ unsafe impl ::windows::core::Abi for SPSERIALIZEDPHRASE {
 }
 impl ::core::cmp::PartialEq for SPSERIALIZEDPHRASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSERIALIZEDPHRASE>()) == 0 }
+        self.ulSerializedSize == other.ulSerializedSize
     }
 }
 impl ::core::cmp::Eq for SPSERIALIZEDPHRASE {}
@@ -15864,7 +15840,7 @@ unsafe impl ::windows::core::Abi for SPSERIALIZEDRESULT {
 }
 impl ::core::cmp::PartialEq for SPSERIALIZEDRESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSERIALIZEDRESULT>()) == 0 }
+        self.ulSerializedSize == other.ulSerializedSize
     }
 }
 impl ::core::cmp::Eq for SPSERIALIZEDRESULT {}
@@ -15898,7 +15874,7 @@ unsafe impl ::windows::core::Abi for SPSHORTCUTPAIR {
 }
 impl ::core::cmp::PartialEq for SPSHORTCUTPAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSHORTCUTPAIR>()) == 0 }
+        self.pNextSHORTCUTPAIR == other.pNextSHORTCUTPAIR && self.LangID == other.LangID && self.shType == other.shType && self.pszDisplay == other.pszDisplay && self.pszSpoken == other.pszSpoken
     }
 }
 impl ::core::cmp::Eq for SPSHORTCUTPAIR {}
@@ -15930,7 +15906,7 @@ unsafe impl ::windows::core::Abi for SPSHORTCUTPAIRLIST {
 }
 impl ::core::cmp::PartialEq for SPSHORTCUTPAIRLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSHORTCUTPAIRLIST>()) == 0 }
+        self.ulSize == other.ulSize && self.pvBuffer == other.pvBuffer && self.pFirstShortcutPair == other.pFirstShortcutPair
     }
 }
 impl ::core::cmp::Eq for SPSHORTCUTPAIRLIST {}
@@ -15960,7 +15936,7 @@ unsafe impl ::windows::core::Abi for SPSTATEHANDLE__ {
 }
 impl ::core::cmp::PartialEq for SPSTATEHANDLE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPSTATEHANDLE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for SPSTATEHANDLE__ {}
@@ -15993,7 +15969,7 @@ unsafe impl ::windows::core::Abi for SPTEXTSELECTIONINFO {
 }
 impl ::core::cmp::PartialEq for SPTEXTSELECTIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPTEXTSELECTIONINFO>()) == 0 }
+        self.ulStartActiveOffset == other.ulStartActiveOffset && self.cchActiveChars == other.cchActiveChars && self.ulStartSelection == other.ulStartSelection && self.cchSelection == other.cchSelection
     }
 }
 impl ::core::cmp::Eq for SPTEXTSELECTIONINFO {}
@@ -16025,7 +16001,7 @@ unsafe impl ::windows::core::Abi for SPVCONTEXT {
 }
 impl ::core::cmp::PartialEq for SPVCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPVCONTEXT>()) == 0 }
+        self.pCategory == other.pCategory && self.pBefore == other.pBefore && self.pAfter == other.pAfter
     }
 }
 impl ::core::cmp::Eq for SPVCONTEXT {}
@@ -16081,7 +16057,7 @@ unsafe impl ::windows::core::Abi for SPVOICESTATUS {
 }
 impl ::core::cmp::PartialEq for SPVOICESTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPVOICESTATUS>()) == 0 }
+        self.ulCurrentStream == other.ulCurrentStream && self.ulLastStreamQueued == other.ulLastStreamQueued && self.hrLastResult == other.hrLastResult && self.dwRunningState == other.dwRunningState && self.ulInputWordPos == other.ulInputWordPos && self.ulInputWordLen == other.ulInputWordLen && self.ulInputSentPos == other.ulInputSentPos && self.ulInputSentLen == other.ulInputSentLen && self.lBookmarkId == other.lBookmarkId && self.PhonemeId == other.PhonemeId && self.VisemeId == other.VisemeId && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for SPVOICESTATUS {}
@@ -16112,7 +16088,7 @@ unsafe impl ::windows::core::Abi for SPVPITCH {
 }
 impl ::core::cmp::PartialEq for SPVPITCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPVPITCH>()) == 0 }
+        self.MiddleAdj == other.MiddleAdj && self.RangeAdj == other.RangeAdj
     }
 }
 impl ::core::cmp::Eq for SPVPITCH {}
@@ -16152,7 +16128,7 @@ unsafe impl ::windows::core::Abi for SPVSTATE {
 }
 impl ::core::cmp::PartialEq for SPVSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPVSTATE>()) == 0 }
+        self.eAction == other.eAction && self.LangID == other.LangID && self.wReserved == other.wReserved && self.EmphAdj == other.EmphAdj && self.RateAdj == other.RateAdj && self.Volume == other.Volume && self.PitchAdj == other.PitchAdj && self.SilenceMSecs == other.SilenceMSecs && self.pPhoneIds == other.pPhoneIds && self.ePartOfSpeech == other.ePartOfSpeech && self.Context == other.Context
     }
 }
 impl ::core::cmp::Eq for SPVSTATE {}
@@ -16187,7 +16163,7 @@ unsafe impl ::windows::core::Abi for SPWORD {
 }
 impl ::core::cmp::PartialEq for SPWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPWORD>()) == 0 }
+        self.pNextWord == other.pNextWord && self.LangID == other.LangID && self.wReserved == other.wReserved && self.eWordType == other.eWordType && self.pszWord == other.pszWord && self.pFirstWordPronunciation == other.pFirstWordPronunciation
     }
 }
 impl ::core::cmp::Eq for SPWORD {}
@@ -16219,7 +16195,7 @@ unsafe impl ::windows::core::Abi for SPWORDLIST {
 }
 impl ::core::cmp::PartialEq for SPWORDLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPWORDLIST>()) == 0 }
+        self.ulSize == other.ulSize && self.pvBuffer == other.pvBuffer && self.pFirstWord == other.pFirstWord
     }
 }
 impl ::core::cmp::Eq for SPWORDLIST {}
@@ -16254,7 +16230,7 @@ unsafe impl ::windows::core::Abi for SPWORDPRONUNCIATION {
 }
 impl ::core::cmp::PartialEq for SPWORDPRONUNCIATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPWORDPRONUNCIATION>()) == 0 }
+        self.pNextWordPronunciation == other.pNextWordPronunciation && self.eLexiconType == other.eLexiconType && self.LangID == other.LangID && self.wPronunciationFlags == other.wPronunciationFlags && self.ePartOfSpeech == other.ePartOfSpeech && self.szPronunciation == other.szPronunciation
     }
 }
 impl ::core::cmp::Eq for SPWORDPRONUNCIATION {}
@@ -16286,7 +16262,7 @@ unsafe impl ::windows::core::Abi for SPWORDPRONUNCIATIONLIST {
 }
 impl ::core::cmp::PartialEq for SPWORDPRONUNCIATIONLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPWORDPRONUNCIATIONLIST>()) == 0 }
+        self.ulSize == other.ulSize && self.pvBuffer == other.pvBuffer && self.pFirstWordPronunciation == other.pFirstWordPronunciation
     }
 }
 impl ::core::cmp::Eq for SPWORDPRONUNCIATIONLIST {}

--- a/crates/libs/windows/src/Windows/Win32/Media/Streaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Streaming/mod.rs
@@ -76,7 +76,7 @@ unsafe impl ::windows::core::Abi for CapturedMetadataExposureCompensation {
 }
 impl ::core::cmp::PartialEq for CapturedMetadataExposureCompensation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CapturedMetadataExposureCompensation>()) == 0 }
+        self.Flags == other.Flags && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CapturedMetadataExposureCompensation {}
@@ -107,7 +107,7 @@ unsafe impl ::windows::core::Abi for CapturedMetadataISOGains {
 }
 impl ::core::cmp::PartialEq for CapturedMetadataISOGains {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CapturedMetadataISOGains>()) == 0 }
+        self.AnalogGain == other.AnalogGain && self.DigitalGain == other.DigitalGain
     }
 }
 impl ::core::cmp::Eq for CapturedMetadataISOGains {}
@@ -139,7 +139,7 @@ unsafe impl ::windows::core::Abi for CapturedMetadataWhiteBalanceGains {
 }
 impl ::core::cmp::PartialEq for CapturedMetadataWhiteBalanceGains {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CapturedMetadataWhiteBalanceGains>()) == 0 }
+        self.R == other.R && self.G == other.G && self.B == other.B
     }
 }
 impl ::core::cmp::Eq for CapturedMetadataWhiteBalanceGains {}
@@ -172,7 +172,7 @@ unsafe impl ::windows::core::Abi for FaceCharacterization {
 }
 impl ::core::cmp::PartialEq for FaceCharacterization {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FaceCharacterization>()) == 0 }
+        self.BlinkScoreLeft == other.BlinkScoreLeft && self.BlinkScoreRight == other.BlinkScoreRight && self.FacialExpression == other.FacialExpression && self.FacialExpressionScore == other.FacialExpressionScore
     }
 }
 impl ::core::cmp::Eq for FaceCharacterization {}
@@ -203,7 +203,7 @@ unsafe impl ::windows::core::Abi for FaceCharacterizationBlobHeader {
 }
 impl ::core::cmp::PartialEq for FaceCharacterizationBlobHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FaceCharacterizationBlobHeader>()) == 0 }
+        self.Size == other.Size && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for FaceCharacterizationBlobHeader {}
@@ -240,7 +240,7 @@ unsafe impl ::windows::core::Abi for FaceRectInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FaceRectInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FaceRectInfo>()) == 0 }
+        self.Region == other.Region && self.confidenceLevel == other.confidenceLevel
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -273,7 +273,7 @@ unsafe impl ::windows::core::Abi for FaceRectInfoBlobHeader {
 }
 impl ::core::cmp::PartialEq for FaceRectInfoBlobHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FaceRectInfoBlobHeader>()) == 0 }
+        self.Size == other.Size && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for FaceRectInfoBlobHeader {}
@@ -304,7 +304,7 @@ unsafe impl ::windows::core::Abi for HistogramBlobHeader {
 }
 impl ::core::cmp::PartialEq for HistogramBlobHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HistogramBlobHeader>()) == 0 }
+        self.Size == other.Size && self.Histograms == other.Histograms
     }
 }
 impl ::core::cmp::Eq for HistogramBlobHeader {}
@@ -336,7 +336,7 @@ unsafe impl ::windows::core::Abi for HistogramDataHeader {
 }
 impl ::core::cmp::PartialEq for HistogramDataHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HistogramDataHeader>()) == 0 }
+        self.Size == other.Size && self.ChannelMask == other.ChannelMask && self.Linear == other.Linear
     }
 }
 impl ::core::cmp::Eq for HistogramDataHeader {}
@@ -374,7 +374,7 @@ unsafe impl ::windows::core::Abi for HistogramGrid {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HistogramGrid {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HistogramGrid>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Region == other.Region
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -416,7 +416,7 @@ unsafe impl ::windows::core::Abi for HistogramHeader {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HistogramHeader {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HistogramHeader>()) == 0 }
+        self.Size == other.Size && self.Bins == other.Bins && self.FourCC == other.FourCC && self.ChannelMasks == other.ChannelMasks && self.Grid == other.Grid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -450,7 +450,7 @@ unsafe impl ::windows::core::Abi for MetadataTimeStamps {
 }
 impl ::core::cmp::PartialEq for MetadataTimeStamps {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MetadataTimeStamps>()) == 0 }
+        self.Flags == other.Flags && self.Device == other.Device && self.Presentation == other.Presentation
     }
 }
 impl ::core::cmp::Eq for MetadataTimeStamps {}

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
@@ -10712,7 +10712,7 @@ unsafe impl ::windows::core::Abi for AM_WMT_EVENT_DATA {
 }
 impl ::core::cmp::PartialEq for AM_WMT_EVENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AM_WMT_EVENT_DATA>()) == 0 }
+        self.hrStatus == other.hrStatus && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for AM_WMT_EVENT_DATA {}
@@ -10744,7 +10744,7 @@ unsafe impl ::windows::core::Abi for DRM_COPY_OPL {
 }
 impl ::core::cmp::PartialEq for DRM_COPY_OPL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_COPY_OPL>()) == 0 }
+        self.wMinimumCopyLevel == other.wMinimumCopyLevel && self.oplIdIncludes == other.oplIdIncludes && self.oplIdExcludes == other.oplIdExcludes
     }
 }
 impl ::core::cmp::Eq for DRM_COPY_OPL {}
@@ -10778,7 +10778,7 @@ unsafe impl ::windows::core::Abi for DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {
 }
 impl ::core::cmp::PartialEq for DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS>()) == 0 }
+        self.wCompressedDigitalVideo == other.wCompressedDigitalVideo && self.wUncompressedDigitalVideo == other.wUncompressedDigitalVideo && self.wAnalogVideo == other.wAnalogVideo && self.wCompressedDigitalAudio == other.wCompressedDigitalAudio && self.wUncompressedDigitalAudio == other.wUncompressedDigitalAudio
     }
 }
 impl ::core::cmp::Eq for DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {}
@@ -10809,7 +10809,7 @@ unsafe impl ::windows::core::Abi for DRM_OPL_OUTPUT_IDS {
 }
 impl ::core::cmp::PartialEq for DRM_OPL_OUTPUT_IDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_OPL_OUTPUT_IDS>()) == 0 }
+        self.cIds == other.cIds && self.rgIds == other.rgIds
     }
 }
 impl ::core::cmp::Eq for DRM_OPL_OUTPUT_IDS {}
@@ -10840,7 +10840,7 @@ unsafe impl ::windows::core::Abi for DRM_OUTPUT_PROTECTION {
 }
 impl ::core::cmp::PartialEq for DRM_OUTPUT_PROTECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_OUTPUT_PROTECTION>()) == 0 }
+        self.guidId == other.guidId && self.bConfigData == other.bConfigData
     }
 }
 impl ::core::cmp::Eq for DRM_OUTPUT_PROTECTION {}
@@ -10872,7 +10872,7 @@ unsafe impl ::windows::core::Abi for DRM_PLAY_OPL {
 }
 impl ::core::cmp::PartialEq for DRM_PLAY_OPL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_PLAY_OPL>()) == 0 }
+        self.minOPL == other.minOPL && self.oplIdReserved == other.oplIdReserved && self.vopi == other.vopi
     }
 }
 impl ::core::cmp::Eq for DRM_PLAY_OPL {}
@@ -10902,7 +10902,7 @@ unsafe impl ::windows::core::Abi for DRM_VAL16 {
 }
 impl ::core::cmp::PartialEq for DRM_VAL16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_VAL16>()) == 0 }
+        self.val == other.val
     }
 }
 impl ::core::cmp::Eq for DRM_VAL16 {}
@@ -10933,7 +10933,7 @@ unsafe impl ::windows::core::Abi for DRM_VIDEO_OUTPUT_PROTECTION_IDS {
 }
 impl ::core::cmp::PartialEq for DRM_VIDEO_OUTPUT_PROTECTION_IDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRM_VIDEO_OUTPUT_PROTECTION_IDS>()) == 0 }
+        self.cEntries == other.cEntries && self.rgVop == other.rgVop
     }
 }
 impl ::core::cmp::Eq for DRM_VIDEO_OUTPUT_PROTECTION_IDS {}
@@ -10967,7 +10967,7 @@ unsafe impl ::windows::core::Abi for WMDRM_IMPORT_INIT_STRUCT {
 }
 impl ::core::cmp::PartialEq for WMDRM_IMPORT_INIT_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMDRM_IMPORT_INIT_STRUCT>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbEncryptedSessionKeyMessage == other.cbEncryptedSessionKeyMessage && self.pbEncryptedSessionKeyMessage == other.pbEncryptedSessionKeyMessage && self.cbEncryptedKeyMessage == other.cbEncryptedKeyMessage && self.pbEncryptedKeyMessage == other.pbEncryptedKeyMessage
     }
 }
 impl ::core::cmp::Eq for WMDRM_IMPORT_INIT_STRUCT {}
@@ -11009,7 +11009,7 @@ unsafe impl ::windows::core::Abi for WMMPEG2VIDEOINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for WMMPEG2VIDEOINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMMPEG2VIDEOINFO>()) == 0 }
+        self.hdr == other.hdr && self.dwStartTimeCode == other.dwStartTimeCode && self.cbSequenceHeader == other.cbSequenceHeader && self.dwProfile == other.dwProfile && self.dwLevel == other.dwLevel && self.dwFlags == other.dwFlags && self.dwSequenceHeader == other.dwSequenceHeader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11041,7 +11041,7 @@ unsafe impl ::windows::core::Abi for WMSCRIPTFORMAT {
 }
 impl ::core::cmp::PartialEq for WMSCRIPTFORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMSCRIPTFORMAT>()) == 0 }
+        self.scriptType == other.scriptType
     }
 }
 impl ::core::cmp::Eq for WMSCRIPTFORMAT {}
@@ -11104,7 +11104,7 @@ unsafe impl ::windows::core::Abi for WMT_COLORSPACEINFO_EXTENSION_DATA {
 }
 impl ::core::cmp::PartialEq for WMT_COLORSPACEINFO_EXTENSION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_COLORSPACEINFO_EXTENSION_DATA>()) == 0 }
+        self.ucColorPrimaries == other.ucColorPrimaries && self.ucColorTransferChar == other.ucColorTransferChar && self.ucColorMatrixCoef == other.ucColorMatrixCoef
     }
 }
 impl ::core::cmp::Eq for WMT_COLORSPACEINFO_EXTENSION_DATA {}
@@ -11199,12 +11199,6 @@ impl ::core::clone::Clone for WMT_TIMECODE_EXTENSION_DATA {
 unsafe impl ::windows::core::Abi for WMT_TIMECODE_EXTENSION_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMT_TIMECODE_EXTENSION_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_TIMECODE_EXTENSION_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMT_TIMECODE_EXTENSION_DATA {}
 impl ::core::default::Default for WMT_TIMECODE_EXTENSION_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11273,7 +11267,27 @@ unsafe impl ::windows::core::Abi for WMT_VIDEOIMAGE_SAMPLE {
 }
 impl ::core::cmp::PartialEq for WMT_VIDEOIMAGE_SAMPLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_VIDEOIMAGE_SAMPLE>()) == 0 }
+        self.dwMagic == other.dwMagic
+            && self.cbStruct == other.cbStruct
+            && self.dwControlFlags == other.dwControlFlags
+            && self.dwInputFlagsCur == other.dwInputFlagsCur
+            && self.lCurMotionXtoX == other.lCurMotionXtoX
+            && self.lCurMotionYtoX == other.lCurMotionYtoX
+            && self.lCurMotionXoffset == other.lCurMotionXoffset
+            && self.lCurMotionXtoY == other.lCurMotionXtoY
+            && self.lCurMotionYtoY == other.lCurMotionYtoY
+            && self.lCurMotionYoffset == other.lCurMotionYoffset
+            && self.lCurBlendCoef1 == other.lCurBlendCoef1
+            && self.lCurBlendCoef2 == other.lCurBlendCoef2
+            && self.dwInputFlagsPrev == other.dwInputFlagsPrev
+            && self.lPrevMotionXtoX == other.lPrevMotionXtoX
+            && self.lPrevMotionYtoX == other.lPrevMotionYtoX
+            && self.lPrevMotionXoffset == other.lPrevMotionXoffset
+            && self.lPrevMotionXtoY == other.lPrevMotionXtoY
+            && self.lPrevMotionYtoY == other.lPrevMotionYtoY
+            && self.lPrevMotionYoffset == other.lPrevMotionYoffset
+            && self.lPrevBlendCoef1 == other.lPrevBlendCoef1
+            && self.lPrevBlendCoef2 == other.lPrevBlendCoef2
     }
 }
 impl ::core::cmp::Eq for WMT_VIDEOIMAGE_SAMPLE {}
@@ -11363,7 +11377,33 @@ unsafe impl ::windows::core::Abi for WMT_VIDEOIMAGE_SAMPLE2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WMT_VIDEOIMAGE_SAMPLE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_VIDEOIMAGE_SAMPLE2>()) == 0 }
+        self.dwMagic == other.dwMagic
+            && self.dwStructSize == other.dwStructSize
+            && self.dwControlFlags == other.dwControlFlags
+            && self.dwViewportWidth == other.dwViewportWidth
+            && self.dwViewportHeight == other.dwViewportHeight
+            && self.dwCurrImageWidth == other.dwCurrImageWidth
+            && self.dwCurrImageHeight == other.dwCurrImageHeight
+            && self.fCurrRegionX0 == other.fCurrRegionX0
+            && self.fCurrRegionY0 == other.fCurrRegionY0
+            && self.fCurrRegionWidth == other.fCurrRegionWidth
+            && self.fCurrRegionHeight == other.fCurrRegionHeight
+            && self.fCurrBlendCoef == other.fCurrBlendCoef
+            && self.dwPrevImageWidth == other.dwPrevImageWidth
+            && self.dwPrevImageHeight == other.dwPrevImageHeight
+            && self.fPrevRegionX0 == other.fPrevRegionX0
+            && self.fPrevRegionY0 == other.fPrevRegionY0
+            && self.fPrevRegionWidth == other.fPrevRegionWidth
+            && self.fPrevRegionHeight == other.fPrevRegionHeight
+            && self.fPrevBlendCoef == other.fPrevBlendCoef
+            && self.dwEffectType == other.dwEffectType
+            && self.dwNumEffectParas == other.dwNumEffectParas
+            && self.fEffectPara0 == other.fEffectPara0
+            && self.fEffectPara1 == other.fEffectPara1
+            && self.fEffectPara2 == other.fEffectPara2
+            && self.fEffectPara3 == other.fEffectPara3
+            && self.fEffectPara4 == other.fEffectPara4
+            && self.bKeepPrevImage == other.bKeepPrevImage
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11398,7 +11438,7 @@ unsafe impl ::windows::core::Abi for WMT_WATERMARK_ENTRY {
 }
 impl ::core::cmp::PartialEq for WMT_WATERMARK_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_WATERMARK_ENTRY>()) == 0 }
+        self.wmetType == other.wmetType && self.clsid == other.clsid && self.cbDisplayName == other.cbDisplayName && self.pwszDisplayName == other.pwszDisplayName
     }
 }
 impl ::core::cmp::Eq for WMT_WATERMARK_ENTRY {}
@@ -11431,7 +11471,7 @@ unsafe impl ::windows::core::Abi for WMT_WEBSTREAM_FORMAT {
 }
 impl ::core::cmp::PartialEq for WMT_WEBSTREAM_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_WEBSTREAM_FORMAT>()) == 0 }
+        self.cbSize == other.cbSize && self.cbSampleHeaderFixedData == other.cbSampleHeaderFixedData && self.wVersion == other.wVersion && self.wReserved == other.wReserved
     }
 }
 impl ::core::cmp::Eq for WMT_WEBSTREAM_FORMAT {}
@@ -11465,7 +11505,7 @@ unsafe impl ::windows::core::Abi for WMT_WEBSTREAM_SAMPLE_HEADER {
 }
 impl ::core::cmp::PartialEq for WMT_WEBSTREAM_SAMPLE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMT_WEBSTREAM_SAMPLE_HEADER>()) == 0 }
+        self.cbLength == other.cbLength && self.wPart == other.wPart && self.cTotalParts == other.cTotalParts && self.wSampleType == other.wSampleType && self.wszURL == other.wszURL
     }
 }
 impl ::core::cmp::Eq for WMT_WEBSTREAM_SAMPLE_HEADER {}
@@ -11506,7 +11546,7 @@ unsafe impl ::windows::core::Abi for WMVIDEOINFOHEADER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for WMVIDEOINFOHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMVIDEOINFOHEADER>()) == 0 }
+        self.rcSource == other.rcSource && self.rcTarget == other.rcTarget && self.dwBitRate == other.dwBitRate && self.dwBitErrorRate == other.dwBitErrorRate && self.AvgTimePerFrame == other.AvgTimePerFrame && self.bmiHeader == other.bmiHeader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11568,7 +11608,7 @@ unsafe impl ::windows::core::Abi for WMVIDEOINFOHEADER2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for WMVIDEOINFOHEADER2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMVIDEOINFOHEADER2>()) == 0 }
+        self.rcSource == other.rcSource && self.rcTarget == other.rcTarget && self.dwBitRate == other.dwBitRate && self.dwBitErrorRate == other.dwBitErrorRate && self.AvgTimePerFrame == other.AvgTimePerFrame && self.dwInterlaceFlags == other.dwInterlaceFlags && self.dwCopyProtectFlags == other.dwCopyProtectFlags && self.dwPictAspectRatioX == other.dwPictAspectRatioX && self.dwPictAspectRatioY == other.dwPictAspectRatioY && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.bmiHeader == other.bmiHeader
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11601,7 +11641,7 @@ unsafe impl ::windows::core::Abi for WM_ADDRESS_ACCESSENTRY {
 }
 impl ::core::cmp::PartialEq for WM_ADDRESS_ACCESSENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_ADDRESS_ACCESSENTRY>()) == 0 }
+        self.dwIPAddress == other.dwIPAddress && self.dwMask == other.dwMask
     }
 }
 impl ::core::cmp::Eq for WM_ADDRESS_ACCESSENTRY {}
@@ -11632,7 +11672,7 @@ unsafe impl ::windows::core::Abi for WM_CLIENT_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WM_CLIENT_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_CLIENT_PROPERTIES>()) == 0 }
+        self.dwIPAddress == other.dwIPAddress && self.dwPort == other.dwPort
     }
 }
 impl ::core::cmp::Eq for WM_CLIENT_PROPERTIES {}
@@ -11665,7 +11705,7 @@ unsafe impl ::windows::core::Abi for WM_CLIENT_PROPERTIES_EX {
 }
 impl ::core::cmp::PartialEq for WM_CLIENT_PROPERTIES_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_CLIENT_PROPERTIES_EX>()) == 0 }
+        self.cbSize == other.cbSize && self.pwszIPAddress == other.pwszIPAddress && self.pwszPort == other.pwszPort && self.pwszDNSName == other.pwszDNSName
     }
 }
 impl ::core::cmp::Eq for WM_CLIENT_PROPERTIES_EX {}
@@ -11689,12 +11729,6 @@ impl ::core::clone::Clone for WM_LEAKY_BUCKET_PAIR {
 unsafe impl ::windows::core::Abi for WM_LEAKY_BUCKET_PAIR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_LEAKY_BUCKET_PAIR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_LEAKY_BUCKET_PAIR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_LEAKY_BUCKET_PAIR {}
 impl ::core::default::Default for WM_LEAKY_BUCKET_PAIR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11772,12 +11806,6 @@ impl ::core::clone::Clone for WM_PICTURE {
 unsafe impl ::windows::core::Abi for WM_PICTURE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_PICTURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_PICTURE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_PICTURE {}
 impl ::core::default::Default for WM_PICTURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11805,7 +11833,7 @@ unsafe impl ::windows::core::Abi for WM_PORT_NUMBER_RANGE {
 }
 impl ::core::cmp::PartialEq for WM_PORT_NUMBER_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_PORT_NUMBER_RANGE>()) == 0 }
+        self.wPortBegin == other.wPortBegin && self.wPortEnd == other.wPortEnd
     }
 }
 impl ::core::cmp::Eq for WM_PORT_NUMBER_RANGE {}
@@ -11849,7 +11877,7 @@ unsafe impl ::windows::core::Abi for WM_READER_CLIENTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WM_READER_CLIENTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_READER_CLIENTINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wszLang == other.wszLang && self.wszBrowserUserAgent == other.wszBrowserUserAgent && self.wszBrowserWebPage == other.wszBrowserWebPage && self.qwReserved == other.qwReserved && self.pReserved == other.pReserved && self.wszHostExe == other.wszHostExe && self.qwHostVersion == other.qwHostVersion && self.wszPlayerUserAgent == other.wszPlayerUserAgent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11886,7 +11914,7 @@ unsafe impl ::windows::core::Abi for WM_READER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for WM_READER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_READER_STATISTICS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwBandwidth == other.dwBandwidth && self.cPacketsReceived == other.cPacketsReceived && self.cPacketsRecovered == other.cPacketsRecovered && self.cPacketsLost == other.cPacketsLost && self.wQuality == other.wQuality
     }
 }
 impl ::core::cmp::Eq for WM_READER_STATISTICS {}
@@ -11915,14 +11943,6 @@ unsafe impl ::windows::core::Abi for WM_STREAM_PRIORITY_RECORD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WM_STREAM_PRIORITY_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_STREAM_PRIORITY_RECORD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WM_STREAM_PRIORITY_RECORD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WM_STREAM_PRIORITY_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11943,12 +11963,6 @@ impl ::core::clone::Clone for WM_STREAM_TYPE_INFO {
 unsafe impl ::windows::core::Abi for WM_STREAM_TYPE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_STREAM_TYPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_STREAM_TYPE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_STREAM_TYPE_INFO {}
 impl ::core::default::Default for WM_STREAM_TYPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11972,12 +11986,6 @@ impl ::core::clone::Clone for WM_SYNCHRONISED_LYRICS {
 unsafe impl ::windows::core::Abi for WM_SYNCHRONISED_LYRICS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_SYNCHRONISED_LYRICS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_SYNCHRONISED_LYRICS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_SYNCHRONISED_LYRICS {}
 impl ::core::default::Default for WM_SYNCHRONISED_LYRICS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11998,12 +12006,6 @@ impl ::core::clone::Clone for WM_USER_TEXT {
 unsafe impl ::windows::core::Abi for WM_USER_TEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_USER_TEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_USER_TEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_USER_TEXT {}
 impl ::core::default::Default for WM_USER_TEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12024,12 +12026,6 @@ impl ::core::clone::Clone for WM_USER_WEB_URL {
 unsafe impl ::windows::core::Abi for WM_USER_WEB_URL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WM_USER_WEB_URL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_USER_WEB_URL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WM_USER_WEB_URL {}
 impl ::core::default::Default for WM_USER_WEB_URL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12076,7 +12072,7 @@ unsafe impl ::windows::core::Abi for WM_WRITER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for WM_WRITER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_WRITER_STATISTICS>()) == 0 }
+        self.qwSampleCount == other.qwSampleCount && self.qwByteCount == other.qwByteCount && self.qwDroppedSampleCount == other.qwDroppedSampleCount && self.qwDroppedByteCount == other.qwDroppedByteCount && self.dwCurrentBitrate == other.dwCurrentBitrate && self.dwAverageBitrate == other.dwAverageBitrate && self.dwExpectedBitrate == other.dwExpectedBitrate && self.dwCurrentSampleRate == other.dwCurrentSampleRate && self.dwAverageSampleRate == other.dwAverageSampleRate && self.dwExpectedSampleRate == other.dwExpectedSampleRate
     }
 }
 impl ::core::cmp::Eq for WM_WRITER_STATISTICS {}
@@ -12120,7 +12116,7 @@ unsafe impl ::windows::core::Abi for WM_WRITER_STATISTICS_EX {
 }
 impl ::core::cmp::PartialEq for WM_WRITER_STATISTICS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WM_WRITER_STATISTICS_EX>()) == 0 }
+        self.dwBitratePlusOverhead == other.dwBitratePlusOverhead && self.dwCurrentSampleDropRateInQueue == other.dwCurrentSampleDropRateInQueue && self.dwCurrentSampleDropRateInCodec == other.dwCurrentSampleDropRateInCodec && self.dwCurrentSampleDropRateInMultiplexer == other.dwCurrentSampleDropRateInMultiplexer && self.dwTotalSampleDropsInQueue == other.dwTotalSampleDropsInQueue && self.dwTotalSampleDropsInCodec == other.dwTotalSampleDropsInCodec && self.dwTotalSampleDropsInMultiplexer == other.dwTotalSampleDropsInMultiplexer
     }
 }
 impl ::core::cmp::Eq for WM_WRITER_STATISTICS_EX {}

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -540,12 +540,6 @@ impl ::core::clone::Clone for MMTIME {
 unsafe impl ::windows::core::Abi for MMTIME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMTIME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMTIME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMTIME {}
 impl ::core::default::Default for MMTIME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -570,12 +564,6 @@ impl ::core::clone::Clone for MMTIME_0 {
 unsafe impl ::windows::core::Abi for MMTIME_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMTIME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMTIME_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMTIME_0 {}
 impl ::core::default::Default for MMTIME_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -595,12 +583,6 @@ impl ::core::clone::Clone for MMTIME_0_0 {
 unsafe impl ::windows::core::Abi for MMTIME_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMTIME_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMTIME_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMTIME_0_0 {}
 impl ::core::default::Default for MMTIME_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -633,7 +615,7 @@ unsafe impl ::windows::core::Abi for MMTIME_0_1 {
 }
 impl ::core::cmp::PartialEq for MMTIME_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMTIME_0_1>()) == 0 }
+        self.hour == other.hour && self.min == other.min && self.sec == other.sec && self.frame == other.frame && self.fps == other.fps && self.dummy == other.dummy && self.pad == other.pad
     }
 }
 impl ::core::cmp::Eq for MMTIME_0_1 {}
@@ -664,7 +646,7 @@ unsafe impl ::windows::core::Abi for TIMECAPS {
 }
 impl ::core::cmp::PartialEq for TIMECAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMECAPS>()) == 0 }
+        self.wPeriodMin == other.wPeriodMin && self.wPeriodMax == other.wPeriodMax
     }
 }
 impl ::core::cmp::Eq for TIMECAPS {}
@@ -688,12 +670,6 @@ impl ::core::clone::Clone for TIMECODE {
 unsafe impl ::windows::core::Abi for TIMECODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TIMECODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMECODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TIMECODE {}
 impl ::core::default::Default for TIMECODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -722,7 +698,7 @@ unsafe impl ::windows::core::Abi for TIMECODE_0 {
 }
 impl ::core::cmp::PartialEq for TIMECODE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMECODE_0>()) == 0 }
+        self.wFrameRate == other.wFrameRate && self.wFrameFract == other.wFrameFract && self.dwFrames == other.dwFrames
     }
 }
 impl ::core::cmp::Eq for TIMECODE_0 {}
@@ -748,12 +724,6 @@ impl ::core::clone::Clone for TIMECODE_SAMPLE {
 unsafe impl ::windows::core::Abi for TIMECODE_SAMPLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TIMECODE_SAMPLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMECODE_SAMPLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TIMECODE_SAMPLE {}
 impl ::core::default::Default for TIMECODE_SAMPLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
@@ -3398,7 +3398,7 @@ unsafe impl ::windows::core::Abi for DATE_TIME {
 }
 impl ::core::cmp::PartialEq for DATE_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATE_TIME>()) == 0 }
+        self.dwLowDateTime == other.dwLowDateTime && self.dwHighDateTime == other.dwHighDateTime
     }
 }
 impl ::core::cmp::Eq for DATE_TIME {}
@@ -3438,7 +3438,7 @@ unsafe impl ::windows::core::Abi for DHCPAPI_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPAPI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPAPI_PARAMS>()) == 0 }
+        self.Flags == other.Flags && self.OptionId == other.OptionId && self.IsVendor == other.IsVendor && self.Data == other.Data && self.nBytesData == other.nBytesData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3472,7 +3472,7 @@ unsafe impl ::windows::core::Abi for DHCPCAPI_CLASSID {
 }
 impl ::core::cmp::PartialEq for DHCPCAPI_CLASSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPCAPI_CLASSID>()) == 0 }
+        self.Flags == other.Flags && self.Data == other.Data && self.nBytesData == other.nBytesData
     }
 }
 impl ::core::cmp::Eq for DHCPCAPI_CLASSID {}
@@ -3509,7 +3509,7 @@ unsafe impl ::windows::core::Abi for DHCPCAPI_PARAMS_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPCAPI_PARAMS_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPCAPI_PARAMS_ARRAY>()) == 0 }
+        self.nParams == other.nParams && self.Params == other.Params
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3547,7 +3547,7 @@ unsafe impl ::windows::core::Abi for DHCPDS_SERVER {
 }
 impl ::core::cmp::PartialEq for DHCPDS_SERVER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPDS_SERVER>()) == 0 }
+        self.Version == other.Version && self.ServerName == other.ServerName && self.ServerAddress == other.ServerAddress && self.Flags == other.Flags && self.State == other.State && self.DsLocation == other.DsLocation && self.DsLocType == other.DsLocType
     }
 }
 impl ::core::cmp::Eq for DHCPDS_SERVER {}
@@ -3579,7 +3579,7 @@ unsafe impl ::windows::core::Abi for DHCPDS_SERVERS {
 }
 impl ::core::cmp::PartialEq for DHCPDS_SERVERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPDS_SERVERS>()) == 0 }
+        self.Flags == other.Flags && self.NumElements == other.NumElements && self.Servers == other.Servers
     }
 }
 impl ::core::cmp::Eq for DHCPDS_SERVERS {}
@@ -3657,7 +3657,27 @@ unsafe impl ::windows::core::Abi for DHCPV4_FAILOVER_CLIENT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV4_FAILOVER_CLIENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV4_FAILOVER_CLIENT_INFO>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress
+            && self.SubnetMask == other.SubnetMask
+            && self.ClientHardwareAddress == other.ClientHardwareAddress
+            && self.ClientName == other.ClientName
+            && self.ClientComment == other.ClientComment
+            && self.ClientLeaseExpires == other.ClientLeaseExpires
+            && self.OwnerHost == other.OwnerHost
+            && self.bClientType == other.bClientType
+            && self.AddressState == other.AddressState
+            && self.Status == other.Status
+            && self.ProbationEnds == other.ProbationEnds
+            && self.QuarantineCapable == other.QuarantineCapable
+            && self.SentPotExpTime == other.SentPotExpTime
+            && self.AckPotExpTime == other.AckPotExpTime
+            && self.RecvPotExpTime == other.RecvPotExpTime
+            && self.StartTime == other.StartTime
+            && self.CltLastTransTime == other.CltLastTransTime
+            && self.LastBndUpdTime == other.LastBndUpdTime
+            && self.BndMsgStatus == other.BndMsgStatus
+            && self.PolicyName == other.PolicyName
+            && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3696,7 +3716,7 @@ unsafe impl ::windows::core::Abi for DHCPV4_FAILOVER_CLIENT_INFO_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV4_FAILOVER_CLIENT_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV4_FAILOVER_CLIENT_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3778,7 +3798,28 @@ unsafe impl ::windows::core::Abi for DHCPV4_FAILOVER_CLIENT_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV4_FAILOVER_CLIENT_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV4_FAILOVER_CLIENT_INFO_EX>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress
+            && self.SubnetMask == other.SubnetMask
+            && self.ClientHardwareAddress == other.ClientHardwareAddress
+            && self.ClientName == other.ClientName
+            && self.ClientComment == other.ClientComment
+            && self.ClientLeaseExpires == other.ClientLeaseExpires
+            && self.OwnerHost == other.OwnerHost
+            && self.bClientType == other.bClientType
+            && self.AddressState == other.AddressState
+            && self.Status == other.Status
+            && self.ProbationEnds == other.ProbationEnds
+            && self.QuarantineCapable == other.QuarantineCapable
+            && self.SentPotExpTime == other.SentPotExpTime
+            && self.AckPotExpTime == other.AckPotExpTime
+            && self.RecvPotExpTime == other.RecvPotExpTime
+            && self.StartTime == other.StartTime
+            && self.CltLastTransTime == other.CltLastTransTime
+            && self.LastBndUpdTime == other.LastBndUpdTime
+            && self.BndMsgStatus == other.BndMsgStatus
+            && self.PolicyName == other.PolicyName
+            && self.Flags == other.Flags
+            && self.AddressStateEx == other.AddressStateEx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3812,7 +3853,7 @@ unsafe impl ::windows::core::Abi for DHCPV6CAPI_CLASSID {
 }
 impl ::core::cmp::PartialEq for DHCPV6CAPI_CLASSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6CAPI_CLASSID>()) == 0 }
+        self.Flags == other.Flags && self.Data == other.Data && self.nBytesData == other.nBytesData
     }
 }
 impl ::core::cmp::Eq for DHCPV6CAPI_CLASSID {}
@@ -3852,7 +3893,7 @@ unsafe impl ::windows::core::Abi for DHCPV6CAPI_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV6CAPI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6CAPI_PARAMS>()) == 0 }
+        self.Flags == other.Flags && self.OptionId == other.OptionId && self.IsVendor == other.IsVendor && self.Data == other.Data && self.nBytesData == other.nBytesData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3891,7 +3932,7 @@ unsafe impl ::windows::core::Abi for DHCPV6CAPI_PARAMS_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV6CAPI_PARAMS_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6CAPI_PARAMS_ARRAY>()) == 0 }
+        self.nParams == other.nParams && self.Params == other.Params
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3927,7 +3968,7 @@ unsafe impl ::windows::core::Abi for DHCPV6Prefix {
 }
 impl ::core::cmp::PartialEq for DHCPV6Prefix {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6Prefix>()) == 0 }
+        self.prefix == other.prefix && self.prefixLength == other.prefixLength && self.preferredLifeTime == other.preferredLifeTime && self.validLifeTime == other.validLifeTime && self.status == other.status
     }
 }
 impl ::core::cmp::Eq for DHCPV6Prefix {}
@@ -3966,7 +4007,7 @@ unsafe impl ::windows::core::Abi for DHCPV6PrefixLeaseInformation {
 }
 impl ::core::cmp::PartialEq for DHCPV6PrefixLeaseInformation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6PrefixLeaseInformation>()) == 0 }
+        self.nPrefixes == other.nPrefixes && self.prefixArray == other.prefixArray && self.iaid == other.iaid && self.T1 == other.T1 && self.T2 == other.T2 && self.MaxLeaseExpirationTime == other.MaxLeaseExpirationTime && self.LastRenewalTime == other.LastRenewalTime && self.status == other.status && self.ServerId == other.ServerId && self.ServerIdLen == other.ServerIdLen
     }
 }
 impl ::core::cmp::Eq for DHCPV6PrefixLeaseInformation {}
@@ -4009,7 +4050,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_BIND_ELEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV6_BIND_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_BIND_ELEMENT>()) == 0 }
+        self.Flags == other.Flags && self.fBoundToDHCPServer == other.fBoundToDHCPServer && self.AdapterPrimaryAddress == other.AdapterPrimaryAddress && self.AdapterSubnetAddress == other.AdapterSubnetAddress && self.IfDescription == other.IfDescription && self.IpV6IfIndex == other.IpV6IfIndex && self.IfIdSize == other.IfIdSize && self.IfId == other.IfId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4048,7 +4089,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_BIND_ELEMENT_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV6_BIND_ELEMENT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_BIND_ELEMENT_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4081,7 +4122,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_IP_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCPV6_IP_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_IP_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCPV6_IP_ARRAY {}
@@ -4118,7 +4159,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_STATELESS_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCPV6_STATELESS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_STATELESS_PARAMS>()) == 0 }
+        self.Status == other.Status && self.PurgeInterval == other.PurgeInterval
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4152,7 +4193,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_STATELESS_SCOPE_STATS {
 }
 impl ::core::cmp::PartialEq for DHCPV6_STATELESS_SCOPE_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_STATELESS_SCOPE_STATS>()) == 0 }
+        self.SubnetAddress == other.SubnetAddress && self.NumStatelessClientsAdded == other.NumStatelessClientsAdded && self.NumStatelessClientsRemoved == other.NumStatelessClientsRemoved
     }
 }
 impl ::core::cmp::Eq for DHCPV6_STATELESS_SCOPE_STATS {}
@@ -4183,7 +4224,7 @@ unsafe impl ::windows::core::Abi for DHCPV6_STATELESS_STATS {
 }
 impl ::core::cmp::PartialEq for DHCPV6_STATELESS_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCPV6_STATELESS_STATS>()) == 0 }
+        self.NumScopes == other.NumScopes && self.ScopeStats == other.ScopeStats
     }
 }
 impl ::core::cmp::Eq for DHCPV6_STATELESS_STATS {}
@@ -4223,7 +4264,7 @@ unsafe impl ::windows::core::Abi for DHCP_ADDR_PATTERN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ADDR_PATTERN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ADDR_PATTERN>()) == 0 }
+        self.MatchHWType == other.MatchHWType && self.HWType == other.HWType && self.IsWildcard == other.IsWildcard && self.Length == other.Length && self.Pattern == other.Pattern
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4258,7 +4299,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTIONS {
 }
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTIONS>()) == 0 }
+        self.Flags == other.Flags && self.NonVendorOptions == other.NonVendorOptions && self.NumVendorOptions == other.NumVendorOptions && self.VendorOptions == other.VendorOptions
     }
 }
 impl ::core::cmp::Eq for DHCP_ALL_OPTIONS {}
@@ -4290,7 +4331,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTIONS_0 {
 }
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTIONS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTIONS_0>()) == 0 }
+        self.Option == other.Option && self.VendorName == other.VendorName && self.ClassName == other.ClassName
     }
 }
 impl ::core::cmp::Eq for DHCP_ALL_OPTIONS_0 {}
@@ -4328,7 +4369,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTION_VALUES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTION_VALUES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTION_VALUES>()) == 0 }
+        self.Flags == other.Flags && self.NumElements == other.NumElements && self.Options == other.Options
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4369,7 +4410,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTION_VALUES_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTION_VALUES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTION_VALUES_0>()) == 0 }
+        self.ClassName == other.ClassName && self.VendorName == other.VendorName && self.IsVendor == other.IsVendor && self.OptionsArray == other.OptionsArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4409,7 +4450,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTION_VALUES_PB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTION_VALUES_PB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTION_VALUES_PB>()) == 0 }
+        self.Flags == other.Flags && self.NumElements == other.NumElements && self.Options == other.Options
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4450,7 +4491,7 @@ unsafe impl ::windows::core::Abi for DHCP_ALL_OPTION_VALUES_PB_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ALL_OPTION_VALUES_PB_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ALL_OPTION_VALUES_PB_0>()) == 0 }
+        self.PolicyName == other.PolicyName && self.VendorName == other.VendorName && self.IsVendor == other.IsVendor && self.OptionsArray == other.OptionsArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4482,14 +4523,6 @@ unsafe impl ::windows::core::Abi for DHCP_ATTRIB {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DHCP_ATTRIB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ATTRIB>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DHCP_ATTRIB {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DHCP_ATTRIB {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4514,14 +4547,6 @@ impl ::core::clone::Clone for DHCP_ATTRIB_0 {
 unsafe impl ::windows::core::Abi for DHCP_ATTRIB_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DHCP_ATTRIB_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ATTRIB_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DHCP_ATTRIB_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DHCP_ATTRIB_0 {
     fn default() -> Self {
@@ -4556,7 +4581,7 @@ unsafe impl ::windows::core::Abi for DHCP_ATTRIB_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_ATTRIB_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_ATTRIB_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.DhcpAttribs == other.DhcpAttribs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4589,7 +4614,7 @@ unsafe impl ::windows::core::Abi for DHCP_BINARY_DATA {
 }
 impl ::core::cmp::PartialEq for DHCP_BINARY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_BINARY_DATA>()) == 0 }
+        self.DataLength == other.DataLength && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DHCP_BINARY_DATA {}
@@ -4631,7 +4656,7 @@ unsafe impl ::windows::core::Abi for DHCP_BIND_ELEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_BIND_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_BIND_ELEMENT>()) == 0 }
+        self.Flags == other.Flags && self.fBoundToDHCPServer == other.fBoundToDHCPServer && self.AdapterPrimaryAddress == other.AdapterPrimaryAddress && self.AdapterSubnetAddress == other.AdapterSubnetAddress && self.IfDescription == other.IfDescription && self.IfIdSize == other.IfIdSize && self.IfId == other.IfId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4670,7 +4695,7 @@ unsafe impl ::windows::core::Abi for DHCP_BIND_ELEMENT_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_BIND_ELEMENT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_BIND_ELEMENT_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4705,7 +4730,7 @@ unsafe impl ::windows::core::Abi for DHCP_BOOTP_IP_RANGE {
 }
 impl ::core::cmp::PartialEq for DHCP_BOOTP_IP_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_BOOTP_IP_RANGE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.EndAddress == other.EndAddress && self.BootpAllocated == other.BootpAllocated && self.MaxBootpAllowed == other.MaxBootpAllowed
     }
 }
 impl ::core::cmp::Eq for DHCP_BOOTP_IP_RANGE {}
@@ -4740,32 +4765,13 @@ impl ::core::clone::Clone for DHCP_CALLOUT_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DHCP_CALLOUT_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DHCP_CALLOUT_TABLE")
-            .field("DhcpControlHook", &self.DhcpControlHook.map(|f| f as usize))
-            .field("DhcpNewPktHook", &self.DhcpNewPktHook.map(|f| f as usize))
-            .field("DhcpPktDropHook", &self.DhcpPktDropHook.map(|f| f as usize))
-            .field("DhcpPktSendHook", &self.DhcpPktSendHook.map(|f| f as usize))
-            .field("DhcpAddressDelHook", &self.DhcpAddressDelHook.map(|f| f as usize))
-            .field("DhcpAddressOfferHook", &self.DhcpAddressOfferHook.map(|f| f as usize))
-            .field("DhcpHandleOptionsHook", &self.DhcpHandleOptionsHook.map(|f| f as usize))
-            .field("DhcpDeleteClientHook", &self.DhcpDeleteClientHook.map(|f| f as usize))
-            .field("DhcpExtensionHook", &self.DhcpExtensionHook)
-            .field("DhcpReservedHook", &self.DhcpReservedHook)
-            .finish()
+        f.debug_struct("DHCP_CALLOUT_TABLE").field("DhcpExtensionHook", &self.DhcpExtensionHook).field("DhcpReservedHook", &self.DhcpReservedHook).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DHCP_CALLOUT_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DHCP_CALLOUT_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CALLOUT_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DHCP_CALLOUT_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DHCP_CALLOUT_TABLE {
     fn default() -> Self {
@@ -4804,7 +4810,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLASS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLASS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLASS_INFO>()) == 0 }
+        self.ClassName == other.ClassName && self.ClassComment == other.ClassComment && self.ClassDataLength == other.ClassDataLength && self.IsVendor == other.IsVendor && self.Flags == other.Flags && self.ClassData == other.ClassData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4843,7 +4849,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLASS_INFO_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLASS_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLASS_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Classes == other.Classes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4882,7 +4888,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLASS_INFO_ARRAY_V6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLASS_INFO_ARRAY_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLASS_INFO_ARRAY_V6>()) == 0 }
+        self.NumElements == other.NumElements && self.Classes == other.Classes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4926,7 +4932,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLASS_INFO_V6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLASS_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLASS_INFO_V6>()) == 0 }
+        self.ClassName == other.ClassName && self.ClassComment == other.ClassComment && self.ClassDataLength == other.ClassDataLength && self.IsVendor == other.IsVendor && self.EnterpriseNumber == other.EnterpriseNumber && self.Flags == other.Flags && self.ClassData == other.ClassData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4990,7 +4996,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_FILTER_STATUS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_FILTER_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_FILTER_STATUS_INFO>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType && self.AddressState == other.AddressState && self.Status == other.Status && self.ProbationEnds == other.ProbationEnds && self.QuarantineCapable == other.QuarantineCapable && self.FilterStatus == other.FilterStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5029,7 +5035,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5067,7 +5073,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO {}
@@ -5098,7 +5104,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_ARRAY {}
@@ -5129,7 +5135,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_ARRAY_V4 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_ARRAY_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_ARRAY_V4>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_ARRAY_V4 {}
@@ -5160,7 +5166,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_ARRAY_V5 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_ARRAY_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_ARRAY_V5>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_ARRAY_V5 {}
@@ -5191,7 +5197,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_ARRAY_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_ARRAY_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_ARRAY_V6>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_ARRAY_V6 {}
@@ -5228,7 +5234,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_ARRAY_VQ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_ARRAY_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_ARRAY_VQ>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5296,7 +5302,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_EX>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType && self.AddressState == other.AddressState && self.Status == other.Status && self.ProbationEnds == other.ProbationEnds && self.QuarantineCapable == other.QuarantineCapable && self.FilterStatus == other.FilterStatus && self.PolicyName == other.PolicyName && self.Properties == other.Properties
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5335,7 +5341,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_EX_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_EX_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_EX_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5401,7 +5407,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_PB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_PB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_PB>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType && self.AddressState == other.AddressState && self.Status == other.Status && self.ProbationEnds == other.ProbationEnds && self.QuarantineCapable == other.QuarantineCapable && self.FilterStatus == other.FilterStatus && self.PolicyName == other.PolicyName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5440,7 +5446,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_PB_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_PB_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_PB_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Clients == other.Clients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5479,7 +5485,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_V4 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_V4>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_V4 {}
@@ -5517,7 +5523,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_V5 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_V5>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType && self.AddressState == other.AddressState
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_V5 {}
@@ -5555,7 +5561,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_V6>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.ClientDUID == other.ClientDUID && self.AddressType == other.AddressType && self.IAID == other.IAID && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientValidLeaseExpires == other.ClientValidLeaseExpires && self.ClientPrefLeaseExpires == other.ClientPrefLeaseExpires && self.OwnerHost == other.OwnerHost
     }
 }
 impl ::core::cmp::Eq for DHCP_CLIENT_INFO_V6 {}
@@ -5615,7 +5621,7 @@ unsafe impl ::windows::core::Abi for DHCP_CLIENT_INFO_VQ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_CLIENT_INFO_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_CLIENT_INFO_VQ>()) == 0 }
+        self.ClientIpAddress == other.ClientIpAddress && self.SubnetMask == other.SubnetMask && self.ClientHardwareAddress == other.ClientHardwareAddress && self.ClientName == other.ClientName && self.ClientComment == other.ClientComment && self.ClientLeaseExpires == other.ClientLeaseExpires && self.OwnerHost == other.OwnerHost && self.bClientType == other.bClientType && self.AddressState == other.AddressState && self.Status == other.Status && self.ProbationEnds == other.ProbationEnds && self.QuarantineCapable == other.QuarantineCapable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5677,7 +5683,7 @@ unsafe impl ::windows::core::Abi for DHCP_FAILOVER_RELATIONSHIP {
 }
 impl ::core::cmp::PartialEq for DHCP_FAILOVER_RELATIONSHIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FAILOVER_RELATIONSHIP>()) == 0 }
+        self.PrimaryServer == other.PrimaryServer && self.SecondaryServer == other.SecondaryServer && self.Mode == other.Mode && self.ServerType == other.ServerType && self.State == other.State && self.PrevState == other.PrevState && self.Mclt == other.Mclt && self.SafePeriod == other.SafePeriod && self.RelationshipName == other.RelationshipName && self.PrimaryServerName == other.PrimaryServerName && self.SecondaryServerName == other.SecondaryServerName && self.pScopes == other.pScopes && self.Percentage == other.Percentage && self.SharedSecret == other.SharedSecret
     }
 }
 impl ::core::cmp::Eq for DHCP_FAILOVER_RELATIONSHIP {}
@@ -5708,7 +5714,7 @@ unsafe impl ::windows::core::Abi for DHCP_FAILOVER_RELATIONSHIP_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_FAILOVER_RELATIONSHIP_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FAILOVER_RELATIONSHIP_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.pRelationships == other.pRelationships
     }
 }
 impl ::core::cmp::Eq for DHCP_FAILOVER_RELATIONSHIP_ARRAY {}
@@ -5744,7 +5750,7 @@ unsafe impl ::windows::core::Abi for DHCP_FAILOVER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for DHCP_FAILOVER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FAILOVER_STATISTICS>()) == 0 }
+        self.NumAddr == other.NumAddr && self.AddrFree == other.AddrFree && self.AddrInUse == other.AddrInUse && self.PartnerAddrFree == other.PartnerAddrFree && self.ThisAddrFree == other.ThisAddrFree && self.PartnerAddrInUse == other.PartnerAddrInUse && self.ThisAddrInUse == other.ThisAddrInUse
     }
 }
 impl ::core::cmp::Eq for DHCP_FAILOVER_STATISTICS {}
@@ -5782,7 +5788,7 @@ unsafe impl ::windows::core::Abi for DHCP_FILTER_ADD_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_FILTER_ADD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FILTER_ADD_INFO>()) == 0 }
+        self.AddrPatt == other.AddrPatt && self.Comment == other.Comment && self.ListType == other.ListType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5821,7 +5827,7 @@ unsafe impl ::windows::core::Abi for DHCP_FILTER_ENUM_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_FILTER_ENUM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FILTER_ENUM_INFO>()) == 0 }
+        self.NumElements == other.NumElements && self.pEnumRecords == other.pEnumRecords
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5860,7 +5866,7 @@ unsafe impl ::windows::core::Abi for DHCP_FILTER_GLOBAL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_FILTER_GLOBAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FILTER_GLOBAL_INFO>()) == 0 }
+        self.EnforceAllowList == other.EnforceAllowList && self.EnforceDenyList == other.EnforceDenyList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5899,7 +5905,7 @@ unsafe impl ::windows::core::Abi for DHCP_FILTER_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_FILTER_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_FILTER_RECORD>()) == 0 }
+        self.AddrPatt == other.AddrPatt && self.Comment == other.Comment
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5933,7 +5939,7 @@ unsafe impl ::windows::core::Abi for DHCP_HOST_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_HOST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_HOST_INFO>()) == 0 }
+        self.IpAddress == other.IpAddress && self.NetBiosName == other.NetBiosName && self.HostName == other.HostName
     }
 }
 impl ::core::cmp::Eq for DHCP_HOST_INFO {}
@@ -5965,7 +5971,7 @@ unsafe impl ::windows::core::Abi for DHCP_HOST_INFO_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_HOST_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_HOST_INFO_V6>()) == 0 }
+        self.IpAddress == other.IpAddress && self.NetBiosName == other.NetBiosName && self.HostName == other.HostName
     }
 }
 impl ::core::cmp::Eq for DHCP_HOST_INFO_V6 {}
@@ -5996,7 +6002,7 @@ unsafe impl ::windows::core::Abi for DHCP_IPV6_ADDRESS {
 }
 impl ::core::cmp::PartialEq for DHCP_IPV6_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IPV6_ADDRESS>()) == 0 }
+        self.HighOrderBits == other.HighOrderBits && self.LowOrderBits == other.LowOrderBits
     }
 }
 impl ::core::cmp::Eq for DHCP_IPV6_ADDRESS {}
@@ -6027,7 +6033,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_ARRAY {}
@@ -6058,7 +6064,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_CLUSTER {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_CLUSTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_CLUSTER>()) == 0 }
+        self.ClusterAddress == other.ClusterAddress && self.ClusterMask == other.ClusterMask
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_CLUSTER {}
@@ -6089,7 +6095,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RANGE {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RANGE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.EndAddress == other.EndAddress
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RANGE {}
@@ -6120,7 +6126,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RANGE_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RANGE_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RANGE_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RANGE_ARRAY {}
@@ -6151,7 +6157,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RANGE_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RANGE_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RANGE_V6>()) == 0 }
+        self.StartAddress == other.StartAddress && self.EndAddress == other.EndAddress
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RANGE_V6 {}
@@ -6182,7 +6188,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RESERVATION {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RESERVATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RESERVATION>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedForClient == other.ReservedForClient
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RESERVATION {}
@@ -6217,7 +6223,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RESERVATION_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RESERVATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RESERVATION_INFO>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedForClient == other.ReservedForClient && self.ReservedClientName == other.ReservedClientName && self.ReservedClientDesc == other.ReservedClientDesc && self.bAllowedClientTypes == other.bAllowedClientTypes && self.fOptionsPresent == other.fOptionsPresent
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RESERVATION_INFO {}
@@ -6249,7 +6255,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RESERVATION_V4 {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RESERVATION_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RESERVATION_V4>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedForClient == other.ReservedForClient && self.bAllowedClientTypes == other.bAllowedClientTypes
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RESERVATION_V4 {}
@@ -6281,7 +6287,7 @@ unsafe impl ::windows::core::Abi for DHCP_IP_RESERVATION_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_IP_RESERVATION_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_IP_RESERVATION_V6>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedForClient == other.ReservedForClient && self.InterfaceId == other.InterfaceId
     }
 }
 impl ::core::cmp::Eq for DHCP_IP_RESERVATION_V6 {}
@@ -6320,7 +6326,7 @@ unsafe impl ::windows::core::Abi for DHCP_MIB_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_MIB_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_MIB_INFO>()) == 0 }
+        self.Discovers == other.Discovers && self.Offers == other.Offers && self.Requests == other.Requests && self.Acks == other.Acks && self.Naks == other.Naks && self.Declines == other.Declines && self.Releases == other.Releases && self.ServerStartTime == other.ServerStartTime && self.Scopes == other.Scopes && self.ScopeInfo == other.ScopeInfo
     }
 }
 impl ::core::cmp::Eq for DHCP_MIB_INFO {}
@@ -6388,7 +6394,7 @@ unsafe impl ::windows::core::Abi for DHCP_MIB_INFO_V5 {
 }
 impl ::core::cmp::PartialEq for DHCP_MIB_INFO_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_MIB_INFO_V5>()) == 0 }
+        self.Discovers == other.Discovers && self.Offers == other.Offers && self.Requests == other.Requests && self.Acks == other.Acks && self.Naks == other.Naks && self.Declines == other.Declines && self.Releases == other.Releases && self.ServerStartTime == other.ServerStartTime && self.QtnNumLeases == other.QtnNumLeases && self.QtnPctQtnLeases == other.QtnPctQtnLeases && self.QtnProbationLeases == other.QtnProbationLeases && self.QtnNonQtnLeases == other.QtnNonQtnLeases && self.QtnExemptLeases == other.QtnExemptLeases && self.QtnCapableClients == other.QtnCapableClients && self.QtnIASErrors == other.QtnIASErrors && self.DelayedOffers == other.DelayedOffers && self.ScopesWithDelayedOffers == other.ScopesWithDelayedOffers && self.Scopes == other.Scopes && self.ScopeInfo == other.ScopeInfo
     }
 }
 impl ::core::cmp::Eq for DHCP_MIB_INFO_V5 {}
@@ -6444,7 +6450,7 @@ unsafe impl ::windows::core::Abi for DHCP_MIB_INFO_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_MIB_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_MIB_INFO_V6>()) == 0 }
+        self.Solicits == other.Solicits && self.Advertises == other.Advertises && self.Requests == other.Requests && self.Renews == other.Renews && self.Rebinds == other.Rebinds && self.Replies == other.Replies && self.Confirms == other.Confirms && self.Declines == other.Declines && self.Releases == other.Releases && self.Informs == other.Informs && self.ServerStartTime == other.ServerStartTime && self.Scopes == other.Scopes && self.ScopeInfo == other.ScopeInfo
     }
 }
 impl ::core::cmp::Eq for DHCP_MIB_INFO_V6 {}
@@ -6508,7 +6514,7 @@ unsafe impl ::windows::core::Abi for DHCP_MIB_INFO_VQ {
 }
 impl ::core::cmp::PartialEq for DHCP_MIB_INFO_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_MIB_INFO_VQ>()) == 0 }
+        self.Discovers == other.Discovers && self.Offers == other.Offers && self.Requests == other.Requests && self.Acks == other.Acks && self.Naks == other.Naks && self.Declines == other.Declines && self.Releases == other.Releases && self.ServerStartTime == other.ServerStartTime && self.QtnNumLeases == other.QtnNumLeases && self.QtnPctQtnLeases == other.QtnPctQtnLeases && self.QtnProbationLeases == other.QtnProbationLeases && self.QtnNonQtnLeases == other.QtnNonQtnLeases && self.QtnExemptLeases == other.QtnExemptLeases && self.QtnCapableClients == other.QtnCapableClients && self.QtnIASErrors == other.QtnIASErrors && self.Scopes == other.Scopes && self.ScopeInfo == other.ScopeInfo
     }
 }
 impl ::core::cmp::Eq for DHCP_MIB_INFO_VQ {}
@@ -6542,7 +6548,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION>()) == 0 }
+        self.OptionID == other.OptionID && self.OptionName == other.OptionName && self.OptionComment == other.OptionComment && self.DefaultValue == other.DefaultValue && self.OptionType == other.OptionType
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION {}
@@ -6573,7 +6579,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Options == other.Options
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION_ARRAY {}
@@ -6604,7 +6610,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION_DATA {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_DATA>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION_DATA {}
@@ -6628,12 +6634,6 @@ impl ::core::clone::Clone for DHCP_OPTION_DATA_ELEMENT {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_DATA_ELEMENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_DATA_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_DATA_ELEMENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_DATA_ELEMENT {}
 impl ::core::default::Default for DHCP_OPTION_DATA_ELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6661,12 +6661,6 @@ impl ::core::clone::Clone for DHCP_OPTION_DATA_ELEMENT_0 {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_DATA_ELEMENT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_DATA_ELEMENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_DATA_ELEMENT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_DATA_ELEMENT_0 {}
 impl ::core::default::Default for DHCP_OPTION_DATA_ELEMENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6696,7 +6690,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION_LIST {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_LIST>()) == 0 }
+        self.NumOptions == other.NumOptions && self.Options == other.Options
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION_LIST {}
@@ -6720,12 +6714,6 @@ impl ::core::clone::Clone for DHCP_OPTION_SCOPE_INFO {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_SCOPE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_SCOPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_SCOPE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_SCOPE_INFO {}
 impl ::core::default::Default for DHCP_OPTION_SCOPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6749,12 +6737,6 @@ impl ::core::clone::Clone for DHCP_OPTION_SCOPE_INFO_0 {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_SCOPE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_SCOPE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_SCOPE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_SCOPE_INFO_0 {}
 impl ::core::default::Default for DHCP_OPTION_SCOPE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6775,12 +6757,6 @@ impl ::core::clone::Clone for DHCP_OPTION_SCOPE_INFO6 {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_SCOPE_INFO6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_SCOPE_INFO6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_SCOPE_INFO6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_SCOPE_INFO6 {}
 impl ::core::default::Default for DHCP_OPTION_SCOPE_INFO6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6802,12 +6778,6 @@ impl ::core::clone::Clone for DHCP_OPTION_SCOPE_INFO6_0 {
 unsafe impl ::windows::core::Abi for DHCP_OPTION_SCOPE_INFO6_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_OPTION_SCOPE_INFO6_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_SCOPE_INFO6_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_OPTION_SCOPE_INFO6_0 {}
 impl ::core::default::Default for DHCP_OPTION_SCOPE_INFO6_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6837,7 +6807,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION_VALUE {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_VALUE>()) == 0 }
+        self.OptionID == other.OptionID && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION_VALUE {}
@@ -6868,7 +6838,7 @@ unsafe impl ::windows::core::Abi for DHCP_OPTION_VALUE_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_OPTION_VALUE_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_OPTION_VALUE_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Values == other.Values
     }
 }
 impl ::core::cmp::Eq for DHCP_OPTION_VALUE_ARRAY {}
@@ -6936,7 +6906,25 @@ unsafe impl ::windows::core::Abi for DHCP_PERF_STATS {
 }
 impl ::core::cmp::PartialEq for DHCP_PERF_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_PERF_STATS>()) == 0 }
+        self.dwNumPacketsReceived == other.dwNumPacketsReceived
+            && self.dwNumPacketsDuplicate == other.dwNumPacketsDuplicate
+            && self.dwNumPacketsExpired == other.dwNumPacketsExpired
+            && self.dwNumMilliSecondsProcessed == other.dwNumMilliSecondsProcessed
+            && self.dwNumPacketsInActiveQueue == other.dwNumPacketsInActiveQueue
+            && self.dwNumPacketsInPingQueue == other.dwNumPacketsInPingQueue
+            && self.dwNumDiscoversReceived == other.dwNumDiscoversReceived
+            && self.dwNumOffersSent == other.dwNumOffersSent
+            && self.dwNumRequestsReceived == other.dwNumRequestsReceived
+            && self.dwNumInformsReceived == other.dwNumInformsReceived
+            && self.dwNumAcksSent == other.dwNumAcksSent
+            && self.dwNumNacksSent == other.dwNumNacksSent
+            && self.dwNumDeclinesReceived == other.dwNumDeclinesReceived
+            && self.dwNumReleasesReceived == other.dwNumReleasesReceived
+            && self.dwNumDelayedOfferInQueue == other.dwNumDelayedOfferInQueue
+            && self.dwNumPacketsProcessed == other.dwNumPacketsProcessed
+            && self.dwNumPacketsInQuarWaitingQueue == other.dwNumPacketsInQuarWaitingQueue
+            && self.dwNumPacketsInQuarReadyQueue == other.dwNumPacketsInQuarReadyQueue
+            && self.dwNumPacketsInQuarDecisionQueue == other.dwNumPacketsInQuarDecisionQueue
     }
 }
 impl ::core::cmp::Eq for DHCP_PERF_STATS {}
@@ -6980,7 +6968,7 @@ unsafe impl ::windows::core::Abi for DHCP_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POLICY>()) == 0 }
+        self.PolicyName == other.PolicyName && self.IsGlobalPolicy == other.IsGlobalPolicy && self.Subnet == other.Subnet && self.ProcessingOrder == other.ProcessingOrder && self.Conditions == other.Conditions && self.Expressions == other.Expressions && self.Ranges == other.Ranges && self.Description == other.Description && self.Enabled == other.Enabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7019,7 +7007,7 @@ unsafe impl ::windows::core::Abi for DHCP_POLICY_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_POLICY_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POLICY_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7066,7 +7054,7 @@ unsafe impl ::windows::core::Abi for DHCP_POLICY_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_POLICY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POLICY_EX>()) == 0 }
+        self.PolicyName == other.PolicyName && self.IsGlobalPolicy == other.IsGlobalPolicy && self.Subnet == other.Subnet && self.ProcessingOrder == other.ProcessingOrder && self.Conditions == other.Conditions && self.Expressions == other.Expressions && self.Ranges == other.Ranges && self.Description == other.Description && self.Enabled == other.Enabled && self.Properties == other.Properties
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7105,7 +7093,7 @@ unsafe impl ::windows::core::Abi for DHCP_POLICY_EX_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_POLICY_EX_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POLICY_EX_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7144,7 +7132,7 @@ unsafe impl ::windows::core::Abi for DHCP_POL_COND {
 }
 impl ::core::cmp::PartialEq for DHCP_POL_COND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POL_COND>()) == 0 }
+        self.ParentExpr == other.ParentExpr && self.Type == other.Type && self.OptionID == other.OptionID && self.SubOptionID == other.SubOptionID && self.VendorName == other.VendorName && self.Operator == other.Operator && self.Value == other.Value && self.ValueLength == other.ValueLength
     }
 }
 impl ::core::cmp::Eq for DHCP_POL_COND {}
@@ -7175,7 +7163,7 @@ unsafe impl ::windows::core::Abi for DHCP_POL_COND_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_POL_COND_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POL_COND_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_POL_COND_ARRAY {}
@@ -7206,7 +7194,7 @@ unsafe impl ::windows::core::Abi for DHCP_POL_EXPR {
 }
 impl ::core::cmp::PartialEq for DHCP_POL_EXPR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POL_EXPR>()) == 0 }
+        self.ParentExpr == other.ParentExpr && self.Operator == other.Operator
     }
 }
 impl ::core::cmp::Eq for DHCP_POL_EXPR {}
@@ -7237,7 +7225,7 @@ unsafe impl ::windows::core::Abi for DHCP_POL_EXPR_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_POL_EXPR_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_POL_EXPR_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_POL_EXPR_ARRAY {}
@@ -7262,12 +7250,6 @@ impl ::core::clone::Clone for DHCP_PROPERTY {
 unsafe impl ::windows::core::Abi for DHCP_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_PROPERTY {}
 impl ::core::default::Default for DHCP_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7291,12 +7273,6 @@ impl ::core::clone::Clone for DHCP_PROPERTY_0 {
 unsafe impl ::windows::core::Abi for DHCP_PROPERTY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_PROPERTY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_PROPERTY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_PROPERTY_0 {}
 impl ::core::default::Default for DHCP_PROPERTY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7324,7 +7300,7 @@ unsafe impl ::windows::core::Abi for DHCP_PROPERTY_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_PROPERTY_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_PROPERTY_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_PROPERTY_ARRAY {}
@@ -7355,7 +7331,7 @@ unsafe impl ::windows::core::Abi for DHCP_RESERVATION_INFO_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_RESERVATION_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_RESERVATION_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_RESERVATION_INFO_ARRAY {}
@@ -7386,7 +7362,7 @@ unsafe impl ::windows::core::Abi for DHCP_RESERVED_SCOPE {
 }
 impl ::core::cmp::PartialEq for DHCP_RESERVED_SCOPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_RESERVED_SCOPE>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedIpSubnetAddress == other.ReservedIpSubnetAddress
     }
 }
 impl ::core::cmp::Eq for DHCP_RESERVED_SCOPE {}
@@ -7417,7 +7393,7 @@ unsafe impl ::windows::core::Abi for DHCP_RESERVED_SCOPE6 {
 }
 impl ::core::cmp::PartialEq for DHCP_RESERVED_SCOPE6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_RESERVED_SCOPE6>()) == 0 }
+        self.ReservedIpAddress == other.ReservedIpAddress && self.ReservedIpSubnetAddress == other.ReservedIpSubnetAddress
     }
 }
 impl ::core::cmp::Eq for DHCP_RESERVED_SCOPE6 {}
@@ -7448,7 +7424,7 @@ unsafe impl ::windows::core::Abi for DHCP_SCAN_ITEM {
 }
 impl ::core::cmp::PartialEq for DHCP_SCAN_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SCAN_ITEM>()) == 0 }
+        self.IpAddress == other.IpAddress && self.ScanFlag == other.ScanFlag
     }
 }
 impl ::core::cmp::Eq for DHCP_SCAN_ITEM {}
@@ -7479,7 +7455,7 @@ unsafe impl ::windows::core::Abi for DHCP_SCAN_LIST {
 }
 impl ::core::cmp::PartialEq for DHCP_SCAN_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SCAN_LIST>()) == 0 }
+        self.NumScanItems == other.NumScanItems && self.ScanItems == other.ScanItems
     }
 }
 impl ::core::cmp::Eq for DHCP_SCAN_LIST {}
@@ -7503,12 +7479,6 @@ impl ::core::clone::Clone for DHCP_SEARCH_INFO {
 unsafe impl ::windows::core::Abi for DHCP_SEARCH_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SEARCH_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SEARCH_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SEARCH_INFO {}
 impl ::core::default::Default for DHCP_SEARCH_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7530,12 +7500,6 @@ impl ::core::clone::Clone for DHCP_SEARCH_INFO_0 {
 unsafe impl ::windows::core::Abi for DHCP_SEARCH_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SEARCH_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SEARCH_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SEARCH_INFO_0 {}
 impl ::core::default::Default for DHCP_SEARCH_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7556,12 +7520,6 @@ impl ::core::clone::Clone for DHCP_SEARCH_INFO_V6 {
 unsafe impl ::windows::core::Abi for DHCP_SEARCH_INFO_V6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SEARCH_INFO_V6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SEARCH_INFO_V6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SEARCH_INFO_V6 {}
 impl ::core::default::Default for DHCP_SEARCH_INFO_V6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7583,12 +7541,6 @@ impl ::core::clone::Clone for DHCP_SEARCH_INFO_V6_0 {
 unsafe impl ::windows::core::Abi for DHCP_SEARCH_INFO_V6_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SEARCH_INFO_V6_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SEARCH_INFO_V6_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SEARCH_INFO_V6_0 {}
 impl ::core::default::Default for DHCP_SEARCH_INFO_V6_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7623,7 +7575,7 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_CONFIG_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_SERVER_CONFIG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_CONFIG_INFO>()) == 0 }
+        self.APIProtocolSupport == other.APIProtocolSupport && self.DatabaseName == other.DatabaseName && self.DatabasePath == other.DatabasePath && self.BackupPath == other.BackupPath && self.BackupInterval == other.BackupInterval && self.DatabaseLoggingFlag == other.DatabaseLoggingFlag && self.RestoreFlag == other.RestoreFlag && self.DatabaseCleanupInterval == other.DatabaseCleanupInterval && self.DebugFlag == other.DebugFlag
     }
 }
 impl ::core::cmp::Eq for DHCP_SERVER_CONFIG_INFO {}
@@ -7685,7 +7637,7 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_CONFIG_INFO_V4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_SERVER_CONFIG_INFO_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_CONFIG_INFO_V4>()) == 0 }
+        self.APIProtocolSupport == other.APIProtocolSupport && self.DatabaseName == other.DatabaseName && self.DatabasePath == other.DatabasePath && self.BackupPath == other.BackupPath && self.BackupInterval == other.BackupInterval && self.DatabaseLoggingFlag == other.DatabaseLoggingFlag && self.RestoreFlag == other.RestoreFlag && self.DatabaseCleanupInterval == other.DatabaseCleanupInterval && self.DebugFlag == other.DebugFlag && self.dwPingRetries == other.dwPingRetries && self.cbBootTableString == other.cbBootTableString && self.wszBootTableString == other.wszBootTableString && self.fAuditLog == other.fAuditLog
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7731,7 +7683,7 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_CONFIG_INFO_V6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_SERVER_CONFIG_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_CONFIG_INFO_V6>()) == 0 }
+        self.UnicastFlag == other.UnicastFlag && self.RapidCommitFlag == other.RapidCommitFlag && self.PreferredLifetime == other.PreferredLifetime && self.ValidLifetime == other.ValidLifetime && self.T1 == other.T1 && self.T2 == other.T2 && self.PreferredLifetimeIATA == other.PreferredLifetimeIATA && self.ValidLifetimeIATA == other.ValidLifetimeIATA && self.fAuditLog == other.fAuditLog
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7801,7 +7753,7 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_CONFIG_INFO_VQ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_SERVER_CONFIG_INFO_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_CONFIG_INFO_VQ>()) == 0 }
+        self.APIProtocolSupport == other.APIProtocolSupport && self.DatabaseName == other.DatabaseName && self.DatabasePath == other.DatabasePath && self.BackupPath == other.BackupPath && self.BackupInterval == other.BackupInterval && self.DatabaseLoggingFlag == other.DatabaseLoggingFlag && self.RestoreFlag == other.RestoreFlag && self.DatabaseCleanupInterval == other.DatabaseCleanupInterval && self.DebugFlag == other.DebugFlag && self.dwPingRetries == other.dwPingRetries && self.cbBootTableString == other.cbBootTableString && self.wszBootTableString == other.wszBootTableString && self.fAuditLog == other.fAuditLog && self.QuarantineOn == other.QuarantineOn && self.QuarDefFail == other.QuarDefFail && self.QuarRuntimeStatus == other.QuarRuntimeStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7889,7 +7841,31 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DHCP_SERVER_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_OPTIONS>()) == 0 }
+        self.MessageType == other.MessageType
+            && self.SubnetMask == other.SubnetMask
+            && self.RequestedAddress == other.RequestedAddress
+            && self.RequestLeaseTime == other.RequestLeaseTime
+            && self.OverlayFields == other.OverlayFields
+            && self.RouterAddress == other.RouterAddress
+            && self.Server == other.Server
+            && self.ParameterRequestList == other.ParameterRequestList
+            && self.ParameterRequestListLength == other.ParameterRequestListLength
+            && self.MachineName == other.MachineName
+            && self.MachineNameLength == other.MachineNameLength
+            && self.ClientHardwareAddressType == other.ClientHardwareAddressType
+            && self.ClientHardwareAddressLength == other.ClientHardwareAddressLength
+            && self.ClientHardwareAddress == other.ClientHardwareAddress
+            && self.ClassIdentifier == other.ClassIdentifier
+            && self.ClassIdentifierLength == other.ClassIdentifierLength
+            && self.VendorClass == other.VendorClass
+            && self.VendorClassLength == other.VendorClassLength
+            && self.DNSFlags == other.DNSFlags
+            && self.DNSNameLength == other.DNSNameLength
+            && self.DNSName == other.DNSName
+            && self.DSDomainNameRequested == other.DSDomainNameRequested
+            && self.DSDomainName == other.DSDomainName
+            && self.DSDomainNameLen == other.DSDomainNameLen
+            && self.ScopeId == other.ScopeId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7922,7 +7898,7 @@ unsafe impl ::windows::core::Abi for DHCP_SERVER_SPECIFIC_STRINGS {
 }
 impl ::core::cmp::PartialEq for DHCP_SERVER_SPECIFIC_STRINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SERVER_SPECIFIC_STRINGS>()) == 0 }
+        self.DefaultVendorClassName == other.DefaultVendorClassName && self.DefaultUserClassName == other.DefaultUserClassName
     }
 }
 impl ::core::cmp::Eq for DHCP_SERVER_SPECIFIC_STRINGS {}
@@ -7946,12 +7922,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7975,12 +7945,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_0 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_0 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8001,12 +7965,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V4 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V4 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8030,12 +7988,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V4_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V4_0 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8056,12 +8008,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V5 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V5 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V5>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V5 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V5 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8085,12 +8031,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V5_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V5_0 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8111,12 +8051,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V6 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V6 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8138,12 +8072,6 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
 unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_DATA_V6_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_DATA_V6_0 {}
 impl ::core::default::Default for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8171,7 +8099,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_INFO_ARRAY {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_INFO_ARRAY>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_INFO_ARRAY {}
@@ -8202,7 +8130,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4 {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4 {}
@@ -8233,7 +8161,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {}
@@ -8264,7 +8192,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6>()) == 0 }
+        self.NumElements == other.NumElements && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {}
@@ -8305,7 +8233,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_INFO {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_INFO>()) == 0 }
+        self.SubnetAddress == other.SubnetAddress && self.SubnetMask == other.SubnetMask && self.SubnetName == other.SubnetName && self.SubnetComment == other.SubnetComment && self.PrimaryHost == other.PrimaryHost && self.SubnetState == other.SubnetState
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_INFO {}
@@ -8341,7 +8269,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_INFO_V6 {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_INFO_V6>()) == 0 }
+        self.SubnetAddress == other.SubnetAddress && self.Prefix == other.Prefix && self.Preference == other.Preference && self.SubnetName == other.SubnetName && self.SubnetComment == other.SubnetComment && self.State == other.State && self.ScopeId == other.ScopeId
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_INFO_V6 {}
@@ -8381,7 +8309,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUBNET_INFO_VQ {
 }
 impl ::core::cmp::PartialEq for DHCP_SUBNET_INFO_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUBNET_INFO_VQ>()) == 0 }
+        self.SubnetAddress == other.SubnetAddress && self.SubnetMask == other.SubnetMask && self.SubnetName == other.SubnetName && self.SubnetComment == other.SubnetComment && self.PrimaryHost == other.PrimaryHost && self.SubnetState == other.SubnetState && self.QuarantineOn == other.QuarantineOn && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4
     }
 }
 impl ::core::cmp::Eq for DHCP_SUBNET_INFO_VQ {}
@@ -8412,7 +8340,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUPER_SCOPE_TABLE {
 }
 impl ::core::cmp::PartialEq for DHCP_SUPER_SCOPE_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUPER_SCOPE_TABLE>()) == 0 }
+        self.cEntries == other.cEntries && self.pEntries == other.pEntries
     }
 }
 impl ::core::cmp::Eq for DHCP_SUPER_SCOPE_TABLE {}
@@ -8445,7 +8373,7 @@ unsafe impl ::windows::core::Abi for DHCP_SUPER_SCOPE_TABLE_ENTRY {
 }
 impl ::core::cmp::PartialEq for DHCP_SUPER_SCOPE_TABLE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DHCP_SUPER_SCOPE_TABLE_ENTRY>()) == 0 }
+        self.SubnetAddress == other.SubnetAddress && self.SuperScopeNumber == other.SuperScopeNumber && self.NextInSuperScope == other.NextInSuperScope && self.SuperScopeName == other.SuperScopeName
     }
 }
 impl ::core::cmp::Eq for DHCP_SUPER_SCOPE_TABLE_ENTRY {}
@@ -8476,7 +8404,7 @@ unsafe impl ::windows::core::Abi for DWORD_DWORD {
 }
 impl ::core::cmp::PartialEq for DWORD_DWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWORD_DWORD>()) == 0 }
+        self.DWord1 == other.DWord1 && self.DWord2 == other.DWord2
     }
 }
 impl ::core::cmp::Eq for DWORD_DWORD {}
@@ -8509,7 +8437,7 @@ unsafe impl ::windows::core::Abi for SCOPE_MIB_INFO {
 }
 impl ::core::cmp::PartialEq for SCOPE_MIB_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_MIB_INFO>()) == 0 }
+        self.Subnet == other.Subnet && self.NumAddressesInuse == other.NumAddressesInuse && self.NumAddressesFree == other.NumAddressesFree && self.NumPendingOffers == other.NumPendingOffers
     }
 }
 impl ::core::cmp::Eq for SCOPE_MIB_INFO {}
@@ -8542,7 +8470,7 @@ unsafe impl ::windows::core::Abi for SCOPE_MIB_INFO_V5 {
 }
 impl ::core::cmp::PartialEq for SCOPE_MIB_INFO_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_MIB_INFO_V5>()) == 0 }
+        self.Subnet == other.Subnet && self.NumAddressesInuse == other.NumAddressesInuse && self.NumAddressesFree == other.NumAddressesFree && self.NumPendingOffers == other.NumPendingOffers
     }
 }
 impl ::core::cmp::Eq for SCOPE_MIB_INFO_V5 {}
@@ -8575,7 +8503,7 @@ unsafe impl ::windows::core::Abi for SCOPE_MIB_INFO_V6 {
 }
 impl ::core::cmp::PartialEq for SCOPE_MIB_INFO_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_MIB_INFO_V6>()) == 0 }
+        self.Subnet == other.Subnet && self.NumAddressesInuse == other.NumAddressesInuse && self.NumAddressesFree == other.NumAddressesFree && self.NumPendingAdvertises == other.NumPendingAdvertises
     }
 }
 impl ::core::cmp::Eq for SCOPE_MIB_INFO_V6 {}
@@ -8625,7 +8553,7 @@ unsafe impl ::windows::core::Abi for SCOPE_MIB_INFO_VQ {
 }
 impl ::core::cmp::PartialEq for SCOPE_MIB_INFO_VQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_MIB_INFO_VQ>()) == 0 }
+        self.Subnet == other.Subnet && self.NumAddressesInuse == other.NumAddressesInuse && self.NumAddressesFree == other.NumAddressesFree && self.NumPendingOffers == other.NumPendingOffers && self.QtnNumLeases == other.QtnNumLeases && self.QtnPctQtnLeases == other.QtnPctQtnLeases && self.QtnProbationLeases == other.QtnProbationLeases && self.QtnNonQtnLeases == other.QtnNonQtnLeases && self.QtnExemptLeases == other.QtnExemptLeases && self.QtnCapableClients == other.QtnCapableClients
     }
 }
 impl ::core::cmp::Eq for SCOPE_MIB_INFO_VQ {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -1519,12 +1519,6 @@ impl ::core::clone::Clone for DNS_AAAA_DATA {
 unsafe impl ::windows::core::Abi for DNS_AAAA_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_AAAA_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_AAAA_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_AAAA_DATA {}
 impl ::core::default::Default for DNS_AAAA_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1550,14 +1544,6 @@ unsafe impl ::windows::core::Abi for DNS_ADDR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_ADDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_ADDR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_ADDR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_ADDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1581,14 +1567,6 @@ impl ::core::clone::Clone for DNS_ADDR_0 {
 unsafe impl ::windows::core::Abi for DNS_ADDR_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_ADDR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_ADDR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_ADDR_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_ADDR_0 {
     fn default() -> Self {
@@ -1623,14 +1601,6 @@ unsafe impl ::windows::core::Abi for DNS_ADDR_ARRAY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_ADDR_ARRAY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_ADDR_ARRAY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_ADDR_ARRAY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_ADDR_ARRAY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1658,7 +1628,7 @@ unsafe impl ::windows::core::Abi for DNS_APPLICATION_SETTINGS {
 }
 impl ::core::cmp::PartialEq for DNS_APPLICATION_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_APPLICATION_SETTINGS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for DNS_APPLICATION_SETTINGS {}
@@ -1689,7 +1659,7 @@ unsafe impl ::windows::core::Abi for DNS_ATMA_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_ATMA_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_ATMA_DATA>()) == 0 }
+        self.AddressType == other.AddressType && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for DNS_ATMA_DATA {}
@@ -1719,7 +1689,7 @@ unsafe impl ::windows::core::Abi for DNS_A_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_A_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_A_DATA>()) == 0 }
+        self.IpAddress == other.IpAddress
     }
 }
 impl ::core::cmp::Eq for DNS_A_DATA {}
@@ -1750,7 +1720,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_IFINDEX_ENTRY {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_IFINDEX_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_IFINDEX_ENTRY>()) == 0 }
+        self.pwszConnectionName == other.pwszConnectionName && self.dwIfIndex == other.dwIfIndex
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_IFINDEX_ENTRY {}
@@ -1781,7 +1751,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_IFINDEX_LIST {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_IFINDEX_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_IFINDEX_LIST>()) == 0 }
+        self.pConnectionIfIndexEntries == other.pConnectionIfIndexEntries && self.nEntries == other.nEntries
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_IFINDEX_LIST {}
@@ -1811,7 +1781,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_NAME {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_NAME>()) == 0 }
+        self.wszName == other.wszName
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_NAME {}
@@ -1842,7 +1812,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_NAME_LIST {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_NAME_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_NAME_LIST>()) == 0 }
+        self.cNames == other.cNames && self.pNames == other.pNames
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_NAME_LIST {}
@@ -1878,7 +1848,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_POLICY_ENTRY {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_POLICY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_POLICY_ENTRY>()) == 0 }
+        self.pwszHost == other.pwszHost && self.pwszAppId == other.pwszAppId && self.cbAppSid == other.cbAppSid && self.pbAppSid == other.pbAppSid && self.nConnections == other.nConnections && self.ppwszConnections == other.ppwszConnections && self.dwPolicyEntryFlags == other.dwPolicyEntryFlags
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_POLICY_ENTRY {}
@@ -1909,7 +1879,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_POLICY_ENTRY_LIST {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_POLICY_ENTRY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_POLICY_ENTRY_LIST>()) == 0 }
+        self.pPolicyEntries == other.pPolicyEntries && self.nEntries == other.nEntries
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_POLICY_ENTRY_LIST {}
@@ -1933,12 +1903,6 @@ impl ::core::clone::Clone for DNS_CONNECTION_PROXY_ELEMENT {
 unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_ELEMENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_ELEMENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_ELEMENT {}
 impl ::core::default::Default for DNS_CONNECTION_PROXY_ELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1962,12 +1926,6 @@ impl ::core::clone::Clone for DNS_CONNECTION_PROXY_INFO {
 unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_INFO {}
 impl ::core::default::Default for DNS_CONNECTION_PROXY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1988,12 +1946,6 @@ impl ::core::clone::Clone for DNS_CONNECTION_PROXY_INFO_0 {
 unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_INFO_0 {}
 impl ::core::default::Default for DNS_CONNECTION_PROXY_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2025,7 +1977,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_INFO_0_0>()) == 0 }
+        self.pwszServer == other.pwszServer && self.pwszUsername == other.pwszUsername && self.pwszPassword == other.pwszPassword && self.pwszException == other.pwszException && self.pwszExtraInfo == other.pwszExtraInfo && self.Port == other.Port
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_INFO_0_0 {}
@@ -2057,7 +2009,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_INFO_0_1 {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_INFO_0_1>()) == 0 }
+        self.pwszScript == other.pwszScript && self.pwszUsername == other.pwszUsername && self.pwszPassword == other.pwszPassword
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_INFO_0_1 {}
@@ -2089,14 +2041,6 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_INFO_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_INFO_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_INFO_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_INFO_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_CONNECTION_PROXY_INFO_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2124,7 +2068,7 @@ unsafe impl ::windows::core::Abi for DNS_CONNECTION_PROXY_LIST {
 }
 impl ::core::cmp::PartialEq for DNS_CONNECTION_PROXY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CONNECTION_PROXY_LIST>()) == 0 }
+        self.cProxies == other.cProxies && self.pProxies == other.pProxies
     }
 }
 impl ::core::cmp::Eq for DNS_CONNECTION_PROXY_LIST {}
@@ -2155,14 +2099,6 @@ unsafe impl ::windows::core::Abi for DNS_CUSTOM_SERVER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_CUSTOM_SERVER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CUSTOM_SERVER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_CUSTOM_SERVER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_CUSTOM_SERVER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2187,14 +2123,6 @@ unsafe impl ::windows::core::Abi for DNS_CUSTOM_SERVER_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_CUSTOM_SERVER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CUSTOM_SERVER_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_CUSTOM_SERVER_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_CUSTOM_SERVER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2218,14 +2146,6 @@ impl ::core::clone::Clone for DNS_CUSTOM_SERVER_1 {
 unsafe impl ::windows::core::Abi for DNS_CUSTOM_SERVER_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_CUSTOM_SERVER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_CUSTOM_SERVER_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_CUSTOM_SERVER_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_CUSTOM_SERVER_1 {
     fn default() -> Self {
@@ -2254,7 +2174,7 @@ unsafe impl ::windows::core::Abi for DNS_DHCID_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_DHCID_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_DHCID_DATA>()) == 0 }
+        self.dwByteCount == other.dwByteCount && self.DHCID == other.DHCID
     }
 }
 impl ::core::cmp::Eq for DNS_DHCID_DATA {}
@@ -2289,7 +2209,7 @@ unsafe impl ::windows::core::Abi for DNS_DS_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_DS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_DS_DATA>()) == 0 }
+        self.wKeyTag == other.wKeyTag && self.chAlgorithm == other.chAlgorithm && self.chDigestType == other.chDigestType && self.wDigestLength == other.wDigestLength && self.wPad == other.wPad && self.Digest == other.Digest
     }
 }
 impl ::core::cmp::Eq for DNS_DS_DATA {}
@@ -2318,12 +2238,6 @@ impl ::core::clone::Clone for DNS_HEADER {
 unsafe impl ::windows::core::Abi for DNS_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_HEADER {}
 impl ::core::default::Default for DNS_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2345,12 +2259,6 @@ impl ::core::clone::Clone for DNS_HEADER_EXT {
 unsafe impl ::windows::core::Abi for DNS_HEADER_EXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_HEADER_EXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_HEADER_EXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_HEADER_EXT {}
 impl ::core::default::Default for DNS_HEADER_EXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2382,7 +2290,7 @@ unsafe impl ::windows::core::Abi for DNS_KEY_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_KEY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_KEY_DATA>()) == 0 }
+        self.wFlags == other.wFlags && self.chProtocol == other.chProtocol && self.chAlgorithm == other.chAlgorithm && self.wKeyLength == other.wKeyLength && self.wPad == other.wPad && self.Key == other.Key
     }
 }
 impl ::core::cmp::Eq for DNS_KEY_DATA {}
@@ -2418,7 +2326,7 @@ unsafe impl ::windows::core::Abi for DNS_LOC_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_LOC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_LOC_DATA>()) == 0 }
+        self.wVersion == other.wVersion && self.wSize == other.wSize && self.wHorPrec == other.wHorPrec && self.wVerPrec == other.wVerPrec && self.dwLatitude == other.dwLatitude && self.dwLongitude == other.dwLongitude && self.dwAltitude == other.dwAltitude
     }
 }
 impl ::core::cmp::Eq for DNS_LOC_DATA {}
@@ -2447,14 +2355,6 @@ unsafe impl ::windows::core::Abi for DNS_MESSAGE_BUFFER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_MESSAGE_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_MESSAGE_BUFFER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_MESSAGE_BUFFER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_MESSAGE_BUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2482,7 +2382,7 @@ unsafe impl ::windows::core::Abi for DNS_MINFO_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_MINFO_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_MINFO_DATAA>()) == 0 }
+        self.pNameMailbox == other.pNameMailbox && self.pNameErrorsMailbox == other.pNameErrorsMailbox
     }
 }
 impl ::core::cmp::Eq for DNS_MINFO_DATAA {}
@@ -2513,7 +2413,7 @@ unsafe impl ::windows::core::Abi for DNS_MINFO_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_MINFO_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_MINFO_DATAW>()) == 0 }
+        self.pNameMailbox == other.pNameMailbox && self.pNameErrorsMailbox == other.pNameErrorsMailbox
     }
 }
 impl ::core::cmp::Eq for DNS_MINFO_DATAW {}
@@ -2545,7 +2445,7 @@ unsafe impl ::windows::core::Abi for DNS_MX_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_MX_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_MX_DATAA>()) == 0 }
+        self.pNameExchange == other.pNameExchange && self.wPreference == other.wPreference && self.Pad == other.Pad
     }
 }
 impl ::core::cmp::Eq for DNS_MX_DATAA {}
@@ -2577,7 +2477,7 @@ unsafe impl ::windows::core::Abi for DNS_MX_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_MX_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_MX_DATAW>()) == 0 }
+        self.pNameExchange == other.pNameExchange && self.wPreference == other.wPreference && self.Pad == other.Pad
     }
 }
 impl ::core::cmp::Eq for DNS_MX_DATAW {}
@@ -2612,7 +2512,7 @@ unsafe impl ::windows::core::Abi for DNS_NAPTR_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_NAPTR_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NAPTR_DATAA>()) == 0 }
+        self.wOrder == other.wOrder && self.wPreference == other.wPreference && self.pFlags == other.pFlags && self.pService == other.pService && self.pRegularExpression == other.pRegularExpression && self.pReplacement == other.pReplacement
     }
 }
 impl ::core::cmp::Eq for DNS_NAPTR_DATAA {}
@@ -2647,7 +2547,7 @@ unsafe impl ::windows::core::Abi for DNS_NAPTR_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_NAPTR_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NAPTR_DATAW>()) == 0 }
+        self.wOrder == other.wOrder && self.wPreference == other.wPreference && self.pFlags == other.pFlags && self.pService == other.pService && self.pRegularExpression == other.pRegularExpression && self.pReplacement == other.pReplacement
     }
 }
 impl ::core::cmp::Eq for DNS_NAPTR_DATAW {}
@@ -2682,7 +2582,7 @@ unsafe impl ::windows::core::Abi for DNS_NSEC3PARAM_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_NSEC3PARAM_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NSEC3PARAM_DATA>()) == 0 }
+        self.chAlgorithm == other.chAlgorithm && self.bFlags == other.bFlags && self.wIterations == other.wIterations && self.bSaltLength == other.bSaltLength && self.bPad == other.bPad && self.pbSalt == other.pbSalt
     }
 }
 impl ::core::cmp::Eq for DNS_NSEC3PARAM_DATA {}
@@ -2718,7 +2618,7 @@ unsafe impl ::windows::core::Abi for DNS_NSEC3_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_NSEC3_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NSEC3_DATA>()) == 0 }
+        self.chAlgorithm == other.chAlgorithm && self.bFlags == other.bFlags && self.wIterations == other.wIterations && self.bSaltLength == other.bSaltLength && self.bHashLength == other.bHashLength && self.wTypeBitMapsLength == other.wTypeBitMapsLength && self.chData == other.chData
     }
 }
 impl ::core::cmp::Eq for DNS_NSEC3_DATA {}
@@ -2751,7 +2651,7 @@ unsafe impl ::windows::core::Abi for DNS_NSEC_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_NSEC_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NSEC_DATAA>()) == 0 }
+        self.pNextDomainName == other.pNextDomainName && self.wTypeBitMapsLength == other.wTypeBitMapsLength && self.wPad == other.wPad && self.TypeBitMaps == other.TypeBitMaps
     }
 }
 impl ::core::cmp::Eq for DNS_NSEC_DATAA {}
@@ -2784,7 +2684,7 @@ unsafe impl ::windows::core::Abi for DNS_NSEC_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_NSEC_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NSEC_DATAW>()) == 0 }
+        self.pNextDomainName == other.pNextDomainName && self.wTypeBitMapsLength == other.wTypeBitMapsLength && self.wPad == other.wPad && self.TypeBitMaps == other.TypeBitMaps
     }
 }
 impl ::core::cmp::Eq for DNS_NSEC_DATAW {}
@@ -2815,7 +2715,7 @@ unsafe impl ::windows::core::Abi for DNS_NULL_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_NULL_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NULL_DATA>()) == 0 }
+        self.dwByteCount == other.dwByteCount && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DNS_NULL_DATA {}
@@ -2847,7 +2747,7 @@ unsafe impl ::windows::core::Abi for DNS_NXT_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_NXT_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NXT_DATAA>()) == 0 }
+        self.pNameNext == other.pNameNext && self.wNumTypes == other.wNumTypes && self.wTypes == other.wTypes
     }
 }
 impl ::core::cmp::Eq for DNS_NXT_DATAA {}
@@ -2879,7 +2779,7 @@ unsafe impl ::windows::core::Abi for DNS_NXT_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_NXT_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_NXT_DATAW>()) == 0 }
+        self.pNameNext == other.pNameNext && self.wNumTypes == other.wNumTypes && self.wTypes == other.wTypes
     }
 }
 impl ::core::cmp::Eq for DNS_NXT_DATAW {}
@@ -2911,7 +2811,7 @@ unsafe impl ::windows::core::Abi for DNS_OPT_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_OPT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_OPT_DATA>()) == 0 }
+        self.wDataLength == other.wDataLength && self.wPad == other.wPad && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DNS_OPT_DATA {}
@@ -2943,7 +2843,7 @@ unsafe impl ::windows::core::Abi for DNS_PROXY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for DNS_PROXY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_PROXY_INFORMATION>()) == 0 }
+        self.version == other.version && self.proxyInformationType == other.proxyInformationType && self.proxyName == other.proxyName
     }
 }
 impl ::core::cmp::Eq for DNS_PROXY_INFORMATION {}
@@ -2973,7 +2873,7 @@ unsafe impl ::windows::core::Abi for DNS_PTR_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_PTR_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_PTR_DATAA>()) == 0 }
+        self.pNameHost == other.pNameHost
     }
 }
 impl ::core::cmp::Eq for DNS_PTR_DATAA {}
@@ -3003,7 +2903,7 @@ unsafe impl ::windows::core::Abi for DNS_PTR_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_PTR_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_PTR_DATAW>()) == 0 }
+        self.pNameHost == other.pNameHost
     }
 }
 impl ::core::cmp::Eq for DNS_PTR_DATAW {}
@@ -3039,7 +2939,7 @@ unsafe impl ::windows::core::Abi for DNS_QUERY_CANCEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_QUERY_CANCEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_QUERY_CANCEL>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3074,21 +2974,13 @@ impl ::core::clone::Clone for DNS_QUERY_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DNS_QUERY_REQUEST {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DNS_QUERY_REQUEST").field("Version", &self.Version).field("QueryName", &self.QueryName).field("QueryType", &self.QueryType).field("QueryOptions", &self.QueryOptions).field("pDnsServerList", &self.pDnsServerList).field("InterfaceIndex", &self.InterfaceIndex).field("pQueryCompletionCallback", &self.pQueryCompletionCallback.map(|f| f as usize)).field("pQueryContext", &self.pQueryContext).finish()
+        f.debug_struct("DNS_QUERY_REQUEST").field("Version", &self.Version).field("QueryName", &self.QueryName).field("QueryType", &self.QueryType).field("QueryOptions", &self.QueryOptions).field("pDnsServerList", &self.pDnsServerList).field("InterfaceIndex", &self.InterfaceIndex).field("pQueryContext", &self.pQueryContext).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DNS_QUERY_REQUEST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_QUERY_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_QUERY_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_QUERY_REQUEST {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_QUERY_REQUEST {
     fn default() -> Self {
@@ -3130,7 +3022,6 @@ impl ::core::fmt::Debug for DNS_QUERY_REQUEST3 {
             .field("QueryOptions", &self.QueryOptions)
             .field("pDnsServerList", &self.pDnsServerList)
             .field("InterfaceIndex", &self.InterfaceIndex)
-            .field("pQueryCompletionCallback", &self.pQueryCompletionCallback.map(|f| f as usize))
             .field("pQueryContext", &self.pQueryContext)
             .field("IsNetworkQueryRequired", &self.IsNetworkQueryRequired)
             .field("RequiredNetworkIndex", &self.RequiredNetworkIndex)
@@ -3143,14 +3034,6 @@ impl ::core::fmt::Debug for DNS_QUERY_REQUEST3 {
 unsafe impl ::windows::core::Abi for DNS_QUERY_REQUEST3 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_QUERY_REQUEST3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_QUERY_REQUEST3>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_QUERY_REQUEST3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_QUERY_REQUEST3 {
     fn default() -> Self {
@@ -3188,7 +3071,7 @@ unsafe impl ::windows::core::Abi for DNS_QUERY_RESULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_QUERY_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_QUERY_RESULT>()) == 0 }
+        self.Version == other.Version && self.QueryStatus == other.QueryStatus && self.QueryOptions == other.QueryOptions && self.pQueryRecords == other.pQueryRecords && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3224,14 +3107,6 @@ impl ::core::clone::Clone for DNS_RECORDA {
 unsafe impl ::windows::core::Abi for DNS_RECORDA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDA {
     fn default() -> Self {
@@ -3340,14 +3215,6 @@ unsafe impl ::windows::core::Abi for DNS_RECORDA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3372,14 +3239,6 @@ impl ::core::clone::Clone for DNS_RECORDA_1 {
 unsafe impl ::windows::core::Abi for DNS_RECORDA_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDA_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDA_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDA_1 {
     fn default() -> Self {
@@ -3411,14 +3270,6 @@ impl ::core::clone::Clone for DNS_RECORDW {
 unsafe impl ::windows::core::Abi for DNS_RECORDW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDW {
     fn default() -> Self {
@@ -3527,14 +3378,6 @@ unsafe impl ::windows::core::Abi for DNS_RECORDW_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDW_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3559,14 +3402,6 @@ impl ::core::clone::Clone for DNS_RECORDW_1 {
 unsafe impl ::windows::core::Abi for DNS_RECORDW_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORDW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORDW_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORDW_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORDW_1 {
     fn default() -> Self {
@@ -3594,7 +3429,7 @@ unsafe impl ::windows::core::Abi for DNS_RECORD_FLAGS {
 }
 impl ::core::cmp::PartialEq for DNS_RECORD_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORD_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DNS_RECORD_FLAGS {}
@@ -3630,14 +3465,6 @@ unsafe impl ::windows::core::Abi for DNS_RECORD_OPTW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORD_OPTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORD_OPTW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORD_OPTW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORD_OPTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3663,14 +3490,6 @@ unsafe impl ::windows::core::Abi for DNS_RECORD_OPTW_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORD_OPTW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORD_OPTW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORD_OPTW_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORD_OPTW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3695,14 +3514,6 @@ impl ::core::clone::Clone for DNS_RECORD_OPTW_1 {
 unsafe impl ::windows::core::Abi for DNS_RECORD_OPTW_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_RECORD_OPTW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RECORD_OPTW_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_RECORD_OPTW_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_RECORD_OPTW_1 {
     fn default() -> Self {
@@ -3737,7 +3548,7 @@ unsafe impl ::windows::core::Abi for DNS_RRSET {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_RRSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_RRSET>()) == 0 }
+        self.pFirstRR == other.pFirstRR && self.pLastRR == other.pLastRR
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3771,14 +3582,6 @@ unsafe impl ::windows::core::Abi for DNS_SERVICE_BROWSE_REQUEST {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_SERVICE_BROWSE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_BROWSE_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_SERVICE_BROWSE_REQUEST {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_SERVICE_BROWSE_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3803,14 +3606,6 @@ impl ::core::clone::Clone for DNS_SERVICE_BROWSE_REQUEST_0 {
 unsafe impl ::windows::core::Abi for DNS_SERVICE_BROWSE_REQUEST_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_SERVICE_BROWSE_REQUEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_BROWSE_REQUEST_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_SERVICE_BROWSE_REQUEST_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_SERVICE_BROWSE_REQUEST_0 {
     fn default() -> Self {
@@ -3838,7 +3633,7 @@ unsafe impl ::windows::core::Abi for DNS_SERVICE_CANCEL {
 }
 impl ::core::cmp::PartialEq for DNS_SERVICE_CANCEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_CANCEL>()) == 0 }
+        self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for DNS_SERVICE_CANCEL {}
@@ -3878,7 +3673,7 @@ unsafe impl ::windows::core::Abi for DNS_SERVICE_INSTANCE {
 }
 impl ::core::cmp::PartialEq for DNS_SERVICE_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_INSTANCE>()) == 0 }
+        self.pszInstanceName == other.pszInstanceName && self.pszHostName == other.pszHostName && self.ip4Address == other.ip4Address && self.ip6Address == other.ip6Address && self.wPort == other.wPort && self.wPriority == other.wPriority && self.wWeight == other.wWeight && self.dwPropertyCount == other.dwPropertyCount && self.keys == other.keys && self.values == other.values && self.dwInterfaceIndex == other.dwInterfaceIndex
     }
 }
 impl ::core::cmp::Eq for DNS_SERVICE_INSTANCE {}
@@ -3910,21 +3705,13 @@ impl ::core::clone::Clone for DNS_SERVICE_REGISTER_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DNS_SERVICE_REGISTER_REQUEST {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DNS_SERVICE_REGISTER_REQUEST").field("Version", &self.Version).field("InterfaceIndex", &self.InterfaceIndex).field("pServiceInstance", &self.pServiceInstance).field("pRegisterCompletionCallback", &self.pRegisterCompletionCallback.map(|f| f as usize)).field("pQueryContext", &self.pQueryContext).field("hCredentials", &self.hCredentials).field("unicastEnabled", &self.unicastEnabled).finish()
+        f.debug_struct("DNS_SERVICE_REGISTER_REQUEST").field("Version", &self.Version).field("InterfaceIndex", &self.InterfaceIndex).field("pServiceInstance", &self.pServiceInstance).field("pQueryContext", &self.pQueryContext).field("hCredentials", &self.hCredentials).field("unicastEnabled", &self.unicastEnabled).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DNS_SERVICE_REGISTER_REQUEST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DNS_SERVICE_REGISTER_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_REGISTER_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DNS_SERVICE_REGISTER_REQUEST {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DNS_SERVICE_REGISTER_REQUEST {
     fn default() -> Self {
@@ -3948,18 +3735,12 @@ impl ::core::clone::Clone for DNS_SERVICE_RESOLVE_REQUEST {
 }
 impl ::core::fmt::Debug for DNS_SERVICE_RESOLVE_REQUEST {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DNS_SERVICE_RESOLVE_REQUEST").field("Version", &self.Version).field("InterfaceIndex", &self.InterfaceIndex).field("QueryName", &self.QueryName).field("pResolveCompletionCallback", &self.pResolveCompletionCallback.map(|f| f as usize)).field("pQueryContext", &self.pQueryContext).finish()
+        f.debug_struct("DNS_SERVICE_RESOLVE_REQUEST").field("Version", &self.Version).field("InterfaceIndex", &self.InterfaceIndex).field("QueryName", &self.QueryName).field("pQueryContext", &self.pQueryContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for DNS_SERVICE_RESOLVE_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_SERVICE_RESOLVE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVICE_RESOLVE_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_SERVICE_RESOLVE_REQUEST {}
 impl ::core::default::Default for DNS_SERVICE_RESOLVE_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3995,7 +3776,7 @@ unsafe impl ::windows::core::Abi for DNS_SIG_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_SIG_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SIG_DATAA>()) == 0 }
+        self.wTypeCovered == other.wTypeCovered && self.chAlgorithm == other.chAlgorithm && self.chLabelCount == other.chLabelCount && self.dwOriginalTtl == other.dwOriginalTtl && self.dwExpiration == other.dwExpiration && self.dwTimeSigned == other.dwTimeSigned && self.wKeyTag == other.wKeyTag && self.wSignatureLength == other.wSignatureLength && self.pNameSigner == other.pNameSigner && self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for DNS_SIG_DATAA {}
@@ -4034,7 +3815,7 @@ unsafe impl ::windows::core::Abi for DNS_SIG_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_SIG_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SIG_DATAW>()) == 0 }
+        self.wTypeCovered == other.wTypeCovered && self.chAlgorithm == other.chAlgorithm && self.chLabelCount == other.chLabelCount && self.dwOriginalTtl == other.dwOriginalTtl && self.dwExpiration == other.dwExpiration && self.dwTimeSigned == other.dwTimeSigned && self.wKeyTag == other.wKeyTag && self.wSignatureLength == other.wSignatureLength && self.pNameSigner == other.pNameSigner && self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for DNS_SIG_DATAW {}
@@ -4070,7 +3851,7 @@ unsafe impl ::windows::core::Abi for DNS_SOA_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_SOA_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SOA_DATAA>()) == 0 }
+        self.pNamePrimaryServer == other.pNamePrimaryServer && self.pNameAdministrator == other.pNameAdministrator && self.dwSerialNo == other.dwSerialNo && self.dwRefresh == other.dwRefresh && self.dwRetry == other.dwRetry && self.dwExpire == other.dwExpire && self.dwDefaultTtl == other.dwDefaultTtl
     }
 }
 impl ::core::cmp::Eq for DNS_SOA_DATAA {}
@@ -4106,7 +3887,7 @@ unsafe impl ::windows::core::Abi for DNS_SOA_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_SOA_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SOA_DATAW>()) == 0 }
+        self.pNamePrimaryServer == other.pNamePrimaryServer && self.pNameAdministrator == other.pNameAdministrator && self.dwSerialNo == other.dwSerialNo && self.dwRefresh == other.dwRefresh && self.dwRetry == other.dwRetry && self.dwExpire == other.dwExpire && self.dwDefaultTtl == other.dwDefaultTtl
     }
 }
 impl ::core::cmp::Eq for DNS_SOA_DATAW {}
@@ -4140,7 +3921,7 @@ unsafe impl ::windows::core::Abi for DNS_SRV_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_SRV_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SRV_DATAA>()) == 0 }
+        self.pNameTarget == other.pNameTarget && self.wPriority == other.wPriority && self.wWeight == other.wWeight && self.wPort == other.wPort && self.Pad == other.Pad
     }
 }
 impl ::core::cmp::Eq for DNS_SRV_DATAA {}
@@ -4174,7 +3955,7 @@ unsafe impl ::windows::core::Abi for DNS_SRV_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_SRV_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SRV_DATAW>()) == 0 }
+        self.pNameTarget == other.pNameTarget && self.wPriority == other.wPriority && self.wWeight == other.wWeight && self.wPort == other.wPort && self.Pad == other.Pad
     }
 }
 impl ::core::cmp::Eq for DNS_SRV_DATAW {}
@@ -4234,7 +4015,7 @@ unsafe impl ::windows::core::Abi for DNS_TKEY_DATAA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_TKEY_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TKEY_DATAA>()) == 0 }
+        self.pNameAlgorithm == other.pNameAlgorithm && self.pAlgorithmPacket == other.pAlgorithmPacket && self.pKey == other.pKey && self.pOtherData == other.pOtherData && self.dwCreateTime == other.dwCreateTime && self.dwExpireTime == other.dwExpireTime && self.wMode == other.wMode && self.wError == other.wError && self.wKeyLength == other.wKeyLength && self.wOtherLength == other.wOtherLength && self.cAlgNameLength == other.cAlgNameLength && self.bPacketPointers == other.bPacketPointers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4296,7 +4077,7 @@ unsafe impl ::windows::core::Abi for DNS_TKEY_DATAW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_TKEY_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TKEY_DATAW>()) == 0 }
+        self.pNameAlgorithm == other.pNameAlgorithm && self.pAlgorithmPacket == other.pAlgorithmPacket && self.pKey == other.pKey && self.pOtherData == other.pOtherData && self.dwCreateTime == other.dwCreateTime && self.dwExpireTime == other.dwExpireTime && self.wMode == other.wMode && self.wError == other.wError && self.wKeyLength == other.wKeyLength && self.wOtherLength == other.wOtherLength && self.cAlgNameLength == other.cAlgNameLength && self.bPacketPointers == other.bPacketPointers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4333,7 +4114,7 @@ unsafe impl ::windows::core::Abi for DNS_TLSA_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_TLSA_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TLSA_DATA>()) == 0 }
+        self.bCertUsage == other.bCertUsage && self.bSelector == other.bSelector && self.bMatchingType == other.bMatchingType && self.bCertificateAssociationDataLength == other.bCertificateAssociationDataLength && self.bPad == other.bPad && self.bCertificateAssociationData == other.bCertificateAssociationData
     }
 }
 impl ::core::cmp::Eq for DNS_TLSA_DATA {}
@@ -4393,7 +4174,7 @@ unsafe impl ::windows::core::Abi for DNS_TSIG_DATAA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_TSIG_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TSIG_DATAA>()) == 0 }
+        self.pNameAlgorithm == other.pNameAlgorithm && self.pAlgorithmPacket == other.pAlgorithmPacket && self.pSignature == other.pSignature && self.pOtherData == other.pOtherData && self.i64CreateTime == other.i64CreateTime && self.wFudgeTime == other.wFudgeTime && self.wOriginalXid == other.wOriginalXid && self.wError == other.wError && self.wSigLength == other.wSigLength && self.wOtherLength == other.wOtherLength && self.cAlgNameLength == other.cAlgNameLength && self.bPacketPointers == other.bPacketPointers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4455,7 +4236,7 @@ unsafe impl ::windows::core::Abi for DNS_TSIG_DATAW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DNS_TSIG_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TSIG_DATAW>()) == 0 }
+        self.pNameAlgorithm == other.pNameAlgorithm && self.pAlgorithmPacket == other.pAlgorithmPacket && self.pSignature == other.pSignature && self.pOtherData == other.pOtherData && self.i64CreateTime == other.i64CreateTime && self.wFudgeTime == other.wFudgeTime && self.wOriginalXid == other.wOriginalXid && self.wError == other.wError && self.wSigLength == other.wSigLength && self.wOtherLength == other.wOtherLength && self.cAlgNameLength == other.cAlgNameLength && self.bPacketPointers == other.bPacketPointers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4488,7 +4269,7 @@ unsafe impl ::windows::core::Abi for DNS_TXT_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_TXT_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TXT_DATAA>()) == 0 }
+        self.dwStringCount == other.dwStringCount && self.pStringArray == other.pStringArray
     }
 }
 impl ::core::cmp::Eq for DNS_TXT_DATAA {}
@@ -4519,7 +4300,7 @@ unsafe impl ::windows::core::Abi for DNS_TXT_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_TXT_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_TXT_DATAW>()) == 0 }
+        self.dwStringCount == other.dwStringCount && self.pStringArray == other.pStringArray
     }
 }
 impl ::core::cmp::Eq for DNS_TXT_DATAW {}
@@ -4550,7 +4331,7 @@ unsafe impl ::windows::core::Abi for DNS_UNKNOWN_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_UNKNOWN_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_UNKNOWN_DATA>()) == 0 }
+        self.dwByteCount == other.dwByteCount && self.bData == other.bData
     }
 }
 impl ::core::cmp::Eq for DNS_UNKNOWN_DATA {}
@@ -4583,7 +4364,7 @@ unsafe impl ::windows::core::Abi for DNS_WINSR_DATAA {
 }
 impl ::core::cmp::PartialEq for DNS_WINSR_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WINSR_DATAA>()) == 0 }
+        self.dwMappingFlag == other.dwMappingFlag && self.dwLookupTimeout == other.dwLookupTimeout && self.dwCacheTimeout == other.dwCacheTimeout && self.pNameResultDomain == other.pNameResultDomain
     }
 }
 impl ::core::cmp::Eq for DNS_WINSR_DATAA {}
@@ -4616,7 +4397,7 @@ unsafe impl ::windows::core::Abi for DNS_WINSR_DATAW {
 }
 impl ::core::cmp::PartialEq for DNS_WINSR_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WINSR_DATAW>()) == 0 }
+        self.dwMappingFlag == other.dwMappingFlag && self.dwLookupTimeout == other.dwLookupTimeout && self.dwCacheTimeout == other.dwCacheTimeout && self.pNameResultDomain == other.pNameResultDomain
     }
 }
 impl ::core::cmp::Eq for DNS_WINSR_DATAW {}
@@ -4650,7 +4431,7 @@ unsafe impl ::windows::core::Abi for DNS_WINS_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_WINS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WINS_DATA>()) == 0 }
+        self.dwMappingFlag == other.dwMappingFlag && self.dwLookupTimeout == other.dwLookupTimeout && self.dwCacheTimeout == other.dwCacheTimeout && self.cWinsServerCount == other.cWinsServerCount && self.WinsServers == other.WinsServers
     }
 }
 impl ::core::cmp::Eq for DNS_WINS_DATA {}
@@ -4674,12 +4455,6 @@ impl ::core::clone::Clone for DNS_WIRE_QUESTION {
 unsafe impl ::windows::core::Abi for DNS_WIRE_QUESTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_WIRE_QUESTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WIRE_QUESTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_WIRE_QUESTION {}
 impl ::core::default::Default for DNS_WIRE_QUESTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4702,12 +4477,6 @@ impl ::core::clone::Clone for DNS_WIRE_RECORD {
 unsafe impl ::windows::core::Abi for DNS_WIRE_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_WIRE_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WIRE_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_WIRE_RECORD {}
 impl ::core::default::Default for DNS_WIRE_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4736,7 +4505,7 @@ unsafe impl ::windows::core::Abi for DNS_WKS_DATA {
 }
 impl ::core::cmp::PartialEq for DNS_WKS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_WKS_DATA>()) == 0 }
+        self.IpAddress == other.IpAddress && self.chProtocol == other.chProtocol && self.BitMask == other.BitMask
     }
 }
 impl ::core::cmp::Eq for DNS_WKS_DATA {}
@@ -4799,7 +4568,7 @@ unsafe impl ::windows::core::Abi for IP4_ARRAY {
 }
 impl ::core::cmp::PartialEq for IP4_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP4_ARRAY>()) == 0 }
+        self.AddrCount == other.AddrCount && self.AddrArray == other.AddrArray
     }
 }
 impl ::core::cmp::Eq for IP4_ARRAY {}
@@ -4830,14 +4599,6 @@ unsafe impl ::windows::core::Abi for IP6_ADDRESS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for IP6_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP6_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for IP6_ADDRESS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for IP6_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4863,14 +4624,6 @@ impl ::core::clone::Clone for IP6_ADDRESS {
 unsafe impl ::windows::core::Abi for IP6_ADDRESS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for IP6_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP6_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for IP6_ADDRESS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for IP6_ADDRESS {
     fn default() -> Self {
@@ -4902,7 +4655,7 @@ unsafe impl ::windows::core::Abi for MDNS_QUERY_HANDLE {
 }
 impl ::core::cmp::PartialEq for MDNS_QUERY_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDNS_QUERY_HANDLE>()) == 0 }
+        self.nameBuf == other.nameBuf && self.wType == other.wType && self.pSubscription == other.pSubscription && self.pWnfCallbackParams == other.pWnfCallbackParams && self.stateNameData == other.stateNameData
     }
 }
 impl ::core::cmp::Eq for MDNS_QUERY_HANDLE {}
@@ -4937,21 +4690,13 @@ impl ::core::clone::Clone for MDNS_QUERY_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for MDNS_QUERY_REQUEST {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MDNS_QUERY_REQUEST").field("Version", &self.Version).field("ulRefCount", &self.ulRefCount).field("Query", &self.Query).field("QueryType", &self.QueryType).field("QueryOptions", &self.QueryOptions).field("InterfaceIndex", &self.InterfaceIndex).field("pQueryCallback", &self.pQueryCallback.map(|f| f as usize)).field("pQueryContext", &self.pQueryContext).field("fAnswerReceived", &self.fAnswerReceived).field("ulResendCount", &self.ulResendCount).finish()
+        f.debug_struct("MDNS_QUERY_REQUEST").field("Version", &self.Version).field("ulRefCount", &self.ulRefCount).field("Query", &self.Query).field("QueryType", &self.QueryType).field("QueryOptions", &self.QueryOptions).field("InterfaceIndex", &self.InterfaceIndex).field("pQueryContext", &self.pQueryContext).field("fAnswerReceived", &self.fAnswerReceived).field("ulResendCount", &self.ulResendCount).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for MDNS_QUERY_REQUEST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MDNS_QUERY_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDNS_QUERY_REQUEST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MDNS_QUERY_REQUEST {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MDNS_QUERY_REQUEST {
     fn default() -> Self {
@@ -4985,14 +4730,6 @@ unsafe impl ::windows::core::Abi for _DnsRecordOptA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for _DnsRecordOptA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_DnsRecordOptA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for _DnsRecordOptA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for _DnsRecordOptA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5018,14 +4755,6 @@ unsafe impl ::windows::core::Abi for _DnsRecordOptA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for _DnsRecordOptA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_DnsRecordOptA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for _DnsRecordOptA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for _DnsRecordOptA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5050,14 +4779,6 @@ impl ::core::clone::Clone for _DnsRecordOptA_1 {
 unsafe impl ::windows::core::Abi for _DnsRecordOptA_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for _DnsRecordOptA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_DnsRecordOptA_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for _DnsRecordOptA_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for _DnsRecordOptA_1 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
@@ -3271,7 +3271,7 @@ unsafe impl ::windows::core::Abi for ARP_SEND_REPLY {
 }
 impl ::core::cmp::PartialEq for ARP_SEND_REPLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARP_SEND_REPLY>()) == 0 }
+        self.DestAddress == other.DestAddress && self.SrcAddress == other.SrcAddress
     }
 }
 impl ::core::cmp::Eq for ARP_SEND_REPLY {}
@@ -3302,7 +3302,7 @@ unsafe impl ::windows::core::Abi for DNS_DOH_SERVER_SETTINGS {
 }
 impl ::core::cmp::PartialEq for DNS_DOH_SERVER_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_DOH_SERVER_SETTINGS>()) == 0 }
+        self.Template == other.Template && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for DNS_DOH_SERVER_SETTINGS {}
@@ -3341,7 +3341,7 @@ unsafe impl ::windows::core::Abi for DNS_INTERFACE_SETTINGS {
 }
 impl ::core::cmp::PartialEq for DNS_INTERFACE_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_INTERFACE_SETTINGS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Domain == other.Domain && self.NameServer == other.NameServer && self.SearchList == other.SearchList && self.RegistrationEnabled == other.RegistrationEnabled && self.RegisterAdapterName == other.RegisterAdapterName && self.EnableLLMNR == other.EnableLLMNR && self.QueryAdapterName == other.QueryAdapterName && self.ProfileNameServer == other.ProfileNameServer
     }
 }
 impl ::core::cmp::Eq for DNS_INTERFACE_SETTINGS {}
@@ -3403,7 +3403,22 @@ unsafe impl ::windows::core::Abi for DNS_INTERFACE_SETTINGS3 {
 }
 impl ::core::cmp::PartialEq for DNS_INTERFACE_SETTINGS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_INTERFACE_SETTINGS3>()) == 0 }
+        self.Version == other.Version
+            && self.Flags == other.Flags
+            && self.Domain == other.Domain
+            && self.NameServer == other.NameServer
+            && self.SearchList == other.SearchList
+            && self.RegistrationEnabled == other.RegistrationEnabled
+            && self.RegisterAdapterName == other.RegisterAdapterName
+            && self.EnableLLMNR == other.EnableLLMNR
+            && self.QueryAdapterName == other.QueryAdapterName
+            && self.ProfileNameServer == other.ProfileNameServer
+            && self.DisableUnconstrainedQueries == other.DisableUnconstrainedQueries
+            && self.SupplementalSearchList == other.SupplementalSearchList
+            && self.cServerProperties == other.cServerProperties
+            && self.ServerProperties == other.ServerProperties
+            && self.cProfileServerProperties == other.cProfileServerProperties
+            && self.ProfileServerProperties == other.ProfileServerProperties
     }
 }
 impl ::core::cmp::Eq for DNS_INTERFACE_SETTINGS3 {}
@@ -3435,7 +3450,7 @@ unsafe impl ::windows::core::Abi for DNS_INTERFACE_SETTINGS_EX {
 }
 impl ::core::cmp::PartialEq for DNS_INTERFACE_SETTINGS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_INTERFACE_SETTINGS_EX>()) == 0 }
+        self.SettingsV1 == other.SettingsV1 && self.DisableUnconstrainedQueries == other.DisableUnconstrainedQueries && self.SupplementalSearchList == other.SupplementalSearchList
     }
 }
 impl ::core::cmp::Eq for DNS_INTERFACE_SETTINGS_EX {}
@@ -3461,12 +3476,6 @@ impl ::core::clone::Clone for DNS_SERVER_PROPERTY {
 unsafe impl ::windows::core::Abi for DNS_SERVER_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_SERVER_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVER_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_SERVER_PROPERTY {}
 impl ::core::default::Default for DNS_SERVER_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3486,12 +3495,6 @@ impl ::core::clone::Clone for DNS_SERVER_PROPERTY_TYPES {
 unsafe impl ::windows::core::Abi for DNS_SERVER_PROPERTY_TYPES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DNS_SERVER_PROPERTY_TYPES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SERVER_PROPERTY_TYPES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DNS_SERVER_PROPERTY_TYPES {}
 impl ::core::default::Default for DNS_SERVER_PROPERTY_TYPES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3522,7 +3525,7 @@ unsafe impl ::windows::core::Abi for DNS_SETTINGS {
 }
 impl ::core::cmp::PartialEq for DNS_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SETTINGS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Hostname == other.Hostname && self.Domain == other.Domain && self.SearchList == other.SearchList
     }
 }
 impl ::core::cmp::Eq for DNS_SETTINGS {}
@@ -3557,7 +3560,7 @@ unsafe impl ::windows::core::Abi for DNS_SETTINGS2 {
 }
 impl ::core::cmp::PartialEq for DNS_SETTINGS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DNS_SETTINGS2>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Hostname == other.Hostname && self.Domain == other.Domain && self.SearchList == other.SearchList && self.SettingFlags == other.SettingFlags
     }
 }
 impl ::core::cmp::Eq for DNS_SETTINGS2 {}
@@ -3601,7 +3604,7 @@ unsafe impl ::windows::core::Abi for FIXED_INFO_W2KSP1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FIXED_INFO_W2KSP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIXED_INFO_W2KSP1>()) == 0 }
+        self.HostName == other.HostName && self.DomainName == other.DomainName && self.CurrentDnsServer == other.CurrentDnsServer && self.DnsServerList == other.DnsServerList && self.NodeType == other.NodeType && self.ScopeId == other.ScopeId && self.EnableRouting == other.EnableRouting && self.EnableProxy == other.EnableProxy && self.EnableDns == other.EnableDns
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3660,12 +3663,6 @@ impl ::core::clone::Clone for ICMPV6_ECHO_REPLY_LH {
 unsafe impl ::windows::core::Abi for ICMPV6_ECHO_REPLY_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV6_ECHO_REPLY_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV6_ECHO_REPLY_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV6_ECHO_REPLY_LH {}
 impl ::core::default::Default for ICMPV6_ECHO_REPLY_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3698,7 +3695,7 @@ unsafe impl ::windows::core::Abi for ICMP_ECHO_REPLY {
 }
 impl ::core::cmp::PartialEq for ICMP_ECHO_REPLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_ECHO_REPLY>()) == 0 }
+        self.Address == other.Address && self.Status == other.Status && self.RoundTripTime == other.RoundTripTime && self.DataSize == other.DataSize && self.Reserved == other.Reserved && self.Data == other.Data && self.Options == other.Options
     }
 }
 impl ::core::cmp::Eq for ICMP_ECHO_REPLY {}
@@ -3740,7 +3737,7 @@ unsafe impl ::windows::core::Abi for ICMP_ECHO_REPLY32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for ICMP_ECHO_REPLY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_ECHO_REPLY32>()) == 0 }
+        self.Address == other.Address && self.Status == other.Status && self.RoundTripTime == other.RoundTripTime && self.DataSize == other.DataSize && self.Reserved == other.Reserved && self.Data == other.Data && self.Options == other.Options
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3774,7 +3771,7 @@ unsafe impl ::windows::core::Abi for INTERFACE_HARDWARE_CROSSTIMESTAMP {
 }
 impl ::core::cmp::PartialEq for INTERFACE_HARDWARE_CROSSTIMESTAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_HARDWARE_CROSSTIMESTAMP>()) == 0 }
+        self.SystemTimestamp1 == other.SystemTimestamp1 && self.HardwareClockTimestamp == other.HardwareClockTimestamp && self.SystemTimestamp2 == other.SystemTimestamp2
     }
 }
 impl ::core::cmp::Eq for INTERFACE_HARDWARE_CROSSTIMESTAMP {}
@@ -3832,7 +3829,17 @@ unsafe impl ::windows::core::Abi for INTERFACE_HARDWARE_TIMESTAMP_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERFACE_HARDWARE_TIMESTAMP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_HARDWARE_TIMESTAMP_CAPABILITIES>()) == 0 }
+        self.PtpV2OverUdpIPv4EventMessageReceive == other.PtpV2OverUdpIPv4EventMessageReceive
+            && self.PtpV2OverUdpIPv4AllMessageReceive == other.PtpV2OverUdpIPv4AllMessageReceive
+            && self.PtpV2OverUdpIPv4EventMessageTransmit == other.PtpV2OverUdpIPv4EventMessageTransmit
+            && self.PtpV2OverUdpIPv4AllMessageTransmit == other.PtpV2OverUdpIPv4AllMessageTransmit
+            && self.PtpV2OverUdpIPv6EventMessageReceive == other.PtpV2OverUdpIPv6EventMessageReceive
+            && self.PtpV2OverUdpIPv6AllMessageReceive == other.PtpV2OverUdpIPv6AllMessageReceive
+            && self.PtpV2OverUdpIPv6EventMessageTransmit == other.PtpV2OverUdpIPv6EventMessageTransmit
+            && self.PtpV2OverUdpIPv6AllMessageTransmit == other.PtpV2OverUdpIPv6AllMessageTransmit
+            && self.AllReceive == other.AllReceive
+            && self.AllTransmit == other.AllTransmit
+            && self.TaggedTransmit == other.TaggedTransmit
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3872,7 +3879,7 @@ unsafe impl ::windows::core::Abi for INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES>()) == 0 }
+        self.AllReceive == other.AllReceive && self.AllTransmit == other.AllTransmit && self.TaggedTransmit == other.TaggedTransmit
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3913,7 +3920,7 @@ unsafe impl ::windows::core::Abi for INTERFACE_TIMESTAMP_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERFACE_TIMESTAMP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_TIMESTAMP_CAPABILITIES>()) == 0 }
+        self.HardwareClockFrequencyHz == other.HardwareClockFrequencyHz && self.SupportsCrossTimestamp == other.SupportsCrossTimestamp && self.HardwareCapabilities == other.HardwareCapabilities && self.SoftwareCapabilities == other.SoftwareCapabilities
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3941,12 +3948,6 @@ impl ::core::clone::Clone for IPV6_ADDRESS_EX {
 unsafe impl ::windows::core::Abi for IPV6_ADDRESS_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_ADDRESS_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_ADDRESS_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_ADDRESS_EX {}
 impl ::core::default::Default for IPV6_ADDRESS_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4006,14 +4007,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_LH {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_LH>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ADDRESSES_LH {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ADDRESSES_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4038,14 +4031,6 @@ impl ::core::clone::Clone for IP_ADAPTER_ADDRESSES_LH_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_LH_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_LH_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ADDRESSES_LH_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ADDRESSES_LH_0 {
     fn default() -> Self {
@@ -4080,7 +4065,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_LH_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_LH_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_LH_0_0>()) == 0 }
+        self.Length == other.Length && self.IfIndex == other.IfIndex
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -4110,14 +4095,6 @@ impl ::core::clone::Clone for IP_ADAPTER_ADDRESSES_LH_1 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_LH_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_LH_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_LH_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ADDRESSES_LH_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ADDRESSES_LH_1 {
     fn default() -> Self {
@@ -4151,7 +4128,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_LH_1_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_LH_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_LH_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -4199,14 +4176,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ADDRESSES_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ADDRESSES_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4231,14 +4200,6 @@ impl ::core::clone::Clone for IP_ADAPTER_ADDRESSES_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ADDRESSES_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ADDRESSES_XP_0 {
     fn default() -> Self {
@@ -4273,7 +4234,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ADDRESSES_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_ADDRESSES_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ADDRESSES_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.IfIndex == other.IfIndex
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -4305,14 +4266,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ANYCAST_ADDRESS_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ANYCAST_ADDRESS_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ANYCAST_ADDRESS_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ANYCAST_ADDRESS_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ANYCAST_ADDRESS_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4337,14 +4290,6 @@ impl ::core::clone::Clone for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ANYCAST_ADDRESS_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
     fn default() -> Self {
@@ -4379,7 +4324,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ANYCAST_ADDRESS_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_ANYCAST_ADDRESS_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ANYCAST_ADDRESS_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4411,14 +4356,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_DNS_SERVER_ADDRESS_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4443,14 +4380,6 @@ impl ::core::clone::Clone for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
     fn default() -> Self {
@@ -4485,7 +4414,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4518,7 +4447,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_DNS_SUFFIX {
 }
 impl ::core::cmp::PartialEq for IP_ADAPTER_DNS_SUFFIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_DNS_SUFFIX>()) == 0 }
+        self.Next == other.Next && self.String == other.String
     }
 }
 impl ::core::cmp::Eq for IP_ADAPTER_DNS_SUFFIX {}
@@ -4548,14 +4477,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_GATEWAY_ADDRESS_LH {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_GATEWAY_ADDRESS_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_GATEWAY_ADDRESS_LH>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_GATEWAY_ADDRESS_LH {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_GATEWAY_ADDRESS_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4580,14 +4501,6 @@ impl ::core::clone::Clone for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_GATEWAY_ADDRESS_LH_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
     fn default() -> Self {
@@ -4622,7 +4535,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_GATEWAY_ADDRESS_LH_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_GATEWAY_ADDRESS_LH_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_GATEWAY_ADDRESS_LH_0_0>()) == 0 }
+        self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4655,7 +4568,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_INDEX_MAP {
 }
 impl ::core::cmp::PartialEq for IP_ADAPTER_INDEX_MAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_INDEX_MAP>()) == 0 }
+        self.Index == other.Index && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for IP_ADAPTER_INDEX_MAP {}
@@ -4727,7 +4640,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IP_ADAPTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_INFO>()) == 0 }
+        self.Next == other.Next && self.ComboIndex == other.ComboIndex && self.AdapterName == other.AdapterName && self.Description == other.Description && self.AddressLength == other.AddressLength && self.Address == other.Address && self.Index == other.Index && self.Type == other.Type && self.DhcpEnabled == other.DhcpEnabled && self.CurrentIpAddress == other.CurrentIpAddress && self.IpAddressList == other.IpAddressList && self.GatewayList == other.GatewayList && self.DhcpServer == other.DhcpServer && self.HaveWins == other.HaveWins && self.PrimaryWinsServer == other.PrimaryWinsServer && self.SecondaryWinsServer == other.SecondaryWinsServer && self.LeaseObtained == other.LeaseObtained && self.LeaseExpires == other.LeaseExpires
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4759,14 +4672,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_MULTICAST_ADDRESS_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_MULTICAST_ADDRESS_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_MULTICAST_ADDRESS_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_MULTICAST_ADDRESS_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_MULTICAST_ADDRESS_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4791,14 +4696,6 @@ impl ::core::clone::Clone for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_MULTICAST_ADDRESS_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
     fn default() -> Self {
@@ -4833,7 +4730,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_MULTICAST_ADDRESS_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_MULTICAST_ADDRESS_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_MULTICAST_ADDRESS_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4866,7 +4763,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_ORDER_MAP {
 }
 impl ::core::cmp::PartialEq for IP_ADAPTER_ORDER_MAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_ORDER_MAP>()) == 0 }
+        self.NumAdapters == other.NumAdapters && self.AdapterOrder == other.AdapterOrder
     }
 }
 impl ::core::cmp::Eq for IP_ADAPTER_ORDER_MAP {}
@@ -4897,14 +4794,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_PREFIX_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_PREFIX_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_PREFIX_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_PREFIX_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_PREFIX_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4929,14 +4818,6 @@ impl ::core::clone::Clone for IP_ADAPTER_PREFIX_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_PREFIX_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_PREFIX_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_PREFIX_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_PREFIX_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_PREFIX_XP_0 {
     fn default() -> Self {
@@ -4971,7 +4852,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_PREFIX_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_PREFIX_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_PREFIX_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5010,14 +4891,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_LH {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_LH>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_UNICAST_ADDRESS_LH {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_UNICAST_ADDRESS_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5042,14 +4915,6 @@ impl ::core::clone::Clone for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_LH_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
     fn default() -> Self {
@@ -5084,7 +4949,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_LH_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_LH_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_LH_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5122,14 +4987,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_XP {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_XP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_XP>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_UNICAST_ADDRESS_XP {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_UNICAST_ADDRESS_XP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5154,14 +5011,6 @@ impl ::core::clone::Clone for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_XP_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
     fn default() -> Self {
@@ -5196,7 +5045,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_UNICAST_ADDRESS_XP_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_UNICAST_ADDRESS_XP_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_UNICAST_ADDRESS_XP_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5228,14 +5077,6 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_WINS_SERVER_ADDRESS_LH>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5260,14 +5101,6 @@ impl ::core::clone::Clone for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
 unsafe impl ::windows::core::Abi for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
     fn default() -> Self {
@@ -5302,7 +5135,7 @@ unsafe impl ::windows::core::Abi for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0_0>()) == 0 }
+        self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5332,14 +5165,6 @@ impl ::core::clone::Clone for IP_ADDRESS_PREFIX {
 unsafe impl ::windows::core::Abi for IP_ADDRESS_PREFIX {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for IP_ADDRESS_PREFIX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADDRESS_PREFIX>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for IP_ADDRESS_PREFIX {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for IP_ADDRESS_PREFIX {
     fn default() -> Self {
@@ -5373,7 +5198,7 @@ unsafe impl ::windows::core::Abi for IP_ADDRESS_STRING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IP_ADDRESS_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADDRESS_STRING>()) == 0 }
+        self.String == other.String
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5414,7 +5239,7 @@ unsafe impl ::windows::core::Abi for IP_ADDR_STRING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IP_ADDR_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_ADDR_STRING>()) == 0 }
+        self.Next == other.Next && self.IpAddress == other.IpAddress && self.IpMask == other.IpMask && self.Context == other.Context
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5447,7 +5272,7 @@ unsafe impl ::windows::core::Abi for IP_INTERFACE_INFO {
 }
 impl ::core::cmp::PartialEq for IP_INTERFACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_INTERFACE_INFO>()) == 0 }
+        self.NumAdapters == other.NumAdapters && self.Adapter == other.Adapter
     }
 }
 impl ::core::cmp::Eq for IP_INTERFACE_INFO {}
@@ -5482,7 +5307,7 @@ unsafe impl ::windows::core::Abi for IP_INTERFACE_NAME_INFO_W2KSP1 {
 }
 impl ::core::cmp::PartialEq for IP_INTERFACE_NAME_INFO_W2KSP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_INTERFACE_NAME_INFO_W2KSP1>()) == 0 }
+        self.Index == other.Index && self.MediaType == other.MediaType && self.ConnectionType == other.ConnectionType && self.AccessType == other.AccessType && self.DeviceGuid == other.DeviceGuid && self.InterfaceGuid == other.InterfaceGuid
     }
 }
 impl ::core::cmp::Eq for IP_INTERFACE_NAME_INFO_W2KSP1 {}
@@ -5515,7 +5340,7 @@ unsafe impl ::windows::core::Abi for IP_MCAST_COUNTER_INFO {
 }
 impl ::core::cmp::PartialEq for IP_MCAST_COUNTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_MCAST_COUNTER_INFO>()) == 0 }
+        self.InMcastOctets == other.InMcastOctets && self.OutMcastOctets == other.OutMcastOctets && self.InMcastPkts == other.InMcastPkts && self.OutMcastPkts == other.OutMcastPkts
     }
 }
 impl ::core::cmp::Eq for IP_MCAST_COUNTER_INFO {}
@@ -5549,7 +5374,7 @@ unsafe impl ::windows::core::Abi for IP_OPTION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for IP_OPTION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_OPTION_INFORMATION>()) == 0 }
+        self.Ttl == other.Ttl && self.Tos == other.Tos && self.Flags == other.Flags && self.OptionsSize == other.OptionsSize && self.OptionsData == other.OptionsData
     }
 }
 impl ::core::cmp::Eq for IP_OPTION_INFORMATION {}
@@ -5589,7 +5414,7 @@ unsafe impl ::windows::core::Abi for IP_OPTION_INFORMATION32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for IP_OPTION_INFORMATION32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_OPTION_INFORMATION32>()) == 0 }
+        self.Ttl == other.Ttl && self.Tos == other.Tos && self.Flags == other.Flags && self.OptionsSize == other.OptionsSize && self.OptionsData == other.OptionsData
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -5630,7 +5455,7 @@ unsafe impl ::windows::core::Abi for IP_PER_ADAPTER_INFO_W2KSP1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IP_PER_ADAPTER_INFO_W2KSP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_PER_ADAPTER_INFO_W2KSP1>()) == 0 }
+        self.AutoconfigEnabled == other.AutoconfigEnabled && self.AutoconfigActive == other.AutoconfigActive && self.CurrentDnsServer == other.CurrentDnsServer && self.DnsServerList == other.DnsServerList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5663,7 +5488,7 @@ unsafe impl ::windows::core::Abi for IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {
 }
 impl ::core::cmp::PartialEq for IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_UNIDIRECTIONAL_ADAPTER_ADDRESS>()) == 0 }
+        self.NumAdapters == other.NumAdapters && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {}
@@ -5726,7 +5551,7 @@ unsafe impl ::windows::core::Abi for MIBICMPINFO {
 }
 impl ::core::cmp::PartialEq for MIBICMPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIBICMPINFO>()) == 0 }
+        self.icmpInStats == other.icmpInStats && self.icmpOutStats == other.icmpOutStats
     }
 }
 impl ::core::cmp::Eq for MIBICMPINFO {}
@@ -5782,7 +5607,7 @@ unsafe impl ::windows::core::Abi for MIBICMPSTATS {
 }
 impl ::core::cmp::PartialEq for MIBICMPSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIBICMPSTATS>()) == 0 }
+        self.dwMsgs == other.dwMsgs && self.dwErrors == other.dwErrors && self.dwDestUnreachs == other.dwDestUnreachs && self.dwTimeExcds == other.dwTimeExcds && self.dwParmProbs == other.dwParmProbs && self.dwSrcQuenchs == other.dwSrcQuenchs && self.dwRedirects == other.dwRedirects && self.dwEchos == other.dwEchos && self.dwEchoReps == other.dwEchoReps && self.dwTimestamps == other.dwTimestamps && self.dwTimestampReps == other.dwTimestampReps && self.dwAddrMasks == other.dwAddrMasks && self.dwAddrMaskReps == other.dwAddrMaskReps
     }
 }
 impl ::core::cmp::Eq for MIBICMPSTATS {}
@@ -5814,7 +5639,7 @@ unsafe impl ::windows::core::Abi for MIBICMPSTATS_EX_XPSP1 {
 }
 impl ::core::cmp::PartialEq for MIBICMPSTATS_EX_XPSP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIBICMPSTATS_EX_XPSP1>()) == 0 }
+        self.dwMsgs == other.dwMsgs && self.dwErrors == other.dwErrors && self.rgdwTypeCount == other.rgdwTypeCount
     }
 }
 impl ::core::cmp::Eq for MIBICMPSTATS_EX_XPSP1 {}
@@ -5845,14 +5670,6 @@ unsafe impl ::windows::core::Abi for MIB_ANYCASTIPADDRESS_ROW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_ANYCASTIPADDRESS_ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_ANYCASTIPADDRESS_ROW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_ANYCASTIPADDRESS_ROW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_ANYCASTIPADDRESS_ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5877,14 +5694,6 @@ impl ::core::clone::Clone for MIB_ANYCASTIPADDRESS_TABLE {
 unsafe impl ::windows::core::Abi for MIB_ANYCASTIPADDRESS_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_ANYCASTIPADDRESS_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_ANYCASTIPADDRESS_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_ANYCASTIPADDRESS_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_ANYCASTIPADDRESS_TABLE {
     fn default() -> Self {
@@ -5913,7 +5722,7 @@ unsafe impl ::windows::core::Abi for MIB_BEST_IF {
 }
 impl ::core::cmp::PartialEq for MIB_BEST_IF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_BEST_IF>()) == 0 }
+        self.dwDestAddr == other.dwDestAddr && self.dwIfIndex == other.dwIfIndex
     }
 }
 impl ::core::cmp::Eq for MIB_BEST_IF {}
@@ -5944,7 +5753,7 @@ unsafe impl ::windows::core::Abi for MIB_BOUNDARYROW {
 }
 impl ::core::cmp::PartialEq for MIB_BOUNDARYROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_BOUNDARYROW>()) == 0 }
+        self.dwGroupAddress == other.dwGroupAddress && self.dwGroupMask == other.dwGroupMask
     }
 }
 impl ::core::cmp::Eq for MIB_BOUNDARYROW {}
@@ -5974,7 +5783,7 @@ unsafe impl ::windows::core::Abi for MIB_ICMP {
 }
 impl ::core::cmp::PartialEq for MIB_ICMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_ICMP>()) == 0 }
+        self.stats == other.stats
     }
 }
 impl ::core::cmp::Eq for MIB_ICMP {}
@@ -6005,7 +5814,7 @@ unsafe impl ::windows::core::Abi for MIB_ICMP_EX_XPSP1 {
 }
 impl ::core::cmp::PartialEq for MIB_ICMP_EX_XPSP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_ICMP_EX_XPSP1>()) == 0 }
+        self.icmpInStats == other.icmpInStats && self.icmpOutStats == other.icmpOutStats
     }
 }
 impl ::core::cmp::Eq for MIB_ICMP_EX_XPSP1 {}
@@ -6035,7 +5844,7 @@ unsafe impl ::windows::core::Abi for MIB_IFNUMBER {
 }
 impl ::core::cmp::PartialEq for MIB_IFNUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFNUMBER>()) == 0 }
+        self.dwValue == other.dwValue
     }
 }
 impl ::core::cmp::Eq for MIB_IFNUMBER {}
@@ -6113,7 +5922,30 @@ unsafe impl ::windows::core::Abi for MIB_IFROW {
 }
 impl ::core::cmp::PartialEq for MIB_IFROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFROW>()) == 0 }
+        self.wszName == other.wszName
+            && self.dwIndex == other.dwIndex
+            && self.dwType == other.dwType
+            && self.dwMtu == other.dwMtu
+            && self.dwSpeed == other.dwSpeed
+            && self.dwPhysAddrLen == other.dwPhysAddrLen
+            && self.bPhysAddr == other.bPhysAddr
+            && self.dwAdminStatus == other.dwAdminStatus
+            && self.dwOperStatus == other.dwOperStatus
+            && self.dwLastChange == other.dwLastChange
+            && self.dwInOctets == other.dwInOctets
+            && self.dwInUcastPkts == other.dwInUcastPkts
+            && self.dwInNUcastPkts == other.dwInNUcastPkts
+            && self.dwInDiscards == other.dwInDiscards
+            && self.dwInErrors == other.dwInErrors
+            && self.dwInUnknownProtos == other.dwInUnknownProtos
+            && self.dwOutOctets == other.dwOutOctets
+            && self.dwOutUcastPkts == other.dwOutUcastPkts
+            && self.dwOutNUcastPkts == other.dwOutNUcastPkts
+            && self.dwOutDiscards == other.dwOutDiscards
+            && self.dwOutErrors == other.dwOutErrors
+            && self.dwOutQLen == other.dwOutQLen
+            && self.dwDescrLen == other.dwDescrLen
+            && self.bDescr == other.bDescr
     }
 }
 impl ::core::cmp::Eq for MIB_IFROW {}
@@ -6144,7 +5976,7 @@ unsafe impl ::windows::core::Abi for MIB_IFSTACK_ROW {
 }
 impl ::core::cmp::PartialEq for MIB_IFSTACK_ROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFSTACK_ROW>()) == 0 }
+        self.HigherLayerInterfaceIndex == other.HigherLayerInterfaceIndex && self.LowerLayerInterfaceIndex == other.LowerLayerInterfaceIndex
     }
 }
 impl ::core::cmp::Eq for MIB_IFSTACK_ROW {}
@@ -6175,7 +6007,7 @@ unsafe impl ::windows::core::Abi for MIB_IFSTACK_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_IFSTACK_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFSTACK_TABLE>()) == 0 }
+        self.NumEntries == other.NumEntries && self.Table == other.Table
     }
 }
 impl ::core::cmp::Eq for MIB_IFSTACK_TABLE {}
@@ -6215,7 +6047,7 @@ unsafe impl ::windows::core::Abi for MIB_IFSTATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MIB_IFSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFSTATUS>()) == 0 }
+        self.dwIfIndex == other.dwIfIndex && self.dwAdminStatus == other.dwAdminStatus && self.dwOperationalStatus == other.dwOperationalStatus && self.bMHbeatActive == other.bMHbeatActive && self.bMHbeatAlive == other.bMHbeatAlive
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6248,7 +6080,7 @@ unsafe impl ::windows::core::Abi for MIB_IFTABLE {
 }
 impl ::core::cmp::PartialEq for MIB_IFTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IFTABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_IFTABLE {}
@@ -6316,14 +6148,6 @@ unsafe impl ::windows::core::Abi for MIB_IF_ROW2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::PartialEq for MIB_IF_ROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IF_ROW2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::Eq for MIB_IF_ROW2 {}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::default::Default for MIB_IF_ROW2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6356,7 +6180,7 @@ unsafe impl ::windows::core::Abi for MIB_IF_ROW2_0 {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for MIB_IF_ROW2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IF_ROW2_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6387,14 +6211,6 @@ unsafe impl ::windows::core::Abi for MIB_IF_TABLE2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::PartialEq for MIB_IF_TABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IF_TABLE2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::Eq for MIB_IF_TABLE2 {}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::default::Default for MIB_IF_TABLE2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6422,7 +6238,7 @@ unsafe impl ::windows::core::Abi for MIB_INVERTEDIFSTACK_ROW {
 }
 impl ::core::cmp::PartialEq for MIB_INVERTEDIFSTACK_ROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_INVERTEDIFSTACK_ROW>()) == 0 }
+        self.LowerLayerInterfaceIndex == other.LowerLayerInterfaceIndex && self.HigherLayerInterfaceIndex == other.HigherLayerInterfaceIndex
     }
 }
 impl ::core::cmp::Eq for MIB_INVERTEDIFSTACK_ROW {}
@@ -6453,7 +6269,7 @@ unsafe impl ::windows::core::Abi for MIB_INVERTEDIFSTACK_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_INVERTEDIFSTACK_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_INVERTEDIFSTACK_TABLE>()) == 0 }
+        self.NumEntries == other.NumEntries && self.Table == other.Table
     }
 }
 impl ::core::cmp::Eq for MIB_INVERTEDIFSTACK_TABLE {}
@@ -6489,7 +6305,7 @@ unsafe impl ::windows::core::Abi for MIB_IPADDRROW_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_IPADDRROW_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPADDRROW_W2K>()) == 0 }
+        self.dwAddr == other.dwAddr && self.dwIndex == other.dwIndex && self.dwMask == other.dwMask && self.dwBCastAddr == other.dwBCastAddr && self.dwReasmSize == other.dwReasmSize && self.unused1 == other.unused1 && self.unused2 == other.unused2
     }
 }
 impl ::core::cmp::Eq for MIB_IPADDRROW_W2K {}
@@ -6525,7 +6341,7 @@ unsafe impl ::windows::core::Abi for MIB_IPADDRROW_XP {
 }
 impl ::core::cmp::PartialEq for MIB_IPADDRROW_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPADDRROW_XP>()) == 0 }
+        self.dwAddr == other.dwAddr && self.dwIndex == other.dwIndex && self.dwMask == other.dwMask && self.dwBCastAddr == other.dwBCastAddr && self.dwReasmSize == other.dwReasmSize && self.unused1 == other.unused1 && self.wType == other.wType
     }
 }
 impl ::core::cmp::Eq for MIB_IPADDRROW_XP {}
@@ -6556,7 +6372,7 @@ unsafe impl ::windows::core::Abi for MIB_IPADDRTABLE {
 }
 impl ::core::cmp::PartialEq for MIB_IPADDRTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPADDRTABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_IPADDRTABLE {}
@@ -6586,14 +6402,6 @@ unsafe impl ::windows::core::Abi for MIB_IPDESTROW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPDESTROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPDESTROW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPDESTROW {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPDESTROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6618,14 +6426,6 @@ impl ::core::clone::Clone for MIB_IPDESTTABLE {
 unsafe impl ::windows::core::Abi for MIB_IPDESTTABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPDESTTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPDESTTABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPDESTTABLE {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPDESTTABLE {
     fn default() -> Self {
@@ -6653,7 +6453,7 @@ unsafe impl ::windows::core::Abi for MIB_IPFORWARDNUMBER {
 }
 impl ::core::cmp::PartialEq for MIB_IPFORWARDNUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARDNUMBER>()) == 0 }
+        self.dwValue == other.dwValue
     }
 }
 impl ::core::cmp::Eq for MIB_IPFORWARDNUMBER {}
@@ -6694,14 +6494,6 @@ unsafe impl ::windows::core::Abi for MIB_IPFORWARDROW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPFORWARDROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARDROW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPFORWARDROW {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPFORWARDROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6726,14 +6518,6 @@ impl ::core::clone::Clone for MIB_IPFORWARDROW_0 {
 unsafe impl ::windows::core::Abi for MIB_IPFORWARDROW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPFORWARDROW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARDROW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPFORWARDROW_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPFORWARDROW_0 {
     fn default() -> Self {
@@ -6760,14 +6544,6 @@ unsafe impl ::windows::core::Abi for MIB_IPFORWARDROW_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPFORWARDROW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARDROW_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPFORWARDROW_1 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPFORWARDROW_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6792,14 +6568,6 @@ impl ::core::clone::Clone for MIB_IPFORWARDTABLE {
 unsafe impl ::windows::core::Abi for MIB_IPFORWARDTABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_IPFORWARDTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARDTABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_IPFORWARDTABLE {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_IPFORWARDTABLE {
     fn default() -> Self {
@@ -6839,14 +6607,6 @@ unsafe impl ::windows::core::Abi for MIB_IPFORWARD_ROW2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPFORWARD_ROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARD_ROW2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPFORWARD_ROW2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPFORWARD_ROW2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6871,14 +6631,6 @@ impl ::core::clone::Clone for MIB_IPFORWARD_TABLE2 {
 unsafe impl ::windows::core::Abi for MIB_IPFORWARD_TABLE2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPFORWARD_TABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPFORWARD_TABLE2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPFORWARD_TABLE2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPFORWARD_TABLE2 {
     fn default() -> Self {
@@ -6938,14 +6690,6 @@ unsafe impl ::windows::core::Abi for MIB_IPINTERFACE_ROW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPINTERFACE_ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPINTERFACE_ROW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPINTERFACE_ROW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPINTERFACE_ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6970,14 +6714,6 @@ impl ::core::clone::Clone for MIB_IPINTERFACE_TABLE {
 unsafe impl ::windows::core::Abi for MIB_IPINTERFACE_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPINTERFACE_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPINTERFACE_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPINTERFACE_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPINTERFACE_TABLE {
     fn default() -> Self {
@@ -7008,7 +6744,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_BOUNDARY {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_BOUNDARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_BOUNDARY>()) == 0 }
+        self.dwIfIndex == other.dwIfIndex && self.dwGroupAddress == other.dwGroupAddress && self.dwGroupMask == other.dwGroupMask && self.dwStatus == other.dwStatus
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_BOUNDARY {}
@@ -7039,7 +6775,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_BOUNDARY_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_BOUNDARY_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_BOUNDARY_TABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_BOUNDARY_TABLE {}
@@ -7069,7 +6805,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_GLOBAL {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_GLOBAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_GLOBAL>()) == 0 }
+        self.dwEnable == other.dwEnable
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_GLOBAL {}
@@ -7104,7 +6840,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_IF_ENTRY {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_IF_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_IF_ENTRY>()) == 0 }
+        self.dwIfIndex == other.dwIfIndex && self.dwTtl == other.dwTtl && self.dwProtocol == other.dwProtocol && self.dwRateLimit == other.dwRateLimit && self.ulInMcastOctets == other.ulInMcastOctets && self.ulOutMcastOctets == other.ulOutMcastOctets
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_IF_ENTRY {}
@@ -7135,7 +6871,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_IF_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_IF_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_IF_TABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_IF_TABLE {}
@@ -7197,7 +6933,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_MFE {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_MFE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_MFE>()) == 0 }
+        self.dwGroup == other.dwGroup && self.dwSource == other.dwSource && self.dwSrcMask == other.dwSrcMask && self.dwUpStrmNgbr == other.dwUpStrmNgbr && self.dwInIfIndex == other.dwInIfIndex && self.dwInIfProtocol == other.dwInIfProtocol && self.dwRouteProtocol == other.dwRouteProtocol && self.dwRouteNetwork == other.dwRouteNetwork && self.dwRouteMask == other.dwRouteMask && self.ulUpTime == other.ulUpTime && self.ulExpiryTime == other.ulExpiryTime && self.ulTimeOut == other.ulTimeOut && self.ulNumOutIf == other.ulNumOutIf && self.fFlags == other.fFlags && self.dwReserved == other.dwReserved && self.rgmioOutInfo == other.rgmioOutInfo
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_MFE {}
@@ -7261,7 +6997,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_MFE_STATS {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_MFE_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_MFE_STATS>()) == 0 }
+        self.dwGroup == other.dwGroup && self.dwSource == other.dwSource && self.dwSrcMask == other.dwSrcMask && self.dwUpStrmNgbr == other.dwUpStrmNgbr && self.dwInIfIndex == other.dwInIfIndex && self.dwInIfProtocol == other.dwInIfProtocol && self.dwRouteProtocol == other.dwRouteProtocol && self.dwRouteNetwork == other.dwRouteNetwork && self.dwRouteMask == other.dwRouteMask && self.ulUpTime == other.ulUpTime && self.ulExpiryTime == other.ulExpiryTime && self.ulNumOutIf == other.ulNumOutIf && self.ulInPkts == other.ulInPkts && self.ulInOctets == other.ulInOctets && self.ulPktsDifferentIf == other.ulPktsDifferentIf && self.ulQueueOverflow == other.ulQueueOverflow && self.rgmiosOutStats == other.rgmiosOutStats
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_MFE_STATS {}
@@ -7335,7 +7071,28 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_MFE_STATS_EX_XP {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_MFE_STATS_EX_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_MFE_STATS_EX_XP>()) == 0 }
+        self.dwGroup == other.dwGroup
+            && self.dwSource == other.dwSource
+            && self.dwSrcMask == other.dwSrcMask
+            && self.dwUpStrmNgbr == other.dwUpStrmNgbr
+            && self.dwInIfIndex == other.dwInIfIndex
+            && self.dwInIfProtocol == other.dwInIfProtocol
+            && self.dwRouteProtocol == other.dwRouteProtocol
+            && self.dwRouteNetwork == other.dwRouteNetwork
+            && self.dwRouteMask == other.dwRouteMask
+            && self.ulUpTime == other.ulUpTime
+            && self.ulExpiryTime == other.ulExpiryTime
+            && self.ulNumOutIf == other.ulNumOutIf
+            && self.ulInPkts == other.ulInPkts
+            && self.ulInOctets == other.ulInOctets
+            && self.ulPktsDifferentIf == other.ulPktsDifferentIf
+            && self.ulQueueOverflow == other.ulQueueOverflow
+            && self.ulUninitMfe == other.ulUninitMfe
+            && self.ulNegativeMfe == other.ulNegativeMfe
+            && self.ulInDiscards == other.ulInDiscards
+            && self.ulInHdrErrors == other.ulInHdrErrors
+            && self.ulTotalOutPackets == other.ulTotalOutPackets
+            && self.rgmiosOutStats == other.rgmiosOutStats
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_MFE_STATS_EX_XP {}
@@ -7371,7 +7128,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_OIF_STATS_LH {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_OIF_STATS_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_OIF_STATS_LH>()) == 0 }
+        self.dwOutIfIndex == other.dwOutIfIndex && self.dwNextHopAddr == other.dwNextHopAddr && self.dwDialContext == other.dwDialContext && self.ulTtlTooLow == other.ulTtlTooLow && self.ulFragNeeded == other.ulFragNeeded && self.ulOutPackets == other.ulOutPackets && self.ulOutDiscards == other.ulOutDiscards
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_OIF_STATS_LH {}
@@ -7407,7 +7164,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_OIF_STATS_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_OIF_STATS_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_OIF_STATS_W2K>()) == 0 }
+        self.dwOutIfIndex == other.dwOutIfIndex && self.dwNextHopAddr == other.dwNextHopAddr && self.pvDialContext == other.pvDialContext && self.ulTtlTooLow == other.ulTtlTooLow && self.ulFragNeeded == other.ulFragNeeded && self.ulOutPackets == other.ulOutPackets && self.ulOutDiscards == other.ulOutDiscards
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_OIF_STATS_W2K {}
@@ -7440,7 +7197,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_OIF_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_OIF_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_OIF_W2K>()) == 0 }
+        self.dwOutIfIndex == other.dwOutIfIndex && self.dwNextHopAddr == other.dwNextHopAddr && self.pvReserved == other.pvReserved && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_OIF_W2K {}
@@ -7473,7 +7230,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_OIF_XP {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_OIF_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_OIF_XP>()) == 0 }
+        self.dwOutIfIndex == other.dwOutIfIndex && self.dwNextHopAddr == other.dwNextHopAddr && self.dwReserved == other.dwReserved && self.dwReserved1 == other.dwReserved1
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_OIF_XP {}
@@ -7506,7 +7263,7 @@ unsafe impl ::windows::core::Abi for MIB_IPMCAST_SCOPE {
 }
 impl ::core::cmp::PartialEq for MIB_IPMCAST_SCOPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPMCAST_SCOPE>()) == 0 }
+        self.dwGroupAddress == other.dwGroupAddress && self.dwGroupMask == other.dwGroupMask && self.snNameBuffer == other.snNameBuffer && self.dwStatus == other.dwStatus
     }
 }
 impl ::core::cmp::Eq for MIB_IPMCAST_SCOPE {}
@@ -7533,12 +7290,6 @@ impl ::core::clone::Clone for MIB_IPNETROW_LH {
 unsafe impl ::windows::core::Abi for MIB_IPNETROW_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_IPNETROW_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNETROW_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_IPNETROW_LH {}
 impl ::core::default::Default for MIB_IPNETROW_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7559,12 +7310,6 @@ impl ::core::clone::Clone for MIB_IPNETROW_LH_0 {
 unsafe impl ::windows::core::Abi for MIB_IPNETROW_LH_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_IPNETROW_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNETROW_LH_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_IPNETROW_LH_0 {}
 impl ::core::default::Default for MIB_IPNETROW_LH_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7595,7 +7340,7 @@ unsafe impl ::windows::core::Abi for MIB_IPNETROW_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_IPNETROW_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNETROW_W2K>()) == 0 }
+        self.dwIndex == other.dwIndex && self.dwPhysAddrLen == other.dwPhysAddrLen && self.bPhysAddr == other.bPhysAddr && self.dwAddr == other.dwAddr && self.dwType == other.dwType
     }
 }
 impl ::core::cmp::Eq for MIB_IPNETROW_W2K {}
@@ -7619,12 +7364,6 @@ impl ::core::clone::Clone for MIB_IPNETTABLE {
 unsafe impl ::windows::core::Abi for MIB_IPNETTABLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_IPNETTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNETTABLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_IPNETTABLE {}
 impl ::core::default::Default for MIB_IPNETTABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7656,14 +7395,6 @@ unsafe impl ::windows::core::Abi for MIB_IPNET_ROW2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPNET_ROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNET_ROW2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPNET_ROW2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPNET_ROW2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7688,14 +7419,6 @@ impl ::core::clone::Clone for MIB_IPNET_ROW2_0 {
 unsafe impl ::windows::core::Abi for MIB_IPNET_ROW2_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPNET_ROW2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNET_ROW2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPNET_ROW2_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPNET_ROW2_0 {
     fn default() -> Self {
@@ -7729,7 +7452,7 @@ unsafe impl ::windows::core::Abi for MIB_IPNET_ROW2_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for MIB_IPNET_ROW2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNET_ROW2_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -7760,14 +7483,6 @@ unsafe impl ::windows::core::Abi for MIB_IPNET_ROW2_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPNET_ROW2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNET_ROW2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPNET_ROW2_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPNET_ROW2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7792,14 +7507,6 @@ impl ::core::clone::Clone for MIB_IPNET_TABLE2 {
 unsafe impl ::windows::core::Abi for MIB_IPNET_TABLE2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPNET_TABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPNET_TABLE2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPNET_TABLE2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPNET_TABLE2 {
     fn default() -> Self {
@@ -7836,14 +7543,6 @@ unsafe impl ::windows::core::Abi for MIB_IPPATH_ROW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPPATH_ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPPATH_ROW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPPATH_ROW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPPATH_ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7869,14 +7568,6 @@ unsafe impl ::windows::core::Abi for MIB_IPPATH_ROW_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPPATH_ROW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPPATH_ROW_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPPATH_ROW_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPPATH_ROW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7901,14 +7592,6 @@ impl ::core::clone::Clone for MIB_IPPATH_TABLE {
 unsafe impl ::windows::core::Abi for MIB_IPPATH_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_IPPATH_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPPATH_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_IPPATH_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_IPPATH_TABLE {
     fn default() -> Self {
@@ -7951,12 +7634,6 @@ impl ::core::clone::Clone for MIB_IPSTATS_LH {
 unsafe impl ::windows::core::Abi for MIB_IPSTATS_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_IPSTATS_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPSTATS_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_IPSTATS_LH {}
 impl ::core::default::Default for MIB_IPSTATS_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7977,12 +7654,6 @@ impl ::core::clone::Clone for MIB_IPSTATS_LH_0 {
 unsafe impl ::windows::core::Abi for MIB_IPSTATS_LH_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_IPSTATS_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPSTATS_LH_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_IPSTATS_LH_0 {}
 impl ::core::default::Default for MIB_IPSTATS_LH_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8055,7 +7726,29 @@ unsafe impl ::windows::core::Abi for MIB_IPSTATS_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_IPSTATS_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IPSTATS_W2K>()) == 0 }
+        self.dwForwarding == other.dwForwarding
+            && self.dwDefaultTTL == other.dwDefaultTTL
+            && self.dwInReceives == other.dwInReceives
+            && self.dwInHdrErrors == other.dwInHdrErrors
+            && self.dwInAddrErrors == other.dwInAddrErrors
+            && self.dwForwDatagrams == other.dwForwDatagrams
+            && self.dwInUnknownProtos == other.dwInUnknownProtos
+            && self.dwInDiscards == other.dwInDiscards
+            && self.dwInDelivers == other.dwInDelivers
+            && self.dwOutRequests == other.dwOutRequests
+            && self.dwRoutingDiscards == other.dwRoutingDiscards
+            && self.dwOutDiscards == other.dwOutDiscards
+            && self.dwOutNoRoutes == other.dwOutNoRoutes
+            && self.dwReasmTimeout == other.dwReasmTimeout
+            && self.dwReasmReqds == other.dwReasmReqds
+            && self.dwReasmOks == other.dwReasmOks
+            && self.dwReasmFails == other.dwReasmFails
+            && self.dwFragOks == other.dwFragOks
+            && self.dwFragFails == other.dwFragFails
+            && self.dwFragCreates == other.dwFragCreates
+            && self.dwNumIf == other.dwNumIf
+            && self.dwNumAddr == other.dwNumAddr
+            && self.dwNumRoutes == other.dwNumRoutes
     }
 }
 impl ::core::cmp::Eq for MIB_IPSTATS_W2K {}
@@ -8092,7 +7785,7 @@ unsafe impl ::windows::core::Abi for MIB_IP_NETWORK_CONNECTION_BANDWIDTH_ESTIMAT
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for MIB_IP_NETWORK_CONNECTION_BANDWIDTH_ESTIMATES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_IP_NETWORK_CONNECTION_BANDWIDTH_ESTIMATES>()) == 0 }
+        self.InboundBandwidthInformation == other.InboundBandwidthInformation && self.OutboundBandwidthInformation == other.OutboundBandwidthInformation
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -8125,7 +7818,7 @@ unsafe impl ::windows::core::Abi for MIB_MCAST_LIMIT_ROW {
 }
 impl ::core::cmp::PartialEq for MIB_MCAST_LIMIT_ROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MCAST_LIMIT_ROW>()) == 0 }
+        self.dwTtl == other.dwTtl && self.dwRateLimit == other.dwRateLimit
     }
 }
 impl ::core::cmp::Eq for MIB_MCAST_LIMIT_ROW {}
@@ -8156,7 +7849,7 @@ unsafe impl ::windows::core::Abi for MIB_MFE_STATS_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_MFE_STATS_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MFE_STATS_TABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_MFE_STATS_TABLE {}
@@ -8187,7 +7880,7 @@ unsafe impl ::windows::core::Abi for MIB_MFE_STATS_TABLE_EX_XP {
 }
 impl ::core::cmp::PartialEq for MIB_MFE_STATS_TABLE_EX_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MFE_STATS_TABLE_EX_XP>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_MFE_STATS_TABLE_EX_XP {}
@@ -8218,7 +7911,7 @@ unsafe impl ::windows::core::Abi for MIB_MFE_TABLE {
 }
 impl ::core::cmp::PartialEq for MIB_MFE_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MFE_TABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_MFE_TABLE {}
@@ -8249,14 +7942,6 @@ unsafe impl ::windows::core::Abi for MIB_MULTICASTIPADDRESS_ROW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_MULTICASTIPADDRESS_ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MULTICASTIPADDRESS_ROW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_MULTICASTIPADDRESS_ROW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_MULTICASTIPADDRESS_ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8282,14 +7967,6 @@ unsafe impl ::windows::core::Abi for MIB_MULTICASTIPADDRESS_TABLE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_MULTICASTIPADDRESS_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_MULTICASTIPADDRESS_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_MULTICASTIPADDRESS_TABLE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_MULTICASTIPADDRESS_TABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8310,12 +7987,6 @@ impl ::core::clone::Clone for MIB_OPAQUE_INFO {
 unsafe impl ::windows::core::Abi for MIB_OPAQUE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_OPAQUE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_OPAQUE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_OPAQUE_INFO {}
 impl ::core::default::Default for MIB_OPAQUE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8336,12 +8007,6 @@ impl ::core::clone::Clone for MIB_OPAQUE_INFO_0 {
 unsafe impl ::windows::core::Abi for MIB_OPAQUE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_OPAQUE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_OPAQUE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_OPAQUE_INFO_0 {}
 impl ::core::default::Default for MIB_OPAQUE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8369,7 +8034,7 @@ unsafe impl ::windows::core::Abi for MIB_OPAQUE_QUERY {
 }
 impl ::core::cmp::PartialEq for MIB_OPAQUE_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_OPAQUE_QUERY>()) == 0 }
+        self.dwVarId == other.dwVarId && self.rgdwVarIndex == other.rgdwVarIndex
     }
 }
 impl ::core::cmp::Eq for MIB_OPAQUE_QUERY {}
@@ -8401,7 +8066,7 @@ unsafe impl ::windows::core::Abi for MIB_PROXYARP {
 }
 impl ::core::cmp::PartialEq for MIB_PROXYARP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_PROXYARP>()) == 0 }
+        self.dwAddress == other.dwAddress && self.dwMask == other.dwMask && self.dwIfIndex == other.dwIfIndex
     }
 }
 impl ::core::cmp::Eq for MIB_PROXYARP {}
@@ -8437,7 +8102,7 @@ unsafe impl ::windows::core::Abi for MIB_ROUTESTATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MIB_ROUTESTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_ROUTESTATE>()) == 0 }
+        self.bRoutesSetToStack == other.bRoutesSetToStack
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8473,14 +8138,6 @@ unsafe impl ::windows::core::Abi for MIB_TCP6ROW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_TCP6ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6ROW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_TCP6ROW {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_TCP6ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8512,14 +8169,6 @@ impl ::core::clone::Clone for MIB_TCP6ROW2 {
 unsafe impl ::windows::core::Abi for MIB_TCP6ROW2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_TCP6ROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6ROW2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_TCP6ROW2 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_TCP6ROW2 {
     fn default() -> Self {
@@ -8567,7 +8216,7 @@ unsafe impl ::windows::core::Abi for MIB_TCP6ROW_OWNER_MODULE {
 }
 impl ::core::cmp::PartialEq for MIB_TCP6ROW_OWNER_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6ROW_OWNER_MODULE>()) == 0 }
+        self.ucLocalAddr == other.ucLocalAddr && self.dwLocalScopeId == other.dwLocalScopeId && self.dwLocalPort == other.dwLocalPort && self.ucRemoteAddr == other.ucRemoteAddr && self.dwRemoteScopeId == other.dwRemoteScopeId && self.dwRemotePort == other.dwRemotePort && self.dwState == other.dwState && self.dwOwningPid == other.dwOwningPid && self.liCreateTimestamp == other.liCreateTimestamp && self.OwningModuleInfo == other.OwningModuleInfo
     }
 }
 impl ::core::cmp::Eq for MIB_TCP6ROW_OWNER_MODULE {}
@@ -8604,7 +8253,7 @@ unsafe impl ::windows::core::Abi for MIB_TCP6ROW_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_TCP6ROW_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6ROW_OWNER_PID>()) == 0 }
+        self.ucLocalAddr == other.ucLocalAddr && self.dwLocalScopeId == other.dwLocalScopeId && self.dwLocalPort == other.dwLocalPort && self.ucRemoteAddr == other.ucRemoteAddr && self.dwRemoteScopeId == other.dwRemoteScopeId && self.dwRemotePort == other.dwRemotePort && self.dwState == other.dwState && self.dwOwningPid == other.dwOwningPid
     }
 }
 impl ::core::cmp::Eq for MIB_TCP6ROW_OWNER_PID {}
@@ -8633,14 +8282,6 @@ unsafe impl ::windows::core::Abi for MIB_TCP6TABLE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_TCP6TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_TCP6TABLE {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_TCP6TABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8665,14 +8306,6 @@ impl ::core::clone::Clone for MIB_TCP6TABLE2 {
 unsafe impl ::windows::core::Abi for MIB_TCP6TABLE2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_TCP6TABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6TABLE2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_TCP6TABLE2 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_TCP6TABLE2 {
     fn default() -> Self {
@@ -8701,7 +8334,7 @@ unsafe impl ::windows::core::Abi for MIB_TCP6TABLE_OWNER_MODULE {
 }
 impl ::core::cmp::PartialEq for MIB_TCP6TABLE_OWNER_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6TABLE_OWNER_MODULE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_TCP6TABLE_OWNER_MODULE {}
@@ -8732,7 +8365,7 @@ unsafe impl ::windows::core::Abi for MIB_TCP6TABLE_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_TCP6TABLE_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCP6TABLE_OWNER_PID>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_TCP6TABLE_OWNER_PID {}
@@ -8768,7 +8401,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPROW2 {
 }
 impl ::core::cmp::PartialEq for MIB_TCPROW2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW2>()) == 0 }
+        self.dwState == other.dwState && self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort && self.dwRemoteAddr == other.dwRemoteAddr && self.dwRemotePort == other.dwRemotePort && self.dwOwningPid == other.dwOwningPid && self.dwOffloadState == other.dwOffloadState
     }
 }
 impl ::core::cmp::Eq for MIB_TCPROW2 {}
@@ -8795,12 +8428,6 @@ impl ::core::clone::Clone for MIB_TCPROW_LH {
 unsafe impl ::windows::core::Abi for MIB_TCPROW_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_TCPROW_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_TCPROW_LH {}
 impl ::core::default::Default for MIB_TCPROW_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8821,12 +8448,6 @@ impl ::core::clone::Clone for MIB_TCPROW_LH_0 {
 unsafe impl ::windows::core::Abi for MIB_TCPROW_LH_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_TCPROW_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW_LH_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_TCPROW_LH_0 {}
 impl ::core::default::Default for MIB_TCPROW_LH_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8860,7 +8481,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPROW_OWNER_MODULE {
 }
 impl ::core::cmp::PartialEq for MIB_TCPROW_OWNER_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW_OWNER_MODULE>()) == 0 }
+        self.dwState == other.dwState && self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort && self.dwRemoteAddr == other.dwRemoteAddr && self.dwRemotePort == other.dwRemotePort && self.dwOwningPid == other.dwOwningPid && self.liCreateTimestamp == other.liCreateTimestamp && self.OwningModuleInfo == other.OwningModuleInfo
     }
 }
 impl ::core::cmp::Eq for MIB_TCPROW_OWNER_MODULE {}
@@ -8895,7 +8516,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPROW_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_TCPROW_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW_OWNER_PID>()) == 0 }
+        self.dwState == other.dwState && self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort && self.dwRemoteAddr == other.dwRemoteAddr && self.dwRemotePort == other.dwRemotePort && self.dwOwningPid == other.dwOwningPid
     }
 }
 impl ::core::cmp::Eq for MIB_TCPROW_OWNER_PID {}
@@ -8929,7 +8550,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPROW_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_TCPROW_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPROW_W2K>()) == 0 }
+        self.dwState == other.dwState && self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort && self.dwRemoteAddr == other.dwRemoteAddr && self.dwRemotePort == other.dwRemotePort
     }
 }
 impl ::core::cmp::Eq for MIB_TCPROW_W2K {}
@@ -8989,7 +8610,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPSTATS2 {
 }
 impl ::core::cmp::PartialEq for MIB_TCPSTATS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPSTATS2>()) == 0 }
+        self.RtoAlgorithm == other.RtoAlgorithm && self.dwRtoMin == other.dwRtoMin && self.dwRtoMax == other.dwRtoMax && self.dwMaxConn == other.dwMaxConn && self.dwActiveOpens == other.dwActiveOpens && self.dwPassiveOpens == other.dwPassiveOpens && self.dwAttemptFails == other.dwAttemptFails && self.dwEstabResets == other.dwEstabResets && self.dwCurrEstab == other.dwCurrEstab && self.dw64InSegs == other.dw64InSegs && self.dw64OutSegs == other.dw64OutSegs && self.dwRetransSegs == other.dwRetransSegs && self.dwInErrs == other.dwInErrs && self.dwOutRsts == other.dwOutRsts && self.dwNumConns == other.dwNumConns
     }
 }
 impl ::core::cmp::Eq for MIB_TCPSTATS2 {}
@@ -9026,12 +8647,6 @@ impl ::core::clone::Clone for MIB_TCPSTATS_LH {
 unsafe impl ::windows::core::Abi for MIB_TCPSTATS_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_TCPSTATS_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPSTATS_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_TCPSTATS_LH {}
 impl ::core::default::Default for MIB_TCPSTATS_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9052,12 +8667,6 @@ impl ::core::clone::Clone for MIB_TCPSTATS_LH_0 {
 unsafe impl ::windows::core::Abi for MIB_TCPSTATS_LH_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_TCPSTATS_LH_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPSTATS_LH_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_TCPSTATS_LH_0 {}
 impl ::core::default::Default for MIB_TCPSTATS_LH_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9114,7 +8723,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPSTATS_W2K {
 }
 impl ::core::cmp::PartialEq for MIB_TCPSTATS_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPSTATS_W2K>()) == 0 }
+        self.dwRtoAlgorithm == other.dwRtoAlgorithm && self.dwRtoMin == other.dwRtoMin && self.dwRtoMax == other.dwRtoMax && self.dwMaxConn == other.dwMaxConn && self.dwActiveOpens == other.dwActiveOpens && self.dwPassiveOpens == other.dwPassiveOpens && self.dwAttemptFails == other.dwAttemptFails && self.dwEstabResets == other.dwEstabResets && self.dwCurrEstab == other.dwCurrEstab && self.dwInSegs == other.dwInSegs && self.dwOutSegs == other.dwOutSegs && self.dwRetransSegs == other.dwRetransSegs && self.dwInErrs == other.dwInErrs && self.dwOutRsts == other.dwOutRsts && self.dwNumConns == other.dwNumConns
     }
 }
 impl ::core::cmp::Eq for MIB_TCPSTATS_W2K {}
@@ -9138,12 +8747,6 @@ impl ::core::clone::Clone for MIB_TCPTABLE {
 unsafe impl ::windows::core::Abi for MIB_TCPTABLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_TCPTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPTABLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_TCPTABLE {}
 impl ::core::default::Default for MIB_TCPTABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9171,7 +8774,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPTABLE2 {
 }
 impl ::core::cmp::PartialEq for MIB_TCPTABLE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPTABLE2>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_TCPTABLE2 {}
@@ -9202,7 +8805,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPTABLE_OWNER_MODULE {
 }
 impl ::core::cmp::PartialEq for MIB_TCPTABLE_OWNER_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPTABLE_OWNER_MODULE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_TCPTABLE_OWNER_MODULE {}
@@ -9233,7 +8836,7 @@ unsafe impl ::windows::core::Abi for MIB_TCPTABLE_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_TCPTABLE_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_TCPTABLE_OWNER_PID>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_TCPTABLE_OWNER_PID {}
@@ -9263,14 +8866,6 @@ unsafe impl ::windows::core::Abi for MIB_UDP6ROW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_UDP6ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_UDP6ROW {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_UDP6ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9299,12 +8894,6 @@ impl ::core::clone::Clone for MIB_UDP6ROW2 {
 unsafe impl ::windows::core::Abi for MIB_UDP6ROW2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6ROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6ROW2 {}
 impl ::core::default::Default for MIB_UDP6ROW2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9325,12 +8914,6 @@ impl ::core::clone::Clone for MIB_UDP6ROW2_0 {
 unsafe impl ::windows::core::Abi for MIB_UDP6ROW2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6ROW2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6ROW2_0 {}
 impl ::core::default::Default for MIB_UDP6ROW2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9357,7 +8940,7 @@ unsafe impl ::windows::core::Abi for MIB_UDP6ROW2_0_0 {
 }
 impl ::core::cmp::PartialEq for MIB_UDP6ROW2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW2_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIB_UDP6ROW2_0_0 {}
@@ -9386,12 +8969,6 @@ impl ::core::clone::Clone for MIB_UDP6ROW_OWNER_MODULE {
 unsafe impl ::windows::core::Abi for MIB_UDP6ROW_OWNER_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6ROW_OWNER_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW_OWNER_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6ROW_OWNER_MODULE {}
 impl ::core::default::Default for MIB_UDP6ROW_OWNER_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9412,12 +8989,6 @@ impl ::core::clone::Clone for MIB_UDP6ROW_OWNER_MODULE_0 {
 unsafe impl ::windows::core::Abi for MIB_UDP6ROW_OWNER_MODULE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6ROW_OWNER_MODULE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW_OWNER_MODULE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6ROW_OWNER_MODULE_0 {}
 impl ::core::default::Default for MIB_UDP6ROW_OWNER_MODULE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9444,7 +9015,7 @@ unsafe impl ::windows::core::Abi for MIB_UDP6ROW_OWNER_MODULE_0_0 {
 }
 impl ::core::cmp::PartialEq for MIB_UDP6ROW_OWNER_MODULE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW_OWNER_MODULE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIB_UDP6ROW_OWNER_MODULE_0_0 {}
@@ -9477,7 +9048,7 @@ unsafe impl ::windows::core::Abi for MIB_UDP6ROW_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_UDP6ROW_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6ROW_OWNER_PID>()) == 0 }
+        self.ucLocalAddr == other.ucLocalAddr && self.dwLocalScopeId == other.dwLocalScopeId && self.dwLocalPort == other.dwLocalPort && self.dwOwningPid == other.dwOwningPid
     }
 }
 impl ::core::cmp::Eq for MIB_UDP6ROW_OWNER_PID {}
@@ -9506,14 +9077,6 @@ unsafe impl ::windows::core::Abi for MIB_UDP6TABLE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MIB_UDP6TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MIB_UDP6TABLE {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MIB_UDP6TABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9534,12 +9097,6 @@ impl ::core::clone::Clone for MIB_UDP6TABLE2 {
 unsafe impl ::windows::core::Abi for MIB_UDP6TABLE2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6TABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6TABLE2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6TABLE2 {}
 impl ::core::default::Default for MIB_UDP6TABLE2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9560,12 +9117,6 @@ impl ::core::clone::Clone for MIB_UDP6TABLE_OWNER_MODULE {
 unsafe impl ::windows::core::Abi for MIB_UDP6TABLE_OWNER_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDP6TABLE_OWNER_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6TABLE_OWNER_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDP6TABLE_OWNER_MODULE {}
 impl ::core::default::Default for MIB_UDP6TABLE_OWNER_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9593,7 +9144,7 @@ unsafe impl ::windows::core::Abi for MIB_UDP6TABLE_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_UDP6TABLE_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDP6TABLE_OWNER_PID>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_UDP6TABLE_OWNER_PID {}
@@ -9624,7 +9175,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPROW {
 }
 impl ::core::cmp::PartialEq for MIB_UDPROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW>()) == 0 }
+        self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort
     }
 }
 impl ::core::cmp::Eq for MIB_UDPROW {}
@@ -9654,12 +9205,6 @@ impl ::core::clone::Clone for MIB_UDPROW2 {
 unsafe impl ::windows::core::Abi for MIB_UDPROW2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPROW2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPROW2 {}
 impl ::core::default::Default for MIB_UDPROW2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9680,12 +9225,6 @@ impl ::core::clone::Clone for MIB_UDPROW2_0 {
 unsafe impl ::windows::core::Abi for MIB_UDPROW2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPROW2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPROW2_0 {}
 impl ::core::default::Default for MIB_UDPROW2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9712,7 +9251,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPROW2_0_0 {
 }
 impl ::core::cmp::PartialEq for MIB_UDPROW2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW2_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIB_UDPROW2_0_0 {}
@@ -9740,12 +9279,6 @@ impl ::core::clone::Clone for MIB_UDPROW_OWNER_MODULE {
 unsafe impl ::windows::core::Abi for MIB_UDPROW_OWNER_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPROW_OWNER_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW_OWNER_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPROW_OWNER_MODULE {}
 impl ::core::default::Default for MIB_UDPROW_OWNER_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9766,12 +9299,6 @@ impl ::core::clone::Clone for MIB_UDPROW_OWNER_MODULE_0 {
 unsafe impl ::windows::core::Abi for MIB_UDPROW_OWNER_MODULE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPROW_OWNER_MODULE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW_OWNER_MODULE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPROW_OWNER_MODULE_0 {}
 impl ::core::default::Default for MIB_UDPROW_OWNER_MODULE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9798,7 +9325,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPROW_OWNER_MODULE_0_0 {
 }
 impl ::core::cmp::PartialEq for MIB_UDPROW_OWNER_MODULE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW_OWNER_MODULE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MIB_UDPROW_OWNER_MODULE_0_0 {}
@@ -9830,7 +9357,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPROW_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_UDPROW_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPROW_OWNER_PID>()) == 0 }
+        self.dwLocalAddr == other.dwLocalAddr && self.dwLocalPort == other.dwLocalPort && self.dwOwningPid == other.dwOwningPid
     }
 }
 impl ::core::cmp::Eq for MIB_UDPROW_OWNER_PID {}
@@ -9864,7 +9391,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPSTATS {
 }
 impl ::core::cmp::PartialEq for MIB_UDPSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPSTATS>()) == 0 }
+        self.dwInDatagrams == other.dwInDatagrams && self.dwNoPorts == other.dwNoPorts && self.dwInErrors == other.dwInErrors && self.dwOutDatagrams == other.dwOutDatagrams && self.dwNumAddrs == other.dwNumAddrs
     }
 }
 impl ::core::cmp::Eq for MIB_UDPSTATS {}
@@ -9898,7 +9425,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPSTATS2 {
 }
 impl ::core::cmp::PartialEq for MIB_UDPSTATS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPSTATS2>()) == 0 }
+        self.dw64InDatagrams == other.dw64InDatagrams && self.dwNoPorts == other.dwNoPorts && self.dwInErrors == other.dwInErrors && self.dw64OutDatagrams == other.dw64OutDatagrams && self.dwNumAddrs == other.dwNumAddrs
     }
 }
 impl ::core::cmp::Eq for MIB_UDPSTATS2 {}
@@ -9929,7 +9456,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPTABLE {
 }
 impl ::core::cmp::PartialEq for MIB_UDPTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPTABLE>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_UDPTABLE {}
@@ -9953,12 +9480,6 @@ impl ::core::clone::Clone for MIB_UDPTABLE2 {
 unsafe impl ::windows::core::Abi for MIB_UDPTABLE2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPTABLE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPTABLE2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPTABLE2 {}
 impl ::core::default::Default for MIB_UDPTABLE2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9979,12 +9500,6 @@ impl ::core::clone::Clone for MIB_UDPTABLE_OWNER_MODULE {
 unsafe impl ::windows::core::Abi for MIB_UDPTABLE_OWNER_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIB_UDPTABLE_OWNER_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPTABLE_OWNER_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIB_UDPTABLE_OWNER_MODULE {}
 impl ::core::default::Default for MIB_UDPTABLE_OWNER_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10012,7 +9527,7 @@ unsafe impl ::windows::core::Abi for MIB_UDPTABLE_OWNER_PID {
 }
 impl ::core::cmp::PartialEq for MIB_UDPTABLE_OWNER_PID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UDPTABLE_OWNER_PID>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.table == other.table
     }
 }
 impl ::core::cmp::Eq for MIB_UDPTABLE_OWNER_PID {}
@@ -10051,14 +9566,6 @@ unsafe impl ::windows::core::Abi for MIB_UNICASTIPADDRESS_ROW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_UNICASTIPADDRESS_ROW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UNICASTIPADDRESS_ROW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_UNICASTIPADDRESS_ROW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_UNICASTIPADDRESS_ROW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10083,14 +9590,6 @@ impl ::core::clone::Clone for MIB_UNICASTIPADDRESS_TABLE {
 unsafe impl ::windows::core::Abi for MIB_UNICASTIPADDRESS_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MIB_UNICASTIPADDRESS_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIB_UNICASTIPADDRESS_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MIB_UNICASTIPADDRESS_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MIB_UNICASTIPADDRESS_TABLE {
     fn default() -> Self {
@@ -10126,7 +9625,7 @@ unsafe impl ::windows::core::Abi for PFLOGFRAME {
 }
 impl ::core::cmp::PartialEq for PFLOGFRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PFLOGFRAME>()) == 0 }
+        self.Timestamp == other.Timestamp && self.pfeTypeOfFrame == other.pfeTypeOfFrame && self.dwTotalSizeUsed == other.dwTotalSizeUsed && self.dwFilterRule == other.dwFilterRule && self.wSizeOfAdditionalData == other.wSizeOfAdditionalData && self.wSizeOfIpHeader == other.wSizeOfIpHeader && self.dwInterfaceName == other.dwInterfaceName && self.dwIPIndex == other.dwIPIndex && self.bPacketData == other.bPacketData
     }
 }
 impl ::core::cmp::Eq for PFLOGFRAME {}
@@ -10182,7 +9681,7 @@ unsafe impl ::windows::core::Abi for PF_FILTER_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for PF_FILTER_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PF_FILTER_DESCRIPTOR>()) == 0 }
+        self.dwFilterFlags == other.dwFilterFlags && self.dwRule == other.dwRule && self.pfatType == other.pfatType && self.SrcAddr == other.SrcAddr && self.SrcMask == other.SrcMask && self.DstAddr == other.DstAddr && self.DstMask == other.DstMask && self.dwProtocol == other.dwProtocol && self.fLateBound == other.fLateBound && self.wSrcPort == other.wSrcPort && self.wDstPort == other.wDstPort && self.wSrcPortHighRange == other.wSrcPortHighRange && self.wDstPortHighRange == other.wDstPortHighRange
     }
 }
 impl ::core::cmp::Eq for PF_FILTER_DESCRIPTOR {}
@@ -10213,7 +9712,7 @@ unsafe impl ::windows::core::Abi for PF_FILTER_STATS {
 }
 impl ::core::cmp::PartialEq for PF_FILTER_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PF_FILTER_STATS>()) == 0 }
+        self.dwNumPacketsFiltered == other.dwNumPacketsFiltered && self.info == other.info
     }
 }
 impl ::core::cmp::Eq for PF_FILTER_STATS {}
@@ -10275,7 +9774,7 @@ unsafe impl ::windows::core::Abi for PF_INTERFACE_STATS {
 }
 impl ::core::cmp::PartialEq for PF_INTERFACE_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PF_INTERFACE_STATS>()) == 0 }
+        self.pvDriverContext == other.pvDriverContext && self.dwFlags == other.dwFlags && self.dwInDrops == other.dwInDrops && self.dwOutDrops == other.dwOutDrops && self.eaInAction == other.eaInAction && self.eaOutAction == other.eaOutAction && self.dwNumInFilters == other.dwNumInFilters && self.dwNumOutFilters == other.dwNumOutFilters && self.dwFrag == other.dwFrag && self.dwSpoof == other.dwSpoof && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.liSYN == other.liSYN && self.liTotalLogged == other.liTotalLogged && self.dwLostLogEntries == other.dwLostLogEntries && self.FilterInfo == other.FilterInfo
     }
 }
 impl ::core::cmp::Eq for PF_INTERFACE_STATS {}
@@ -10307,7 +9806,7 @@ unsafe impl ::windows::core::Abi for PF_LATEBIND_INFO {
 }
 impl ::core::cmp::PartialEq for PF_LATEBIND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PF_LATEBIND_INFO>()) == 0 }
+        self.SrcAddr == other.SrcAddr && self.DstAddr == other.DstAddr && self.Mask == other.Mask
     }
 }
 impl ::core::cmp::Eq for PF_LATEBIND_INFO {}
@@ -10338,7 +9837,7 @@ unsafe impl ::windows::core::Abi for TCPIP_OWNER_MODULE_BASIC_INFO {
 }
 impl ::core::cmp::PartialEq for TCPIP_OWNER_MODULE_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCPIP_OWNER_MODULE_BASIC_INFO>()) == 0 }
+        self.pModuleName == other.pModuleName && self.pModulePath == other.pModulePath
     }
 }
 impl ::core::cmp::Eq for TCPIP_OWNER_MODULE_BASIC_INFO {}
@@ -10379,7 +9878,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_BANDWIDTH_ROD_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_BANDWIDTH_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_BANDWIDTH_ROD_v0>()) == 0 }
+        self.OutboundBandwidth == other.OutboundBandwidth && self.InboundBandwidth == other.InboundBandwidth && self.OutboundInstability == other.OutboundInstability && self.InboundInstability == other.InboundInstability && self.OutboundBandwidthPeaked == other.OutboundBandwidthPeaked && self.InboundBandwidthPeaked == other.InboundBandwidthPeaked
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10412,7 +9911,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_BANDWIDTH_RW_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_BANDWIDTH_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_BANDWIDTH_RW_v0>()) == 0 }
+        self.EnableCollectionOutbound == other.EnableCollectionOutbound && self.EnableCollectionInbound == other.EnableCollectionInbound
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_BANDWIDTH_RW_v0 {}
@@ -10470,7 +9969,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_DATA_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_DATA_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_DATA_ROD_v0>()) == 0 }
+        self.DataBytesOut == other.DataBytesOut && self.DataSegsOut == other.DataSegsOut && self.DataBytesIn == other.DataBytesIn && self.DataSegsIn == other.DataSegsIn && self.SegsOut == other.SegsOut && self.SegsIn == other.SegsIn && self.SoftErrors == other.SoftErrors && self.SoftErrorReason == other.SoftErrorReason && self.SndUna == other.SndUna && self.SndNxt == other.SndNxt && self.SndMax == other.SndMax && self.ThruBytesAcked == other.ThruBytesAcked && self.RcvNxt == other.RcvNxt && self.ThruBytesReceived == other.ThruBytesReceived
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_DATA_ROD_v0 {}
@@ -10506,7 +10005,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_DATA_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_DATA_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_DATA_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10541,7 +10040,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_FINE_RTT_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_FINE_RTT_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_FINE_RTT_ROD_v0>()) == 0 }
+        self.RttVar == other.RttVar && self.MaxRtt == other.MaxRtt && self.MinRtt == other.MinRtt && self.SumRtt == other.SumRtt
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_FINE_RTT_ROD_v0 {}
@@ -10577,7 +10076,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_FINE_RTT_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_FINE_RTT_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_FINE_RTT_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10612,7 +10111,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_OBS_REC_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_OBS_REC_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_OBS_REC_ROD_v0>()) == 0 }
+        self.CurRwinRcvd == other.CurRwinRcvd && self.MaxRwinRcvd == other.MaxRwinRcvd && self.MinRwinRcvd == other.MinRwinRcvd && self.WinScaleRcvd == other.WinScaleRcvd
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_OBS_REC_ROD_v0 {}
@@ -10648,7 +10147,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_OBS_REC_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_OBS_REC_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_OBS_REC_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10760,7 +10259,46 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_PATH_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_PATH_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_PATH_ROD_v0>()) == 0 }
+        self.FastRetran == other.FastRetran
+            && self.Timeouts == other.Timeouts
+            && self.SubsequentTimeouts == other.SubsequentTimeouts
+            && self.CurTimeoutCount == other.CurTimeoutCount
+            && self.AbruptTimeouts == other.AbruptTimeouts
+            && self.PktsRetrans == other.PktsRetrans
+            && self.BytesRetrans == other.BytesRetrans
+            && self.DupAcksIn == other.DupAcksIn
+            && self.SacksRcvd == other.SacksRcvd
+            && self.SackBlocksRcvd == other.SackBlocksRcvd
+            && self.CongSignals == other.CongSignals
+            && self.PreCongSumCwnd == other.PreCongSumCwnd
+            && self.PreCongSumRtt == other.PreCongSumRtt
+            && self.PostCongSumRtt == other.PostCongSumRtt
+            && self.PostCongCountRtt == other.PostCongCountRtt
+            && self.EcnSignals == other.EcnSignals
+            && self.EceRcvd == other.EceRcvd
+            && self.SendStall == other.SendStall
+            && self.QuenchRcvd == other.QuenchRcvd
+            && self.RetranThresh == other.RetranThresh
+            && self.SndDupAckEpisodes == other.SndDupAckEpisodes
+            && self.SumBytesReordered == other.SumBytesReordered
+            && self.NonRecovDa == other.NonRecovDa
+            && self.NonRecovDaEpisodes == other.NonRecovDaEpisodes
+            && self.AckAfterFr == other.AckAfterFr
+            && self.DsackDups == other.DsackDups
+            && self.SampleRtt == other.SampleRtt
+            && self.SmoothedRtt == other.SmoothedRtt
+            && self.RttVar == other.RttVar
+            && self.MaxRtt == other.MaxRtt
+            && self.MinRtt == other.MinRtt
+            && self.SumRtt == other.SumRtt
+            && self.CountRtt == other.CountRtt
+            && self.CurRto == other.CurRto
+            && self.MaxRto == other.MaxRto
+            && self.MinRto == other.MinRto
+            && self.CurMss == other.CurMss
+            && self.MaxMss == other.MaxMss
+            && self.MinMss == other.MinMss
+            && self.SpuriousRtoDetections == other.SpuriousRtoDetections
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_PATH_ROD_v0 {}
@@ -10796,7 +10334,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_PATH_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_PATH_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_PATH_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10856,7 +10394,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_REC_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_REC_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_REC_ROD_v0>()) == 0 }
+        self.CurRwinSent == other.CurRwinSent && self.MaxRwinSent == other.MaxRwinSent && self.MinRwinSent == other.MinRwinSent && self.LimRwin == other.LimRwin && self.DupAckEpisodes == other.DupAckEpisodes && self.DupAcksOut == other.DupAcksOut && self.CeRcvd == other.CeRcvd && self.EcnSent == other.EcnSent && self.EcnNoncesRcvd == other.EcnNoncesRcvd && self.CurReasmQueue == other.CurReasmQueue && self.MaxReasmQueue == other.MaxReasmQueue && self.CurAppRQueue == other.CurAppRQueue && self.MaxAppRQueue == other.MaxAppRQueue && self.WinScaleSent == other.WinScaleSent
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_REC_ROD_v0 {}
@@ -10892,7 +10430,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_REC_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_REC_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_REC_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10927,7 +10465,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SEND_BUFF_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_SEND_BUFF_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SEND_BUFF_ROD_v0>()) == 0 }
+        self.CurRetxQueue == other.CurRetxQueue && self.MaxRetxQueue == other.MaxRetxQueue && self.CurAppWQueue == other.CurAppWQueue && self.MaxAppWQueue == other.MaxAppWQueue
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_SEND_BUFF_ROD_v0 {}
@@ -10963,7 +10501,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SEND_BUFF_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_SEND_BUFF_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SEND_BUFF_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11031,7 +10569,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SND_CONG_ROD_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_SND_CONG_ROD_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SND_CONG_ROD_v0>()) == 0 }
+        self.SndLimTransRwin == other.SndLimTransRwin && self.SndLimTimeRwin == other.SndLimTimeRwin && self.SndLimBytesRwin == other.SndLimBytesRwin && self.SndLimTransCwnd == other.SndLimTransCwnd && self.SndLimTimeCwnd == other.SndLimTimeCwnd && self.SndLimBytesCwnd == other.SndLimBytesCwnd && self.SndLimTransSnd == other.SndLimTransSnd && self.SndLimTimeSnd == other.SndLimTimeSnd && self.SndLimBytesSnd == other.SndLimBytesSnd && self.SlowStart == other.SlowStart && self.CongAvoid == other.CongAvoid && self.OtherReductions == other.OtherReductions && self.CurCwnd == other.CurCwnd && self.MaxSsCwnd == other.MaxSsCwnd && self.MaxCaCwnd == other.MaxCaCwnd && self.CurSsthresh == other.CurSsthresh && self.MaxSsthresh == other.MaxSsthresh && self.MinSsthresh == other.MinSsthresh
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_SND_CONG_ROD_v0 {}
@@ -11061,7 +10599,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SND_CONG_ROS_v0 {
 }
 impl ::core::cmp::PartialEq for TCP_ESTATS_SND_CONG_ROS_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SND_CONG_ROS_v0>()) == 0 }
+        self.LimCwnd == other.LimCwnd
     }
 }
 impl ::core::cmp::Eq for TCP_ESTATS_SND_CONG_ROS_v0 {}
@@ -11097,7 +10635,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SND_CONG_RW_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_SND_CONG_RW_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SND_CONG_RW_v0>()) == 0 }
+        self.EnableCollection == other.EnableCollection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11137,7 +10675,7 @@ unsafe impl ::windows::core::Abi for TCP_ESTATS_SYN_OPTS_ROS_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_ESTATS_SYN_OPTS_ROS_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ESTATS_SYN_OPTS_ROS_v0>()) == 0 }
+        self.ActiveOpen == other.ActiveOpen && self.MssRcvd == other.MssRcvd && self.MssSent == other.MssSent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11170,7 +10708,7 @@ unsafe impl ::windows::core::Abi for TCP_RESERVE_PORT_RANGE {
 }
 impl ::core::cmp::PartialEq for TCP_RESERVE_PORT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_RESERVE_PORT_RANGE>()) == 0 }
+        self.UpperRange == other.UpperRange && self.LowerRange == other.LowerRange
     }
 }
 impl ::core::cmp::Eq for TCP_RESERVE_PORT_RANGE {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
@@ -3988,7 +3988,7 @@ unsafe impl ::windows::core::Abi for MBN_PIN_INFO {
 }
 impl ::core::cmp::PartialEq for MBN_PIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MBN_PIN_INFO>()) == 0 }
+        self.pinState == other.pinState && self.pinType == other.pinType && self.attemptsRemaining == other.attemptsRemaining
     }
 }
 impl ::core::cmp::Eq for MBN_PIN_INFO {}
@@ -4083,7 +4083,7 @@ unsafe impl ::windows::core::Abi for MBN_SMS_FILTER {
 }
 impl ::core::cmp::PartialEq for MBN_SMS_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MBN_SMS_FILTER>()) == 0 }
+        self.flag == other.flag && self.messageIndex == other.messageIndex
     }
 }
 impl ::core::cmp::Eq for MBN_SMS_FILTER {}
@@ -4114,7 +4114,7 @@ unsafe impl ::windows::core::Abi for MBN_SMS_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for MBN_SMS_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MBN_SMS_STATUS_INFO>()) == 0 }
+        self.flag == other.flag && self.messageIndex == other.messageIndex
     }
 }
 impl ::core::cmp::Eq for MBN_SMS_STATUS_INFO {}
@@ -4144,7 +4144,7 @@ unsafe impl ::windows::core::Abi for __DummyPinType__ {
 }
 impl ::core::cmp::PartialEq for __DummyPinType__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<__DummyPinType__>()) == 0 }
+        self.pinType == other.pinType
     }
 }
 impl ::core::cmp::Eq for __DummyPinType__ {}
@@ -4202,7 +4202,7 @@ unsafe impl ::windows::core::Abi for __mbnapi_ReferenceRemainingTypes__ {
 }
 impl ::core::cmp::PartialEq for __mbnapi_ReferenceRemainingTypes__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<__mbnapi_ReferenceRemainingTypes__>()) == 0 }
+        self.bandClass == other.bandClass && self.contextConstants == other.contextConstants && self.ctrlCaps == other.ctrlCaps && self.dataClass == other.dataClass && self.interfaceCapsConstants == other.interfaceCapsConstants && self.pinConstants == other.pinConstants && self.providerConstants == other.providerConstants && self.providerState == other.providerState && self.registrationConstants == other.registrationConstants && self.signalConstants == other.signalConstants && self.smsCaps == other.smsCaps && self.smsConstants == other.smsConstants && self.wwaextSmsConstants == other.wwaextSmsConstants && self.smsStatusFlag == other.smsStatusFlag
     }
 }
 impl ::core::cmp::Eq for __mbnapi_ReferenceRemainingTypes__ {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Multicast/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Multicast/mod.rs
@@ -67,12 +67,6 @@ impl ::core::clone::Clone for IPNG_ADDRESS {
 unsafe impl ::windows::core::Abi for IPNG_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPNG_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPNG_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPNG_ADDRESS {}
 impl ::core::default::Default for IPNG_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -100,7 +94,7 @@ unsafe impl ::windows::core::Abi for MCAST_CLIENT_UID {
 }
 impl ::core::cmp::PartialEq for MCAST_CLIENT_UID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCAST_CLIENT_UID>()) == 0 }
+        self.ClientUID == other.ClientUID && self.ClientUIDLength == other.ClientUIDLength
     }
 }
 impl ::core::cmp::Eq for MCAST_CLIENT_UID {}
@@ -130,12 +124,6 @@ impl ::core::clone::Clone for MCAST_LEASE_REQUEST {
 unsafe impl ::windows::core::Abi for MCAST_LEASE_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCAST_LEASE_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCAST_LEASE_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCAST_LEASE_REQUEST {}
 impl ::core::default::Default for MCAST_LEASE_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -159,12 +147,6 @@ impl ::core::clone::Clone for MCAST_LEASE_RESPONSE {
 unsafe impl ::windows::core::Abi for MCAST_LEASE_RESPONSE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCAST_LEASE_RESPONSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCAST_LEASE_RESPONSE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCAST_LEASE_RESPONSE {}
 impl ::core::default::Default for MCAST_LEASE_RESPONSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -186,12 +168,6 @@ impl ::core::clone::Clone for MCAST_SCOPE_CTX {
 unsafe impl ::windows::core::Abi for MCAST_SCOPE_CTX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MCAST_SCOPE_CTX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCAST_SCOPE_CTX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MCAST_SCOPE_CTX {}
 impl ::core::default::Default for MCAST_SCOPE_CTX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -218,14 +194,6 @@ impl ::core::clone::Clone for MCAST_SCOPE_ENTRY {
 unsafe impl ::windows::core::Abi for MCAST_SCOPE_ENTRY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MCAST_SCOPE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCAST_SCOPE_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MCAST_SCOPE_ENTRY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MCAST_SCOPE_ENTRY {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
@@ -5157,7 +5157,7 @@ unsafe impl ::windows::core::Abi for BSSID_INFO {
 }
 impl ::core::cmp::PartialEq for BSSID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BSSID_INFO>()) == 0 }
+        self.BSSID == other.BSSID && self.PMKID == other.PMKID
     }
 }
 impl ::core::cmp::Eq for BSSID_INFO {}
@@ -5187,7 +5187,7 @@ unsafe impl ::windows::core::Abi for GEN_GET_NETCARD_TIME {
 }
 impl ::core::cmp::PartialEq for GEN_GET_NETCARD_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GEN_GET_NETCARD_TIME>()) == 0 }
+        self.ReadTime == other.ReadTime
     }
 }
 impl ::core::cmp::Eq for GEN_GET_NETCARD_TIME {}
@@ -5218,7 +5218,7 @@ unsafe impl ::windows::core::Abi for GEN_GET_TIME_CAPS {
 }
 impl ::core::cmp::PartialEq for GEN_GET_TIME_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GEN_GET_TIME_CAPS>()) == 0 }
+        self.Flags == other.Flags && self.ClockPrecision == other.ClockPrecision
     }
 }
 impl ::core::cmp::Eq for GEN_GET_TIME_CAPS {}
@@ -5249,7 +5249,7 @@ unsafe impl ::windows::core::Abi for IF_COUNTED_STRING_LH {
 }
 impl ::core::cmp::PartialEq for IF_COUNTED_STRING_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IF_COUNTED_STRING_LH>()) == 0 }
+        self.Length == other.Length && self.String == other.String
     }
 }
 impl ::core::cmp::Eq for IF_COUNTED_STRING_LH {}
@@ -5280,7 +5280,7 @@ unsafe impl ::windows::core::Abi for IF_PHYSICAL_ADDRESS_LH {
 }
 impl ::core::cmp::PartialEq for IF_PHYSICAL_ADDRESS_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IF_PHYSICAL_ADDRESS_LH>()) == 0 }
+        self.Length == other.Length && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for IF_PHYSICAL_ADDRESS_LH {}
@@ -5312,7 +5312,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_AI_REQFI {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_AI_REQFI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_AI_REQFI>()) == 0 }
+        self.Capabilities == other.Capabilities && self.ListenInterval == other.ListenInterval && self.CurrentAPAddress == other.CurrentAPAddress
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_AI_REQFI {}
@@ -5344,7 +5344,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_AI_RESFI {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_AI_RESFI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_AI_RESFI>()) == 0 }
+        self.Capabilities == other.Capabilities && self.StatusCode == other.StatusCode && self.AssociationId == other.AssociationId
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_AI_RESFI {}
@@ -5392,7 +5392,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_ASSOCIATION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_ASSOCIATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_ASSOCIATION_INFORMATION>()) == 0 }
+        self.Length == other.Length && self.AvailableRequestFixedIEs == other.AvailableRequestFixedIEs && self.RequestFixedIEs == other.RequestFixedIEs && self.RequestIELength == other.RequestIELength && self.OffsetRequestIEs == other.OffsetRequestIEs && self.AvailableResponseFixedIEs == other.AvailableResponseFixedIEs && self.ResponseFixedIEs == other.ResponseFixedIEs && self.ResponseIELength == other.ResponseIELength && self.OffsetResponseIEs == other.OffsetResponseIEs
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_ASSOCIATION_INFORMATION {}
@@ -5423,7 +5423,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_AUTHENTICATION_ENCRYPTION>()) == 0 }
+        self.AuthModeSupported == other.AuthModeSupported && self.EncryptStatusSupported == other.EncryptStatusSupported
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_AUTHENTICATION_ENCRYPTION {}
@@ -5454,7 +5454,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_AUTHENTICATION_EVENT {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_AUTHENTICATION_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_AUTHENTICATION_EVENT>()) == 0 }
+        self.Status == other.Status && self.Request == other.Request
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_AUTHENTICATION_EVENT {}
@@ -5486,7 +5486,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_AUTHENTICATION_REQUEST {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_AUTHENTICATION_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_AUTHENTICATION_REQUEST>()) == 0 }
+        self.Length == other.Length && self.Bssid == other.Bssid && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_AUTHENTICATION_REQUEST {}
@@ -5517,7 +5517,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_BSSID_LIST {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_BSSID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_BSSID_LIST>()) == 0 }
+        self.NumberOfItems == other.NumberOfItems && self.Bssid == other.Bssid
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_BSSID_LIST {}
@@ -5548,7 +5548,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_BSSID_LIST_EX {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_BSSID_LIST_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_BSSID_LIST_EX>()) == 0 }
+        self.NumberOfItems == other.NumberOfItems && self.Bssid == other.Bssid
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_BSSID_LIST_EX {}
@@ -5582,7 +5582,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_CAPABILITY>()) == 0 }
+        self.Length == other.Length && self.Version == other.Version && self.NoOfPMKIDs == other.NoOfPMKIDs && self.NoOfAuthEncryptPairsSupported == other.NoOfAuthEncryptPairsSupported && self.AuthenticationEncryptionSupported == other.AuthenticationEncryptionSupported
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_CAPABILITY {}
@@ -5616,7 +5616,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_CONFIGURATION {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_CONFIGURATION>()) == 0 }
+        self.Length == other.Length && self.BeaconPeriod == other.BeaconPeriod && self.ATIMWindow == other.ATIMWindow && self.DSConfig == other.DSConfig && self.FHConfig == other.FHConfig
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_CONFIGURATION {}
@@ -5649,7 +5649,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_CONFIGURATION_FH {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_CONFIGURATION_FH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_CONFIGURATION_FH>()) == 0 }
+        self.Length == other.Length && self.HopPattern == other.HopPattern && self.HopSet == other.HopSet && self.DwellTime == other.DwellTime
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_CONFIGURATION_FH {}
@@ -5681,7 +5681,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_FIXED_IEs {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_FIXED_IEs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_FIXED_IEs>()) == 0 }
+        self.Timestamp == other.Timestamp && self.BeaconInterval == other.BeaconInterval && self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_FIXED_IEs {}
@@ -5716,7 +5716,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_KEY {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_KEY>()) == 0 }
+        self.Length == other.Length && self.KeyIndex == other.KeyIndex && self.KeyLength == other.KeyLength && self.BSSID == other.BSSID && self.KeyRSC == other.KeyRSC && self.KeyMaterial == other.KeyMaterial
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_KEY {}
@@ -5747,7 +5747,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_NETWORK_TYPE_LIST {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_NETWORK_TYPE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_NETWORK_TYPE_LIST>()) == 0 }
+        self.NumberOfItems == other.NumberOfItems && self.NetworkType == other.NetworkType
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_NETWORK_TYPE_LIST {}
@@ -5778,7 +5778,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_NON_BCAST_SSID_LIST {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_NON_BCAST_SSID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_NON_BCAST_SSID_LIST>()) == 0 }
+        self.NumberOfItems == other.NumberOfItems && self.Non_Bcast_Ssid == other.Non_Bcast_Ssid
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_NON_BCAST_SSID_LIST {}
@@ -5810,7 +5810,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_PMKID {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_PMKID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_PMKID>()) == 0 }
+        self.Length == other.Length && self.BSSIDInfoCount == other.BSSIDInfoCount && self.BSSIDInfo == other.BSSIDInfo
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_PMKID {}
@@ -5842,7 +5842,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_PMKID_CANDIDATE_LIST {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_PMKID_CANDIDATE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_PMKID_CANDIDATE_LIST>()) == 0 }
+        self.Version == other.Version && self.NumCandidates == other.NumCandidates && self.CandidateList == other.CandidateList
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_PMKID_CANDIDATE_LIST {}
@@ -5874,7 +5874,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_REMOVE_KEY {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_REMOVE_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_REMOVE_KEY>()) == 0 }
+        self.Length == other.Length && self.KeyIndex == other.KeyIndex && self.BSSID == other.BSSID
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_REMOVE_KEY {}
@@ -5905,7 +5905,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_SSID {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_SSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_SSID>()) == 0 }
+        self.SsidLength == other.SsidLength && self.Ssid == other.Ssid
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_SSID {}
@@ -5985,7 +5985,31 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_STATISTICS {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_STATISTICS>()) == 0 }
+        self.Length == other.Length
+            && self.TransmittedFragmentCount == other.TransmittedFragmentCount
+            && self.MulticastTransmittedFrameCount == other.MulticastTransmittedFrameCount
+            && self.FailedCount == other.FailedCount
+            && self.RetryCount == other.RetryCount
+            && self.MultipleRetryCount == other.MultipleRetryCount
+            && self.RTSSuccessCount == other.RTSSuccessCount
+            && self.RTSFailureCount == other.RTSFailureCount
+            && self.ACKFailureCount == other.ACKFailureCount
+            && self.FrameDuplicateCount == other.FrameDuplicateCount
+            && self.ReceivedFragmentCount == other.ReceivedFragmentCount
+            && self.MulticastReceivedFrameCount == other.MulticastReceivedFrameCount
+            && self.FCSErrorCount == other.FCSErrorCount
+            && self.TKIPLocalMICFailures == other.TKIPLocalMICFailures
+            && self.TKIPICVErrorCount == other.TKIPICVErrorCount
+            && self.TKIPCounterMeasuresInvoked == other.TKIPCounterMeasuresInvoked
+            && self.TKIPReplays == other.TKIPReplays
+            && self.CCMPFormatErrors == other.CCMPFormatErrors
+            && self.CCMPReplays == other.CCMPReplays
+            && self.CCMPDecryptErrors == other.CCMPDecryptErrors
+            && self.FourWayHandshakeFailures == other.FourWayHandshakeFailures
+            && self.WEPUndecryptableCount == other.WEPUndecryptableCount
+            && self.WEPICVErrorCount == other.WEPICVErrorCount
+            && self.DecryptSuccessCount == other.DecryptSuccessCount
+            && self.DecryptFailureCount == other.DecryptFailureCount
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_STATISTICS {}
@@ -6015,7 +6039,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_STATUS_INDICATION {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_STATUS_INDICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_STATUS_INDICATION>()) == 0 }
+        self.StatusType == other.StatusType
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_STATUS_INDICATION {}
@@ -6040,12 +6064,6 @@ impl ::core::clone::Clone for NDIS_802_11_TEST {
 unsafe impl ::windows::core::Abi for NDIS_802_11_TEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_802_11_TEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_TEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_802_11_TEST {}
 impl ::core::default::Default for NDIS_802_11_TEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6066,12 +6084,6 @@ impl ::core::clone::Clone for NDIS_802_11_TEST_0 {
 unsafe impl ::windows::core::Abi for NDIS_802_11_TEST_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_802_11_TEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_TEST_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_802_11_TEST_0 {}
 impl ::core::default::Default for NDIS_802_11_TEST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6100,7 +6112,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_VARIABLE_IEs {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_VARIABLE_IEs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_VARIABLE_IEs>()) == 0 }
+        self.ElementID == other.ElementID && self.Length == other.Length && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_VARIABLE_IEs {}
@@ -6133,7 +6145,7 @@ unsafe impl ::windows::core::Abi for NDIS_802_11_WEP {
 }
 impl ::core::cmp::PartialEq for NDIS_802_11_WEP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_802_11_WEP>()) == 0 }
+        self.Length == other.Length && self.KeyIndex == other.KeyIndex && self.KeyLength == other.KeyLength && self.KeyMaterial == other.KeyMaterial
     }
 }
 impl ::core::cmp::Eq for NDIS_802_11_WEP {}
@@ -6219,7 +6231,34 @@ unsafe impl ::windows::core::Abi for NDIS_CO_DEVICE_PROFILE {
 }
 impl ::core::cmp::PartialEq for NDIS_CO_DEVICE_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_CO_DEVICE_PROFILE>()) == 0 }
+        self.DeviceDescription == other.DeviceDescription
+            && self.DevSpecificInfo == other.DevSpecificInfo
+            && self.ulTAPISupplementaryPassThru == other.ulTAPISupplementaryPassThru
+            && self.ulAddressModes == other.ulAddressModes
+            && self.ulNumAddresses == other.ulNumAddresses
+            && self.ulBearerModes == other.ulBearerModes
+            && self.ulMaxTxRate == other.ulMaxTxRate
+            && self.ulMinTxRate == other.ulMinTxRate
+            && self.ulMaxRxRate == other.ulMaxRxRate
+            && self.ulMinRxRate == other.ulMinRxRate
+            && self.ulMediaModes == other.ulMediaModes
+            && self.ulGenerateToneModes == other.ulGenerateToneModes
+            && self.ulGenerateToneMaxNumFreq == other.ulGenerateToneMaxNumFreq
+            && self.ulGenerateDigitModes == other.ulGenerateDigitModes
+            && self.ulMonitorToneMaxNumFreq == other.ulMonitorToneMaxNumFreq
+            && self.ulMonitorToneMaxNumEntries == other.ulMonitorToneMaxNumEntries
+            && self.ulMonitorDigitModes == other.ulMonitorDigitModes
+            && self.ulGatherDigitsMinTimeout == other.ulGatherDigitsMinTimeout
+            && self.ulGatherDigitsMaxTimeout == other.ulGatherDigitsMaxTimeout
+            && self.ulDevCapFlags == other.ulDevCapFlags
+            && self.ulMaxNumActiveCalls == other.ulMaxNumActiveCalls
+            && self.ulAnswerMode == other.ulAnswerMode
+            && self.ulUUIAcceptSize == other.ulUUIAcceptSize
+            && self.ulUUIAnswerSize == other.ulUUIAnswerSize
+            && self.ulUUIMakeCallSize == other.ulUUIMakeCallSize
+            && self.ulUUIDropSize == other.ulUUIDropSize
+            && self.ulUUISendUserUserInfoSize == other.ulUUISendUserUserInfoSize
+            && self.ulUUICallInfoSize == other.ulUUICallInfoSize
     }
 }
 impl ::core::cmp::Eq for NDIS_CO_DEVICE_PROFILE {}
@@ -6250,7 +6289,7 @@ unsafe impl ::windows::core::Abi for NDIS_CO_LINK_SPEED {
 }
 impl ::core::cmp::PartialEq for NDIS_CO_LINK_SPEED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_CO_LINK_SPEED>()) == 0 }
+        self.Outbound == other.Outbound && self.Inbound == other.Inbound
     }
 }
 impl ::core::cmp::Eq for NDIS_CO_LINK_SPEED {}
@@ -6276,12 +6315,6 @@ impl ::core::clone::Clone for NDIS_GUID {
 unsafe impl ::windows::core::Abi for NDIS_GUID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_GUID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_GUID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_GUID {}
 impl ::core::default::Default for NDIS_GUID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6302,12 +6335,6 @@ impl ::core::clone::Clone for NDIS_GUID_0 {
 unsafe impl ::windows::core::Abi for NDIS_GUID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_GUID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_GUID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_GUID_0 {}
 impl ::core::default::Default for NDIS_GUID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6338,7 +6365,7 @@ unsafe impl ::windows::core::Abi for NDIS_HARDWARE_CROSSTIMESTAMP {
 }
 impl ::core::cmp::PartialEq for NDIS_HARDWARE_CROSSTIMESTAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_HARDWARE_CROSSTIMESTAMP>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.SystemTimestamp1 == other.SystemTimestamp1 && self.HardwareClockTimestamp == other.HardwareClockTimestamp && self.SystemTimestamp2 == other.SystemTimestamp2
     }
 }
 impl ::core::cmp::Eq for NDIS_HARDWARE_CROSSTIMESTAMP {}
@@ -6438,7 +6465,38 @@ unsafe impl ::windows::core::Abi for NDIS_INTERFACE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NDIS_INTERFACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_INTERFACE_INFORMATION>()) == 0 }
+        self.ifOperStatus == other.ifOperStatus
+            && self.ifOperStatusFlags == other.ifOperStatusFlags
+            && self.MediaConnectState == other.MediaConnectState
+            && self.MediaDuplexState == other.MediaDuplexState
+            && self.ifMtu == other.ifMtu
+            && self.ifPromiscuousMode == other.ifPromiscuousMode
+            && self.ifDeviceWakeUpEnable == other.ifDeviceWakeUpEnable
+            && self.XmitLinkSpeed == other.XmitLinkSpeed
+            && self.RcvLinkSpeed == other.RcvLinkSpeed
+            && self.ifLastChange == other.ifLastChange
+            && self.ifCounterDiscontinuityTime == other.ifCounterDiscontinuityTime
+            && self.ifInUnknownProtos == other.ifInUnknownProtos
+            && self.ifInDiscards == other.ifInDiscards
+            && self.ifInErrors == other.ifInErrors
+            && self.ifHCInOctets == other.ifHCInOctets
+            && self.ifHCInUcastPkts == other.ifHCInUcastPkts
+            && self.ifHCInMulticastPkts == other.ifHCInMulticastPkts
+            && self.ifHCInBroadcastPkts == other.ifHCInBroadcastPkts
+            && self.ifHCOutOctets == other.ifHCOutOctets
+            && self.ifHCOutUcastPkts == other.ifHCOutUcastPkts
+            && self.ifHCOutMulticastPkts == other.ifHCOutMulticastPkts
+            && self.ifHCOutBroadcastPkts == other.ifHCOutBroadcastPkts
+            && self.ifOutErrors == other.ifOutErrors
+            && self.ifOutDiscards == other.ifOutDiscards
+            && self.ifHCInUcastOctets == other.ifHCInUcastOctets
+            && self.ifHCInMulticastOctets == other.ifHCInMulticastOctets
+            && self.ifHCInBroadcastOctets == other.ifHCInBroadcastOctets
+            && self.ifHCOutUcastOctets == other.ifHCOutUcastOctets
+            && self.ifHCOutMulticastOctets == other.ifHCOutMulticastOctets
+            && self.ifHCOutBroadcastOctets == other.ifHCOutBroadcastOctets
+            && self.CompartmentId == other.CompartmentId
+            && self.SupportedStatistics == other.SupportedStatistics
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6472,7 +6530,7 @@ unsafe impl ::windows::core::Abi for NDIS_INTERRUPT_MODERATION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_INTERRUPT_MODERATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_INTERRUPT_MODERATION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.InterruptModeration == other.InterruptModeration
     }
 }
 impl ::core::cmp::Eq for NDIS_INTERRUPT_MODERATION_PARAMETERS {}
@@ -6504,7 +6562,7 @@ unsafe impl ::windows::core::Abi for NDIS_IPSEC_OFFLOAD_V1 {
 }
 impl ::core::cmp::PartialEq for NDIS_IPSEC_OFFLOAD_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IPSEC_OFFLOAD_V1>()) == 0 }
+        self.Supported == other.Supported && self.IPv4AH == other.IPv4AH && self.IPv4ESP == other.IPv4ESP
     }
 }
 impl ::core::cmp::Eq for NDIS_IPSEC_OFFLOAD_V1 {}
@@ -6534,7 +6592,7 @@ unsafe impl ::windows::core::Abi for NDIS_IPSEC_OFFLOAD_V1_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IPSEC_OFFLOAD_V1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_IPSEC_OFFLOAD_V1_0 {}
@@ -6564,7 +6622,7 @@ unsafe impl ::windows::core::Abi for NDIS_IPSEC_OFFLOAD_V1_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_IPSEC_OFFLOAD_V1_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IPSEC_OFFLOAD_V1_1>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_IPSEC_OFFLOAD_V1_1 {}
@@ -6598,7 +6656,7 @@ unsafe impl ::windows::core::Abi for NDIS_IPSEC_OFFLOAD_V1_2 {
 }
 impl ::core::cmp::PartialEq for NDIS_IPSEC_OFFLOAD_V1_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IPSEC_OFFLOAD_V1_2>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.AhEspCombined == other.AhEspCombined && self.TransportTunnelCombined == other.TransportTunnelCombined && self.IPv4Options == other.IPv4Options && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_IPSEC_OFFLOAD_V1_2 {}
@@ -6630,7 +6688,7 @@ unsafe impl ::windows::core::Abi for NDIS_IP_OPER_STATE {
 }
 impl ::core::cmp::PartialEq for NDIS_IP_OPER_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IP_OPER_STATE>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.IpOperationalStatus == other.IpOperationalStatus
     }
 }
 impl ::core::cmp::Eq for NDIS_IP_OPER_STATE {}
@@ -6662,7 +6720,7 @@ unsafe impl ::windows::core::Abi for NDIS_IP_OPER_STATUS {
 }
 impl ::core::cmp::PartialEq for NDIS_IP_OPER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IP_OPER_STATUS>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.OperationalStatus == other.OperationalStatus && self.OperationalStatusFlags == other.OperationalStatusFlags
     }
 }
 impl ::core::cmp::Eq for NDIS_IP_OPER_STATUS {}
@@ -6695,7 +6753,7 @@ unsafe impl ::windows::core::Abi for NDIS_IP_OPER_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for NDIS_IP_OPER_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IP_OPER_STATUS_INFO>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.NumberofAddressFamiliesReturned == other.NumberofAddressFamiliesReturned && self.IpOperationalStatus == other.IpOperationalStatus
     }
 }
 impl ::core::cmp::Eq for NDIS_IP_OPER_STATUS_INFO {}
@@ -6726,7 +6784,7 @@ unsafe impl ::windows::core::Abi for NDIS_IRDA_PACKET_INFO {
 }
 impl ::core::cmp::PartialEq for NDIS_IRDA_PACKET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_IRDA_PACKET_INFO>()) == 0 }
+        self.ExtraBOFs == other.ExtraBOFs && self.MinTurnAroundTime == other.MinTurnAroundTime
     }
 }
 impl ::core::cmp::Eq for NDIS_IRDA_PACKET_INFO {}
@@ -6761,7 +6819,7 @@ unsafe impl ::windows::core::Abi for NDIS_LINK_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_LINK_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_LINK_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.MediaDuplexState == other.MediaDuplexState && self.XmitLinkSpeed == other.XmitLinkSpeed && self.RcvLinkSpeed == other.RcvLinkSpeed && self.PauseFunctions == other.PauseFunctions && self.AutoNegotiationFlags == other.AutoNegotiationFlags
     }
 }
 impl ::core::cmp::Eq for NDIS_LINK_PARAMETERS {}
@@ -6792,7 +6850,7 @@ unsafe impl ::windows::core::Abi for NDIS_LINK_SPEED {
 }
 impl ::core::cmp::PartialEq for NDIS_LINK_SPEED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_LINK_SPEED>()) == 0 }
+        self.XmitLinkSpeed == other.XmitLinkSpeed && self.RcvLinkSpeed == other.RcvLinkSpeed
     }
 }
 impl ::core::cmp::Eq for NDIS_LINK_SPEED {}
@@ -6828,7 +6886,7 @@ unsafe impl ::windows::core::Abi for NDIS_LINK_STATE {
 }
 impl ::core::cmp::PartialEq for NDIS_LINK_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_LINK_STATE>()) == 0 }
+        self.Header == other.Header && self.MediaConnectState == other.MediaConnectState && self.MediaDuplexState == other.MediaDuplexState && self.XmitLinkSpeed == other.XmitLinkSpeed && self.RcvLinkSpeed == other.RcvLinkSpeed && self.PauseFunctions == other.PauseFunctions && self.AutoNegotiationFlags == other.AutoNegotiationFlags
     }
 }
 impl ::core::cmp::Eq for NDIS_LINK_STATE {}
@@ -6860,7 +6918,7 @@ unsafe impl ::windows::core::Abi for NDIS_OBJECT_HEADER {
 }
 impl ::core::cmp::PartialEq for NDIS_OBJECT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_OBJECT_HEADER>()) == 0 }
+        self.Type == other.Type && self.Revision == other.Revision && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for NDIS_OBJECT_HEADER {}
@@ -6895,7 +6953,7 @@ unsafe impl ::windows::core::Abi for NDIS_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_OFFLOAD>()) == 0 }
+        self.Header == other.Header && self.Checksum == other.Checksum && self.LsoV1 == other.LsoV1 && self.IPsecV1 == other.IPsecV1 && self.LsoV2 == other.LsoV2 && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_OFFLOAD {}
@@ -6951,7 +7009,7 @@ unsafe impl ::windows::core::Abi for NDIS_OFFLOAD_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_OFFLOAD_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_OFFLOAD_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.IPv4Checksum == other.IPv4Checksum && self.TCPIPv4Checksum == other.TCPIPv4Checksum && self.UDPIPv4Checksum == other.UDPIPv4Checksum && self.TCPIPv6Checksum == other.TCPIPv6Checksum && self.UDPIPv6Checksum == other.UDPIPv6Checksum && self.LsoV1 == other.LsoV1 && self.IPsecV1 == other.IPsecV1 && self.LsoV2IPv4 == other.LsoV2IPv4 && self.LsoV2IPv6 == other.LsoV2IPv6 && self.TcpConnectionIPv4 == other.TcpConnectionIPv4 && self.TcpConnectionIPv6 == other.TcpConnectionIPv6 && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_OFFLOAD_PARAMETERS {}
@@ -6983,7 +7041,7 @@ unsafe impl ::windows::core::Abi for NDIS_OPER_STATE {
 }
 impl ::core::cmp::PartialEq for NDIS_OPER_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_OPER_STATE>()) == 0 }
+        self.Header == other.Header && self.OperationalStatus == other.OperationalStatus && self.OperationalStatusFlags == other.OperationalStatusFlags
     }
 }
 impl ::core::cmp::Eq for NDIS_OPER_STATE {}
@@ -7039,7 +7097,7 @@ unsafe impl ::windows::core::Abi for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PCI_DEVICE_CUSTOM_PROPERTIES>()) == 0 }
+        self.Header == other.Header && self.DeviceType == other.DeviceType && self.CurrentSpeedAndMode == other.CurrentSpeedAndMode && self.CurrentPayloadSize == other.CurrentPayloadSize && self.MaxPayloadSize == other.MaxPayloadSize && self.MaxReadRequestSize == other.MaxReadRequestSize && self.CurrentLinkSpeed == other.CurrentLinkSpeed && self.CurrentLinkWidth == other.CurrentLinkWidth && self.MaxLinkSpeed == other.MaxLinkSpeed && self.MaxLinkWidth == other.MaxLinkWidth && self.PciExpressVersion == other.PciExpressVersion && self.InterruptType == other.InterruptType && self.MaxInterruptMessages == other.MaxInterruptMessages
     }
 }
 impl ::core::cmp::Eq for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {}
@@ -7074,7 +7132,7 @@ unsafe impl ::windows::core::Abi for NDIS_PM_PACKET_PATTERN {
 }
 impl ::core::cmp::PartialEq for NDIS_PM_PACKET_PATTERN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PM_PACKET_PATTERN>()) == 0 }
+        self.Priority == other.Priority && self.Reserved == other.Reserved && self.MaskSize == other.MaskSize && self.PatternOffset == other.PatternOffset && self.PatternSize == other.PatternSize && self.PatternFlags == other.PatternFlags
     }
 }
 impl ::core::cmp::Eq for NDIS_PM_PACKET_PATTERN {}
@@ -7106,7 +7164,7 @@ unsafe impl ::windows::core::Abi for NDIS_PM_WAKE_UP_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for NDIS_PM_WAKE_UP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PM_WAKE_UP_CAPABILITIES>()) == 0 }
+        self.MinMagicPacketWakeUp == other.MinMagicPacketWakeUp && self.MinPatternWakeUp == other.MinPatternWakeUp && self.MinLinkChangeWakeUp == other.MinLinkChangeWakeUp
     }
 }
 impl ::core::cmp::Eq for NDIS_PM_WAKE_UP_CAPABILITIES {}
@@ -7137,7 +7195,7 @@ unsafe impl ::windows::core::Abi for NDIS_PNP_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for NDIS_PNP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PNP_CAPABILITIES>()) == 0 }
+        self.Flags == other.Flags && self.WakeUpCapabilities == other.WakeUpCapabilities
     }
 }
 impl ::core::cmp::Eq for NDIS_PNP_CAPABILITIES {}
@@ -7171,7 +7229,7 @@ unsafe impl ::windows::core::Abi for NDIS_PORT {
 }
 impl ::core::cmp::PartialEq for NDIS_PORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PORT>()) == 0 }
+        self.Next == other.Next && self.NdisReserved == other.NdisReserved && self.MiniportReserved == other.MiniportReserved && self.ProtocolReserved == other.ProtocolReserved && self.PortCharacteristics == other.PortCharacteristics
     }
 }
 impl ::core::cmp::Eq for NDIS_PORT {}
@@ -7205,7 +7263,7 @@ unsafe impl ::windows::core::Abi for NDIS_PORT_ARRAY {
 }
 impl ::core::cmp::PartialEq for NDIS_PORT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PORT_ARRAY>()) == 0 }
+        self.Header == other.Header && self.NumberOfPorts == other.NumberOfPorts && self.OffsetFirstPort == other.OffsetFirstPort && self.ElementSize == other.ElementSize && self.Ports == other.Ports
     }
 }
 impl ::core::cmp::Eq for NDIS_PORT_ARRAY {}
@@ -7239,7 +7297,7 @@ unsafe impl ::windows::core::Abi for NDIS_PORT_AUTHENTICATION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_PORT_AUTHENTICATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PORT_AUTHENTICATION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.SendControlState == other.SendControlState && self.RcvControlState == other.RcvControlState && self.SendAuthorizationState == other.SendAuthorizationState && self.RcvAuthorizationState == other.RcvAuthorizationState
     }
 }
 impl ::core::cmp::Eq for NDIS_PORT_AUTHENTICATION_PARAMETERS {}
@@ -7293,7 +7351,7 @@ unsafe impl ::windows::core::Abi for NDIS_PORT_CHARACTERISTICS {
 }
 impl ::core::cmp::PartialEq for NDIS_PORT_CHARACTERISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PORT_CHARACTERISTICS>()) == 0 }
+        self.Header == other.Header && self.PortNumber == other.PortNumber && self.Flags == other.Flags && self.Type == other.Type && self.MediaConnectState == other.MediaConnectState && self.XmitLinkSpeed == other.XmitLinkSpeed && self.RcvLinkSpeed == other.RcvLinkSpeed && self.Direction == other.Direction && self.SendControlState == other.SendControlState && self.RcvControlState == other.RcvControlState && self.SendAuthorizationState == other.SendAuthorizationState && self.RcvAuthorizationState == other.RcvAuthorizationState
     }
 }
 impl ::core::cmp::Eq for NDIS_PORT_CHARACTERISTICS {}
@@ -7343,7 +7401,7 @@ unsafe impl ::windows::core::Abi for NDIS_PORT_STATE {
 }
 impl ::core::cmp::PartialEq for NDIS_PORT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_PORT_STATE>()) == 0 }
+        self.Header == other.Header && self.MediaConnectState == other.MediaConnectState && self.XmitLinkSpeed == other.XmitLinkSpeed && self.RcvLinkSpeed == other.RcvLinkSpeed && self.Direction == other.Direction && self.SendControlState == other.SendControlState && self.RcvControlState == other.RcvControlState && self.SendAuthorizationState == other.SendAuthorizationState && self.RcvAuthorizationState == other.RcvAuthorizationState && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_PORT_STATE {}
@@ -7377,7 +7435,7 @@ unsafe impl ::windows::core::Abi for NDIS_RECEIVE_HASH_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_RECEIVE_HASH_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_RECEIVE_HASH_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.HashInformation == other.HashInformation && self.HashSecretKeySize == other.HashSecretKeySize && self.HashSecretKeyOffset == other.HashSecretKeyOffset
     }
 }
 impl ::core::cmp::Eq for NDIS_RECEIVE_HASH_PARAMETERS {}
@@ -7410,7 +7468,7 @@ unsafe impl ::windows::core::Abi for NDIS_RECEIVE_SCALE_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for NDIS_RECEIVE_SCALE_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_RECEIVE_SCALE_CAPABILITIES>()) == 0 }
+        self.Header == other.Header && self.CapabilitiesFlags == other.CapabilitiesFlags && self.NumberOfInterruptMessages == other.NumberOfInterruptMessages && self.NumberOfReceiveQueues == other.NumberOfReceiveQueues
     }
 }
 impl ::core::cmp::Eq for NDIS_RECEIVE_SCALE_CAPABILITIES {}
@@ -7447,7 +7505,7 @@ unsafe impl ::windows::core::Abi for NDIS_RECEIVE_SCALE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for NDIS_RECEIVE_SCALE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_RECEIVE_SCALE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.BaseCpuNumber == other.BaseCpuNumber && self.HashInformation == other.HashInformation && self.IndirectionTableSize == other.IndirectionTableSize && self.IndirectionTableOffset == other.IndirectionTableOffset && self.HashSecretKeySize == other.HashSecretKeySize && self.HashSecretKeyOffset == other.HashSecretKeyOffset
     }
 }
 impl ::core::cmp::Eq for NDIS_RECEIVE_SCALE_PARAMETERS {}
@@ -7517,7 +7575,26 @@ unsafe impl ::windows::core::Abi for NDIS_STATISTICS_INFO {
 }
 impl ::core::cmp::PartialEq for NDIS_STATISTICS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_STATISTICS_INFO>()) == 0 }
+        self.Header == other.Header
+            && self.SupportedStatistics == other.SupportedStatistics
+            && self.ifInDiscards == other.ifInDiscards
+            && self.ifInErrors == other.ifInErrors
+            && self.ifHCInOctets == other.ifHCInOctets
+            && self.ifHCInUcastPkts == other.ifHCInUcastPkts
+            && self.ifHCInMulticastPkts == other.ifHCInMulticastPkts
+            && self.ifHCInBroadcastPkts == other.ifHCInBroadcastPkts
+            && self.ifHCOutOctets == other.ifHCOutOctets
+            && self.ifHCOutUcastPkts == other.ifHCOutUcastPkts
+            && self.ifHCOutMulticastPkts == other.ifHCOutMulticastPkts
+            && self.ifHCOutBroadcastPkts == other.ifHCOutBroadcastPkts
+            && self.ifOutErrors == other.ifOutErrors
+            && self.ifOutDiscards == other.ifOutDiscards
+            && self.ifHCInUcastOctets == other.ifHCInUcastOctets
+            && self.ifHCInMulticastOctets == other.ifHCInMulticastOctets
+            && self.ifHCInBroadcastOctets == other.ifHCInBroadcastOctets
+            && self.ifHCOutUcastOctets == other.ifHCOutUcastOctets
+            && self.ifHCOutMulticastOctets == other.ifHCOutMulticastOctets
+            && self.ifHCOutBroadcastOctets == other.ifHCOutBroadcastOctets
     }
 }
 impl ::core::cmp::Eq for NDIS_STATISTICS_INFO {}
@@ -7549,7 +7626,7 @@ unsafe impl ::windows::core::Abi for NDIS_STATISTICS_VALUE {
 }
 impl ::core::cmp::PartialEq for NDIS_STATISTICS_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_STATISTICS_VALUE>()) == 0 }
+        self.Oid == other.Oid && self.DataLength == other.DataLength && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for NDIS_STATISTICS_VALUE {}
@@ -7582,7 +7659,7 @@ unsafe impl ::windows::core::Abi for NDIS_STATISTICS_VALUE_EX {
 }
 impl ::core::cmp::PartialEq for NDIS_STATISTICS_VALUE_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_STATISTICS_VALUE_EX>()) == 0 }
+        self.Oid == other.Oid && self.DataLength == other.DataLength && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for NDIS_STATISTICS_VALUE_EX {}
@@ -7616,7 +7693,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_CONNECTION_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_CONNECTION_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_CONNECTION_OFFLOAD>()) == 0 }
+        self.Header == other.Header && self.Encapsulation == other.Encapsulation && self._bitfield == other._bitfield && self.TcpConnectionOffloadCapacity == other.TcpConnectionOffloadCapacity && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_CONNECTION_OFFLOAD {}
@@ -7649,7 +7726,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_IP_CHECKSUM_OFFLOAD>()) == 0 }
+        self.IPv4Transmit == other.IPv4Transmit && self.IPv4Receive == other.IPv4Receive && self.IPv6Transmit == other.IPv6Transmit && self.IPv6Receive == other.IPv6Receive
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_IP_CHECKSUM_OFFLOAD {}
@@ -7680,7 +7757,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_IP_CHECKSUM_OFFLOAD_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {}
@@ -7711,7 +7788,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_IP_CHECKSUM_OFFLOAD_1>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {}
@@ -7742,7 +7819,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_IP_CHECKSUM_OFFLOAD_2>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {}
@@ -7773,7 +7850,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_IP_CHECKSUM_OFFLOAD_3>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {}
@@ -7803,7 +7880,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_LARGE_SEND_OFFLOAD_V1>()) == 0 }
+        self.IPv4 == other.IPv4
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {}
@@ -7836,7 +7913,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {}
@@ -7867,7 +7944,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_LARGE_SEND_OFFLOAD_V2>()) == 0 }
+        self.IPv4 == other.IPv4 && self.IPv6 == other.IPv6
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {}
@@ -7899,7 +7976,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {}
@@ -7932,7 +8009,7 @@ unsafe impl ::windows::core::Abi for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {}
@@ -7965,7 +8042,7 @@ unsafe impl ::windows::core::Abi for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.TimeoutArrayLength == other.TimeoutArrayLength && self.TimeoutArray == other.TimeoutArray
     }
 }
 impl ::core::cmp::Eq for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {}
@@ -8006,7 +8083,7 @@ unsafe impl ::windows::core::Abi for NDIS_TIMESTAMP_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NDIS_TIMESTAMP_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TIMESTAMP_CAPABILITIES>()) == 0 }
+        self.Header == other.Header && self.HardwareClockFrequencyHz == other.HardwareClockFrequencyHz && self.CrossTimestamp == other.CrossTimestamp && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.TimestampFlags == other.TimestampFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8072,7 +8149,20 @@ unsafe impl ::windows::core::Abi for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_TIMESTAMP_CAPABILITY_FLAGS>()) == 0 }
+        self.PtpV2OverUdpIPv4EventMsgReceiveHw == other.PtpV2OverUdpIPv4EventMsgReceiveHw
+            && self.PtpV2OverUdpIPv4AllMsgReceiveHw == other.PtpV2OverUdpIPv4AllMsgReceiveHw
+            && self.PtpV2OverUdpIPv4EventMsgTransmitHw == other.PtpV2OverUdpIPv4EventMsgTransmitHw
+            && self.PtpV2OverUdpIPv4AllMsgTransmitHw == other.PtpV2OverUdpIPv4AllMsgTransmitHw
+            && self.PtpV2OverUdpIPv6EventMsgReceiveHw == other.PtpV2OverUdpIPv6EventMsgReceiveHw
+            && self.PtpV2OverUdpIPv6AllMsgReceiveHw == other.PtpV2OverUdpIPv6AllMsgReceiveHw
+            && self.PtpV2OverUdpIPv6EventMsgTransmitHw == other.PtpV2OverUdpIPv6EventMsgTransmitHw
+            && self.PtpV2OverUdpIPv6AllMsgTransmitHw == other.PtpV2OverUdpIPv6AllMsgTransmitHw
+            && self.AllReceiveHw == other.AllReceiveHw
+            && self.AllTransmitHw == other.AllTransmitHw
+            && self.TaggedTransmitHw == other.TaggedTransmitHw
+            && self.AllReceiveSw == other.AllReceiveSw
+            && self.AllTransmitSw == other.AllTransmitSw
+            && self.TaggedTransmitSw == other.TaggedTransmitSw
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8106,7 +8196,7 @@ unsafe impl ::windows::core::Abi for NDIS_VAR_DATA_DESC {
 }
 impl ::core::cmp::PartialEq for NDIS_VAR_DATA_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_VAR_DATA_DESC>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for NDIS_VAR_DATA_DESC {}
@@ -8137,7 +8227,7 @@ unsafe impl ::windows::core::Abi for NDIS_WAN_PROTOCOL_CAPS {
 }
 impl ::core::cmp::PartialEq for NDIS_WAN_PROTOCOL_CAPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WAN_PROTOCOL_CAPS>()) == 0 }
+        self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDIS_WAN_PROTOCOL_CAPS {}
@@ -8176,7 +8266,7 @@ unsafe impl ::windows::core::Abi for NDIS_WLAN_BSSID {
 }
 impl ::core::cmp::PartialEq for NDIS_WLAN_BSSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WLAN_BSSID>()) == 0 }
+        self.Length == other.Length && self.MacAddress == other.MacAddress && self.Reserved == other.Reserved && self.Ssid == other.Ssid && self.Privacy == other.Privacy && self.Rssi == other.Rssi && self.NetworkTypeInUse == other.NetworkTypeInUse && self.Configuration == other.Configuration && self.InfrastructureMode == other.InfrastructureMode && self.SupportedRates == other.SupportedRates
     }
 }
 impl ::core::cmp::Eq for NDIS_WLAN_BSSID {}
@@ -8230,7 +8320,7 @@ unsafe impl ::windows::core::Abi for NDIS_WLAN_BSSID_EX {
 }
 impl ::core::cmp::PartialEq for NDIS_WLAN_BSSID_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WLAN_BSSID_EX>()) == 0 }
+        self.Length == other.Length && self.MacAddress == other.MacAddress && self.Reserved == other.Reserved && self.Ssid == other.Ssid && self.Privacy == other.Privacy && self.Rssi == other.Rssi && self.NetworkTypeInUse == other.NetworkTypeInUse && self.Configuration == other.Configuration && self.InfrastructureMode == other.InfrastructureMode && self.SupportedRates == other.SupportedRates && self.IELength == other.IELength && self.IEs == other.IEs
     }
 }
 impl ::core::cmp::Eq for NDIS_WLAN_BSSID_EX {}
@@ -8262,14 +8352,6 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_ENUM_ADAPTER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NDIS_WMI_ENUM_ADAPTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_ENUM_ADAPTER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NDIS_WMI_ENUM_ADAPTER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NDIS_WMI_ENUM_ADAPTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8296,12 +8378,6 @@ impl ::core::clone::Clone for NDIS_WMI_EVENT_HEADER {
 unsafe impl ::windows::core::Abi for NDIS_WMI_EVENT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_WMI_EVENT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_EVENT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_WMI_EVENT_HEADER {}
 impl ::core::default::Default for NDIS_WMI_EVENT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8330,7 +8406,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_IPSEC_OFFLOAD_V1 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_IPSEC_OFFLOAD_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_IPSEC_OFFLOAD_V1>()) == 0 }
+        self.Supported == other.Supported && self.IPv4AH == other.IPv4AH && self.IPv4ESP == other.IPv4ESP
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_IPSEC_OFFLOAD_V1 {}
@@ -8365,7 +8441,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_IPSEC_OFFLOAD_V1_0>()) == 0 }
+        self.Md5 == other.Md5 && self.Sha_1 == other.Sha_1 && self.Transport == other.Transport && self.Tunnel == other.Tunnel && self.Send == other.Send && self.Receive == other.Receive
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {}
@@ -8402,7 +8478,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_IPSEC_OFFLOAD_V1_1>()) == 0 }
+        self.Des == other.Des && self.Reserved == other.Reserved && self.TripleDes == other.TripleDes && self.NullEsp == other.NullEsp && self.Transport == other.Transport && self.Tunnel == other.Tunnel && self.Send == other.Send && self.Receive == other.Receive
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {}
@@ -8436,7 +8512,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_IPSEC_OFFLOAD_V1_2>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.AhEspCombined == other.AhEspCombined && self.TransportTunnelCombined == other.TransportTunnelCombined && self.IPv4Options == other.IPv4Options && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {}
@@ -8464,12 +8540,6 @@ impl ::core::clone::Clone for NDIS_WMI_METHOD_HEADER {
 unsafe impl ::windows::core::Abi for NDIS_WMI_METHOD_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_WMI_METHOD_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_METHOD_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_WMI_METHOD_HEADER {}
 impl ::core::default::Default for NDIS_WMI_METHOD_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8501,7 +8571,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_OFFLOAD>()) == 0 }
+        self.Header == other.Header && self.Checksum == other.Checksum && self.LsoV1 == other.LsoV1 && self.IPsecV1 == other.IPsecV1 && self.LsoV2 == other.LsoV2 && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_OFFLOAD {}
@@ -8534,7 +8604,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_OUTPUT_INFO {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_OUTPUT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_OUTPUT_INFO>()) == 0 }
+        self.Header == other.Header && self.Flags == other.Flags && self.SupportedRevision == other.SupportedRevision && self.DataOffset == other.DataOffset
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_OUTPUT_INFO {}
@@ -8562,12 +8632,6 @@ impl ::core::clone::Clone for NDIS_WMI_SET_HEADER {
 unsafe impl ::windows::core::Abi for NDIS_WMI_SET_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDIS_WMI_SET_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_SET_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDIS_WMI_SET_HEADER {}
 impl ::core::default::Default for NDIS_WMI_SET_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8601,7 +8665,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_CONNECTION_OFFLOAD>()) == 0 }
+        self.Header == other.Header && self.Encapsulation == other.Encapsulation && self.SupportIPv4 == other.SupportIPv4 && self.SupportIPv6 == other.SupportIPv6 && self.SupportIPv6ExtensionHeaders == other.SupportIPv6ExtensionHeaders && self.SupportSack == other.SupportSack && self.TcpConnectionOffloadCapacity == other.TcpConnectionOffloadCapacity && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_CONNECTION_OFFLOAD {}
@@ -8634,7 +8698,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD>()) == 0 }
+        self.IPv4Transmit == other.IPv4Transmit && self.IPv4Receive == other.IPv4Receive && self.IPv6Transmit == other.IPv6Transmit && self.IPv6Receive == other.IPv6Receive
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {}
@@ -8669,7 +8733,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.IpOptionsSupported == other.IpOptionsSupported && self.TcpOptionsSupported == other.TcpOptionsSupported && self.TcpChecksum == other.TcpChecksum && self.UdpChecksum == other.UdpChecksum && self.IpChecksum == other.IpChecksum
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {}
@@ -8704,7 +8768,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.IpOptionsSupported == other.IpOptionsSupported && self.TcpOptionsSupported == other.TcpOptionsSupported && self.TcpChecksum == other.TcpChecksum && self.UdpChecksum == other.UdpChecksum && self.IpChecksum == other.IpChecksum
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {}
@@ -8738,7 +8802,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.IpExtensionHeadersSupported == other.IpExtensionHeadersSupported && self.TcpOptionsSupported == other.TcpOptionsSupported && self.TcpChecksum == other.TcpChecksum && self.UdpChecksum == other.UdpChecksum
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {}
@@ -8772,7 +8836,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.IpExtensionHeadersSupported == other.IpExtensionHeadersSupported && self.TcpOptionsSupported == other.TcpOptionsSupported && self.TcpChecksum == other.TcpChecksum && self.UdpChecksum == other.UdpChecksum
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {}
@@ -8802,7 +8866,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1>()) == 0 }
+        self.IPv4 == other.IPv4
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {}
@@ -8836,7 +8900,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount && self.TcpOptions == other.TcpOptions && self.IpOptions == other.IpOptions
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {}
@@ -8867,7 +8931,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2>()) == 0 }
+        self.IPv4 == other.IPv4 && self.IPv6 == other.IPv6
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {}
@@ -8899,7 +8963,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {}
@@ -8933,7 +8997,7 @@ unsafe impl ::windows::core::Abi for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
 }
 impl ::core::cmp::PartialEq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1>()) == 0 }
+        self.Encapsulation == other.Encapsulation && self.MaxOffLoadSize == other.MaxOffLoadSize && self.MinSegmentCount == other.MinSegmentCount && self.IpExtensionHeadersSupported == other.IpExtensionHeadersSupported && self.TcpOptionsSupported == other.TcpOptionsSupported
     }
 }
 impl ::core::cmp::Eq for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {}
@@ -9007,7 +9071,28 @@ unsafe impl ::windows::core::Abi for NDK_ADAPTER_INFO {
 }
 impl ::core::cmp::PartialEq for NDK_ADAPTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDK_ADAPTER_INFO>()) == 0 }
+        self.Version == other.Version
+            && self.VendorId == other.VendorId
+            && self.DeviceId == other.DeviceId
+            && self.MaxRegistrationSize == other.MaxRegistrationSize
+            && self.MaxWindowSize == other.MaxWindowSize
+            && self.FRMRPageCount == other.FRMRPageCount
+            && self.MaxInitiatorRequestSge == other.MaxInitiatorRequestSge
+            && self.MaxReceiveRequestSge == other.MaxReceiveRequestSge
+            && self.MaxReadRequestSge == other.MaxReadRequestSge
+            && self.MaxTransferLength == other.MaxTransferLength
+            && self.MaxInlineDataSize == other.MaxInlineDataSize
+            && self.MaxInboundReadLimit == other.MaxInboundReadLimit
+            && self.MaxOutboundReadLimit == other.MaxOutboundReadLimit
+            && self.MaxReceiveQueueDepth == other.MaxReceiveQueueDepth
+            && self.MaxInitiatorQueueDepth == other.MaxInitiatorQueueDepth
+            && self.MaxSrqDepth == other.MaxSrqDepth
+            && self.MaxCqDepth == other.MaxCqDepth
+            && self.LargeRequestThreshold == other.LargeRequestThreshold
+            && self.MaxCallerData == other.MaxCallerData
+            && self.MaxCalleeData == other.MaxCalleeData
+            && self.AdapterFlags == other.AdapterFlags
+            && self.RdmaTechnology == other.RdmaTechnology
     }
 }
 impl ::core::cmp::Eq for NDK_ADAPTER_INFO {}
@@ -9038,7 +9123,7 @@ unsafe impl ::windows::core::Abi for NDK_VERSION {
 }
 impl ::core::cmp::PartialEq for NDK_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDK_VERSION>()) == 0 }
+        self.Major == other.Major && self.Minor == other.Minor
     }
 }
 impl ::core::cmp::Eq for NDK_VERSION {}
@@ -9070,7 +9155,7 @@ unsafe impl ::windows::core::Abi for NETWORK_ADDRESS {
 }
 impl ::core::cmp::PartialEq for NETWORK_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_ADDRESS>()) == 0 }
+        self.AddressLength == other.AddressLength && self.AddressType == other.AddressType && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for NETWORK_ADDRESS {}
@@ -9102,7 +9187,7 @@ unsafe impl ::windows::core::Abi for NETWORK_ADDRESS_IP {
 }
 impl ::core::cmp::PartialEq for NETWORK_ADDRESS_IP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_ADDRESS_IP>()) == 0 }
+        self.sin_port == other.sin_port && self.IN_ADDR == other.IN_ADDR && self.sin_zero == other.sin_zero
     }
 }
 impl ::core::cmp::Eq for NETWORK_ADDRESS_IP {}
@@ -9135,7 +9220,7 @@ unsafe impl ::windows::core::Abi for NETWORK_ADDRESS_IP6 {
 }
 impl ::core::cmp::PartialEq for NETWORK_ADDRESS_IP6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_ADDRESS_IP6>()) == 0 }
+        self.sin6_port == other.sin6_port && self.sin6_flowinfo == other.sin6_flowinfo && self.sin6_addr == other.sin6_addr && self.sin6_scope_id == other.sin6_scope_id
     }
 }
 impl ::core::cmp::Eq for NETWORK_ADDRESS_IP6 {}
@@ -9167,7 +9252,7 @@ unsafe impl ::windows::core::Abi for NETWORK_ADDRESS_IPX {
 }
 impl ::core::cmp::PartialEq for NETWORK_ADDRESS_IPX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_ADDRESS_IPX>()) == 0 }
+        self.NetworkAddress == other.NetworkAddress && self.NodeAddress == other.NodeAddress && self.Socket == other.Socket
     }
 }
 impl ::core::cmp::Eq for NETWORK_ADDRESS_IPX {}
@@ -9199,7 +9284,7 @@ unsafe impl ::windows::core::Abi for NETWORK_ADDRESS_LIST {
 }
 impl ::core::cmp::PartialEq for NETWORK_ADDRESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_ADDRESS_LIST>()) == 0 }
+        self.AddressCount == other.AddressCount && self.AddressType == other.AddressType && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for NETWORK_ADDRESS_LIST {}
@@ -9230,7 +9315,7 @@ unsafe impl ::windows::core::Abi for NET_IF_ALIAS_LH {
 }
 impl ::core::cmp::PartialEq for NET_IF_ALIAS_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_IF_ALIAS_LH>()) == 0 }
+        self.ifAliasLength == other.ifAliasLength && self.ifAliasOffset == other.ifAliasOffset
     }
 }
 impl ::core::cmp::Eq for NET_IF_ALIAS_LH {}
@@ -9262,7 +9347,7 @@ unsafe impl ::windows::core::Abi for NET_IF_RCV_ADDRESS_LH {
 }
 impl ::core::cmp::PartialEq for NET_IF_RCV_ADDRESS_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_IF_RCV_ADDRESS_LH>()) == 0 }
+        self.ifRcvAddressType == other.ifRcvAddressType && self.ifRcvAddressLength == other.ifRcvAddressLength && self.ifRcvAddressOffset == other.ifRcvAddressOffset
     }
 }
 impl ::core::cmp::Eq for NET_IF_RCV_ADDRESS_LH {}
@@ -9286,12 +9371,6 @@ impl ::core::clone::Clone for NET_LUID_LH {
 unsafe impl ::windows::core::Abi for NET_LUID_LH {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NET_LUID_LH {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_LUID_LH>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NET_LUID_LH {}
 impl ::core::default::Default for NET_LUID_LH {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9318,7 +9397,7 @@ unsafe impl ::windows::core::Abi for NET_LUID_LH_0 {
 }
 impl ::core::cmp::PartialEq for NET_LUID_LH_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_LUID_LH_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NET_LUID_LH_0 {}
@@ -9350,7 +9429,7 @@ unsafe impl ::windows::core::Abi for NET_PHYSICAL_LOCATION_LH {
 }
 impl ::core::cmp::PartialEq for NET_PHYSICAL_LOCATION_LH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_PHYSICAL_LOCATION_LH>()) == 0 }
+        self.BusNumber == other.BusNumber && self.SlotNumber == other.SlotNumber && self.FunctionNumber == other.FunctionNumber
     }
 }
 impl ::core::cmp::Eq for NET_PHYSICAL_LOCATION_LH {}
@@ -9382,7 +9461,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_ALGO_INFO {
 }
 impl ::core::cmp::PartialEq for OFFLOAD_ALGO_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_ALGO_INFO>()) == 0 }
+        self.algoIdentifier == other.algoIdentifier && self.algoKeylen == other.algoKeylen && self.algoRounds == other.algoRounds
     }
 }
 impl ::core::cmp::Eq for OFFLOAD_ALGO_INFO {}
@@ -9448,7 +9527,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_IPSEC_ADD_SA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OFFLOAD_IPSEC_ADD_SA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_IPSEC_ADD_SA>()) == 0 }
+        self.SrcAddr == other.SrcAddr && self.SrcMask == other.SrcMask && self.DestAddr == other.DestAddr && self.DestMask == other.DestMask && self.Protocol == other.Protocol && self.SrcPort == other.SrcPort && self.DestPort == other.DestPort && self.SrcTunnelAddr == other.SrcTunnelAddr && self.DestTunnelAddr == other.DestTunnelAddr && self.Flags == other.Flags && self.NumSAs == other.NumSAs && self.SecAssoc == other.SecAssoc && self.OffloadHandle == other.OffloadHandle && self.KeyLen == other.KeyLen && self.KeyMat == other.KeyMat
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9520,7 +9599,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_IPSEC_ADD_UDPESP_SA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OFFLOAD_IPSEC_ADD_UDPESP_SA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_IPSEC_ADD_UDPESP_SA>()) == 0 }
+        self.SrcAddr == other.SrcAddr && self.SrcMask == other.SrcMask && self.DstAddr == other.DstAddr && self.DstMask == other.DstMask && self.Protocol == other.Protocol && self.SrcPort == other.SrcPort && self.DstPort == other.DstPort && self.SrcTunnelAddr == other.SrcTunnelAddr && self.DstTunnelAddr == other.DstTunnelAddr && self.Flags == other.Flags && self.NumSAs == other.NumSAs && self.SecAssoc == other.SecAssoc && self.OffloadHandle == other.OffloadHandle && self.EncapTypeEntry == other.EncapTypeEntry && self.EncapTypeEntryOffldHandle == other.EncapTypeEntryOffldHandle && self.KeyLen == other.KeyLen && self.KeyMat == other.KeyMat
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9558,7 +9637,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_IPSEC_DELETE_SA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OFFLOAD_IPSEC_DELETE_SA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_IPSEC_DELETE_SA>()) == 0 }
+        self.OffloadHandle == other.OffloadHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9597,7 +9676,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_IPSEC_DELETE_UDPESP_SA>()) == 0 }
+        self.OffloadHandle == other.OffloadHandle && self.EncapTypeEntryOffldHandle == other.EncapTypeEntryOffldHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9630,7 +9709,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
 }
 impl ::core::cmp::PartialEq for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY>()) == 0 }
+        self.UdpEncapType == other.UdpEncapType && self.DstEncapPort == other.DstEncapPort
     }
 }
 impl ::core::cmp::Eq for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {}
@@ -9664,7 +9743,7 @@ unsafe impl ::windows::core::Abi for OFFLOAD_SECURITY_ASSOCIATION {
 }
 impl ::core::cmp::PartialEq for OFFLOAD_SECURITY_ASSOCIATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFLOAD_SECURITY_ASSOCIATION>()) == 0 }
+        self.Operation == other.Operation && self.SPI == other.SPI && self.IntegrityAlgo == other.IntegrityAlgo && self.ConfAlgo == other.ConfAlgo && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for OFFLOAD_SECURITY_ASSOCIATION {}
@@ -9695,7 +9774,7 @@ unsafe impl ::windows::core::Abi for PMKID_CANDIDATE {
 }
 impl ::core::cmp::PartialEq for PMKID_CANDIDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PMKID_CANDIDATE>()) == 0 }
+        self.BSSID == other.BSSID && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for PMKID_CANDIDATE {}
@@ -9726,7 +9805,7 @@ unsafe impl ::windows::core::Abi for TRANSPORT_HEADER_OFFSET {
 }
 impl ::core::cmp::PartialEq for TRANSPORT_HEADER_OFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORT_HEADER_OFFSET>()) == 0 }
+        self.ProtocolType == other.ProtocolType && self.HeaderOffset == other.HeaderOffset
     }
 }
 impl ::core::cmp::Eq for TRANSPORT_HEADER_OFFSET {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetBios/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetBios/mod.rs
@@ -196,7 +196,7 @@ unsafe impl ::windows::core::Abi for ACTION_HEADER {
 }
 impl ::core::cmp::PartialEq for ACTION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTION_HEADER>()) == 0 }
+        self.transport_id == other.transport_id && self.action_code == other.action_code && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for ACTION_HEADER {}
@@ -280,7 +280,33 @@ unsafe impl ::windows::core::Abi for ADAPTER_STATUS {
 }
 impl ::core::cmp::PartialEq for ADAPTER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADAPTER_STATUS>()) == 0 }
+        self.adapter_address == other.adapter_address
+            && self.rev_major == other.rev_major
+            && self.reserved0 == other.reserved0
+            && self.adapter_type == other.adapter_type
+            && self.rev_minor == other.rev_minor
+            && self.duration == other.duration
+            && self.frmr_recv == other.frmr_recv
+            && self.frmr_xmit == other.frmr_xmit
+            && self.iframe_recv_err == other.iframe_recv_err
+            && self.xmit_aborts == other.xmit_aborts
+            && self.xmit_success == other.xmit_success
+            && self.recv_success == other.recv_success
+            && self.iframe_xmit_err == other.iframe_xmit_err
+            && self.recv_buff_unavail == other.recv_buff_unavail
+            && self.t1_timeouts == other.t1_timeouts
+            && self.ti_timeouts == other.ti_timeouts
+            && self.reserved1 == other.reserved1
+            && self.free_ncbs == other.free_ncbs
+            && self.max_cfg_ncbs == other.max_cfg_ncbs
+            && self.max_ncbs == other.max_ncbs
+            && self.xmit_buf_unavail == other.xmit_buf_unavail
+            && self.max_dgram_size == other.max_dgram_size
+            && self.pending_sess == other.pending_sess
+            && self.max_cfg_sess == other.max_cfg_sess
+            && self.max_sess == other.max_sess
+            && self.max_sess_pkt_size == other.max_sess_pkt_size
+            && self.name_count == other.name_count
     }
 }
 impl ::core::cmp::Eq for ADAPTER_STATUS {}
@@ -315,7 +341,7 @@ unsafe impl ::windows::core::Abi for FIND_NAME_BUFFER {
 }
 impl ::core::cmp::PartialEq for FIND_NAME_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIND_NAME_BUFFER>()) == 0 }
+        self.length == other.length && self.access_control == other.access_control && self.frame_control == other.frame_control && self.destination_addr == other.destination_addr && self.source_addr == other.source_addr && self.routing_info == other.routing_info
     }
 }
 impl ::core::cmp::Eq for FIND_NAME_BUFFER {}
@@ -347,7 +373,7 @@ unsafe impl ::windows::core::Abi for FIND_NAME_HEADER {
 }
 impl ::core::cmp::PartialEq for FIND_NAME_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIND_NAME_HEADER>()) == 0 }
+        self.node_count == other.node_count && self.reserved == other.reserved && self.unique_group == other.unique_group
     }
 }
 impl ::core::cmp::Eq for FIND_NAME_HEADER {}
@@ -378,7 +404,7 @@ unsafe impl ::windows::core::Abi for LANA_ENUM {
 }
 impl ::core::cmp::PartialEq for LANA_ENUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LANA_ENUM>()) == 0 }
+        self.length == other.length && self.lana == other.lana
     }
 }
 impl ::core::cmp::Eq for LANA_ENUM {}
@@ -410,7 +436,7 @@ unsafe impl ::windows::core::Abi for NAME_BUFFER {
 }
 impl ::core::cmp::PartialEq for NAME_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAME_BUFFER>()) == 0 }
+        self.name == other.name && self.name_num == other.name_num && self.name_flags == other.name_flags
     }
 }
 impl ::core::cmp::Eq for NAME_BUFFER {}
@@ -482,7 +508,7 @@ unsafe impl ::windows::core::Abi for NCB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NCB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCB>()) == 0 }
+        self.ncb_command == other.ncb_command && self.ncb_retcode == other.ncb_retcode && self.ncb_lsn == other.ncb_lsn && self.ncb_num == other.ncb_num && self.ncb_buffer == other.ncb_buffer && self.ncb_length == other.ncb_length && self.ncb_callname == other.ncb_callname && self.ncb_name == other.ncb_name && self.ncb_rto == other.ncb_rto && self.ncb_sto == other.ncb_sto && self.ncb_post == other.ncb_post && self.ncb_lana_num == other.ncb_lana_num && self.ncb_cmd_cplt == other.ncb_cmd_cplt && self.ncb_reserve == other.ncb_reserve && self.ncb_event == other.ncb_event
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -558,7 +584,7 @@ unsafe impl ::windows::core::Abi for NCB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NCB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCB>()) == 0 }
+        self.ncb_command == other.ncb_command && self.ncb_retcode == other.ncb_retcode && self.ncb_lsn == other.ncb_lsn && self.ncb_num == other.ncb_num && self.ncb_buffer == other.ncb_buffer && self.ncb_length == other.ncb_length && self.ncb_callname == other.ncb_callname && self.ncb_name == other.ncb_name && self.ncb_rto == other.ncb_rto && self.ncb_sto == other.ncb_sto && self.ncb_post == other.ncb_post && self.ncb_lana_num == other.ncb_lana_num && self.ncb_cmd_cplt == other.ncb_cmd_cplt && self.ncb_reserve == other.ncb_reserve && self.ncb_event == other.ncb_event
     }
 }
 #[cfg(target_arch = "x86")]
@@ -597,7 +623,7 @@ unsafe impl ::windows::core::Abi for SESSION_BUFFER {
 }
 impl ::core::cmp::PartialEq for SESSION_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_BUFFER>()) == 0 }
+        self.lsn == other.lsn && self.state == other.state && self.local_name == other.local_name && self.remote_name == other.remote_name && self.rcvs_outstanding == other.rcvs_outstanding && self.sends_outstanding == other.sends_outstanding
     }
 }
 impl ::core::cmp::Eq for SESSION_BUFFER {}
@@ -630,7 +656,7 @@ unsafe impl ::windows::core::Abi for SESSION_HEADER {
 }
 impl ::core::cmp::PartialEq for SESSION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_HEADER>()) == 0 }
+        self.sess_name == other.sess_name && self.num_sess == other.num_sess && self.rcv_dg_outstanding == other.rcv_dg_outstanding && self.rcv_any_outstanding == other.rcv_any_outstanding
     }
 }
 impl ::core::cmp::Eq for SESSION_HEADER {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -8618,7 +8618,7 @@ unsafe impl ::windows::core::Abi for ACCESS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for ACCESS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_INFO_0>()) == 0 }
+        self.acc0_resource_name == other.acc0_resource_name
     }
 }
 impl ::core::cmp::Eq for ACCESS_INFO_0 {}
@@ -8650,7 +8650,7 @@ unsafe impl ::windows::core::Abi for ACCESS_INFO_1 {
 }
 impl ::core::cmp::PartialEq for ACCESS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_INFO_1>()) == 0 }
+        self.acc1_resource_name == other.acc1_resource_name && self.acc1_attr == other.acc1_attr && self.acc1_count == other.acc1_count
     }
 }
 impl ::core::cmp::Eq for ACCESS_INFO_1 {}
@@ -8680,7 +8680,7 @@ unsafe impl ::windows::core::Abi for ACCESS_INFO_1002 {
 }
 impl ::core::cmp::PartialEq for ACCESS_INFO_1002 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_INFO_1002>()) == 0 }
+        self.acc1002_attr == other.acc1002_attr
     }
 }
 impl ::core::cmp::Eq for ACCESS_INFO_1002 {}
@@ -8711,7 +8711,7 @@ unsafe impl ::windows::core::Abi for ACCESS_LIST {
 }
 impl ::core::cmp::PartialEq for ACCESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_LIST>()) == 0 }
+        self.acl_ugname == other.acl_ugname && self.acl_access == other.acl_access
     }
 }
 impl ::core::cmp::Eq for ACCESS_LIST {}
@@ -8742,7 +8742,7 @@ unsafe impl ::windows::core::Abi for ADMIN_OTHER_INFO {
 }
 impl ::core::cmp::PartialEq for ADMIN_OTHER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADMIN_OTHER_INFO>()) == 0 }
+        self.alrtad_errcode == other.alrtad_errcode && self.alrtad_numstrings == other.alrtad_numstrings
     }
 }
 impl ::core::cmp::Eq for ADMIN_OTHER_INFO {}
@@ -8775,7 +8775,7 @@ unsafe impl ::windows::core::Abi for AE_ACCLIM {
 }
 impl ::core::cmp::PartialEq for AE_ACCLIM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_ACCLIM>()) == 0 }
+        self.ae_al_compname == other.ae_al_compname && self.ae_al_username == other.ae_al_username && self.ae_al_resname == other.ae_al_resname && self.ae_al_limit == other.ae_al_limit
     }
 }
 impl ::core::cmp::Eq for AE_ACCLIM {}
@@ -8809,7 +8809,7 @@ unsafe impl ::windows::core::Abi for AE_ACLMOD {
 }
 impl ::core::cmp::PartialEq for AE_ACLMOD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_ACLMOD>()) == 0 }
+        self.ae_am_compname == other.ae_am_compname && self.ae_am_username == other.ae_am_username && self.ae_am_resname == other.ae_am_resname && self.ae_am_action == other.ae_am_action && self.ae_am_datalen == other.ae_am_datalen
     }
 }
 impl ::core::cmp::Eq for AE_ACLMOD {}
@@ -8844,7 +8844,7 @@ unsafe impl ::windows::core::Abi for AE_CLOSEFILE {
 }
 impl ::core::cmp::PartialEq for AE_CLOSEFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_CLOSEFILE>()) == 0 }
+        self.ae_cf_compname == other.ae_cf_compname && self.ae_cf_username == other.ae_cf_username && self.ae_cf_resname == other.ae_cf_resname && self.ae_cf_fileid == other.ae_cf_fileid && self.ae_cf_duration == other.ae_cf_duration && self.ae_cf_reason == other.ae_cf_reason
     }
 }
 impl ::core::cmp::Eq for AE_CLOSEFILE {}
@@ -8877,7 +8877,7 @@ unsafe impl ::windows::core::Abi for AE_CONNREJ {
 }
 impl ::core::cmp::PartialEq for AE_CONNREJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_CONNREJ>()) == 0 }
+        self.ae_cr_compname == other.ae_cr_compname && self.ae_cr_username == other.ae_cr_username && self.ae_cr_netname == other.ae_cr_netname && self.ae_cr_reason == other.ae_cr_reason
     }
 }
 impl ::core::cmp::Eq for AE_CONNREJ {}
@@ -8910,7 +8910,7 @@ unsafe impl ::windows::core::Abi for AE_CONNSTART {
 }
 impl ::core::cmp::PartialEq for AE_CONNSTART {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_CONNSTART>()) == 0 }
+        self.ae_ct_compname == other.ae_ct_compname && self.ae_ct_username == other.ae_ct_username && self.ae_ct_netname == other.ae_ct_netname && self.ae_ct_connid == other.ae_ct_connid
     }
 }
 impl ::core::cmp::Eq for AE_CONNSTART {}
@@ -8944,7 +8944,7 @@ unsafe impl ::windows::core::Abi for AE_CONNSTOP {
 }
 impl ::core::cmp::PartialEq for AE_CONNSTOP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_CONNSTOP>()) == 0 }
+        self.ae_cp_compname == other.ae_cp_compname && self.ae_cp_username == other.ae_cp_username && self.ae_cp_netname == other.ae_cp_netname && self.ae_cp_connid == other.ae_cp_connid && self.ae_cp_reason == other.ae_cp_reason
     }
 }
 impl ::core::cmp::Eq for AE_CONNSTOP {}
@@ -8998,7 +8998,7 @@ unsafe impl ::windows::core::Abi for AE_GENERIC {
 }
 impl ::core::cmp::PartialEq for AE_GENERIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_GENERIC>()) == 0 }
+        self.ae_ge_msgfile == other.ae_ge_msgfile && self.ae_ge_msgnum == other.ae_ge_msgnum && self.ae_ge_params == other.ae_ge_params && self.ae_ge_param1 == other.ae_ge_param1 && self.ae_ge_param2 == other.ae_ge_param2 && self.ae_ge_param3 == other.ae_ge_param3 && self.ae_ge_param4 == other.ae_ge_param4 && self.ae_ge_param5 == other.ae_ge_param5 && self.ae_ge_param6 == other.ae_ge_param6 && self.ae_ge_param7 == other.ae_ge_param7 && self.ae_ge_param8 == other.ae_ge_param8 && self.ae_ge_param9 == other.ae_ge_param9
     }
 }
 impl ::core::cmp::Eq for AE_GENERIC {}
@@ -9031,7 +9031,7 @@ unsafe impl ::windows::core::Abi for AE_LOCKOUT {
 }
 impl ::core::cmp::PartialEq for AE_LOCKOUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_LOCKOUT>()) == 0 }
+        self.ae_lk_compname == other.ae_lk_compname && self.ae_lk_username == other.ae_lk_username && self.ae_lk_action == other.ae_lk_action && self.ae_lk_bad_pw_count == other.ae_lk_bad_pw_count
     }
 }
 impl ::core::cmp::Eq for AE_LOCKOUT {}
@@ -9064,7 +9064,7 @@ unsafe impl ::windows::core::Abi for AE_NETLOGOFF {
 }
 impl ::core::cmp::PartialEq for AE_NETLOGOFF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_NETLOGOFF>()) == 0 }
+        self.ae_nf_compname == other.ae_nf_compname && self.ae_nf_username == other.ae_nf_username && self.ae_nf_reserved1 == other.ae_nf_reserved1 && self.ae_nf_reserved2 == other.ae_nf_reserved2
     }
 }
 impl ::core::cmp::Eq for AE_NETLOGOFF {}
@@ -9097,7 +9097,7 @@ unsafe impl ::windows::core::Abi for AE_NETLOGON {
 }
 impl ::core::cmp::PartialEq for AE_NETLOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_NETLOGON>()) == 0 }
+        self.ae_no_compname == other.ae_no_compname && self.ae_no_username == other.ae_no_username && self.ae_no_privilege == other.ae_no_privilege && self.ae_no_authflags == other.ae_no_authflags
     }
 }
 impl ::core::cmp::Eq for AE_NETLOGON {}
@@ -9133,7 +9133,7 @@ unsafe impl ::windows::core::Abi for AE_RESACCESS {
 }
 impl ::core::cmp::PartialEq for AE_RESACCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_RESACCESS>()) == 0 }
+        self.ae_ra_compname == other.ae_ra_compname && self.ae_ra_username == other.ae_ra_username && self.ae_ra_resname == other.ae_ra_resname && self.ae_ra_operation == other.ae_ra_operation && self.ae_ra_returncode == other.ae_ra_returncode && self.ae_ra_restype == other.ae_ra_restype && self.ae_ra_fileid == other.ae_ra_fileid
     }
 }
 impl ::core::cmp::Eq for AE_RESACCESS {}
@@ -9166,7 +9166,7 @@ unsafe impl ::windows::core::Abi for AE_RESACCESSREJ {
 }
 impl ::core::cmp::PartialEq for AE_RESACCESSREJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_RESACCESSREJ>()) == 0 }
+        self.ae_rr_compname == other.ae_rr_compname && self.ae_rr_username == other.ae_rr_username && self.ae_rr_resname == other.ae_rr_resname && self.ae_rr_operation == other.ae_rr_operation
     }
 }
 impl ::core::cmp::Eq for AE_RESACCESSREJ {}
@@ -9202,7 +9202,7 @@ unsafe impl ::windows::core::Abi for AE_SERVICESTAT {
 }
 impl ::core::cmp::PartialEq for AE_SERVICESTAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_SERVICESTAT>()) == 0 }
+        self.ae_ss_compname == other.ae_ss_compname && self.ae_ss_username == other.ae_ss_username && self.ae_ss_svcname == other.ae_ss_svcname && self.ae_ss_status == other.ae_ss_status && self.ae_ss_code == other.ae_ss_code && self.ae_ss_text == other.ae_ss_text && self.ae_ss_returnval == other.ae_ss_returnval
     }
 }
 impl ::core::cmp::Eq for AE_SERVICESTAT {}
@@ -9234,7 +9234,7 @@ unsafe impl ::windows::core::Abi for AE_SESSLOGOFF {
 }
 impl ::core::cmp::PartialEq for AE_SESSLOGOFF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_SESSLOGOFF>()) == 0 }
+        self.ae_sf_compname == other.ae_sf_compname && self.ae_sf_username == other.ae_sf_username && self.ae_sf_reason == other.ae_sf_reason
     }
 }
 impl ::core::cmp::Eq for AE_SESSLOGOFF {}
@@ -9266,7 +9266,7 @@ unsafe impl ::windows::core::Abi for AE_SESSLOGON {
 }
 impl ::core::cmp::PartialEq for AE_SESSLOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_SESSLOGON>()) == 0 }
+        self.ae_so_compname == other.ae_so_compname && self.ae_so_username == other.ae_so_username && self.ae_so_privilege == other.ae_so_privilege
     }
 }
 impl ::core::cmp::Eq for AE_SESSLOGON {}
@@ -9297,7 +9297,7 @@ unsafe impl ::windows::core::Abi for AE_SESSPWERR {
 }
 impl ::core::cmp::PartialEq for AE_SESSPWERR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_SESSPWERR>()) == 0 }
+        self.ae_sp_compname == other.ae_sp_compname && self.ae_sp_username == other.ae_sp_username
     }
 }
 impl ::core::cmp::Eq for AE_SESSPWERR {}
@@ -9327,7 +9327,7 @@ unsafe impl ::windows::core::Abi for AE_SRVSTATUS {
 }
 impl ::core::cmp::PartialEq for AE_SRVSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_SRVSTATUS>()) == 0 }
+        self.ae_sv_status == other.ae_sv_status
     }
 }
 impl ::core::cmp::Eq for AE_SRVSTATUS {}
@@ -9362,7 +9362,7 @@ unsafe impl ::windows::core::Abi for AE_UASMOD {
 }
 impl ::core::cmp::PartialEq for AE_UASMOD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_UASMOD>()) == 0 }
+        self.ae_um_compname == other.ae_um_compname && self.ae_um_username == other.ae_um_username && self.ae_um_resname == other.ae_um_resname && self.ae_um_rectype == other.ae_um_rectype && self.ae_um_action == other.ae_um_action && self.ae_um_datalen == other.ae_um_datalen
     }
 }
 impl ::core::cmp::Eq for AE_UASMOD {}
@@ -9397,7 +9397,7 @@ unsafe impl ::windows::core::Abi for AT_ENUM {
 }
 impl ::core::cmp::PartialEq for AT_ENUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AT_ENUM>()) == 0 }
+        self.JobId == other.JobId && self.JobTime == other.JobTime && self.DaysOfMonth == other.DaysOfMonth && self.DaysOfWeek == other.DaysOfWeek && self.Flags == other.Flags && self.Command == other.Command
     }
 }
 impl ::core::cmp::Eq for AT_ENUM {}
@@ -9431,7 +9431,7 @@ unsafe impl ::windows::core::Abi for AT_INFO {
 }
 impl ::core::cmp::PartialEq for AT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AT_INFO>()) == 0 }
+        self.JobTime == other.JobTime && self.DaysOfMonth == other.DaysOfMonth && self.DaysOfWeek == other.DaysOfWeek && self.Flags == other.Flags && self.Command == other.Command
     }
 }
 impl ::core::cmp::Eq for AT_INFO {}
@@ -9466,7 +9466,7 @@ unsafe impl ::windows::core::Abi for AUDIT_ENTRY {
 }
 impl ::core::cmp::PartialEq for AUDIT_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_ENTRY>()) == 0 }
+        self.ae_len == other.ae_len && self.ae_reserved == other.ae_reserved && self.ae_time == other.ae_time && self.ae_type == other.ae_type && self.ae_data_offset == other.ae_data_offset && self.ae_data_size == other.ae_data_size
     }
 }
 impl ::core::cmp::Eq for AUDIT_ENTRY {}
@@ -9497,7 +9497,7 @@ unsafe impl ::windows::core::Abi for CONFIG_INFO_0 {
 }
 impl ::core::cmp::PartialEq for CONFIG_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFIG_INFO_0>()) == 0 }
+        self.cfgi0_key == other.cfgi0_key && self.cfgi0_data == other.cfgi0_data
     }
 }
 impl ::core::cmp::Eq for CONFIG_INFO_0 {}
@@ -9557,7 +9557,7 @@ unsafe impl ::windows::core::Abi for DSREG_JOIN_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for DSREG_JOIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSREG_JOIN_INFO>()) == 0 }
+        self.joinType == other.joinType && self.pJoinCertificate == other.pJoinCertificate && self.pszDeviceId == other.pszDeviceId && self.pszIdpDomain == other.pszIdpDomain && self.pszTenantId == other.pszTenantId && self.pszJoinUserEmail == other.pszJoinUserEmail && self.pszTenantDisplayName == other.pszTenantDisplayName && self.pszMdmEnrollmentUrl == other.pszMdmEnrollmentUrl && self.pszMdmTermsOfUseUrl == other.pszMdmTermsOfUseUrl && self.pszMdmComplianceUrl == other.pszMdmComplianceUrl && self.pszUserSettingSyncUrl == other.pszUserSettingSyncUrl && self.pUserInfo == other.pUserInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -9591,7 +9591,7 @@ unsafe impl ::windows::core::Abi for DSREG_USER_INFO {
 }
 impl ::core::cmp::PartialEq for DSREG_USER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSREG_USER_INFO>()) == 0 }
+        self.pszUserEmail == other.pszUserEmail && self.pszUserKeyId == other.pszUserKeyId && self.pszUserKeyName == other.pszUserKeyName
     }
 }
 impl ::core::cmp::Eq for DSREG_USER_INFO {}
@@ -9622,7 +9622,7 @@ unsafe impl ::windows::core::Abi for ERRLOG_OTHER_INFO {
 }
 impl ::core::cmp::PartialEq for ERRLOG_OTHER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERRLOG_OTHER_INFO>()) == 0 }
+        self.alrter_errcode == other.alrter_errcode && self.alrter_offset == other.alrter_offset
     }
 }
 impl ::core::cmp::Eq for ERRLOG_OTHER_INFO {}
@@ -9660,7 +9660,7 @@ unsafe impl ::windows::core::Abi for ERROR_LOG {
 }
 impl ::core::cmp::PartialEq for ERROR_LOG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERROR_LOG>()) == 0 }
+        self.el_len == other.el_len && self.el_reserved == other.el_reserved && self.el_time == other.el_time && self.el_error == other.el_error && self.el_name == other.el_name && self.el_text == other.el_text && self.el_data == other.el_data && self.el_data_size == other.el_data_size && self.el_nstrings == other.el_nstrings
     }
 }
 impl ::core::cmp::Eq for ERROR_LOG {}
@@ -9698,7 +9698,7 @@ unsafe impl ::windows::core::Abi for FLAT_STRING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FLAT_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLAT_STRING>()) == 0 }
+        self.MaximumLength == other.MaximumLength && self.Length == other.Length && self.Buffer == other.Buffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9730,7 +9730,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_0 {
 }
 impl ::core::cmp::PartialEq for GROUP_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_0>()) == 0 }
+        self.grpi0_name == other.grpi0_name
     }
 }
 impl ::core::cmp::Eq for GROUP_INFO_0 {}
@@ -9761,7 +9761,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_1 {
 }
 impl ::core::cmp::PartialEq for GROUP_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_1>()) == 0 }
+        self.grpi1_name == other.grpi1_name && self.grpi1_comment == other.grpi1_comment
     }
 }
 impl ::core::cmp::Eq for GROUP_INFO_1 {}
@@ -9791,7 +9791,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_1002 {
 }
 impl ::core::cmp::PartialEq for GROUP_INFO_1002 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_1002>()) == 0 }
+        self.grpi1002_comment == other.grpi1002_comment
     }
 }
 impl ::core::cmp::Eq for GROUP_INFO_1002 {}
@@ -9821,7 +9821,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_1005 {
 }
 impl ::core::cmp::PartialEq for GROUP_INFO_1005 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_1005>()) == 0 }
+        self.grpi1005_attributes == other.grpi1005_attributes
     }
 }
 impl ::core::cmp::Eq for GROUP_INFO_1005 {}
@@ -9854,7 +9854,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_2 {
 }
 impl ::core::cmp::PartialEq for GROUP_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_2>()) == 0 }
+        self.grpi2_name == other.grpi2_name && self.grpi2_comment == other.grpi2_comment && self.grpi2_group_id == other.grpi2_group_id && self.grpi2_attributes == other.grpi2_attributes
     }
 }
 impl ::core::cmp::Eq for GROUP_INFO_2 {}
@@ -9893,7 +9893,7 @@ unsafe impl ::windows::core::Abi for GROUP_INFO_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_INFO_3>()) == 0 }
+        self.grpi3_name == other.grpi3_name && self.grpi3_comment == other.grpi3_comment && self.grpi3_group_sid == other.grpi3_group_sid && self.grpi3_attributes == other.grpi3_attributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9925,7 +9925,7 @@ unsafe impl ::windows::core::Abi for GROUP_USERS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for GROUP_USERS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_USERS_INFO_0>()) == 0 }
+        self.grui0_name == other.grui0_name
     }
 }
 impl ::core::cmp::Eq for GROUP_USERS_INFO_0 {}
@@ -9956,7 +9956,7 @@ unsafe impl ::windows::core::Abi for GROUP_USERS_INFO_1 {
 }
 impl ::core::cmp::PartialEq for GROUP_USERS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_USERS_INFO_1>()) == 0 }
+        self.grui1_name == other.grui1_name && self.grui1_attributes == other.grui1_attributes
     }
 }
 impl ::core::cmp::Eq for GROUP_USERS_INFO_1 {}
@@ -9986,7 +9986,7 @@ unsafe impl ::windows::core::Abi for HARDWARE_ADDRESS {
 }
 impl ::core::cmp::PartialEq for HARDWARE_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HARDWARE_ADDRESS>()) == 0 }
+        self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for HARDWARE_ADDRESS {}
@@ -10019,7 +10019,7 @@ unsafe impl ::windows::core::Abi for HLOG {
 }
 impl ::core::cmp::PartialEq for HLOG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HLOG>()) == 0 }
+        self.time == other.time && self.last_flags == other.last_flags && self.offset == other.offset && self.rec_offset == other.rec_offset
     }
 }
 impl ::core::cmp::Eq for HLOG {}
@@ -10049,7 +10049,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_INFO_0 {
 }
 impl ::core::cmp::PartialEq for LOCALGROUP_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_INFO_0>()) == 0 }
+        self.lgrpi0_name == other.lgrpi0_name
     }
 }
 impl ::core::cmp::Eq for LOCALGROUP_INFO_0 {}
@@ -10080,7 +10080,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_INFO_1 {
 }
 impl ::core::cmp::PartialEq for LOCALGROUP_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_INFO_1>()) == 0 }
+        self.lgrpi1_name == other.lgrpi1_name && self.lgrpi1_comment == other.lgrpi1_comment
     }
 }
 impl ::core::cmp::Eq for LOCALGROUP_INFO_1 {}
@@ -10110,7 +10110,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_INFO_1002 {
 }
 impl ::core::cmp::PartialEq for LOCALGROUP_INFO_1002 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_INFO_1002>()) == 0 }
+        self.lgrpi1002_comment == other.lgrpi1002_comment
     }
 }
 impl ::core::cmp::Eq for LOCALGROUP_INFO_1002 {}
@@ -10146,7 +10146,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_MEMBERS_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOCALGROUP_MEMBERS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_MEMBERS_INFO_0>()) == 0 }
+        self.lgrmi0_sid == other.lgrmi0_sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10186,7 +10186,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_MEMBERS_INFO_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for LOCALGROUP_MEMBERS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_MEMBERS_INFO_1>()) == 0 }
+        self.lgrmi1_sid == other.lgrmi1_sid && self.lgrmi1_sidusage == other.lgrmi1_sidusage && self.lgrmi1_name == other.lgrmi1_name
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -10226,7 +10226,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_MEMBERS_INFO_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for LOCALGROUP_MEMBERS_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_MEMBERS_INFO_2>()) == 0 }
+        self.lgrmi2_sid == other.lgrmi2_sid && self.lgrmi2_sidusage == other.lgrmi2_sidusage && self.lgrmi2_domainandname == other.lgrmi2_domainandname
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -10258,7 +10258,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_MEMBERS_INFO_3 {
 }
 impl ::core::cmp::PartialEq for LOCALGROUP_MEMBERS_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_MEMBERS_INFO_3>()) == 0 }
+        self.lgrmi3_domainandname == other.lgrmi3_domainandname
     }
 }
 impl ::core::cmp::Eq for LOCALGROUP_MEMBERS_INFO_3 {}
@@ -10288,7 +10288,7 @@ unsafe impl ::windows::core::Abi for LOCALGROUP_USERS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for LOCALGROUP_USERS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALGROUP_USERS_INFO_0>()) == 0 }
+        self.lgrui0_name == other.lgrui0_name
     }
 }
 impl ::core::cmp::Eq for LOCALGROUP_USERS_INFO_0 {}
@@ -10320,7 +10320,7 @@ unsafe impl ::windows::core::Abi for MPR_PROTOCOL_0 {
 }
 impl ::core::cmp::PartialEq for MPR_PROTOCOL_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_PROTOCOL_0>()) == 0 }
+        self.dwProtocolId == other.dwProtocolId && self.wszProtocol == other.wszProtocol && self.wszDLLName == other.wszDLLName
     }
 }
 impl ::core::cmp::Eq for MPR_PROTOCOL_0 {}
@@ -10350,7 +10350,7 @@ unsafe impl ::windows::core::Abi for MSA_INFO_0 {
 }
 impl ::core::cmp::PartialEq for MSA_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSA_INFO_0>()) == 0 }
+        self.State == other.State
     }
 }
 impl ::core::cmp::Eq for MSA_INFO_0 {}
@@ -10380,7 +10380,7 @@ unsafe impl ::windows::core::Abi for MSG_INFO_0 {
 }
 impl ::core::cmp::PartialEq for MSG_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSG_INFO_0>()) == 0 }
+        self.msgi0_name == other.msgi0_name
     }
 }
 impl ::core::cmp::Eq for MSG_INFO_0 {}
@@ -10412,7 +10412,7 @@ unsafe impl ::windows::core::Abi for MSG_INFO_1 {
 }
 impl ::core::cmp::PartialEq for MSG_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSG_INFO_1>()) == 0 }
+        self.msgi1_name == other.msgi1_name && self.msgi1_forward_flag == other.msgi1_forward_flag && self.msgi1_forward == other.msgi1_forward
     }
 }
 impl ::core::cmp::Eq for MSG_INFO_1 {}
@@ -10443,7 +10443,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_INFO_1 {
 }
 impl ::core::cmp::PartialEq for NETLOGON_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_INFO_1>()) == 0 }
+        self.netlog1_flags == other.netlog1_flags && self.netlog1_pdc_connection_status == other.netlog1_pdc_connection_status
     }
 }
 impl ::core::cmp::Eq for NETLOGON_INFO_1 {}
@@ -10476,7 +10476,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_INFO_2 {
 }
 impl ::core::cmp::PartialEq for NETLOGON_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_INFO_2>()) == 0 }
+        self.netlog2_flags == other.netlog2_flags && self.netlog2_pdc_connection_status == other.netlog2_pdc_connection_status && self.netlog2_trusted_dc_name == other.netlog2_trusted_dc_name && self.netlog2_tc_connection_status == other.netlog2_tc_connection_status
     }
 }
 impl ::core::cmp::Eq for NETLOGON_INFO_2 {}
@@ -10512,7 +10512,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_INFO_3 {
 }
 impl ::core::cmp::PartialEq for NETLOGON_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_INFO_3>()) == 0 }
+        self.netlog3_flags == other.netlog3_flags && self.netlog3_logon_attempts == other.netlog3_logon_attempts && self.netlog3_reserved1 == other.netlog3_reserved1 && self.netlog3_reserved2 == other.netlog3_reserved2 && self.netlog3_reserved3 == other.netlog3_reserved3 && self.netlog3_reserved4 == other.netlog3_reserved4 && self.netlog3_reserved5 == other.netlog3_reserved5
     }
 }
 impl ::core::cmp::Eq for NETLOGON_INFO_3 {}
@@ -10543,7 +10543,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_INFO_4 {
 }
 impl ::core::cmp::PartialEq for NETLOGON_INFO_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_INFO_4>()) == 0 }
+        self.netlog4_trusted_dc_name == other.netlog4_trusted_dc_name && self.netlog4_trusted_domain_name == other.netlog4_trusted_domain_name
     }
 }
 impl ::core::cmp::Eq for NETLOGON_INFO_4 {}
@@ -10603,7 +10603,7 @@ unsafe impl ::windows::core::Abi for NETSETUP_PROVISIONING_PARAMS {
 }
 impl ::core::cmp::PartialEq for NETSETUP_PROVISIONING_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETSETUP_PROVISIONING_PARAMS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.lpDomain == other.lpDomain && self.lpHostName == other.lpHostName && self.lpMachineAccountOU == other.lpMachineAccountOU && self.lpDcName == other.lpDcName && self.dwProvisionOptions == other.dwProvisionOptions && self.aCertTemplateNames == other.aCertTemplateNames && self.cCertTemplateNames == other.cCertTemplateNames && self.aMachinePolicyNames == other.aMachinePolicyNames && self.cMachinePolicyNames == other.cMachinePolicyNames && self.aMachinePolicyPaths == other.aMachinePolicyPaths && self.cMachinePolicyPaths == other.cMachinePolicyPaths && self.lpNetbiosName == other.lpNetbiosName && self.lpSiteName == other.lpSiteName && self.lpPrimaryDNSDomain == other.lpPrimaryDNSDomain
     }
 }
 impl ::core::cmp::Eq for NETSETUP_PROVISIONING_PARAMS {}
@@ -10639,7 +10639,7 @@ unsafe impl ::windows::core::Abi for NETWORK_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NETWORK_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_NAME>()) == 0 }
+        self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10675,7 +10675,7 @@ unsafe impl ::windows::core::Abi for NET_DISPLAY_GROUP {
 }
 impl ::core::cmp::PartialEq for NET_DISPLAY_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_DISPLAY_GROUP>()) == 0 }
+        self.grpi3_name == other.grpi3_name && self.grpi3_comment == other.grpi3_comment && self.grpi3_group_id == other.grpi3_group_id && self.grpi3_attributes == other.grpi3_attributes && self.grpi3_next_index == other.grpi3_next_index
     }
 }
 impl ::core::cmp::Eq for NET_DISPLAY_GROUP {}
@@ -10709,7 +10709,7 @@ unsafe impl ::windows::core::Abi for NET_DISPLAY_MACHINE {
 }
 impl ::core::cmp::PartialEq for NET_DISPLAY_MACHINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_DISPLAY_MACHINE>()) == 0 }
+        self.usri2_name == other.usri2_name && self.usri2_comment == other.usri2_comment && self.usri2_flags == other.usri2_flags && self.usri2_user_id == other.usri2_user_id && self.usri2_next_index == other.usri2_next_index
     }
 }
 impl ::core::cmp::Eq for NET_DISPLAY_MACHINE {}
@@ -10744,7 +10744,7 @@ unsafe impl ::windows::core::Abi for NET_DISPLAY_USER {
 }
 impl ::core::cmp::PartialEq for NET_DISPLAY_USER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_DISPLAY_USER>()) == 0 }
+        self.usri1_name == other.usri1_name && self.usri1_comment == other.usri1_comment && self.usri1_flags == other.usri1_flags && self.usri1_full_name == other.usri1_full_name && self.usri1_user_id == other.usri1_user_id && self.usri1_next_index == other.usri1_next_index
     }
 }
 impl ::core::cmp::Eq for NET_DISPLAY_USER {}
@@ -10781,7 +10781,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_AUTHENTICATION_INPUT_ARG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_VALIDATE_AUTHENTICATION_INPUT_ARG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_AUTHENTICATION_INPUT_ARG>()) == 0 }
+        self.InputPersistedFields == other.InputPersistedFields && self.PasswordMatched == other.PasswordMatched
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10820,7 +10820,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_OUTPUT_ARG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_VALIDATE_OUTPUT_ARG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_OUTPUT_ARG>()) == 0 }
+        self.ChangedPersistedFields == other.ChangedPersistedFields && self.ValidationStatus == other.ValidationStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10862,7 +10862,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_PASSWORD_CHANGE_INPUT_ARG>()) == 0 }
+        self.InputPersistedFields == other.InputPersistedFields && self.ClearPassword == other.ClearPassword && self.UserAccountName == other.UserAccountName && self.HashedPassword == other.HashedPassword && self.PasswordMatch == other.PasswordMatch
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10895,7 +10895,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_PASSWORD_HASH {
 }
 impl ::core::cmp::PartialEq for NET_VALIDATE_PASSWORD_HASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_PASSWORD_HASH>()) == 0 }
+        self.Length == other.Length && self.Hash == other.Hash
     }
 }
 impl ::core::cmp::Eq for NET_VALIDATE_PASSWORD_HASH {}
@@ -10936,7 +10936,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_PASSWORD_RESET_INPUT_ARG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_VALIDATE_PASSWORD_RESET_INPUT_ARG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_PASSWORD_RESET_INPUT_ARG>()) == 0 }
+        self.InputPersistedFields == other.InputPersistedFields && self.ClearPassword == other.ClearPassword && self.UserAccountName == other.UserAccountName && self.HashedPassword == other.HashedPassword && self.PasswordMustChangeAtNextLogon == other.PasswordMustChangeAtNextLogon && self.ClearLockout == other.ClearLockout
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10980,7 +10980,7 @@ unsafe impl ::windows::core::Abi for NET_VALIDATE_PERSISTED_FIELDS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_VALIDATE_PERSISTED_FIELDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_VALIDATE_PERSISTED_FIELDS>()) == 0 }
+        self.PresentFields == other.PresentFields && self.PasswordLastSet == other.PasswordLastSet && self.BadPasswordTime == other.BadPasswordTime && self.LockoutTime == other.LockoutTime && self.BadPasswordCount == other.BadPasswordCount && self.PasswordHistoryLength == other.PasswordHistoryLength && self.PasswordHistory == other.PasswordHistory
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11063,7 +11063,7 @@ unsafe impl ::windows::core::Abi for PRINT_OTHER_INFO {
 }
 impl ::core::cmp::PartialEq for PRINT_OTHER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINT_OTHER_INFO>()) == 0 }
+        self.alrtpr_jobid == other.alrtpr_jobid && self.alrtpr_status == other.alrtpr_status && self.alrtpr_submitted == other.alrtpr_submitted && self.alrtpr_size == other.alrtpr_size
     }
 }
 impl ::core::cmp::Eq for PRINT_OTHER_INFO {}
@@ -11129,7 +11129,7 @@ unsafe impl ::windows::core::Abi for RASCON_IPUI {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASCON_IPUI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCON_IPUI>()) == 0 }
+        self.guidConnection == other.guidConnection && self.fIPv6Cfg == other.fIPv6Cfg && self.dwFlags == other.dwFlags && self.pszwIpAddr == other.pszwIpAddr && self.pszwDnsAddr == other.pszwDnsAddr && self.pszwDns2Addr == other.pszwDns2Addr && self.pszwWinsAddr == other.pszwWinsAddr && self.pszwWins2Addr == other.pszwWins2Addr && self.pszwDnsSuffix == other.pszwDnsSuffix && self.pszwIpv6Addr == other.pszwIpv6Addr && self.dwIpv6PrefixLength == other.dwIpv6PrefixLength && self.pszwIpv6DnsAddr == other.pszwIpv6DnsAddr && self.pszwIpv6Dns2Addr == other.pszwIpv6Dns2Addr && self.dwIPv4InfMetric == other.dwIPv4InfMetric && self.dwIPv6InfMetric == other.dwIPv6InfMetric
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11161,7 +11161,7 @@ unsafe impl ::windows::core::Abi for REPL_EDIR_INFO_0 {
 }
 impl ::core::cmp::PartialEq for REPL_EDIR_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_EDIR_INFO_0>()) == 0 }
+        self.rped0_dirname == other.rped0_dirname
     }
 }
 impl ::core::cmp::Eq for REPL_EDIR_INFO_0 {}
@@ -11193,7 +11193,7 @@ unsafe impl ::windows::core::Abi for REPL_EDIR_INFO_1 {
 }
 impl ::core::cmp::PartialEq for REPL_EDIR_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_EDIR_INFO_1>()) == 0 }
+        self.rped1_dirname == other.rped1_dirname && self.rped1_integrity == other.rped1_integrity && self.rped1_extent == other.rped1_extent
     }
 }
 impl ::core::cmp::Eq for REPL_EDIR_INFO_1 {}
@@ -11223,7 +11223,7 @@ unsafe impl ::windows::core::Abi for REPL_EDIR_INFO_1000 {
 }
 impl ::core::cmp::PartialEq for REPL_EDIR_INFO_1000 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_EDIR_INFO_1000>()) == 0 }
+        self.rped1000_integrity == other.rped1000_integrity
     }
 }
 impl ::core::cmp::Eq for REPL_EDIR_INFO_1000 {}
@@ -11253,7 +11253,7 @@ unsafe impl ::windows::core::Abi for REPL_EDIR_INFO_1001 {
 }
 impl ::core::cmp::PartialEq for REPL_EDIR_INFO_1001 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_EDIR_INFO_1001>()) == 0 }
+        self.rped1001_extent == other.rped1001_extent
     }
 }
 impl ::core::cmp::Eq for REPL_EDIR_INFO_1001 {}
@@ -11287,7 +11287,7 @@ unsafe impl ::windows::core::Abi for REPL_EDIR_INFO_2 {
 }
 impl ::core::cmp::PartialEq for REPL_EDIR_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_EDIR_INFO_2>()) == 0 }
+        self.rped2_dirname == other.rped2_dirname && self.rped2_integrity == other.rped2_integrity && self.rped2_extent == other.rped2_extent && self.rped2_lockcount == other.rped2_lockcount && self.rped2_locktime == other.rped2_locktime
     }
 }
 impl ::core::cmp::Eq for REPL_EDIR_INFO_2 {}
@@ -11317,7 +11317,7 @@ unsafe impl ::windows::core::Abi for REPL_IDIR_INFO_0 {
 }
 impl ::core::cmp::PartialEq for REPL_IDIR_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_IDIR_INFO_0>()) == 0 }
+        self.rpid0_dirname == other.rpid0_dirname
     }
 }
 impl ::core::cmp::Eq for REPL_IDIR_INFO_0 {}
@@ -11352,7 +11352,7 @@ unsafe impl ::windows::core::Abi for REPL_IDIR_INFO_1 {
 }
 impl ::core::cmp::PartialEq for REPL_IDIR_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_IDIR_INFO_1>()) == 0 }
+        self.rpid1_dirname == other.rpid1_dirname && self.rpid1_state == other.rpid1_state && self.rpid1_mastername == other.rpid1_mastername && self.rpid1_last_update_time == other.rpid1_last_update_time && self.rpid1_lockcount == other.rpid1_lockcount && self.rpid1_locktime == other.rpid1_locktime
     }
 }
 impl ::core::cmp::Eq for REPL_IDIR_INFO_1 {}
@@ -11391,7 +11391,7 @@ unsafe impl ::windows::core::Abi for REPL_INFO_0 {
 }
 impl ::core::cmp::PartialEq for REPL_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_INFO_0>()) == 0 }
+        self.rp0_role == other.rp0_role && self.rp0_exportpath == other.rp0_exportpath && self.rp0_exportlist == other.rp0_exportlist && self.rp0_importpath == other.rp0_importpath && self.rp0_importlist == other.rp0_importlist && self.rp0_logonusername == other.rp0_logonusername && self.rp0_interval == other.rp0_interval && self.rp0_pulse == other.rp0_pulse && self.rp0_guardtime == other.rp0_guardtime && self.rp0_random == other.rp0_random
     }
 }
 impl ::core::cmp::Eq for REPL_INFO_0 {}
@@ -11421,7 +11421,7 @@ unsafe impl ::windows::core::Abi for REPL_INFO_1000 {
 }
 impl ::core::cmp::PartialEq for REPL_INFO_1000 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_INFO_1000>()) == 0 }
+        self.rp1000_interval == other.rp1000_interval
     }
 }
 impl ::core::cmp::Eq for REPL_INFO_1000 {}
@@ -11451,7 +11451,7 @@ unsafe impl ::windows::core::Abi for REPL_INFO_1001 {
 }
 impl ::core::cmp::PartialEq for REPL_INFO_1001 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_INFO_1001>()) == 0 }
+        self.rp1001_pulse == other.rp1001_pulse
     }
 }
 impl ::core::cmp::Eq for REPL_INFO_1001 {}
@@ -11481,7 +11481,7 @@ unsafe impl ::windows::core::Abi for REPL_INFO_1002 {
 }
 impl ::core::cmp::PartialEq for REPL_INFO_1002 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_INFO_1002>()) == 0 }
+        self.rp1002_guardtime == other.rp1002_guardtime
     }
 }
 impl ::core::cmp::Eq for REPL_INFO_1002 {}
@@ -11511,7 +11511,7 @@ unsafe impl ::windows::core::Abi for REPL_INFO_1003 {
 }
 impl ::core::cmp::PartialEq for REPL_INFO_1003 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPL_INFO_1003>()) == 0 }
+        self.rp1003_random == other.rp1003_random
     }
 }
 impl ::core::cmp::Eq for REPL_INFO_1003 {}
@@ -11544,7 +11544,7 @@ unsafe impl ::windows::core::Abi for RTR_INFO_BLOCK_HEADER {
 }
 impl ::core::cmp::PartialEq for RTR_INFO_BLOCK_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTR_INFO_BLOCK_HEADER>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.TocEntriesCount == other.TocEntriesCount && self.TocEntry == other.TocEntry
     }
 }
 impl ::core::cmp::Eq for RTR_INFO_BLOCK_HEADER {}
@@ -11577,7 +11577,7 @@ unsafe impl ::windows::core::Abi for RTR_TOC_ENTRY {
 }
 impl ::core::cmp::PartialEq for RTR_TOC_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTR_TOC_ENTRY>()) == 0 }
+        self.InfoType == other.InfoType && self.InfoSize == other.InfoSize && self.Count == other.Count && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for RTR_TOC_ENTRY {}
@@ -11608,7 +11608,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_100 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_100 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_100>()) == 0 }
+        self.sv100_platform_id == other.sv100_platform_id && self.sv100_name == other.sv100_name
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_100 {}
@@ -11638,7 +11638,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1005 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1005 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1005>()) == 0 }
+        self.sv1005_comment == other.sv1005_comment
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1005 {}
@@ -11673,7 +11673,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_101 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_101 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_101>()) == 0 }
+        self.sv101_platform_id == other.sv101_platform_id && self.sv101_name == other.sv101_name && self.sv101_version_major == other.sv101_version_major && self.sv101_version_minor == other.sv101_version_minor && self.sv101_type == other.sv101_type && self.sv101_comment == other.sv101_comment
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_101 {}
@@ -11703,7 +11703,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1010 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1010 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1010>()) == 0 }
+        self.sv1010_disc == other.sv1010_disc
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1010 {}
@@ -11733,7 +11733,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1016 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1016 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1016>()) == 0 }
+        self.sv1016_hidden == other.sv1016_hidden
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1016 {}
@@ -11763,7 +11763,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1017 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1017 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1017>()) == 0 }
+        self.sv1017_announce == other.sv1017_announce
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1017 {}
@@ -11793,7 +11793,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1018 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1018 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1018>()) == 0 }
+        self.sv1018_anndelta == other.sv1018_anndelta
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1018 {}
@@ -11849,7 +11849,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_102 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_102 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_102>()) == 0 }
+        self.sv102_platform_id == other.sv102_platform_id && self.sv102_name == other.sv102_name && self.sv102_version_major == other.sv102_version_major && self.sv102_version_minor == other.sv102_version_minor && self.sv102_type == other.sv102_type && self.sv102_comment == other.sv102_comment && self.sv102_users == other.sv102_users && self.sv102_disc == other.sv102_disc && self.sv102_hidden == other.sv102_hidden && self.sv102_announce == other.sv102_announce && self.sv102_anndelta == other.sv102_anndelta && self.sv102_licenses == other.sv102_licenses && self.sv102_userpath == other.sv102_userpath
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_102 {}
@@ -11913,7 +11913,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_103 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_103 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_103>()) == 0 }
+        self.sv103_platform_id == other.sv103_platform_id && self.sv103_name == other.sv103_name && self.sv103_version_major == other.sv103_version_major && self.sv103_version_minor == other.sv103_version_minor && self.sv103_type == other.sv103_type && self.sv103_comment == other.sv103_comment && self.sv103_users == other.sv103_users && self.sv103_disc == other.sv103_disc && self.sv103_hidden == other.sv103_hidden && self.sv103_announce == other.sv103_announce && self.sv103_anndelta == other.sv103_anndelta && self.sv103_licenses == other.sv103_licenses && self.sv103_userpath == other.sv103_userpath && self.sv103_capabilities == other.sv103_capabilities
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11945,7 +11945,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1107 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1107 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1107>()) == 0 }
+        self.sv1107_users == other.sv1107_users
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1107 {}
@@ -11975,7 +11975,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1501 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1501 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1501>()) == 0 }
+        self.sv1501_sessopens == other.sv1501_sessopens
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1501 {}
@@ -12005,7 +12005,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1502 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1502 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1502>()) == 0 }
+        self.sv1502_sessvcs == other.sv1502_sessvcs
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1502 {}
@@ -12035,7 +12035,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1503 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1503 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1503>()) == 0 }
+        self.sv1503_opensearch == other.sv1503_opensearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1503 {}
@@ -12065,7 +12065,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1506 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1506 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1506>()) == 0 }
+        self.sv1506_maxworkitems == other.sv1506_maxworkitems
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1506 {}
@@ -12095,7 +12095,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1509 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1509 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1509>()) == 0 }
+        self.sv1509_maxrawbuflen == other.sv1509_maxrawbuflen
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1509 {}
@@ -12125,7 +12125,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1510 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1510 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1510>()) == 0 }
+        self.sv1510_sessusers == other.sv1510_sessusers
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1510 {}
@@ -12155,7 +12155,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1511 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1511 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1511>()) == 0 }
+        self.sv1511_sessconns == other.sv1511_sessconns
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1511 {}
@@ -12185,7 +12185,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1512 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1512 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1512>()) == 0 }
+        self.sv1512_maxnonpagedmemoryusage == other.sv1512_maxnonpagedmemoryusage
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1512 {}
@@ -12215,7 +12215,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1513 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1513 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1513>()) == 0 }
+        self.sv1513_maxpagedmemoryusage == other.sv1513_maxpagedmemoryusage
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1513 {}
@@ -12251,7 +12251,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1514 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1514 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1514>()) == 0 }
+        self.sv1514_enablesoftcompat == other.sv1514_enablesoftcompat
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12289,7 +12289,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1515 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1515 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1515>()) == 0 }
+        self.sv1515_enableforcedlogoff == other.sv1515_enableforcedlogoff
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12327,7 +12327,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1516 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1516 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1516>()) == 0 }
+        self.sv1516_timesource == other.sv1516_timesource
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12365,7 +12365,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1518 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1518 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1518>()) == 0 }
+        self.sv1518_lmannounce == other.sv1518_lmannounce
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12397,7 +12397,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1520 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1520 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1520>()) == 0 }
+        self.sv1520_maxcopyreadlen == other.sv1520_maxcopyreadlen
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1520 {}
@@ -12427,7 +12427,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1521 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1521 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1521>()) == 0 }
+        self.sv1521_maxcopywritelen == other.sv1521_maxcopywritelen
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1521 {}
@@ -12457,7 +12457,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1522 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1522 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1522>()) == 0 }
+        self.sv1522_minkeepsearch == other.sv1522_minkeepsearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1522 {}
@@ -12487,7 +12487,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1523 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1523 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1523>()) == 0 }
+        self.sv1523_maxkeepsearch == other.sv1523_maxkeepsearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1523 {}
@@ -12517,7 +12517,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1524 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1524 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1524>()) == 0 }
+        self.sv1524_minkeepcomplsearch == other.sv1524_minkeepcomplsearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1524 {}
@@ -12547,7 +12547,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1525 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1525 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1525>()) == 0 }
+        self.sv1525_maxkeepcomplsearch == other.sv1525_maxkeepcomplsearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1525 {}
@@ -12577,7 +12577,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1528 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1528 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1528>()) == 0 }
+        self.sv1528_scavtimeout == other.sv1528_scavtimeout
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1528 {}
@@ -12607,7 +12607,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1529 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1529 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1529>()) == 0 }
+        self.sv1529_minrcvqueue == other.sv1529_minrcvqueue
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1529 {}
@@ -12637,7 +12637,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1530 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1530 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1530>()) == 0 }
+        self.sv1530_minfreeworkitems == other.sv1530_minfreeworkitems
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1530 {}
@@ -12667,7 +12667,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1533 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1533 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1533>()) == 0 }
+        self.sv1533_maxmpxct == other.sv1533_maxmpxct
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1533 {}
@@ -12697,7 +12697,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1534 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1534 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1534>()) == 0 }
+        self.sv1534_oplockbreakwait == other.sv1534_oplockbreakwait
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1534 {}
@@ -12727,7 +12727,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1535 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1535 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1535>()) == 0 }
+        self.sv1535_oplockbreakresponsewait == other.sv1535_oplockbreakresponsewait
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1535 {}
@@ -12763,7 +12763,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1536 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1536 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1536>()) == 0 }
+        self.sv1536_enableoplocks == other.sv1536_enableoplocks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12801,7 +12801,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1537 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1537 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1537>()) == 0 }
+        self.sv1537_enableoplockforceclose == other.sv1537_enableoplockforceclose
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12839,7 +12839,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1538 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1538 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1538>()) == 0 }
+        self.sv1538_enablefcbopens == other.sv1538_enablefcbopens
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12877,7 +12877,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1539 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1539 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1539>()) == 0 }
+        self.sv1539_enableraw == other.sv1539_enableraw
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12915,7 +12915,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1540 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1540 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1540>()) == 0 }
+        self.sv1540_enablesharednetdrives == other.sv1540_enablesharednetdrives
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12953,7 +12953,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1541 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1541 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1541>()) == 0 }
+        self.sv1541_minfreeconnections == other.sv1541_minfreeconnections
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12991,7 +12991,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1542 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1542 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1542>()) == 0 }
+        self.sv1542_maxfreeconnections == other.sv1542_maxfreeconnections
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13023,7 +13023,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1543 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1543 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1543>()) == 0 }
+        self.sv1543_initsesstable == other.sv1543_initsesstable
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1543 {}
@@ -13053,7 +13053,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1544 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1544 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1544>()) == 0 }
+        self.sv1544_initconntable == other.sv1544_initconntable
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1544 {}
@@ -13083,7 +13083,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1545 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1545 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1545>()) == 0 }
+        self.sv1545_initfiletable == other.sv1545_initfiletable
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1545 {}
@@ -13113,7 +13113,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1546 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1546 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1546>()) == 0 }
+        self.sv1546_initsearchtable == other.sv1546_initsearchtable
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1546 {}
@@ -13143,7 +13143,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1547 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1547 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1547>()) == 0 }
+        self.sv1547_alertschedule == other.sv1547_alertschedule
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1547 {}
@@ -13173,7 +13173,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1548 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1548 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1548>()) == 0 }
+        self.sv1548_errorthreshold == other.sv1548_errorthreshold
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1548 {}
@@ -13203,7 +13203,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1549 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1549 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1549>()) == 0 }
+        self.sv1549_networkerrorthreshold == other.sv1549_networkerrorthreshold
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1549 {}
@@ -13233,7 +13233,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1550 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1550 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1550>()) == 0 }
+        self.sv1550_diskspacethreshold == other.sv1550_diskspacethreshold
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1550 {}
@@ -13263,7 +13263,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1552 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1552 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1552>()) == 0 }
+        self.sv1552_maxlinkdelay == other.sv1552_maxlinkdelay
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1552 {}
@@ -13293,7 +13293,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1553 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1553 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1553>()) == 0 }
+        self.sv1553_minlinkthroughput == other.sv1553_minlinkthroughput
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1553 {}
@@ -13323,7 +13323,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1554 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1554 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1554>()) == 0 }
+        self.sv1554_linkinfovalidtime == other.sv1554_linkinfovalidtime
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1554 {}
@@ -13353,7 +13353,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1555 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1555 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1555>()) == 0 }
+        self.sv1555_scavqosinfoupdatetime == other.sv1555_scavqosinfoupdatetime
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1555 {}
@@ -13383,7 +13383,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1556 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1556 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1556>()) == 0 }
+        self.sv1556_maxworkitemidletime == other.sv1556_maxworkitemidletime
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1556 {}
@@ -13413,7 +13413,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1557 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1557 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1557>()) == 0 }
+        self.sv1557_maxrawworkitems == other.sv1557_maxrawworkitems
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1557 {}
@@ -13443,7 +13443,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1560 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1560 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1560>()) == 0 }
+        self.sv1560_producttype == other.sv1560_producttype
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1560 {}
@@ -13473,7 +13473,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1561 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1561 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1561>()) == 0 }
+        self.sv1561_serversize == other.sv1561_serversize
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1561 {}
@@ -13503,7 +13503,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1562 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1562 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1562>()) == 0 }
+        self.sv1562_connectionlessautodisc == other.sv1562_connectionlessautodisc
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1562 {}
@@ -13533,7 +13533,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1563 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1563 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1563>()) == 0 }
+        self.sv1563_sharingviolationretries == other.sv1563_sharingviolationretries
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1563 {}
@@ -13563,7 +13563,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1564 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1564 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1564>()) == 0 }
+        self.sv1564_sharingviolationdelay == other.sv1564_sharingviolationdelay
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1564 {}
@@ -13593,7 +13593,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1565 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1565 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1565>()) == 0 }
+        self.sv1565_maxglobalopensearch == other.sv1565_maxglobalopensearch
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1565 {}
@@ -13629,7 +13629,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1566 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1566 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1566>()) == 0 }
+        self.sv1566_removeduplicatesearches == other.sv1566_removeduplicatesearches
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13661,7 +13661,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1567 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1567 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1567>()) == 0 }
+        self.sv1567_lockviolationretries == other.sv1567_lockviolationretries
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1567 {}
@@ -13691,7 +13691,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1568 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1568 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1568>()) == 0 }
+        self.sv1568_lockviolationoffset == other.sv1568_lockviolationoffset
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1568 {}
@@ -13721,7 +13721,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1569 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1569 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1569>()) == 0 }
+        self.sv1569_lockviolationdelay == other.sv1569_lockviolationdelay
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1569 {}
@@ -13751,7 +13751,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1570 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1570 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1570>()) == 0 }
+        self.sv1570_mdlreadswitchover == other.sv1570_mdlreadswitchover
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1570 {}
@@ -13781,7 +13781,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1571 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1571 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1571>()) == 0 }
+        self.sv1571_cachedopenlimit == other.sv1571_cachedopenlimit
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1571 {}
@@ -13811,7 +13811,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1572 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1572 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1572>()) == 0 }
+        self.sv1572_criticalthreads == other.sv1572_criticalthreads
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1572 {}
@@ -13841,7 +13841,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1573 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1573 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1573>()) == 0 }
+        self.sv1573_restrictnullsessaccess == other.sv1573_restrictnullsessaccess
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1573 {}
@@ -13871,7 +13871,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1574 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1574 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1574>()) == 0 }
+        self.sv1574_enablewfw311directipx == other.sv1574_enablewfw311directipx
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1574 {}
@@ -13901,7 +13901,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1575 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1575 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1575>()) == 0 }
+        self.sv1575_otherqueueaffinity == other.sv1575_otherqueueaffinity
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1575 {}
@@ -13931,7 +13931,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1576 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1576 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1576>()) == 0 }
+        self.sv1576_queuesamplesecs == other.sv1576_queuesamplesecs
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1576 {}
@@ -13961,7 +13961,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1577 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1577 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1577>()) == 0 }
+        self.sv1577_balancecount == other.sv1577_balancecount
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1577 {}
@@ -13991,7 +13991,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1578 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1578 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1578>()) == 0 }
+        self.sv1578_preferredaffinity == other.sv1578_preferredaffinity
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1578 {}
@@ -14021,7 +14021,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1579 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1579 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1579>()) == 0 }
+        self.sv1579_maxfreerfcbs == other.sv1579_maxfreerfcbs
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1579 {}
@@ -14051,7 +14051,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1580 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1580 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1580>()) == 0 }
+        self.sv1580_maxfreemfcbs == other.sv1580_maxfreemfcbs
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1580 {}
@@ -14081,7 +14081,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1581 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1581 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1581>()) == 0 }
+        self.sv1581_maxfreemlcbs == other.sv1581_maxfreemlcbs
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1581 {}
@@ -14111,7 +14111,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1582 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1582 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1582>()) == 0 }
+        self.sv1582_maxfreepagedpoolchunks == other.sv1582_maxfreepagedpoolchunks
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1582 {}
@@ -14141,7 +14141,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1583 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1583 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1583>()) == 0 }
+        self.sv1583_minpagedpoolchunksize == other.sv1583_minpagedpoolchunksize
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1583 {}
@@ -14171,7 +14171,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1584 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1584 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1584>()) == 0 }
+        self.sv1584_maxpagedpoolchunksize == other.sv1584_maxpagedpoolchunksize
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1584 {}
@@ -14207,7 +14207,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1585 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1585 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1585>()) == 0 }
+        self.sv1585_sendsfrompreferredprocessor == other.sv1585_sendsfrompreferredprocessor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14239,7 +14239,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1586 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1586 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1586>()) == 0 }
+        self.sv1586_maxthreadsperqueue == other.sv1586_maxthreadsperqueue
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1586 {}
@@ -14269,7 +14269,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1587 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1587 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1587>()) == 0 }
+        self.sv1587_cacheddirectorylimit == other.sv1587_cacheddirectorylimit
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1587 {}
@@ -14299,7 +14299,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1588 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1588 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1588>()) == 0 }
+        self.sv1588_maxcopylength == other.sv1588_maxcopylength
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1588 {}
@@ -14329,7 +14329,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1590 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1590 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1590>()) == 0 }
+        self.sv1590_enablecompression == other.sv1590_enablecompression
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1590 {}
@@ -14359,7 +14359,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1591 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1591 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1591>()) == 0 }
+        self.sv1591_autosharewks == other.sv1591_autosharewks
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1591 {}
@@ -14389,7 +14389,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1592 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1592 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1592>()) == 0 }
+        self.sv1592_autosharewks == other.sv1592_autosharewks
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1592 {}
@@ -14419,7 +14419,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1593 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1593 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1593>()) == 0 }
+        self.sv1593_enablesecuritysignature == other.sv1593_enablesecuritysignature
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1593 {}
@@ -14449,7 +14449,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1594 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1594 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1594>()) == 0 }
+        self.sv1594_requiresecuritysignature == other.sv1594_requiresecuritysignature
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1594 {}
@@ -14479,7 +14479,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1595 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1595 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1595>()) == 0 }
+        self.sv1595_minclientbuffersize == other.sv1595_minclientbuffersize
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1595 {}
@@ -14509,7 +14509,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1596 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1596 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1596>()) == 0 }
+        self.sv1596_ConnectionNoSessionsTimeout == other.sv1596_ConnectionNoSessionsTimeout
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1596 {}
@@ -14539,7 +14539,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1597 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1597 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1597>()) == 0 }
+        self.sv1597_IdleThreadTimeOut == other.sv1597_IdleThreadTimeOut
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1597 {}
@@ -14569,7 +14569,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1598 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1598 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1598>()) == 0 }
+        self.sv1598_enableW9xsecuritysignature == other.sv1598_enableW9xsecuritysignature
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1598 {}
@@ -14605,7 +14605,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1599 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1599 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1599>()) == 0 }
+        self.sv1598_enforcekerberosreauthentication == other.sv1598_enforcekerberosreauthentication
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14643,7 +14643,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1600 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1600 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1600>()) == 0 }
+        self.sv1598_disabledos == other.sv1598_disabledos
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14675,7 +14675,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1601 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_1601 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1601>()) == 0 }
+        self.sv1598_lowdiskspaceminimum == other.sv1598_lowdiskspaceminimum
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_1601 {}
@@ -14711,7 +14711,7 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_1602 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_1602 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_1602>()) == 0 }
+        self.sv_1598_disablestrictnamechecking == other.sv_1598_disablestrictnamechecking
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14805,7 +14805,37 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_402 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_402 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_402>()) == 0 }
+        self.sv402_ulist_mtime == other.sv402_ulist_mtime
+            && self.sv402_glist_mtime == other.sv402_glist_mtime
+            && self.sv402_alist_mtime == other.sv402_alist_mtime
+            && self.sv402_alerts == other.sv402_alerts
+            && self.sv402_security == other.sv402_security
+            && self.sv402_numadmin == other.sv402_numadmin
+            && self.sv402_lanmask == other.sv402_lanmask
+            && self.sv402_guestacct == other.sv402_guestacct
+            && self.sv402_chdevs == other.sv402_chdevs
+            && self.sv402_chdevq == other.sv402_chdevq
+            && self.sv402_chdevjobs == other.sv402_chdevjobs
+            && self.sv402_connections == other.sv402_connections
+            && self.sv402_shares == other.sv402_shares
+            && self.sv402_openfiles == other.sv402_openfiles
+            && self.sv402_sessopens == other.sv402_sessopens
+            && self.sv402_sessvcs == other.sv402_sessvcs
+            && self.sv402_sessreqs == other.sv402_sessreqs
+            && self.sv402_opensearch == other.sv402_opensearch
+            && self.sv402_activelocks == other.sv402_activelocks
+            && self.sv402_numreqbuf == other.sv402_numreqbuf
+            && self.sv402_sizreqbuf == other.sv402_sizreqbuf
+            && self.sv402_numbigbuf == other.sv402_numbigbuf
+            && self.sv402_numfiletasks == other.sv402_numfiletasks
+            && self.sv402_alertsched == other.sv402_alertsched
+            && self.sv402_erroralert == other.sv402_erroralert
+            && self.sv402_logonalert == other.sv402_logonalert
+            && self.sv402_accessalert == other.sv402_accessalert
+            && self.sv402_diskalert == other.sv402_diskalert
+            && self.sv402_netioalert == other.sv402_netioalert
+            && self.sv402_maxauditsz == other.sv402_maxauditsz
+            && self.sv402_srvheuristics == other.sv402_srvheuristics
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_402 {}
@@ -14903,7 +14933,40 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_403 {
 }
 impl ::core::cmp::PartialEq for SERVER_INFO_403 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_403>()) == 0 }
+        self.sv403_ulist_mtime == other.sv403_ulist_mtime
+            && self.sv403_glist_mtime == other.sv403_glist_mtime
+            && self.sv403_alist_mtime == other.sv403_alist_mtime
+            && self.sv403_alerts == other.sv403_alerts
+            && self.sv403_security == other.sv403_security
+            && self.sv403_numadmin == other.sv403_numadmin
+            && self.sv403_lanmask == other.sv403_lanmask
+            && self.sv403_guestacct == other.sv403_guestacct
+            && self.sv403_chdevs == other.sv403_chdevs
+            && self.sv403_chdevq == other.sv403_chdevq
+            && self.sv403_chdevjobs == other.sv403_chdevjobs
+            && self.sv403_connections == other.sv403_connections
+            && self.sv403_shares == other.sv403_shares
+            && self.sv403_openfiles == other.sv403_openfiles
+            && self.sv403_sessopens == other.sv403_sessopens
+            && self.sv403_sessvcs == other.sv403_sessvcs
+            && self.sv403_sessreqs == other.sv403_sessreqs
+            && self.sv403_opensearch == other.sv403_opensearch
+            && self.sv403_activelocks == other.sv403_activelocks
+            && self.sv403_numreqbuf == other.sv403_numreqbuf
+            && self.sv403_sizreqbuf == other.sv403_sizreqbuf
+            && self.sv403_numbigbuf == other.sv403_numbigbuf
+            && self.sv403_numfiletasks == other.sv403_numfiletasks
+            && self.sv403_alertsched == other.sv403_alertsched
+            && self.sv403_erroralert == other.sv403_erroralert
+            && self.sv403_logonalert == other.sv403_logonalert
+            && self.sv403_accessalert == other.sv403_accessalert
+            && self.sv403_diskalert == other.sv403_diskalert
+            && self.sv403_netioalert == other.sv403_netioalert
+            && self.sv403_maxauditsz == other.sv403_maxauditsz
+            && self.sv403_srvheuristics == other.sv403_srvheuristics
+            && self.sv403_auditedevents == other.sv403_auditedevents
+            && self.sv403_autoprofile == other.sv403_autoprofile
+            && self.sv403_autopath == other.sv403_autopath
     }
 }
 impl ::core::cmp::Eq for SERVER_INFO_403 {}
@@ -14975,7 +15038,24 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_502 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_502 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_502>()) == 0 }
+        self.sv502_sessopens == other.sv502_sessopens
+            && self.sv502_sessvcs == other.sv502_sessvcs
+            && self.sv502_opensearch == other.sv502_opensearch
+            && self.sv502_sizreqbuf == other.sv502_sizreqbuf
+            && self.sv502_initworkitems == other.sv502_initworkitems
+            && self.sv502_maxworkitems == other.sv502_maxworkitems
+            && self.sv502_rawworkitems == other.sv502_rawworkitems
+            && self.sv502_irpstacksize == other.sv502_irpstacksize
+            && self.sv502_maxrawbuflen == other.sv502_maxrawbuflen
+            && self.sv502_sessusers == other.sv502_sessusers
+            && self.sv502_sessconns == other.sv502_sessconns
+            && self.sv502_maxpagedmemoryusage == other.sv502_maxpagedmemoryusage
+            && self.sv502_maxnonpagedmemoryusage == other.sv502_maxnonpagedmemoryusage
+            && self.sv502_enablesoftcompat == other.sv502_enablesoftcompat
+            && self.sv502_enableforcedlogoff == other.sv502_enableforcedlogoff
+            && self.sv502_timesource == other.sv502_timesource
+            && self.sv502_acceptdownlevelapis == other.sv502_acceptdownlevelapis
+            && self.sv502_lmannounce == other.sv502_lmannounce
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15097,7 +15177,48 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_503 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_503 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_503>()) == 0 }
+        self.sv503_sessopens == other.sv503_sessopens
+            && self.sv503_sessvcs == other.sv503_sessvcs
+            && self.sv503_opensearch == other.sv503_opensearch
+            && self.sv503_sizreqbuf == other.sv503_sizreqbuf
+            && self.sv503_initworkitems == other.sv503_initworkitems
+            && self.sv503_maxworkitems == other.sv503_maxworkitems
+            && self.sv503_rawworkitems == other.sv503_rawworkitems
+            && self.sv503_irpstacksize == other.sv503_irpstacksize
+            && self.sv503_maxrawbuflen == other.sv503_maxrawbuflen
+            && self.sv503_sessusers == other.sv503_sessusers
+            && self.sv503_sessconns == other.sv503_sessconns
+            && self.sv503_maxpagedmemoryusage == other.sv503_maxpagedmemoryusage
+            && self.sv503_maxnonpagedmemoryusage == other.sv503_maxnonpagedmemoryusage
+            && self.sv503_enablesoftcompat == other.sv503_enablesoftcompat
+            && self.sv503_enableforcedlogoff == other.sv503_enableforcedlogoff
+            && self.sv503_timesource == other.sv503_timesource
+            && self.sv503_acceptdownlevelapis == other.sv503_acceptdownlevelapis
+            && self.sv503_lmannounce == other.sv503_lmannounce
+            && self.sv503_domain == other.sv503_domain
+            && self.sv503_maxcopyreadlen == other.sv503_maxcopyreadlen
+            && self.sv503_maxcopywritelen == other.sv503_maxcopywritelen
+            && self.sv503_minkeepsearch == other.sv503_minkeepsearch
+            && self.sv503_maxkeepsearch == other.sv503_maxkeepsearch
+            && self.sv503_minkeepcomplsearch == other.sv503_minkeepcomplsearch
+            && self.sv503_maxkeepcomplsearch == other.sv503_maxkeepcomplsearch
+            && self.sv503_threadcountadd == other.sv503_threadcountadd
+            && self.sv503_numblockthreads == other.sv503_numblockthreads
+            && self.sv503_scavtimeout == other.sv503_scavtimeout
+            && self.sv503_minrcvqueue == other.sv503_minrcvqueue
+            && self.sv503_minfreeworkitems == other.sv503_minfreeworkitems
+            && self.sv503_xactmemsize == other.sv503_xactmemsize
+            && self.sv503_threadpriority == other.sv503_threadpriority
+            && self.sv503_maxmpxct == other.sv503_maxmpxct
+            && self.sv503_oplockbreakwait == other.sv503_oplockbreakwait
+            && self.sv503_oplockbreakresponsewait == other.sv503_oplockbreakresponsewait
+            && self.sv503_enableoplocks == other.sv503_enableoplocks
+            && self.sv503_enableoplockforceclose == other.sv503_enableoplockforceclose
+            && self.sv503_enablefcbopens == other.sv503_enablefcbopens
+            && self.sv503_enableraw == other.sv503_enableraw
+            && self.sv503_enablesharednetdrives == other.sv503_enablesharednetdrives
+            && self.sv503_minfreeconnections == other.sv503_minfreeconnections
+            && self.sv503_maxfreeconnections == other.sv503_maxfreeconnections
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15221,7 +15342,49 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_598 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_598 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_598>()) == 0 }
+        self.sv598_maxrawworkitems == other.sv598_maxrawworkitems
+            && self.sv598_maxthreadsperqueue == other.sv598_maxthreadsperqueue
+            && self.sv598_producttype == other.sv598_producttype
+            && self.sv598_serversize == other.sv598_serversize
+            && self.sv598_connectionlessautodisc == other.sv598_connectionlessautodisc
+            && self.sv598_sharingviolationretries == other.sv598_sharingviolationretries
+            && self.sv598_sharingviolationdelay == other.sv598_sharingviolationdelay
+            && self.sv598_maxglobalopensearch == other.sv598_maxglobalopensearch
+            && self.sv598_removeduplicatesearches == other.sv598_removeduplicatesearches
+            && self.sv598_lockviolationoffset == other.sv598_lockviolationoffset
+            && self.sv598_lockviolationdelay == other.sv598_lockviolationdelay
+            && self.sv598_mdlreadswitchover == other.sv598_mdlreadswitchover
+            && self.sv598_cachedopenlimit == other.sv598_cachedopenlimit
+            && self.sv598_otherqueueaffinity == other.sv598_otherqueueaffinity
+            && self.sv598_restrictnullsessaccess == other.sv598_restrictnullsessaccess
+            && self.sv598_enablewfw311directipx == other.sv598_enablewfw311directipx
+            && self.sv598_queuesamplesecs == other.sv598_queuesamplesecs
+            && self.sv598_balancecount == other.sv598_balancecount
+            && self.sv598_preferredaffinity == other.sv598_preferredaffinity
+            && self.sv598_maxfreerfcbs == other.sv598_maxfreerfcbs
+            && self.sv598_maxfreemfcbs == other.sv598_maxfreemfcbs
+            && self.sv598_maxfreelfcbs == other.sv598_maxfreelfcbs
+            && self.sv598_maxfreepagedpoolchunks == other.sv598_maxfreepagedpoolchunks
+            && self.sv598_minpagedpoolchunksize == other.sv598_minpagedpoolchunksize
+            && self.sv598_maxpagedpoolchunksize == other.sv598_maxpagedpoolchunksize
+            && self.sv598_sendsfrompreferredprocessor == other.sv598_sendsfrompreferredprocessor
+            && self.sv598_cacheddirectorylimit == other.sv598_cacheddirectorylimit
+            && self.sv598_maxcopylength == other.sv598_maxcopylength
+            && self.sv598_enablecompression == other.sv598_enablecompression
+            && self.sv598_autosharewks == other.sv598_autosharewks
+            && self.sv598_autoshareserver == other.sv598_autoshareserver
+            && self.sv598_enablesecuritysignature == other.sv598_enablesecuritysignature
+            && self.sv598_requiresecuritysignature == other.sv598_requiresecuritysignature
+            && self.sv598_minclientbuffersize == other.sv598_minclientbuffersize
+            && self.sv598_serverguid == other.sv598_serverguid
+            && self.sv598_ConnectionNoSessionsTimeout == other.sv598_ConnectionNoSessionsTimeout
+            && self.sv598_IdleThreadTimeOut == other.sv598_IdleThreadTimeOut
+            && self.sv598_enableW9xsecuritysignature == other.sv598_enableW9xsecuritysignature
+            && self.sv598_enforcekerberosreauthentication == other.sv598_enforcekerberosreauthentication
+            && self.sv598_disabledos == other.sv598_disabledos
+            && self.sv598_lowdiskspaceminimum == other.sv598_lowdiskspaceminimum
+            && self.sv598_disablestrictnamechecking == other.sv598_disablestrictnamechecking
+            && self.sv598_enableauthenticateusersharing == other.sv598_enableauthenticateusersharing
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15371,7 +15534,62 @@ unsafe impl ::windows::core::Abi for SERVER_INFO_599 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_INFO_599 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_INFO_599>()) == 0 }
+        self.sv599_sessopens == other.sv599_sessopens
+            && self.sv599_sessvcs == other.sv599_sessvcs
+            && self.sv599_opensearch == other.sv599_opensearch
+            && self.sv599_sizreqbuf == other.sv599_sizreqbuf
+            && self.sv599_initworkitems == other.sv599_initworkitems
+            && self.sv599_maxworkitems == other.sv599_maxworkitems
+            && self.sv599_rawworkitems == other.sv599_rawworkitems
+            && self.sv599_irpstacksize == other.sv599_irpstacksize
+            && self.sv599_maxrawbuflen == other.sv599_maxrawbuflen
+            && self.sv599_sessusers == other.sv599_sessusers
+            && self.sv599_sessconns == other.sv599_sessconns
+            && self.sv599_maxpagedmemoryusage == other.sv599_maxpagedmemoryusage
+            && self.sv599_maxnonpagedmemoryusage == other.sv599_maxnonpagedmemoryusage
+            && self.sv599_enablesoftcompat == other.sv599_enablesoftcompat
+            && self.sv599_enableforcedlogoff == other.sv599_enableforcedlogoff
+            && self.sv599_timesource == other.sv599_timesource
+            && self.sv599_acceptdownlevelapis == other.sv599_acceptdownlevelapis
+            && self.sv599_lmannounce == other.sv599_lmannounce
+            && self.sv599_domain == other.sv599_domain
+            && self.sv599_maxcopyreadlen == other.sv599_maxcopyreadlen
+            && self.sv599_maxcopywritelen == other.sv599_maxcopywritelen
+            && self.sv599_minkeepsearch == other.sv599_minkeepsearch
+            && self.sv599_maxkeepsearch == other.sv599_maxkeepsearch
+            && self.sv599_minkeepcomplsearch == other.sv599_minkeepcomplsearch
+            && self.sv599_maxkeepcomplsearch == other.sv599_maxkeepcomplsearch
+            && self.sv599_threadcountadd == other.sv599_threadcountadd
+            && self.sv599_numblockthreads == other.sv599_numblockthreads
+            && self.sv599_scavtimeout == other.sv599_scavtimeout
+            && self.sv599_minrcvqueue == other.sv599_minrcvqueue
+            && self.sv599_minfreeworkitems == other.sv599_minfreeworkitems
+            && self.sv599_xactmemsize == other.sv599_xactmemsize
+            && self.sv599_threadpriority == other.sv599_threadpriority
+            && self.sv599_maxmpxct == other.sv599_maxmpxct
+            && self.sv599_oplockbreakwait == other.sv599_oplockbreakwait
+            && self.sv599_oplockbreakresponsewait == other.sv599_oplockbreakresponsewait
+            && self.sv599_enableoplocks == other.sv599_enableoplocks
+            && self.sv599_enableoplockforceclose == other.sv599_enableoplockforceclose
+            && self.sv599_enablefcbopens == other.sv599_enablefcbopens
+            && self.sv599_enableraw == other.sv599_enableraw
+            && self.sv599_enablesharednetdrives == other.sv599_enablesharednetdrives
+            && self.sv599_minfreeconnections == other.sv599_minfreeconnections
+            && self.sv599_maxfreeconnections == other.sv599_maxfreeconnections
+            && self.sv599_initsesstable == other.sv599_initsesstable
+            && self.sv599_initconntable == other.sv599_initconntable
+            && self.sv599_initfiletable == other.sv599_initfiletable
+            && self.sv599_initsearchtable == other.sv599_initsearchtable
+            && self.sv599_alertschedule == other.sv599_alertschedule
+            && self.sv599_errorthreshold == other.sv599_errorthreshold
+            && self.sv599_networkerrorthreshold == other.sv599_networkerrorthreshold
+            && self.sv599_diskspacethreshold == other.sv599_diskspacethreshold
+            && self.sv599_reserved == other.sv599_reserved
+            && self.sv599_maxlinkdelay == other.sv599_maxlinkdelay
+            && self.sv599_minlinkthroughput == other.sv599_minlinkthroughput
+            && self.sv599_linkinfovalidtime == other.sv599_linkinfovalidtime
+            && self.sv599_scavqosinfoupdatetime == other.sv599_scavqosinfoupdatetime
+            && self.sv599_maxworkitemidletime == other.sv599_maxworkitemidletime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15407,7 +15625,7 @@ unsafe impl ::windows::core::Abi for SERVER_TRANSPORT_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SERVER_TRANSPORT_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_TRANSPORT_INFO_0>()) == 0 }
+        self.svti0_numberofvcs == other.svti0_numberofvcs && self.svti0_transportname == other.svti0_transportname && self.svti0_transportaddress == other.svti0_transportaddress && self.svti0_transportaddresslength == other.svti0_transportaddresslength && self.svti0_networkaddress == other.svti0_networkaddress
     }
 }
 impl ::core::cmp::Eq for SERVER_TRANSPORT_INFO_0 {}
@@ -15442,7 +15660,7 @@ unsafe impl ::windows::core::Abi for SERVER_TRANSPORT_INFO_1 {
 }
 impl ::core::cmp::PartialEq for SERVER_TRANSPORT_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_TRANSPORT_INFO_1>()) == 0 }
+        self.svti1_numberofvcs == other.svti1_numberofvcs && self.svti1_transportname == other.svti1_transportname && self.svti1_transportaddress == other.svti1_transportaddress && self.svti1_transportaddresslength == other.svti1_transportaddresslength && self.svti1_networkaddress == other.svti1_networkaddress && self.svti1_domain == other.svti1_domain
     }
 }
 impl ::core::cmp::Eq for SERVER_TRANSPORT_INFO_1 {}
@@ -15478,7 +15696,7 @@ unsafe impl ::windows::core::Abi for SERVER_TRANSPORT_INFO_2 {
 }
 impl ::core::cmp::PartialEq for SERVER_TRANSPORT_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_TRANSPORT_INFO_2>()) == 0 }
+        self.svti2_numberofvcs == other.svti2_numberofvcs && self.svti2_transportname == other.svti2_transportname && self.svti2_transportaddress == other.svti2_transportaddress && self.svti2_transportaddresslength == other.svti2_transportaddresslength && self.svti2_networkaddress == other.svti2_networkaddress && self.svti2_domain == other.svti2_domain && self.svti2_flags == other.svti2_flags
     }
 }
 impl ::core::cmp::Eq for SERVER_TRANSPORT_INFO_2 {}
@@ -15526,7 +15744,7 @@ unsafe impl ::windows::core::Abi for SERVER_TRANSPORT_INFO_3 {
 }
 impl ::core::cmp::PartialEq for SERVER_TRANSPORT_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_TRANSPORT_INFO_3>()) == 0 }
+        self.svti3_numberofvcs == other.svti3_numberofvcs && self.svti3_transportname == other.svti3_transportname && self.svti3_transportaddress == other.svti3_transportaddress && self.svti3_transportaddresslength == other.svti3_transportaddresslength && self.svti3_networkaddress == other.svti3_networkaddress && self.svti3_domain == other.svti3_domain && self.svti3_flags == other.svti3_flags && self.svti3_passwordlength == other.svti3_passwordlength && self.svti3_password == other.svti3_password
     }
 }
 impl ::core::cmp::Eq for SERVER_TRANSPORT_INFO_3 {}
@@ -15556,7 +15774,7 @@ unsafe impl ::windows::core::Abi for SERVICE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SERVICE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_INFO_0>()) == 0 }
+        self.svci0_name == other.svci0_name
     }
 }
 impl ::core::cmp::Eq for SERVICE_INFO_0 {}
@@ -15589,7 +15807,7 @@ unsafe impl ::windows::core::Abi for SERVICE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for SERVICE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_INFO_1>()) == 0 }
+        self.svci1_name == other.svci1_name && self.svci1_status == other.svci1_status && self.svci1_code == other.svci1_code && self.svci1_pid == other.svci1_pid
     }
 }
 impl ::core::cmp::Eq for SERVICE_INFO_1 {}
@@ -15625,7 +15843,7 @@ unsafe impl ::windows::core::Abi for SERVICE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for SERVICE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_INFO_2>()) == 0 }
+        self.svci2_name == other.svci2_name && self.svci2_status == other.svci2_status && self.svci2_code == other.svci2_code && self.svci2_pid == other.svci2_pid && self.svci2_text == other.svci2_text && self.svci2_specific_error == other.svci2_specific_error && self.svci2_display_name == other.svci2_display_name
     }
 }
 impl ::core::cmp::Eq for SERVICE_INFO_2 {}
@@ -15664,7 +15882,7 @@ unsafe impl ::windows::core::Abi for SMB_COMPRESSION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SMB_COMPRESSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMB_COMPRESSION_INFO>()) == 0 }
+        self.Switch == other.Switch && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15699,7 +15917,7 @@ unsafe impl ::windows::core::Abi for SMB_TREE_CONNECT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for SMB_TREE_CONNECT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMB_TREE_CONNECT_PARAMETERS>()) == 0 }
+        self.EABufferOffset == other.EABufferOffset && self.EABufferLen == other.EABufferLen && self.CreateOptions == other.CreateOptions && self.TreeConnectAttributes == other.TreeConnectAttributes
     }
 }
 impl ::core::cmp::Eq for SMB_TREE_CONNECT_PARAMETERS {}
@@ -15731,7 +15949,7 @@ unsafe impl ::windows::core::Abi for SMB_USE_OPTION_COMPRESSION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for SMB_USE_OPTION_COMPRESSION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMB_USE_OPTION_COMPRESSION_PARAMETERS>()) == 0 }
+        self.Tag == other.Tag && self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for SMB_USE_OPTION_COMPRESSION_PARAMETERS {}
@@ -15763,7 +15981,7 @@ unsafe impl ::windows::core::Abi for STD_ALERT {
 }
 impl ::core::cmp::PartialEq for STD_ALERT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STD_ALERT>()) == 0 }
+        self.alrt_timestamp == other.alrt_timestamp && self.alrt_eventname == other.alrt_eventname && self.alrt_servicename == other.alrt_servicename
     }
 }
 impl ::core::cmp::Eq for STD_ALERT {}
@@ -15817,7 +16035,7 @@ unsafe impl ::windows::core::Abi for TIME_OF_DAY_INFO {
 }
 impl ::core::cmp::PartialEq for TIME_OF_DAY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIME_OF_DAY_INFO>()) == 0 }
+        self.tod_elapsedt == other.tod_elapsedt && self.tod_msecs == other.tod_msecs && self.tod_hours == other.tod_hours && self.tod_mins == other.tod_mins && self.tod_secs == other.tod_secs && self.tod_hunds == other.tod_hunds && self.tod_timezone == other.tod_timezone && self.tod_tinterval == other.tod_tinterval && self.tod_day == other.tod_day && self.tod_month == other.tod_month && self.tod_year == other.tod_year && self.tod_weekday == other.tod_weekday
     }
 }
 impl ::core::cmp::Eq for TIME_OF_DAY_INFO {}
@@ -15854,7 +16072,7 @@ unsafe impl ::windows::core::Abi for TRANSPORT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRANSPORT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORT_INFO>()) == 0 }
+        self.Type == other.Type && self.SkipCertificateCheck == other.SkipCertificateCheck
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15886,7 +16104,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_0 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_0>()) == 0 }
+        self.usri0_name == other.usri0_name
     }
 }
 impl ::core::cmp::Eq for USER_INFO_0 {}
@@ -15923,7 +16141,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1>()) == 0 }
+        self.usri1_name == other.usri1_name && self.usri1_password == other.usri1_password && self.usri1_password_age == other.usri1_password_age && self.usri1_priv == other.usri1_priv && self.usri1_home_dir == other.usri1_home_dir && self.usri1_comment == other.usri1_comment && self.usri1_flags == other.usri1_flags && self.usri1_script_path == other.usri1_script_path
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1 {}
@@ -15956,7 +16174,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_10 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_10>()) == 0 }
+        self.usri10_name == other.usri10_name && self.usri10_comment == other.usri10_comment && self.usri10_usr_comment == other.usri10_usr_comment && self.usri10_full_name == other.usri10_full_name
     }
 }
 impl ::core::cmp::Eq for USER_INFO_10 {}
@@ -15986,7 +16204,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1003 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1003 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1003>()) == 0 }
+        self.usri1003_password == other.usri1003_password
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1003 {}
@@ -16016,7 +16234,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1005 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1005 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1005>()) == 0 }
+        self.usri1005_priv == other.usri1005_priv
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1005 {}
@@ -16046,7 +16264,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1006 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1006 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1006>()) == 0 }
+        self.usri1006_home_dir == other.usri1006_home_dir
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1006 {}
@@ -16076,7 +16294,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1007 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1007 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1007>()) == 0 }
+        self.usri1007_comment == other.usri1007_comment
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1007 {}
@@ -16106,7 +16324,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1008 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1008 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1008>()) == 0 }
+        self.usri1008_flags == other.usri1008_flags
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1008 {}
@@ -16136,7 +16354,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1009 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1009 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1009>()) == 0 }
+        self.usri1009_script_path == other.usri1009_script_path
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1009 {}
@@ -16166,7 +16384,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1010 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1010 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1010>()) == 0 }
+        self.usri1010_auth_flags == other.usri1010_auth_flags
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1010 {}
@@ -16196,7 +16414,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1011 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1011 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1011>()) == 0 }
+        self.usri1011_full_name == other.usri1011_full_name
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1011 {}
@@ -16226,7 +16444,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1012 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1012 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1012>()) == 0 }
+        self.usri1012_usr_comment == other.usri1012_usr_comment
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1012 {}
@@ -16256,7 +16474,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1013 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1013 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1013>()) == 0 }
+        self.usri1013_parms == other.usri1013_parms
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1013 {}
@@ -16286,7 +16504,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1014 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1014 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1014>()) == 0 }
+        self.usri1014_workstations == other.usri1014_workstations
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1014 {}
@@ -16316,7 +16534,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1017 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1017 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1017>()) == 0 }
+        self.usri1017_acct_expires == other.usri1017_acct_expires
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1017 {}
@@ -16346,7 +16564,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1018 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1018 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1018>()) == 0 }
+        self.usri1018_max_storage == other.usri1018_max_storage
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1018 {}
@@ -16377,7 +16595,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1020 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1020 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1020>()) == 0 }
+        self.usri1020_units_per_week == other.usri1020_units_per_week && self.usri1020_logon_hours == other.usri1020_logon_hours
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1020 {}
@@ -16407,7 +16625,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1023 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1023 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1023>()) == 0 }
+        self.usri1023_logon_server == other.usri1023_logon_server
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1023 {}
@@ -16437,7 +16655,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1024 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1024 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1024>()) == 0 }
+        self.usri1024_country_code == other.usri1024_country_code
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1024 {}
@@ -16467,7 +16685,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1025 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1025 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1025>()) == 0 }
+        self.usri1025_code_page == other.usri1025_code_page
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1025 {}
@@ -16497,7 +16715,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1051 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1051 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1051>()) == 0 }
+        self.usri1051_primary_group_id == other.usri1051_primary_group_id
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1051 {}
@@ -16527,7 +16745,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1052 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1052 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1052>()) == 0 }
+        self.usri1052_profile == other.usri1052_profile
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1052 {}
@@ -16557,7 +16775,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_1053 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_1053 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_1053>()) == 0 }
+        self.usri1053_home_dir_drive == other.usri1053_home_dir_drive
     }
 }
 impl ::core::cmp::Eq for USER_INFO_1053 {}
@@ -16627,7 +16845,26 @@ unsafe impl ::windows::core::Abi for USER_INFO_11 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_11 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_11>()) == 0 }
+        self.usri11_name == other.usri11_name
+            && self.usri11_comment == other.usri11_comment
+            && self.usri11_usr_comment == other.usri11_usr_comment
+            && self.usri11_full_name == other.usri11_full_name
+            && self.usri11_priv == other.usri11_priv
+            && self.usri11_auth_flags == other.usri11_auth_flags
+            && self.usri11_password_age == other.usri11_password_age
+            && self.usri11_home_dir == other.usri11_home_dir
+            && self.usri11_parms == other.usri11_parms
+            && self.usri11_last_logon == other.usri11_last_logon
+            && self.usri11_last_logoff == other.usri11_last_logoff
+            && self.usri11_bad_pw_count == other.usri11_bad_pw_count
+            && self.usri11_num_logons == other.usri11_num_logons
+            && self.usri11_logon_server == other.usri11_logon_server
+            && self.usri11_country_code == other.usri11_country_code
+            && self.usri11_workstations == other.usri11_workstations
+            && self.usri11_max_storage == other.usri11_max_storage
+            && self.usri11_units_per_week == other.usri11_units_per_week
+            && self.usri11_logon_hours == other.usri11_logon_hours
+            && self.usri11_code_page == other.usri11_code_page
     }
 }
 impl ::core::cmp::Eq for USER_INFO_11 {}
@@ -16705,7 +16942,30 @@ unsafe impl ::windows::core::Abi for USER_INFO_2 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_2>()) == 0 }
+        self.usri2_name == other.usri2_name
+            && self.usri2_password == other.usri2_password
+            && self.usri2_password_age == other.usri2_password_age
+            && self.usri2_priv == other.usri2_priv
+            && self.usri2_home_dir == other.usri2_home_dir
+            && self.usri2_comment == other.usri2_comment
+            && self.usri2_flags == other.usri2_flags
+            && self.usri2_script_path == other.usri2_script_path
+            && self.usri2_auth_flags == other.usri2_auth_flags
+            && self.usri2_full_name == other.usri2_full_name
+            && self.usri2_usr_comment == other.usri2_usr_comment
+            && self.usri2_parms == other.usri2_parms
+            && self.usri2_workstations == other.usri2_workstations
+            && self.usri2_last_logon == other.usri2_last_logon
+            && self.usri2_last_logoff == other.usri2_last_logoff
+            && self.usri2_acct_expires == other.usri2_acct_expires
+            && self.usri2_max_storage == other.usri2_max_storage
+            && self.usri2_units_per_week == other.usri2_units_per_week
+            && self.usri2_logon_hours == other.usri2_logon_hours
+            && self.usri2_bad_pw_count == other.usri2_bad_pw_count
+            && self.usri2_num_logons == other.usri2_num_logons
+            && self.usri2_logon_server == other.usri2_logon_server
+            && self.usri2_country_code == other.usri2_country_code
+            && self.usri2_code_page == other.usri2_code_page
     }
 }
 impl ::core::cmp::Eq for USER_INFO_2 {}
@@ -16739,7 +16999,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_20 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_20 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_20>()) == 0 }
+        self.usri20_name == other.usri20_name && self.usri20_full_name == other.usri20_full_name && self.usri20_comment == other.usri20_comment && self.usri20_flags == other.usri20_flags && self.usri20_user_id == other.usri20_user_id
     }
 }
 impl ::core::cmp::Eq for USER_INFO_20 {}
@@ -16769,7 +17029,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_21 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_21 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_21>()) == 0 }
+        self.usri21_password == other.usri21_password
     }
 }
 impl ::core::cmp::Eq for USER_INFO_21 {}
@@ -16847,7 +17107,30 @@ unsafe impl ::windows::core::Abi for USER_INFO_22 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_22 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_22>()) == 0 }
+        self.usri22_name == other.usri22_name
+            && self.usri22_password == other.usri22_password
+            && self.usri22_password_age == other.usri22_password_age
+            && self.usri22_priv == other.usri22_priv
+            && self.usri22_home_dir == other.usri22_home_dir
+            && self.usri22_comment == other.usri22_comment
+            && self.usri22_flags == other.usri22_flags
+            && self.usri22_script_path == other.usri22_script_path
+            && self.usri22_auth_flags == other.usri22_auth_flags
+            && self.usri22_full_name == other.usri22_full_name
+            && self.usri22_usr_comment == other.usri22_usr_comment
+            && self.usri22_parms == other.usri22_parms
+            && self.usri22_workstations == other.usri22_workstations
+            && self.usri22_last_logon == other.usri22_last_logon
+            && self.usri22_last_logoff == other.usri22_last_logoff
+            && self.usri22_acct_expires == other.usri22_acct_expires
+            && self.usri22_max_storage == other.usri22_max_storage
+            && self.usri22_units_per_week == other.usri22_units_per_week
+            && self.usri22_logon_hours == other.usri22_logon_hours
+            && self.usri22_bad_pw_count == other.usri22_bad_pw_count
+            && self.usri22_num_logons == other.usri22_num_logons
+            && self.usri22_logon_server == other.usri22_logon_server
+            && self.usri22_country_code == other.usri22_country_code
+            && self.usri22_code_page == other.usri22_code_page
     }
 }
 impl ::core::cmp::Eq for USER_INFO_22 {}
@@ -16887,7 +17170,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_23 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USER_INFO_23 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_23>()) == 0 }
+        self.usri23_name == other.usri23_name && self.usri23_full_name == other.usri23_full_name && self.usri23_comment == other.usri23_comment && self.usri23_flags == other.usri23_flags && self.usri23_user_sid == other.usri23_user_sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16929,7 +17212,7 @@ unsafe impl ::windows::core::Abi for USER_INFO_24 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USER_INFO_24 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_24>()) == 0 }
+        self.usri24_internet_identity == other.usri24_internet_identity && self.usri24_flags == other.usri24_flags && self.usri24_internet_provider_name == other.usri24_internet_provider_name && self.usri24_internet_principal_name == other.usri24_internet_principal_name && self.usri24_user_sid == other.usri24_user_sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17019,7 +17302,35 @@ unsafe impl ::windows::core::Abi for USER_INFO_3 {
 }
 impl ::core::cmp::PartialEq for USER_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_3>()) == 0 }
+        self.usri3_name == other.usri3_name
+            && self.usri3_password == other.usri3_password
+            && self.usri3_password_age == other.usri3_password_age
+            && self.usri3_priv == other.usri3_priv
+            && self.usri3_home_dir == other.usri3_home_dir
+            && self.usri3_comment == other.usri3_comment
+            && self.usri3_flags == other.usri3_flags
+            && self.usri3_script_path == other.usri3_script_path
+            && self.usri3_auth_flags == other.usri3_auth_flags
+            && self.usri3_full_name == other.usri3_full_name
+            && self.usri3_usr_comment == other.usri3_usr_comment
+            && self.usri3_parms == other.usri3_parms
+            && self.usri3_workstations == other.usri3_workstations
+            && self.usri3_last_logon == other.usri3_last_logon
+            && self.usri3_last_logoff == other.usri3_last_logoff
+            && self.usri3_acct_expires == other.usri3_acct_expires
+            && self.usri3_max_storage == other.usri3_max_storage
+            && self.usri3_units_per_week == other.usri3_units_per_week
+            && self.usri3_logon_hours == other.usri3_logon_hours
+            && self.usri3_bad_pw_count == other.usri3_bad_pw_count
+            && self.usri3_num_logons == other.usri3_num_logons
+            && self.usri3_logon_server == other.usri3_logon_server
+            && self.usri3_country_code == other.usri3_country_code
+            && self.usri3_code_page == other.usri3_code_page
+            && self.usri3_user_id == other.usri3_user_id
+            && self.usri3_primary_group_id == other.usri3_primary_group_id
+            && self.usri3_profile == other.usri3_profile
+            && self.usri3_home_dir_drive == other.usri3_home_dir_drive
+            && self.usri3_password_expired == other.usri3_password_expired
     }
 }
 impl ::core::cmp::Eq for USER_INFO_3 {}
@@ -17113,7 +17424,35 @@ unsafe impl ::windows::core::Abi for USER_INFO_4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USER_INFO_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_INFO_4>()) == 0 }
+        self.usri4_name == other.usri4_name
+            && self.usri4_password == other.usri4_password
+            && self.usri4_password_age == other.usri4_password_age
+            && self.usri4_priv == other.usri4_priv
+            && self.usri4_home_dir == other.usri4_home_dir
+            && self.usri4_comment == other.usri4_comment
+            && self.usri4_flags == other.usri4_flags
+            && self.usri4_script_path == other.usri4_script_path
+            && self.usri4_auth_flags == other.usri4_auth_flags
+            && self.usri4_full_name == other.usri4_full_name
+            && self.usri4_usr_comment == other.usri4_usr_comment
+            && self.usri4_parms == other.usri4_parms
+            && self.usri4_workstations == other.usri4_workstations
+            && self.usri4_last_logon == other.usri4_last_logon
+            && self.usri4_last_logoff == other.usri4_last_logoff
+            && self.usri4_acct_expires == other.usri4_acct_expires
+            && self.usri4_max_storage == other.usri4_max_storage
+            && self.usri4_units_per_week == other.usri4_units_per_week
+            && self.usri4_logon_hours == other.usri4_logon_hours
+            && self.usri4_bad_pw_count == other.usri4_bad_pw_count
+            && self.usri4_num_logons == other.usri4_num_logons
+            && self.usri4_logon_server == other.usri4_logon_server
+            && self.usri4_country_code == other.usri4_country_code
+            && self.usri4_code_page == other.usri4_code_page
+            && self.usri4_user_sid == other.usri4_user_sid
+            && self.usri4_primary_group_id == other.usri4_primary_group_id
+            && self.usri4_profile == other.usri4_profile
+            && self.usri4_home_dir_drive == other.usri4_home_dir_drive
+            && self.usri4_password_expired == other.usri4_password_expired
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17149,7 +17488,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_0>()) == 0 }
+        self.usrmod0_min_passwd_len == other.usrmod0_min_passwd_len && self.usrmod0_max_passwd_age == other.usrmod0_max_passwd_age && self.usrmod0_min_passwd_age == other.usrmod0_min_passwd_age && self.usrmod0_force_logoff == other.usrmod0_force_logoff && self.usrmod0_password_hist_len == other.usrmod0_password_hist_len
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_0 {}
@@ -17180,7 +17519,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1>()) == 0 }
+        self.usrmod1_role == other.usrmod1_role && self.usrmod1_primary == other.usrmod1_primary
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1 {}
@@ -17210,7 +17549,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1001 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1001 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1001>()) == 0 }
+        self.usrmod1001_min_passwd_len == other.usrmod1001_min_passwd_len
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1001 {}
@@ -17240,7 +17579,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1002 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1002 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1002>()) == 0 }
+        self.usrmod1002_max_passwd_age == other.usrmod1002_max_passwd_age
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1002 {}
@@ -17270,7 +17609,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1003 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1003 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1003>()) == 0 }
+        self.usrmod1003_min_passwd_age == other.usrmod1003_min_passwd_age
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1003 {}
@@ -17300,7 +17639,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1004 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1004 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1004>()) == 0 }
+        self.usrmod1004_force_logoff == other.usrmod1004_force_logoff
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1004 {}
@@ -17330,7 +17669,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1005 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1005 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1005>()) == 0 }
+        self.usrmod1005_password_hist_len == other.usrmod1005_password_hist_len
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1005 {}
@@ -17360,7 +17699,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1006 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1006 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1006>()) == 0 }
+        self.usrmod1006_role == other.usrmod1006_role
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1006 {}
@@ -17390,7 +17729,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_1007 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_1007 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_1007>()) == 0 }
+        self.usrmod1007_primary == other.usrmod1007_primary
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_1007 {}
@@ -17427,7 +17766,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_2>()) == 0 }
+        self.usrmod2_domain_name == other.usrmod2_domain_name && self.usrmod2_domain_id == other.usrmod2_domain_id
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17461,7 +17800,7 @@ unsafe impl ::windows::core::Abi for USER_MODALS_INFO_3 {
 }
 impl ::core::cmp::PartialEq for USER_MODALS_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MODALS_INFO_3>()) == 0 }
+        self.usrmod3_lockout_duration == other.usrmod3_lockout_duration && self.usrmod3_lockout_observation_window == other.usrmod3_lockout_observation_window && self.usrmod3_lockout_threshold == other.usrmod3_lockout_threshold
     }
 }
 impl ::core::cmp::Eq for USER_MODALS_INFO_3 {}
@@ -17492,7 +17831,7 @@ unsafe impl ::windows::core::Abi for USER_OTHER_INFO {
 }
 impl ::core::cmp::PartialEq for USER_OTHER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_OTHER_INFO>()) == 0 }
+        self.alrtus_errcode == other.alrtus_errcode && self.alrtus_numstrings == other.alrtus_numstrings
     }
 }
 impl ::core::cmp::Eq for USER_OTHER_INFO {}
@@ -17523,7 +17862,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_0>()) == 0 }
+        self.ui0_local == other.ui0_local && self.ui0_remote == other.ui0_remote
     }
 }
 impl ::core::cmp::Eq for USE_INFO_0 {}
@@ -17559,7 +17898,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_1>()) == 0 }
+        self.ui1_local == other.ui1_local && self.ui1_remote == other.ui1_remote && self.ui1_password == other.ui1_password && self.ui1_status == other.ui1_status && self.ui1_asg_type == other.ui1_asg_type && self.ui1_refcount == other.ui1_refcount && self.ui1_usecount == other.ui1_usecount
     }
 }
 impl ::core::cmp::Eq for USE_INFO_1 {}
@@ -17597,7 +17936,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_2>()) == 0 }
+        self.ui2_local == other.ui2_local && self.ui2_remote == other.ui2_remote && self.ui2_password == other.ui2_password && self.ui2_status == other.ui2_status && self.ui2_asg_type == other.ui2_asg_type && self.ui2_refcount == other.ui2_refcount && self.ui2_usecount == other.ui2_usecount && self.ui2_username == other.ui2_username && self.ui2_domainname == other.ui2_domainname
     }
 }
 impl ::core::cmp::Eq for USE_INFO_2 {}
@@ -17628,7 +17967,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_3 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_3>()) == 0 }
+        self.ui3_ui2 == other.ui3_ui2 && self.ui3_flags == other.ui3_flags
     }
 }
 impl ::core::cmp::Eq for USE_INFO_3 {}
@@ -17660,7 +17999,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_4 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_4>()) == 0 }
+        self.ui4_ui3 == other.ui4_ui3 && self.ui4_auth_identity_length == other.ui4_auth_identity_length && self.ui4_auth_identity == other.ui4_auth_identity
     }
 }
 impl ::core::cmp::Eq for USE_INFO_4 {}
@@ -17696,7 +18035,7 @@ unsafe impl ::windows::core::Abi for USE_INFO_5 {
 }
 impl ::core::cmp::PartialEq for USE_INFO_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_INFO_5>()) == 0 }
+        self.ui4_ui3 == other.ui4_ui3 && self.ui4_auth_identity_length == other.ui4_auth_identity_length && self.ui4_auth_identity == other.ui4_auth_identity && self.ui5_security_descriptor_length == other.ui5_security_descriptor_length && self.ui5_security_descriptor == other.ui5_security_descriptor && self.ui5_use_options_length == other.ui5_use_options_length && self.ui5_use_options == other.ui5_use_options
     }
 }
 impl ::core::cmp::Eq for USE_INFO_5 {}
@@ -17728,7 +18067,7 @@ unsafe impl ::windows::core::Abi for USE_OPTION_DEFERRED_CONNECTION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for USE_OPTION_DEFERRED_CONNECTION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_OPTION_DEFERRED_CONNECTION_PARAMETERS>()) == 0 }
+        self.Tag == other.Tag && self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for USE_OPTION_DEFERRED_CONNECTION_PARAMETERS {}
@@ -17760,7 +18099,7 @@ unsafe impl ::windows::core::Abi for USE_OPTION_GENERIC {
 }
 impl ::core::cmp::PartialEq for USE_OPTION_GENERIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_OPTION_GENERIC>()) == 0 }
+        self.Tag == other.Tag && self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for USE_OPTION_GENERIC {}
@@ -17792,7 +18131,7 @@ unsafe impl ::windows::core::Abi for USE_OPTION_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for USE_OPTION_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_OPTION_PROPERTIES>()) == 0 }
+        self.Tag == other.Tag && self.pInfo == other.pInfo && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for USE_OPTION_PROPERTIES {}
@@ -17824,7 +18163,7 @@ unsafe impl ::windows::core::Abi for USE_OPTION_TRANSPORT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for USE_OPTION_TRANSPORT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USE_OPTION_TRANSPORT_PARAMETERS>()) == 0 }
+        self.Tag == other.Tag && self.Length == other.Length && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for USE_OPTION_TRANSPORT_PARAMETERS {}
@@ -17858,7 +18197,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_100 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_100 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_100>()) == 0 }
+        self.wki100_platform_id == other.wki100_platform_id && self.wki100_computername == other.wki100_computername && self.wki100_langroup == other.wki100_langroup && self.wki100_ver_major == other.wki100_ver_major && self.wki100_ver_minor == other.wki100_ver_minor
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_100 {}
@@ -17893,7 +18232,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_101 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_101 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_101>()) == 0 }
+        self.wki101_platform_id == other.wki101_platform_id && self.wki101_computername == other.wki101_computername && self.wki101_langroup == other.wki101_langroup && self.wki101_ver_major == other.wki101_ver_major && self.wki101_ver_minor == other.wki101_ver_minor && self.wki101_lanroot == other.wki101_lanroot
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_101 {}
@@ -17923,7 +18262,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1010 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1010 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1010>()) == 0 }
+        self.wki1010_char_wait == other.wki1010_char_wait
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1010 {}
@@ -17953,7 +18292,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1011 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1011 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1011>()) == 0 }
+        self.wki1011_collection_time == other.wki1011_collection_time
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1011 {}
@@ -17983,7 +18322,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1012 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1012 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1012>()) == 0 }
+        self.wki1012_maximum_collection_count == other.wki1012_maximum_collection_count
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1012 {}
@@ -18013,7 +18352,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1013 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1013 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1013>()) == 0 }
+        self.wki1013_keep_conn == other.wki1013_keep_conn
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1013 {}
@@ -18043,7 +18382,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1018 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1018 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1018>()) == 0 }
+        self.wki1018_sess_timeout == other.wki1018_sess_timeout
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1018 {}
@@ -18079,7 +18418,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_102 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_102 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_102>()) == 0 }
+        self.wki102_platform_id == other.wki102_platform_id && self.wki102_computername == other.wki102_computername && self.wki102_langroup == other.wki102_langroup && self.wki102_ver_major == other.wki102_ver_major && self.wki102_ver_minor == other.wki102_ver_minor && self.wki102_lanroot == other.wki102_lanroot && self.wki102_logged_on_users == other.wki102_logged_on_users
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_102 {}
@@ -18109,7 +18448,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1023 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1023 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1023>()) == 0 }
+        self.wki1023_siz_char_buf == other.wki1023_siz_char_buf
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1023 {}
@@ -18139,7 +18478,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1027 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1027 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1027>()) == 0 }
+        self.wki1027_errlog_sz == other.wki1027_errlog_sz
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1027 {}
@@ -18169,7 +18508,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1028 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1028 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1028>()) == 0 }
+        self.wki1028_print_buf_time == other.wki1028_print_buf_time
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1028 {}
@@ -18199,7 +18538,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1032 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1032 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1032>()) == 0 }
+        self.wki1032_wrk_heuristics == other.wki1032_wrk_heuristics
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1032 {}
@@ -18229,7 +18568,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1033 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1033 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1033>()) == 0 }
+        self.wki1033_max_threads == other.wki1033_max_threads
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1033 {}
@@ -18259,7 +18598,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1041 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1041 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1041>()) == 0 }
+        self.wki1041_lock_quota == other.wki1041_lock_quota
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1041 {}
@@ -18289,7 +18628,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1042 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1042 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1042>()) == 0 }
+        self.wki1042_lock_increment == other.wki1042_lock_increment
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1042 {}
@@ -18319,7 +18658,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1043 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1043 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1043>()) == 0 }
+        self.wki1043_lock_maximum == other.wki1043_lock_maximum
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1043 {}
@@ -18349,7 +18688,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1044 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1044 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1044>()) == 0 }
+        self.wki1044_pipe_increment == other.wki1044_pipe_increment
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1044 {}
@@ -18379,7 +18718,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1045 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1045 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1045>()) == 0 }
+        self.wki1045_pipe_maximum == other.wki1045_pipe_maximum
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1045 {}
@@ -18409,7 +18748,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1046 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1046 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1046>()) == 0 }
+        self.wki1046_dormant_file_limit == other.wki1046_dormant_file_limit
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1046 {}
@@ -18439,7 +18778,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1047 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1047 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1047>()) == 0 }
+        self.wki1047_cache_file_timeout == other.wki1047_cache_file_timeout
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1047 {}
@@ -18475,7 +18814,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1048 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1048 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1048>()) == 0 }
+        self.wki1048_use_opportunistic_locking == other.wki1048_use_opportunistic_locking
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18513,7 +18852,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1049 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1049 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1049>()) == 0 }
+        self.wki1049_use_unlock_behind == other.wki1049_use_unlock_behind
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18551,7 +18890,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1050 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1050 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1050>()) == 0 }
+        self.wki1050_use_close_behind == other.wki1050_use_close_behind
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18589,7 +18928,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1051 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1051 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1051>()) == 0 }
+        self.wki1051_buf_named_pipes == other.wki1051_buf_named_pipes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18627,7 +18966,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1052 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1052 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1052>()) == 0 }
+        self.wki1052_use_lock_read_unlock == other.wki1052_use_lock_read_unlock
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18665,7 +19004,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1053 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1053 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1053>()) == 0 }
+        self.wki1053_utilize_nt_caching == other.wki1053_utilize_nt_caching
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18703,7 +19042,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1054 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1054 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1054>()) == 0 }
+        self.wki1054_use_raw_read == other.wki1054_use_raw_read
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18741,7 +19080,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1055 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1055 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1055>()) == 0 }
+        self.wki1055_use_raw_write == other.wki1055_use_raw_write
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18779,7 +19118,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1056 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1056 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1056>()) == 0 }
+        self.wki1056_use_write_raw_data == other.wki1056_use_write_raw_data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18817,7 +19156,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1057 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1057 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1057>()) == 0 }
+        self.wki1057_use_encryption == other.wki1057_use_encryption
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18855,7 +19194,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1058 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1058 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1058>()) == 0 }
+        self.wki1058_buf_files_deny_write == other.wki1058_buf_files_deny_write
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18893,7 +19232,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1059 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1059 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1059>()) == 0 }
+        self.wki1059_buf_read_only_files == other.wki1059_buf_read_only_files
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18931,7 +19270,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1060 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1060 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1060>()) == 0 }
+        self.wki1060_force_core_create_mode == other.wki1060_force_core_create_mode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18969,7 +19308,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1061 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_1061 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1061>()) == 0 }
+        self.wki1061_use_512_byte_max_transfer == other.wki1061_use_512_byte_max_transfer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19001,7 +19340,7 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_1062 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_1062 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_1062>()) == 0 }
+        self.wki1062_read_ahead_throughput == other.wki1062_read_ahead_throughput
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_1062 {}
@@ -19071,7 +19410,26 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_302 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_302 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_302>()) == 0 }
+        self.wki302_char_wait == other.wki302_char_wait
+            && self.wki302_collection_time == other.wki302_collection_time
+            && self.wki302_maximum_collection_count == other.wki302_maximum_collection_count
+            && self.wki302_keep_conn == other.wki302_keep_conn
+            && self.wki302_keep_search == other.wki302_keep_search
+            && self.wki302_max_cmds == other.wki302_max_cmds
+            && self.wki302_num_work_buf == other.wki302_num_work_buf
+            && self.wki302_siz_work_buf == other.wki302_siz_work_buf
+            && self.wki302_max_wrk_cache == other.wki302_max_wrk_cache
+            && self.wki302_sess_timeout == other.wki302_sess_timeout
+            && self.wki302_siz_error == other.wki302_siz_error
+            && self.wki302_num_alerts == other.wki302_num_alerts
+            && self.wki302_num_services == other.wki302_num_services
+            && self.wki302_errlog_sz == other.wki302_errlog_sz
+            && self.wki302_print_buf_time == other.wki302_print_buf_time
+            && self.wki302_num_char_buf == other.wki302_num_char_buf
+            && self.wki302_siz_char_buf == other.wki302_siz_char_buf
+            && self.wki302_wrk_heuristics == other.wki302_wrk_heuristics
+            && self.wki302_mailslots == other.wki302_mailslots
+            && self.wki302_num_dgram_buf == other.wki302_num_dgram_buf
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_302 {}
@@ -19143,7 +19501,27 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_402 {
 }
 impl ::core::cmp::PartialEq for WKSTA_INFO_402 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_402>()) == 0 }
+        self.wki402_char_wait == other.wki402_char_wait
+            && self.wki402_collection_time == other.wki402_collection_time
+            && self.wki402_maximum_collection_count == other.wki402_maximum_collection_count
+            && self.wki402_keep_conn == other.wki402_keep_conn
+            && self.wki402_keep_search == other.wki402_keep_search
+            && self.wki402_max_cmds == other.wki402_max_cmds
+            && self.wki402_num_work_buf == other.wki402_num_work_buf
+            && self.wki402_siz_work_buf == other.wki402_siz_work_buf
+            && self.wki402_max_wrk_cache == other.wki402_max_wrk_cache
+            && self.wki402_sess_timeout == other.wki402_sess_timeout
+            && self.wki402_siz_error == other.wki402_siz_error
+            && self.wki402_num_alerts == other.wki402_num_alerts
+            && self.wki402_num_services == other.wki402_num_services
+            && self.wki402_errlog_sz == other.wki402_errlog_sz
+            && self.wki402_print_buf_time == other.wki402_print_buf_time
+            && self.wki402_num_char_buf == other.wki402_num_char_buf
+            && self.wki402_siz_char_buf == other.wki402_siz_char_buf
+            && self.wki402_wrk_heuristics == other.wki402_wrk_heuristics
+            && self.wki402_mailslots == other.wki402_mailslots
+            && self.wki402_num_dgram_buf == other.wki402_num_dgram_buf
+            && self.wki402_max_threads == other.wki402_max_threads
     }
 }
 impl ::core::cmp::Eq for WKSTA_INFO_402 {}
@@ -19249,7 +19627,41 @@ unsafe impl ::windows::core::Abi for WKSTA_INFO_502 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_INFO_502 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_INFO_502>()) == 0 }
+        self.wki502_char_wait == other.wki502_char_wait
+            && self.wki502_collection_time == other.wki502_collection_time
+            && self.wki502_maximum_collection_count == other.wki502_maximum_collection_count
+            && self.wki502_keep_conn == other.wki502_keep_conn
+            && self.wki502_max_cmds == other.wki502_max_cmds
+            && self.wki502_sess_timeout == other.wki502_sess_timeout
+            && self.wki502_siz_char_buf == other.wki502_siz_char_buf
+            && self.wki502_max_threads == other.wki502_max_threads
+            && self.wki502_lock_quota == other.wki502_lock_quota
+            && self.wki502_lock_increment == other.wki502_lock_increment
+            && self.wki502_lock_maximum == other.wki502_lock_maximum
+            && self.wki502_pipe_increment == other.wki502_pipe_increment
+            && self.wki502_pipe_maximum == other.wki502_pipe_maximum
+            && self.wki502_cache_file_timeout == other.wki502_cache_file_timeout
+            && self.wki502_dormant_file_limit == other.wki502_dormant_file_limit
+            && self.wki502_read_ahead_throughput == other.wki502_read_ahead_throughput
+            && self.wki502_num_mailslot_buffers == other.wki502_num_mailslot_buffers
+            && self.wki502_num_srv_announce_buffers == other.wki502_num_srv_announce_buffers
+            && self.wki502_max_illegal_datagram_events == other.wki502_max_illegal_datagram_events
+            && self.wki502_illegal_datagram_event_reset_frequency == other.wki502_illegal_datagram_event_reset_frequency
+            && self.wki502_log_election_packets == other.wki502_log_election_packets
+            && self.wki502_use_opportunistic_locking == other.wki502_use_opportunistic_locking
+            && self.wki502_use_unlock_behind == other.wki502_use_unlock_behind
+            && self.wki502_use_close_behind == other.wki502_use_close_behind
+            && self.wki502_buf_named_pipes == other.wki502_buf_named_pipes
+            && self.wki502_use_lock_read_unlock == other.wki502_use_lock_read_unlock
+            && self.wki502_utilize_nt_caching == other.wki502_utilize_nt_caching
+            && self.wki502_use_raw_read == other.wki502_use_raw_read
+            && self.wki502_use_raw_write == other.wki502_use_raw_write
+            && self.wki502_use_write_raw_data == other.wki502_use_write_raw_data
+            && self.wki502_use_encryption == other.wki502_use_encryption
+            && self.wki502_buf_files_deny_write == other.wki502_buf_files_deny_write
+            && self.wki502_buf_read_only_files == other.wki502_buf_read_only_files
+            && self.wki502_force_core_create_mode == other.wki502_force_core_create_mode
+            && self.wki502_use_512_byte_max_transfer == other.wki502_use_512_byte_max_transfer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19291,7 +19703,7 @@ unsafe impl ::windows::core::Abi for WKSTA_TRANSPORT_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WKSTA_TRANSPORT_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_TRANSPORT_INFO_0>()) == 0 }
+        self.wkti0_quality_of_service == other.wkti0_quality_of_service && self.wkti0_number_of_vcs == other.wkti0_number_of_vcs && self.wkti0_transport_name == other.wkti0_transport_name && self.wkti0_transport_address == other.wkti0_transport_address && self.wkti0_wan_ish == other.wkti0_wan_ish
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19323,7 +19735,7 @@ unsafe impl ::windows::core::Abi for WKSTA_USER_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WKSTA_USER_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_USER_INFO_0>()) == 0 }
+        self.wkui0_username == other.wkui0_username
     }
 }
 impl ::core::cmp::Eq for WKSTA_USER_INFO_0 {}
@@ -19356,7 +19768,7 @@ unsafe impl ::windows::core::Abi for WKSTA_USER_INFO_1 {
 }
 impl ::core::cmp::PartialEq for WKSTA_USER_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_USER_INFO_1>()) == 0 }
+        self.wkui1_username == other.wkui1_username && self.wkui1_logon_domain == other.wkui1_logon_domain && self.wkui1_oth_domains == other.wkui1_oth_domains && self.wkui1_logon_server == other.wkui1_logon_server
     }
 }
 impl ::core::cmp::Eq for WKSTA_USER_INFO_1 {}
@@ -19386,7 +19798,7 @@ unsafe impl ::windows::core::Abi for WKSTA_USER_INFO_1101 {
 }
 impl ::core::cmp::PartialEq for WKSTA_USER_INFO_1101 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WKSTA_USER_INFO_1101>()) == 0 }
+        self.wkui1101_oth_domains == other.wkui1101_oth_domains
     }
 }
 impl ::core::cmp::Eq for WKSTA_USER_INFO_1101 {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetShell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetShell/mod.rs
@@ -292,21 +292,13 @@ impl ::core::clone::Clone for CMD_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CMD_ENTRY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CMD_ENTRY").field("pwszCmdToken", &self.pwszCmdToken).field("pfnCmdHandler", &self.pfnCmdHandler.map(|f| f as usize)).field("dwShortCmdHelpToken", &self.dwShortCmdHelpToken).field("dwCmdHlpToken", &self.dwCmdHlpToken).field("dwFlags", &self.dwFlags).field("pOsVersionCheck", &self.pOsVersionCheck.map(|f| f as usize)).finish()
+        f.debug_struct("CMD_ENTRY").field("pwszCmdToken", &self.pwszCmdToken).field("dwShortCmdHelpToken", &self.dwShortCmdHelpToken).field("dwCmdHlpToken", &self.dwCmdHlpToken).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CMD_ENTRY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMD_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMD_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMD_ENTRY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMD_ENTRY {
     fn default() -> Self {
@@ -335,21 +327,13 @@ impl ::core::clone::Clone for CMD_GROUP_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CMD_GROUP_ENTRY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CMD_GROUP_ENTRY").field("pwszCmdGroupToken", &self.pwszCmdGroupToken).field("dwShortCmdHelpToken", &self.dwShortCmdHelpToken).field("ulCmdGroupSize", &self.ulCmdGroupSize).field("dwFlags", &self.dwFlags).field("pCmdGroup", &self.pCmdGroup).field("pOsVersionCheck", &self.pOsVersionCheck.map(|f| f as usize)).finish()
+        f.debug_struct("CMD_GROUP_ENTRY").field("pwszCmdGroupToken", &self.pwszCmdGroupToken).field("dwShortCmdHelpToken", &self.dwShortCmdHelpToken).field("ulCmdGroupSize", &self.ulCmdGroupSize).field("dwFlags", &self.dwFlags).field("pCmdGroup", &self.pCmdGroup).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CMD_GROUP_ENTRY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMD_GROUP_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMD_GROUP_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMD_GROUP_ENTRY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMD_GROUP_ENTRY {
     fn default() -> Self {
@@ -388,14 +372,6 @@ unsafe impl ::windows::core::Abi for NS_CONTEXT_ATTRIBUTES {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NS_CONTEXT_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_CONTEXT_ATTRIBUTES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NS_CONTEXT_ATTRIBUTES {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NS_CONTEXT_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -420,14 +396,6 @@ impl ::core::clone::Clone for NS_CONTEXT_ATTRIBUTES_0 {
 unsafe impl ::windows::core::Abi for NS_CONTEXT_ATTRIBUTES_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NS_CONTEXT_ATTRIBUTES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_CONTEXT_ATTRIBUTES_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NS_CONTEXT_ATTRIBUTES_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NS_CONTEXT_ATTRIBUTES_0 {
     fn default() -> Self {
@@ -462,7 +430,7 @@ unsafe impl ::windows::core::Abi for NS_CONTEXT_ATTRIBUTES_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NS_CONTEXT_ATTRIBUTES_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_CONTEXT_ATTRIBUTES_0_0>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -490,12 +458,6 @@ impl ::core::clone::Clone for NS_HELPER_ATTRIBUTES {
 unsafe impl ::windows::core::Abi for NS_HELPER_ATTRIBUTES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NS_HELPER_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_HELPER_ATTRIBUTES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NS_HELPER_ATTRIBUTES {}
 impl ::core::default::Default for NS_HELPER_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -516,12 +478,6 @@ impl ::core::clone::Clone for NS_HELPER_ATTRIBUTES_0 {
 unsafe impl ::windows::core::Abi for NS_HELPER_ATTRIBUTES_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NS_HELPER_ATTRIBUTES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_HELPER_ATTRIBUTES_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NS_HELPER_ATTRIBUTES_0 {}
 impl ::core::default::Default for NS_HELPER_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -549,7 +505,7 @@ unsafe impl ::windows::core::Abi for NS_HELPER_ATTRIBUTES_0_0 {
 }
 impl ::core::cmp::PartialEq for NS_HELPER_ATTRIBUTES_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_HELPER_ATTRIBUTES_0_0>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for NS_HELPER_ATTRIBUTES_0_0 {}
@@ -587,7 +543,7 @@ unsafe impl ::windows::core::Abi for TAG_TYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAG_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAG_TYPE>()) == 0 }
+        self.pwszTag == other.pwszTag && self.dwRequired == other.dwRequired && self.bPresent == other.bPresent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -620,7 +576,7 @@ unsafe impl ::windows::core::Abi for TOKEN_VALUE {
 }
 impl ::core::cmp::PartialEq for TOKEN_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_VALUE>()) == 0 }
+        self.pwszToken == other.pwszToken && self.dwValue == other.dwValue
     }
 }
 impl ::core::cmp::Eq for TOKEN_VALUE {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
@@ -815,7 +815,7 @@ unsafe impl ::windows::core::Abi for DIAG_SOCKADDR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIAG_SOCKADDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAG_SOCKADDR>()) == 0 }
+        self.family == other.family && self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -848,7 +848,7 @@ unsafe impl ::windows::core::Abi for DiagnosticsInfo {
 }
 impl ::core::cmp::PartialEq for DiagnosticsInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DiagnosticsInfo>()) == 0 }
+        self.cost == other.cost && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for DiagnosticsInfo {}
@@ -877,14 +877,6 @@ impl ::core::clone::Clone for HELPER_ATTRIBUTE {
 unsafe impl ::windows::core::Abi for HELPER_ATTRIBUTE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HELPER_ATTRIBUTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HELPER_ATTRIBUTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HELPER_ATTRIBUTE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HELPER_ATTRIBUTE {
     fn default() -> Self {
@@ -923,14 +915,6 @@ unsafe impl ::windows::core::Abi for HELPER_ATTRIBUTE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HELPER_ATTRIBUTE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HELPER_ATTRIBUTE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HELPER_ATTRIBUTE_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HELPER_ATTRIBUTE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -966,7 +950,7 @@ unsafe impl ::windows::core::Abi for HYPOTHESIS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HYPOTHESIS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYPOTHESIS>()) == 0 }
+        self.pwszClassName == other.pwszClassName && self.pwszDescription == other.pwszDescription && self.celt == other.celt && self.rgAttributes == other.rgAttributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -999,7 +983,7 @@ unsafe impl ::windows::core::Abi for HelperAttributeInfo {
 }
 impl ::core::cmp::PartialEq for HelperAttributeInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HelperAttributeInfo>()) == 0 }
+        self.pwszName == other.pwszName && self.r#type == other.r#type
     }
 }
 impl ::core::cmp::Eq for HelperAttributeInfo {}
@@ -1036,7 +1020,7 @@ unsafe impl ::windows::core::Abi for HypothesisResult {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HypothesisResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HypothesisResult>()) == 0 }
+        self.hypothesis == other.hypothesis && self.pathStatus == other.pathStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1075,7 +1059,7 @@ unsafe impl ::windows::core::Abi for LIFE_TIME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LIFE_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIFE_TIME>()) == 0 }
+        self.startTime == other.startTime && self.endTime == other.endTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1108,7 +1092,7 @@ unsafe impl ::windows::core::Abi for OCTET_STRING {
 }
 impl ::core::cmp::PartialEq for OCTET_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCTET_STRING>()) == 0 }
+        self.dwLength == other.dwLength && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for OCTET_STRING {}
@@ -1140,12 +1124,6 @@ impl ::core::clone::Clone for RepairInfo {
 unsafe impl ::windows::core::Abi for RepairInfo {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RepairInfo {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RepairInfo>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RepairInfo {}
 impl ::core::default::Default for RepairInfo {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1166,12 +1144,6 @@ impl ::core::clone::Clone for RepairInfoEx {
 unsafe impl ::windows::core::Abi for RepairInfoEx {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RepairInfoEx {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RepairInfoEx>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RepairInfoEx {}
 impl ::core::default::Default for RepairInfoEx {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1203,7 +1175,7 @@ unsafe impl ::windows::core::Abi for RootCauseInfo {
 }
 impl ::core::cmp::PartialEq for RootCauseInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RootCauseInfo>()) == 0 }
+        self.pwszDescription == other.pwszDescription && self.rootCauseID == other.rootCauseID && self.rootCauseFlags == other.rootCauseFlags && self.networkInterfaceID == other.networkInterfaceID && self.pRepairs == other.pRepairs && self.repairCount == other.repairCount
     }
 }
 impl ::core::cmp::Eq for RootCauseInfo {}
@@ -1237,7 +1209,7 @@ unsafe impl ::windows::core::Abi for ShellCommandInfo {
 }
 impl ::core::cmp::PartialEq for ShellCommandInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ShellCommandInfo>()) == 0 }
+        self.pwszOperation == other.pwszOperation && self.pwszFile == other.pwszFile && self.pwszParameters == other.pwszParameters && self.pwszDirectory == other.pwszDirectory && self.nShowCmd == other.nShowCmd
     }
 }
 impl ::core::cmp::Eq for ShellCommandInfo {}
@@ -1261,12 +1233,6 @@ impl ::core::clone::Clone for UiInfo {
 unsafe impl ::windows::core::Abi for UiInfo {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UiInfo {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiInfo>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UiInfo {}
 impl ::core::default::Default for UiInfo {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1289,12 +1255,6 @@ impl ::core::clone::Clone for UiInfo_0 {
 unsafe impl ::windows::core::Abi for UiInfo_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UiInfo_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiInfo_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UiInfo_0 {}
 impl ::core::default::Default for UiInfo_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
@@ -2926,12 +2926,6 @@ impl ::core::clone::Clone for RADIUS_ATTRIBUTE {
 unsafe impl ::windows::core::Abi for RADIUS_ATTRIBUTE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RADIUS_ATTRIBUTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RADIUS_ATTRIBUTE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RADIUS_ATTRIBUTE {}
 impl ::core::default::Default for RADIUS_ATTRIBUTE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2952,12 +2946,6 @@ impl ::core::clone::Clone for RADIUS_ATTRIBUTE_0 {
 unsafe impl ::windows::core::Abi for RADIUS_ATTRIBUTE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RADIUS_ATTRIBUTE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RADIUS_ATTRIBUTE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RADIUS_ATTRIBUTE_0 {}
 impl ::core::default::Default for RADIUS_ATTRIBUTE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2990,7 +2978,7 @@ unsafe impl ::windows::core::Abi for RADIUS_ATTRIBUTE_ARRAY {
 }
 impl ::core::cmp::PartialEq for RADIUS_ATTRIBUTE_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RADIUS_ATTRIBUTE_ARRAY>()) == 0 }
+        self.cbSize == other.cbSize && self.Add == other.Add && self.AttributeAt == other.AttributeAt && self.GetSize == other.GetSize && self.InsertAt == other.InsertAt && self.RemoveAt == other.RemoveAt && self.SetAt == other.SetAt
     }
 }
 impl ::core::cmp::Eq for RADIUS_ATTRIBUTE_ARRAY {}
@@ -3027,7 +3015,7 @@ unsafe impl ::windows::core::Abi for RADIUS_EXTENSION_CONTROL_BLOCK {
 }
 impl ::core::cmp::PartialEq for RADIUS_EXTENSION_CONTROL_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RADIUS_EXTENSION_CONTROL_BLOCK>()) == 0 }
+        self.cbSize == other.cbSize && self.dwVersion == other.dwVersion && self.repPoint == other.repPoint && self.rcRequestType == other.rcRequestType && self.rcResponseType == other.rcResponseType && self.GetRequest == other.GetRequest && self.GetResponse == other.GetResponse && self.SetResponseType == other.SetResponseType
     }
 }
 impl ::core::cmp::Eq for RADIUS_EXTENSION_CONTROL_BLOCK {}
@@ -3060,7 +3048,7 @@ unsafe impl ::windows::core::Abi for RADIUS_VSA_FORMAT {
 }
 impl ::core::cmp::PartialEq for RADIUS_VSA_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RADIUS_VSA_FORMAT>()) == 0 }
+        self.VendorId == other.VendorId && self.VendorType == other.VendorType && self.VendorLength == other.VendorLength && self.AttributeSpecific == other.AttributeSpecific
     }
 }
 impl ::core::cmp::Eq for RADIUS_VSA_FORMAT {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
@@ -3035,7 +3035,7 @@ unsafe impl ::windows::core::Abi for DRT_ADDRESS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_ADDRESS>()) == 0 }
+        self.socketAddress == other.socketAddress && self.flags == other.flags && self.nearness == other.nearness && self.latency == other.latency
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3074,7 +3074,7 @@ unsafe impl ::windows::core::Abi for DRT_ADDRESS_LIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_ADDRESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_ADDRESS_LIST>()) == 0 }
+        self.AddressCount == other.AddressCount && self.AddressList == other.AddressList
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3113,7 +3113,7 @@ unsafe impl ::windows::core::Abi for DRT_BOOTSTRAP_PROVIDER {
 }
 impl ::core::cmp::PartialEq for DRT_BOOTSTRAP_PROVIDER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_BOOTSTRAP_PROVIDER>()) == 0 }
+        self.pvContext == other.pvContext && self.Attach == other.Attach && self.Detach == other.Detach && self.InitResolve == other.InitResolve && self.IssueResolve == other.IssueResolve && self.EndResolve == other.EndResolve && self.Register == other.Register && self.Unregister == other.Unregister
     }
 }
 impl ::core::cmp::Eq for DRT_BOOTSTRAP_PROVIDER {}
@@ -3144,7 +3144,7 @@ unsafe impl ::windows::core::Abi for DRT_DATA {
 }
 impl ::core::cmp::PartialEq for DRT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_DATA>()) == 0 }
+        self.cb == other.cb && self.pb == other.pb
     }
 }
 impl ::core::cmp::Eq for DRT_DATA {}
@@ -3175,14 +3175,6 @@ unsafe impl ::windows::core::Abi for DRT_EVENT_DATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for DRT_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for DRT_EVENT_DATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for DRT_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3208,14 +3200,6 @@ impl ::core::clone::Clone for DRT_EVENT_DATA_0 {
 unsafe impl ::windows::core::Abi for DRT_EVENT_DATA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for DRT_EVENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for DRT_EVENT_DATA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for DRT_EVENT_DATA_0 {
     fn default() -> Self {
@@ -3251,7 +3235,7 @@ unsafe impl ::windows::core::Abi for DRT_EVENT_DATA_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_EVENT_DATA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA_0_0>()) == 0 }
+        self.change == other.change && self.localKey == other.localKey && self.remoteKey == other.remoteKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3290,7 +3274,7 @@ unsafe impl ::windows::core::Abi for DRT_EVENT_DATA_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_EVENT_DATA_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA_0_1>()) == 0 }
+        self.state == other.state && self.localKey == other.localKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3329,7 +3313,7 @@ unsafe impl ::windows::core::Abi for DRT_EVENT_DATA_0_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_EVENT_DATA_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA_0_2>()) == 0 }
+        self.status == other.status && self.bootstrapAddresses == other.bootstrapAddresses
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3368,7 +3352,7 @@ unsafe impl ::windows::core::Abi for DRT_EVENT_DATA_0_2_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for DRT_EVENT_DATA_0_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_EVENT_DATA_0_2_0>()) == 0 }
+        self.cntAddress == other.cntAddress && self.pAddresses == other.pAddresses
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3401,7 +3385,7 @@ unsafe impl ::windows::core::Abi for DRT_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for DRT_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_REGISTRATION>()) == 0 }
+        self.key == other.key && self.appData == other.appData
     }
 }
 impl ::core::cmp::Eq for DRT_REGISTRATION {}
@@ -3443,7 +3427,7 @@ unsafe impl ::windows::core::Abi for DRT_SEARCH_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRT_SEARCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_SEARCH_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.fIterative == other.fIterative && self.fAllowCurrentInstanceMatch == other.fAllowCurrentInstanceMatch && self.fAnyMatchInRange == other.fAnyMatchInRange && self.cMaxEndpoints == other.cMaxEndpoints && self.pMaximumKey == other.pMaximumKey && self.pMinimumKey == other.pMinimumKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3478,7 +3462,7 @@ unsafe impl ::windows::core::Abi for DRT_SEARCH_RESULT {
 }
 impl ::core::cmp::PartialEq for DRT_SEARCH_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_SEARCH_RESULT>()) == 0 }
+        self.dwSize == other.dwSize && self.r#type == other.r#type && self.pvContext == other.pvContext && self.registration == other.registration
     }
 }
 impl ::core::cmp::Eq for DRT_SEARCH_RESULT {}
@@ -3536,7 +3520,7 @@ unsafe impl ::windows::core::Abi for DRT_SECURITY_PROVIDER {
 }
 impl ::core::cmp::PartialEq for DRT_SECURITY_PROVIDER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_SECURITY_PROVIDER>()) == 0 }
+        self.pvContext == other.pvContext && self.Attach == other.Attach && self.Detach == other.Detach && self.RegisterKey == other.RegisterKey && self.UnregisterKey == other.UnregisterKey && self.ValidateAndUnpackPayload == other.ValidateAndUnpackPayload && self.SecureAndPackPayload == other.SecureAndPackPayload && self.FreeData == other.FreeData && self.EncryptData == other.EncryptData && self.DecryptData == other.DecryptData && self.GetSerializedCredential == other.GetSerializedCredential && self.ValidateRemoteCredential == other.ValidateRemoteCredential && self.SignData == other.SignData && self.VerifyData == other.VerifyData
     }
 }
 impl ::core::cmp::Eq for DRT_SECURITY_PROVIDER {}
@@ -3586,7 +3570,7 @@ unsafe impl ::windows::core::Abi for DRT_SETTINGS {
 }
 impl ::core::cmp::PartialEq for DRT_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRT_SETTINGS>()) == 0 }
+        self.dwSize == other.dwSize && self.cbKey == other.cbKey && self.bProtocolMajorVersion == other.bProtocolMajorVersion && self.bProtocolMinorVersion == other.bProtocolMinorVersion && self.ulMaxRoutingAddresses == other.ulMaxRoutingAddresses && self.pwzDrtInstancePrefix == other.pwzDrtInstancePrefix && self.hTransport == other.hTransport && self.pSecurityProvider == other.pSecurityProvider && self.pBootstrapProvider == other.pBootstrapProvider && self.eSecurityMode == other.eSecurityMode
     }
 }
 impl ::core::cmp::Eq for DRT_SETTINGS {}
@@ -3622,7 +3606,7 @@ unsafe impl ::windows::core::Abi for PEERDIST_CLIENT_BASIC_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PEERDIST_CLIENT_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEERDIST_CLIENT_BASIC_INFO>()) == 0 }
+        self.fFlashCrowd == other.fFlashCrowd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3654,7 +3638,7 @@ unsafe impl ::windows::core::Abi for PEERDIST_CONTENT_TAG {
 }
 impl ::core::cmp::PartialEq for PEERDIST_CONTENT_TAG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEERDIST_CONTENT_TAG>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for PEERDIST_CONTENT_TAG {}
@@ -3685,7 +3669,7 @@ unsafe impl ::windows::core::Abi for PEERDIST_PUBLICATION_OPTIONS {
 }
 impl ::core::cmp::PartialEq for PEERDIST_PUBLICATION_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEERDIST_PUBLICATION_OPTIONS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for PEERDIST_PUBLICATION_OPTIONS {}
@@ -3718,7 +3702,7 @@ unsafe impl ::windows::core::Abi for PEERDIST_RETRIEVAL_OPTIONS {
 }
 impl ::core::cmp::PartialEq for PEERDIST_RETRIEVAL_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEERDIST_RETRIEVAL_OPTIONS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwContentInfoMinVersion == other.dwContentInfoMinVersion && self.dwContentInfoMaxVersion == other.dwContentInfoMaxVersion && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for PEERDIST_RETRIEVAL_OPTIONS {}
@@ -3751,7 +3735,7 @@ unsafe impl ::windows::core::Abi for PEERDIST_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for PEERDIST_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEERDIST_STATUS_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.status == other.status && self.dwMinVer == other.dwMinVer && self.dwMaxVer == other.dwMaxVer
     }
 }
 impl ::core::cmp::Eq for PEERDIST_STATUS_INFO {}
@@ -3779,14 +3763,6 @@ impl ::core::clone::Clone for PEER_ADDRESS {
 unsafe impl ::windows::core::Abi for PEER_ADDRESS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for PEER_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for PEER_ADDRESS {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for PEER_ADDRESS {
     fn default() -> Self {
@@ -3816,7 +3792,7 @@ unsafe impl ::windows::core::Abi for PEER_APPLICATION {
 }
 impl ::core::cmp::PartialEq for PEER_APPLICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_APPLICATION>()) == 0 }
+        self.id == other.id && self.data == other.data && self.pwzDescription == other.pwzDescription
     }
 }
 impl ::core::cmp::Eq for PEER_APPLICATION {}
@@ -3849,7 +3825,7 @@ unsafe impl ::windows::core::Abi for PEER_APPLICATION_REGISTRATION_INFO {
 }
 impl ::core::cmp::PartialEq for PEER_APPLICATION_REGISTRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_APPLICATION_REGISTRATION_INFO>()) == 0 }
+        self.application == other.application && self.pwzApplicationToLaunch == other.pwzApplicationToLaunch && self.pwzApplicationArguments == other.pwzApplicationArguments && self.dwPublicationScope == other.dwPublicationScope
     }
 }
 impl ::core::cmp::Eq for PEER_APPLICATION_REGISTRATION_INFO {}
@@ -3887,7 +3863,7 @@ unsafe impl ::windows::core::Abi for PEER_APP_LAUNCH_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_APP_LAUNCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_APP_LAUNCH_INFO>()) == 0 }
+        self.pContact == other.pContact && self.pEndpoint == other.pEndpoint && self.pInvitation == other.pInvitation
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3917,14 +3893,6 @@ impl ::core::clone::Clone for PEER_COLLAB_EVENT_DATA {
 unsafe impl ::windows::core::Abi for PEER_COLLAB_EVENT_DATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for PEER_COLLAB_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_COLLAB_EVENT_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for PEER_COLLAB_EVENT_DATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for PEER_COLLAB_EVENT_DATA {
     fn default() -> Self {
@@ -3956,14 +3924,6 @@ unsafe impl ::windows::core::Abi for PEER_COLLAB_EVENT_DATA_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for PEER_COLLAB_EVENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_COLLAB_EVENT_DATA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for PEER_COLLAB_EVENT_DATA_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for PEER_COLLAB_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3991,7 +3951,7 @@ unsafe impl ::windows::core::Abi for PEER_COLLAB_EVENT_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for PEER_COLLAB_EVENT_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_COLLAB_EVENT_REGISTRATION>()) == 0 }
+        self.eventType == other.eventType && self.pInstance == other.pInstance
     }
 }
 impl ::core::cmp::Eq for PEER_COLLAB_EVENT_REGISTRATION {}
@@ -4023,14 +3983,6 @@ impl ::core::clone::Clone for PEER_CONNECTION_INFO {
 unsafe impl ::windows::core::Abi for PEER_CONNECTION_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for PEER_CONNECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_CONNECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for PEER_CONNECTION_INFO {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for PEER_CONNECTION_INFO {
     fn default() -> Self {
@@ -4070,7 +4022,7 @@ unsafe impl ::windows::core::Abi for PEER_CONTACT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PEER_CONTACT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_CONTACT>()) == 0 }
+        self.pwzPeerName == other.pwzPeerName && self.pwzNickName == other.pwzNickName && self.pwzDisplayName == other.pwzDisplayName && self.pwzEmailAddress == other.pwzEmailAddress && self.fWatch == other.fWatch && self.WatcherPermissions == other.WatcherPermissions && self.credentials == other.credentials
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4117,7 +4069,7 @@ unsafe impl ::windows::core::Abi for PEER_CREDENTIAL_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for PEER_CREDENTIAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_CREDENTIAL_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.pwzFriendlyName == other.pwzFriendlyName && self.pPublicKey == other.pPublicKey && self.pwzIssuerPeerName == other.pwzIssuerPeerName && self.pwzIssuerFriendlyName == other.pwzIssuerFriendlyName && self.ftValidityStart == other.ftValidityStart && self.ftValidityEnd == other.ftValidityEnd && self.cRoles == other.cRoles && self.pRoles == other.pRoles
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -4150,7 +4102,7 @@ unsafe impl ::windows::core::Abi for PEER_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_DATA>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for PEER_DATA {}
@@ -4178,14 +4130,6 @@ impl ::core::clone::Clone for PEER_ENDPOINT {
 unsafe impl ::windows::core::Abi for PEER_ENDPOINT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for PEER_ENDPOINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_ENDPOINT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for PEER_ENDPOINT {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for PEER_ENDPOINT {
     fn default() -> Self {
@@ -4222,7 +4166,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_APPLICATION_CHANGED_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_EVENT_APPLICATION_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_APPLICATION_CHANGED_DATA>()) == 0 }
+        self.pContact == other.pContact && self.pEndpoint == other.pEndpoint && self.changeType == other.changeType && self.pApplication == other.pApplication
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4259,7 +4203,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_CONNECTION_CHANGE_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_CONNECTION_CHANGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_CONNECTION_CHANGE_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.status == other.status && self.ullConnectionId == other.ullConnectionId && self.ullNodeId == other.ullNodeId && self.ullNextConnectionId == other.ullNextConnectionId && self.hrConnectionFailedReason == other.hrConnectionFailedReason
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_CONNECTION_CHANGE_DATA {}
@@ -4296,7 +4240,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_ENDPOINT_CHANGED_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_EVENT_ENDPOINT_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_ENDPOINT_CHANGED_DATA>()) == 0 }
+        self.pContact == other.pContact && self.pEndpoint == other.pEndpoint
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4331,7 +4275,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_INCOMING_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_INCOMING_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_INCOMING_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.ullConnectionId == other.ullConnectionId && self.r#type == other.r#type && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_INCOMING_DATA {}
@@ -4363,7 +4307,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_MEMBER_CHANGE_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_MEMBER_CHANGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_MEMBER_CHANGE_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.changeType == other.changeType && self.pwzIdentity == other.pwzIdentity
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_MEMBER_CHANGE_DATA {}
@@ -4396,7 +4340,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_NODE_CHANGE_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_NODE_CHANGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_NODE_CHANGE_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.changeType == other.changeType && self.ullNodeId == other.ullNodeId && self.pwzPeerId == other.pwzPeerId
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_NODE_CHANGE_DATA {}
@@ -4435,7 +4379,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_OBJECT_CHANGED_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_EVENT_OBJECT_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_OBJECT_CHANGED_DATA>()) == 0 }
+        self.pContact == other.pContact && self.pEndpoint == other.pEndpoint && self.changeType == other.changeType && self.pObject == other.pObject
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4474,7 +4418,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA>()) == 0 }
+        self.changeType == other.changeType && self.pPeopleNearMe == other.pPeopleNearMe
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4515,7 +4459,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_PRESENCE_CHANGED_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_EVENT_PRESENCE_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_PRESENCE_CHANGED_DATA>()) == 0 }
+        self.pContact == other.pContact && self.pEndpoint == other.pEndpoint && self.changeType == other.changeType && self.pPresenceInfo == other.pPresenceInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4550,7 +4494,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_RECORD_CHANGE_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_RECORD_CHANGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_RECORD_CHANGE_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.changeType == other.changeType && self.recordId == other.recordId && self.recordType == other.recordType
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_RECORD_CHANGE_DATA {}
@@ -4587,7 +4531,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_REQUEST_STATUS_CHANGED_DATA {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for PEER_EVENT_REQUEST_STATUS_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_REQUEST_STATUS_CHANGED_DATA>()) == 0 }
+        self.pEndpoint == other.pEndpoint && self.hrChange == other.hrChange
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4620,7 +4564,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_SYNCHRONIZED_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_EVENT_SYNCHRONIZED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_SYNCHRONIZED_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.recordType == other.recordType
     }
 }
 impl ::core::cmp::Eq for PEER_EVENT_SYNCHRONIZED_DATA {}
@@ -4657,7 +4601,7 @@ unsafe impl ::windows::core::Abi for PEER_EVENT_WATCHLIST_CHANGED_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PEER_EVENT_WATCHLIST_CHANGED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_EVENT_WATCHLIST_CHANGED_DATA>()) == 0 }
+        self.pContact == other.pContact && self.changeType == other.changeType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4683,12 +4627,6 @@ impl ::core::clone::Clone for PEER_GRAPH_EVENT_DATA {
 unsafe impl ::windows::core::Abi for PEER_GRAPH_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PEER_GRAPH_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GRAPH_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PEER_GRAPH_EVENT_DATA {}
 impl ::core::default::Default for PEER_GRAPH_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4713,12 +4651,6 @@ impl ::core::clone::Clone for PEER_GRAPH_EVENT_DATA_0 {
 unsafe impl ::windows::core::Abi for PEER_GRAPH_EVENT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PEER_GRAPH_EVENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GRAPH_EVENT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PEER_GRAPH_EVENT_DATA_0 {}
 impl ::core::default::Default for PEER_GRAPH_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4746,7 +4678,7 @@ unsafe impl ::windows::core::Abi for PEER_GRAPH_EVENT_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for PEER_GRAPH_EVENT_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GRAPH_EVENT_REGISTRATION>()) == 0 }
+        self.eventType == other.eventType && self.pType == other.pType
     }
 }
 impl ::core::cmp::Eq for PEER_GRAPH_EVENT_REGISTRATION {}
@@ -4785,7 +4717,7 @@ unsafe impl ::windows::core::Abi for PEER_GRAPH_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for PEER_GRAPH_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GRAPH_PROPERTIES>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwScope == other.dwScope && self.dwMaxRecordSize == other.dwMaxRecordSize && self.pwzGraphId == other.pwzGraphId && self.pwzCreatorId == other.pwzCreatorId && self.pwzFriendlyName == other.pwzFriendlyName && self.pwzComment == other.pwzComment && self.ulPresenceLifetime == other.ulPresenceLifetime && self.cPresenceMax == other.cPresenceMax
     }
 }
 impl ::core::cmp::Eq for PEER_GRAPH_PROPERTIES {}
@@ -4809,12 +4741,6 @@ impl ::core::clone::Clone for PEER_GROUP_EVENT_DATA {
 unsafe impl ::windows::core::Abi for PEER_GROUP_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PEER_GROUP_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GROUP_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PEER_GROUP_EVENT_DATA {}
 impl ::core::default::Default for PEER_GROUP_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4839,12 +4765,6 @@ impl ::core::clone::Clone for PEER_GROUP_EVENT_DATA_0 {
 unsafe impl ::windows::core::Abi for PEER_GROUP_EVENT_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PEER_GROUP_EVENT_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GROUP_EVENT_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PEER_GROUP_EVENT_DATA_0 {}
 impl ::core::default::Default for PEER_GROUP_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4872,7 +4792,7 @@ unsafe impl ::windows::core::Abi for PEER_GROUP_EVENT_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for PEER_GROUP_EVENT_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GROUP_EVENT_REGISTRATION>()) == 0 }
+        self.eventType == other.eventType && self.pType == other.pType
     }
 }
 impl ::core::cmp::Eq for PEER_GROUP_EVENT_REGISTRATION {}
@@ -4928,7 +4848,7 @@ unsafe impl ::windows::core::Abi for PEER_GROUP_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for PEER_GROUP_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_GROUP_PROPERTIES>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.pwzCloud == other.pwzCloud && self.pwzClassifier == other.pwzClassifier && self.pwzGroupPeerName == other.pwzGroupPeerName && self.pwzCreatorPeerName == other.pwzCreatorPeerName && self.pwzFriendlyName == other.pwzFriendlyName && self.pwzComment == other.pwzComment && self.ulMemberDataLifetime == other.ulMemberDataLifetime && self.ulPresenceLifetime == other.ulPresenceLifetime && self.dwAuthenticationSchemes == other.dwAuthenticationSchemes && self.pwzGroupPassword == other.pwzGroupPassword && self.groupPasswordRole == other.groupPasswordRole
     }
 }
 impl ::core::cmp::Eq for PEER_GROUP_PROPERTIES {}
@@ -4960,7 +4880,7 @@ unsafe impl ::windows::core::Abi for PEER_INVITATION {
 }
 impl ::core::cmp::PartialEq for PEER_INVITATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_INVITATION>()) == 0 }
+        self.applicationId == other.applicationId && self.applicationData == other.applicationData && self.pwzMessage == other.pwzMessage
     }
 }
 impl ::core::cmp::Eq for PEER_INVITATION {}
@@ -5034,7 +4954,25 @@ unsafe impl ::windows::core::Abi for PEER_INVITATION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for PEER_INVITATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_INVITATION_INFO>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwFlags == other.dwFlags
+            && self.pwzCloudName == other.pwzCloudName
+            && self.dwScope == other.dwScope
+            && self.dwCloudFlags == other.dwCloudFlags
+            && self.pwzGroupPeerName == other.pwzGroupPeerName
+            && self.pwzIssuerPeerName == other.pwzIssuerPeerName
+            && self.pwzSubjectPeerName == other.pwzSubjectPeerName
+            && self.pwzGroupFriendlyName == other.pwzGroupFriendlyName
+            && self.pwzIssuerFriendlyName == other.pwzIssuerFriendlyName
+            && self.pwzSubjectFriendlyName == other.pwzSubjectFriendlyName
+            && self.ftValidityStart == other.ftValidityStart
+            && self.ftValidityEnd == other.ftValidityEnd
+            && self.cRoles == other.cRoles
+            && self.pRoles == other.pRoles
+            && self.cClassifiers == other.cClassifiers
+            && self.ppwzClassifiers == other.ppwzClassifiers
+            && self.pSubjectPublicKey == other.pSubjectPublicKey
+            && self.authScheme == other.authScheme
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -5068,7 +5006,7 @@ unsafe impl ::windows::core::Abi for PEER_INVITATION_RESPONSE {
 }
 impl ::core::cmp::PartialEq for PEER_INVITATION_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_INVITATION_RESPONSE>()) == 0 }
+        self.action == other.action && self.pwzMessage == other.pwzMessage && self.hrExtendedInfo == other.hrExtendedInfo
     }
 }
 impl ::core::cmp::Eq for PEER_INVITATION_RESPONSE {}
@@ -5111,7 +5049,7 @@ unsafe impl ::windows::core::Abi for PEER_MEMBER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for PEER_MEMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_MEMBER>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.pwzIdentity == other.pwzIdentity && self.pwzAttributes == other.pwzAttributes && self.ullNodeId == other.ullNodeId && self.cAddresses == other.cAddresses && self.pAddresses == other.pAddresses && self.pCredentialInfo == other.pCredentialInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
@@ -5145,7 +5083,7 @@ unsafe impl ::windows::core::Abi for PEER_NAME_PAIR {
 }
 impl ::core::cmp::PartialEq for PEER_NAME_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_NAME_PAIR>()) == 0 }
+        self.dwSize == other.dwSize && self.pwzPeerName == other.pwzPeerName && self.pwzFriendlyName == other.pwzFriendlyName
     }
 }
 impl ::core::cmp::Eq for PEER_NAME_PAIR {}
@@ -5186,7 +5124,7 @@ unsafe impl ::windows::core::Abi for PEER_NODE_INFO {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for PEER_NODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_NODE_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.ullNodeId == other.ullNodeId && self.pwzPeerId == other.pwzPeerId && self.cAddresses == other.cAddresses && self.pAddresses == other.pAddresses && self.pwzAttributes == other.pwzAttributes
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -5220,7 +5158,7 @@ unsafe impl ::windows::core::Abi for PEER_OBJECT {
 }
 impl ::core::cmp::PartialEq for PEER_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_OBJECT>()) == 0 }
+        self.id == other.id && self.data == other.data && self.dwPublicationScope == other.dwPublicationScope
     }
 }
 impl ::core::cmp::Eq for PEER_OBJECT {}
@@ -5250,14 +5188,6 @@ unsafe impl ::windows::core::Abi for PEER_PEOPLE_NEAR_ME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for PEER_PEOPLE_NEAR_ME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_PEOPLE_NEAR_ME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for PEER_PEOPLE_NEAR_ME {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for PEER_PEOPLE_NEAR_ME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5286,7 +5216,7 @@ unsafe impl ::windows::core::Abi for PEER_PNRP_CLOUD_INFO {
 }
 impl ::core::cmp::PartialEq for PEER_PNRP_CLOUD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_PNRP_CLOUD_INFO>()) == 0 }
+        self.pwzCloudName == other.pwzCloudName && self.dwScope == other.dwScope && self.dwScopeId == other.dwScopeId
     }
 }
 impl ::core::cmp::Eq for PEER_PNRP_CLOUD_INFO {}
@@ -5326,7 +5256,7 @@ unsafe impl ::windows::core::Abi for PEER_PNRP_ENDPOINT_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_PNRP_ENDPOINT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_PNRP_ENDPOINT_INFO>()) == 0 }
+        self.pwzPeerName == other.pwzPeerName && self.cAddresses == other.cAddresses && self.ppAddresses == other.ppAddresses && self.pwzComment == other.pwzComment && self.payload == other.payload
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5370,7 +5300,7 @@ unsafe impl ::windows::core::Abi for PEER_PNRP_REGISTRATION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PEER_PNRP_REGISTRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_PNRP_REGISTRATION_INFO>()) == 0 }
+        self.pwzCloudName == other.pwzCloudName && self.pwzPublishingIdentity == other.pwzPublishingIdentity && self.cAddresses == other.cAddresses && self.ppAddresses == other.ppAddresses && self.wPort == other.wPort && self.pwzComment == other.pwzComment && self.payload == other.payload
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5403,7 +5333,7 @@ unsafe impl ::windows::core::Abi for PEER_PRESENCE_INFO {
 }
 impl ::core::cmp::PartialEq for PEER_PRESENCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_PRESENCE_INFO>()) == 0 }
+        self.status == other.status && self.pwzDescriptiveText == other.pwzDescriptiveText
     }
 }
 impl ::core::cmp::Eq for PEER_PRESENCE_INFO {}
@@ -5465,7 +5395,7 @@ unsafe impl ::windows::core::Abi for PEER_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PEER_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_RECORD>()) == 0 }
+        self.dwSize == other.dwSize && self.r#type == other.r#type && self.id == other.id && self.dwVersion == other.dwVersion && self.dwFlags == other.dwFlags && self.pwzCreatorId == other.pwzCreatorId && self.pwzModifiedById == other.pwzModifiedById && self.pwzAttributes == other.pwzAttributes && self.ftCreation == other.ftCreation && self.ftExpiration == other.ftExpiration && self.ftLastModified == other.ftLastModified && self.securityData == other.securityData && self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5502,32 +5432,13 @@ impl ::core::clone::Clone for PEER_SECURITY_INTERFACE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PEER_SECURITY_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PEER_SECURITY_INTERFACE")
-            .field("dwSize", &self.dwSize)
-            .field("pwzSspFilename", &self.pwzSspFilename)
-            .field("pwzPackageName", &self.pwzPackageName)
-            .field("cbSecurityInfo", &self.cbSecurityInfo)
-            .field("pbSecurityInfo", &self.pbSecurityInfo)
-            .field("pvContext", &self.pvContext)
-            .field("pfnValidateRecord", &self.pfnValidateRecord.map(|f| f as usize))
-            .field("pfnSecureRecord", &self.pfnSecureRecord.map(|f| f as usize))
-            .field("pfnFreeSecurityData", &self.pfnFreeSecurityData.map(|f| f as usize))
-            .field("pfnAuthFailed", &self.pfnAuthFailed.map(|f| f as usize))
-            .finish()
+        f.debug_struct("PEER_SECURITY_INTERFACE").field("dwSize", &self.dwSize).field("pwzSspFilename", &self.pwzSspFilename).field("pwzPackageName", &self.pwzPackageName).field("cbSecurityInfo", &self.cbSecurityInfo).field("pbSecurityInfo", &self.pbSecurityInfo).field("pvContext", &self.pvContext).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PEER_SECURITY_INTERFACE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PEER_SECURITY_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_SECURITY_INTERFACE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PEER_SECURITY_INTERFACE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PEER_SECURITY_INTERFACE {
     fn default() -> Self {
@@ -5556,7 +5467,7 @@ unsafe impl ::windows::core::Abi for PEER_VERSION_DATA {
 }
 impl ::core::cmp::PartialEq for PEER_VERSION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEER_VERSION_DATA>()) == 0 }
+        self.wVersion == other.wVersion && self.wHighestVersion == other.wHighestVersion
     }
 }
 impl ::core::cmp::Eq for PEER_VERSION_DATA {}
@@ -5589,7 +5500,7 @@ unsafe impl ::windows::core::Abi for PNRPCLOUDINFO {
 }
 impl ::core::cmp::PartialEq for PNRPCLOUDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PNRPCLOUDINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.Cloud == other.Cloud && self.enCloudState == other.enCloudState && self.enCloudFlags == other.enCloudFlags
     }
 }
 impl ::core::cmp::Eq for PNRPCLOUDINFO {}
@@ -5633,7 +5544,7 @@ unsafe impl ::windows::core::Abi for PNRPINFO_V1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for PNRPINFO_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PNRPINFO_V1>()) == 0 }
+        self.dwSize == other.dwSize && self.lpwszIdentity == other.lpwszIdentity && self.nMaxResolve == other.nMaxResolve && self.dwTimeout == other.dwTimeout && self.dwLifetime == other.dwLifetime && self.enResolveCriteria == other.enResolveCriteria && self.dwFlags == other.dwFlags && self.saHint == other.saHint && self.enNameState == other.enNameState
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5673,14 +5584,6 @@ unsafe impl ::windows::core::Abi for PNRPINFO_V2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for PNRPINFO_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PNRPINFO_V2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for PNRPINFO_V2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
 impl ::core::default::Default for PNRPINFO_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5705,14 +5608,6 @@ impl ::core::clone::Clone for PNRPINFO_V2_0 {
 unsafe impl ::windows::core::Abi for PNRPINFO_V2_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for PNRPINFO_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PNRPINFO_V2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for PNRPINFO_V2_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
 impl ::core::default::Default for PNRPINFO_V2_0 {
     fn default() -> Self {
@@ -5742,7 +5637,7 @@ unsafe impl ::windows::core::Abi for PNRP_CLOUD_ID {
 }
 impl ::core::cmp::PartialEq for PNRP_CLOUD_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PNRP_CLOUD_ID>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.Scope == other.Scope && self.ScopeId == other.ScopeId
     }
 }
 impl ::core::cmp::Eq for PNRP_CLOUD_ID {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -1621,7 +1621,7 @@ unsafe impl ::windows::core::Abi for ADDRESS_LIST_DESCRIPTOR {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for ADDRESS_LIST_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRESS_LIST_DESCRIPTOR>()) == 0 }
+        self.MediaType == other.MediaType && self.AddressList == other.AddressList
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1654,7 +1654,7 @@ unsafe impl ::windows::core::Abi for ADSPEC {
 }
 impl ::core::cmp::PartialEq for ADSPEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADSPEC>()) == 0 }
+        self.adspec_header == other.adspec_header && self.adspec_body == other.adspec_body
     }
 }
 impl ::core::cmp::Eq for ADSPEC {}
@@ -1688,7 +1688,7 @@ unsafe impl ::windows::core::Abi for AD_GENERAL_PARAMS {
 }
 impl ::core::cmp::PartialEq for AD_GENERAL_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AD_GENERAL_PARAMS>()) == 0 }
+        self.IntServAwareHopCount == other.IntServAwareHopCount && self.PathBandwidthEstimate == other.PathBandwidthEstimate && self.MinimumLatency == other.MinimumLatency && self.PathMTU == other.PathMTU && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for AD_GENERAL_PARAMS {}
@@ -1721,7 +1721,7 @@ unsafe impl ::windows::core::Abi for AD_GUARANTEED {
 }
 impl ::core::cmp::PartialEq for AD_GUARANTEED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AD_GUARANTEED>()) == 0 }
+        self.CTotal == other.CTotal && self.DTotal == other.DTotal && self.CSum == other.CSum && self.DSum == other.DSum
     }
 }
 impl ::core::cmp::Eq for AD_GUARANTEED {}
@@ -1747,12 +1747,6 @@ impl ::core::clone::Clone for CONTROL_SERVICE {
 unsafe impl ::windows::core::Abi for CONTROL_SERVICE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CONTROL_SERVICE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTROL_SERVICE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CONTROL_SERVICE {}
 impl ::core::default::Default for CONTROL_SERVICE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1773,12 +1767,6 @@ impl ::core::clone::Clone for CONTROL_SERVICE_0 {
 unsafe impl ::windows::core::Abi for CONTROL_SERVICE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CONTROL_SERVICE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTROL_SERVICE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CONTROL_SERVICE_0 {}
 impl ::core::default::Default for CONTROL_SERVICE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1807,7 +1795,7 @@ unsafe impl ::windows::core::Abi for CtrlLoadFlowspec {
 }
 impl ::core::cmp::PartialEq for CtrlLoadFlowspec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CtrlLoadFlowspec>()) == 0 }
+        self.CL_spec_serv_hdr == other.CL_spec_serv_hdr && self.CL_spec_parm_hdr == other.CL_spec_parm_hdr && self.CL_spec_parms == other.CL_spec_parms
     }
 }
 impl ::core::cmp::Eq for CtrlLoadFlowspec {}
@@ -1849,7 +1837,7 @@ unsafe impl ::windows::core::Abi for ENUMERATION_BUFFER {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for ENUMERATION_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMERATION_BUFFER>()) == 0 }
+        self.Length == other.Length && self.OwnerProcessId == other.OwnerProcessId && self.FlowNameLength == other.FlowNameLength && self.FlowName == other.FlowName && self.pFlow == other.pFlow && self.NumberOfFilters == other.NumberOfFilters && self.GenericFilter == other.GenericFilter
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1880,14 +1868,6 @@ unsafe impl ::windows::core::Abi for ERROR_SPEC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for ERROR_SPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERROR_SPEC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for ERROR_SPEC {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for ERROR_SPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1911,14 +1891,6 @@ impl ::core::clone::Clone for ERROR_SPEC_0 {
 unsafe impl ::windows::core::Abi for ERROR_SPEC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for ERROR_SPEC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERROR_SPEC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for ERROR_SPEC_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for ERROR_SPEC_0 {
     fn default() -> Self {
@@ -1947,14 +1919,6 @@ unsafe impl ::windows::core::Abi for Error_Spec_IPv4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Error_Spec_IPv4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Error_Spec_IPv4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Error_Spec_IPv4 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Error_Spec_IPv4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1980,14 +1944,6 @@ unsafe impl ::windows::core::Abi for FILTER_SPEC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for FILTER_SPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_SPEC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for FILTER_SPEC {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for FILTER_SPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2012,14 +1968,6 @@ impl ::core::clone::Clone for FILTER_SPEC_0 {
 unsafe impl ::windows::core::Abi for FILTER_SPEC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for FILTER_SPEC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_SPEC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for FILTER_SPEC_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for FILTER_SPEC_0 {
     fn default() -> Self {
@@ -2055,7 +2003,7 @@ unsafe impl ::windows::core::Abi for FLOWDESCRIPTOR {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for FLOWDESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOWDESCRIPTOR>()) == 0 }
+        self.FlowSpec == other.FlowSpec && self.NumFilters == other.NumFilters && self.FilterList == other.FilterList
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2086,14 +2034,6 @@ unsafe impl ::windows::core::Abi for FLOW_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for FLOW_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOW_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for FLOW_DESC {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for FLOW_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2119,14 +2059,6 @@ unsafe impl ::windows::core::Abi for FLOW_DESC_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for FLOW_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOW_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for FLOW_DESC_0 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for FLOW_DESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2151,14 +2083,6 @@ impl ::core::clone::Clone for FLOW_DESC_1 {
 unsafe impl ::windows::core::Abi for FLOW_DESC_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for FLOW_DESC_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOW_DESC_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for FLOW_DESC_1 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for FLOW_DESC_1 {
     fn default() -> Self {
@@ -2186,14 +2110,6 @@ unsafe impl ::windows::core::Abi for Filter_Spec_IPv4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Filter_Spec_IPv4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Filter_Spec_IPv4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Filter_Spec_IPv4 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Filter_Spec_IPv4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2218,14 +2134,6 @@ impl ::core::clone::Clone for Filter_Spec_IPv4GPI {
 unsafe impl ::windows::core::Abi for Filter_Spec_IPv4GPI {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Filter_Spec_IPv4GPI {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Filter_Spec_IPv4GPI>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Filter_Spec_IPv4GPI {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Filter_Spec_IPv4GPI {
     fn default() -> Self {
@@ -2261,7 +2169,7 @@ unsafe impl ::windows::core::Abi for Gads_parms_t {
 }
 impl ::core::cmp::PartialEq for Gads_parms_t {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Gads_parms_t>()) == 0 }
+        self.Gads_serv_hdr == other.Gads_serv_hdr && self.Gads_Ctot_hdr == other.Gads_Ctot_hdr && self.Gads_Ctot == other.Gads_Ctot && self.Gads_Dtot_hdr == other.Gads_Dtot_hdr && self.Gads_Dtot == other.Gads_Dtot && self.Gads_Csum_hdr == other.Gads_Csum_hdr && self.Gads_Csum == other.Gads_Csum && self.Gads_Dsum_hdr == other.Gads_Dsum_hdr && self.Gads_Dsum == other.Gads_Dsum
     }
 }
 impl ::core::cmp::Eq for Gads_parms_t {}
@@ -2309,7 +2217,7 @@ unsafe impl ::windows::core::Abi for GenAdspecParams {
 }
 impl ::core::cmp::PartialEq for GenAdspecParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GenAdspecParams>()) == 0 }
+        self.gen_parm_hdr == other.gen_parm_hdr && self.gen_parm_hopcnt_hdr == other.gen_parm_hopcnt_hdr && self.gen_parm_hopcnt == other.gen_parm_hopcnt && self.gen_parm_pathbw_hdr == other.gen_parm_pathbw_hdr && self.gen_parm_path_bw == other.gen_parm_path_bw && self.gen_parm_minlat_hdr == other.gen_parm_minlat_hdr && self.gen_parm_min_latency == other.gen_parm_min_latency && self.gen_parm_compmtu_hdr == other.gen_parm_compmtu_hdr && self.gen_parm_composed_MTU == other.gen_parm_composed_MTU
     }
 }
 impl ::core::cmp::Eq for GenAdspecParams {}
@@ -2341,7 +2249,7 @@ unsafe impl ::windows::core::Abi for GenTspec {
 }
 impl ::core::cmp::PartialEq for GenTspec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GenTspec>()) == 0 }
+        self.gen_Tspec_serv_hdr == other.gen_Tspec_serv_hdr && self.gen_Tspec_parm_hdr == other.gen_Tspec_parm_hdr && self.gen_Tspec_parms == other.gen_Tspec_parms
     }
 }
 impl ::core::cmp::Eq for GenTspec {}
@@ -2375,7 +2283,7 @@ unsafe impl ::windows::core::Abi for GenTspecParms {
 }
 impl ::core::cmp::PartialEq for GenTspecParms {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GenTspecParms>()) == 0 }
+        self.TB_Tspec_r == other.TB_Tspec_r && self.TB_Tspec_b == other.TB_Tspec_b && self.TB_Tspec_p == other.TB_Tspec_p && self.TB_Tspec_m == other.TB_Tspec_m && self.TB_Tspec_M == other.TB_Tspec_M
     }
 }
 impl ::core::cmp::Eq for GenTspecParms {}
@@ -2409,7 +2317,7 @@ unsafe impl ::windows::core::Abi for GuarFlowSpec {
 }
 impl ::core::cmp::PartialEq for GuarFlowSpec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GuarFlowSpec>()) == 0 }
+        self.Guar_serv_hdr == other.Guar_serv_hdr && self.Guar_Tspec_hdr == other.Guar_Tspec_hdr && self.Guar_Tspec_parms == other.Guar_Tspec_parms && self.Guar_Rspec_hdr == other.Guar_Rspec_hdr && self.Guar_Rspec == other.Guar_Rspec
     }
 }
 impl ::core::cmp::Eq for GuarFlowSpec {}
@@ -2440,7 +2348,7 @@ unsafe impl ::windows::core::Abi for GuarRspec {
 }
 impl ::core::cmp::PartialEq for GuarRspec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GuarRspec>()) == 0 }
+        self.Guar_R == other.Guar_R && self.Guar_S == other.Guar_S
     }
 }
 impl ::core::cmp::Eq for GuarRspec {}
@@ -2473,7 +2381,7 @@ unsafe impl ::windows::core::Abi for IDPE_ATTR {
 }
 impl ::core::cmp::PartialEq for IDPE_ATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IDPE_ATTR>()) == 0 }
+        self.PeAttribLength == other.PeAttribLength && self.PeAttribType == other.PeAttribType && self.PeAttribSubType == other.PeAttribSubType && self.PeAttribValue == other.PeAttribValue
     }
 }
 impl ::core::cmp::Eq for IDPE_ATTR {}
@@ -2508,7 +2416,7 @@ unsafe impl ::windows::core::Abi for ID_ERROR_OBJECT {
 }
 impl ::core::cmp::PartialEq for ID_ERROR_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ID_ERROR_OBJECT>()) == 0 }
+        self.usIdErrLength == other.usIdErrLength && self.ucAType == other.ucAType && self.ucSubType == other.ucSubType && self.usReserved == other.usReserved && self.usIdErrorValue == other.usIdErrorValue && self.ucIdErrData == other.ucIdErrData
     }
 }
 impl ::core::cmp::Eq for ID_ERROR_OBJECT {}
@@ -2532,12 +2440,6 @@ impl ::core::clone::Clone for IN_ADDR_IPV4 {
 unsafe impl ::windows::core::Abi for IN_ADDR_IPV4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN_ADDR_IPV4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR_IPV4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN_ADDR_IPV4 {}
 impl ::core::default::Default for IN_ADDR_IPV4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2564,7 +2466,7 @@ unsafe impl ::windows::core::Abi for IN_ADDR_IPV6 {
 }
 impl ::core::cmp::PartialEq for IN_ADDR_IPV6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR_IPV6>()) == 0 }
+        self.Addr == other.Addr
     }
 }
 impl ::core::cmp::Eq for IN_ADDR_IPV6 {}
@@ -2595,7 +2497,7 @@ unsafe impl ::windows::core::Abi for IPX_PATTERN {
 }
 impl ::core::cmp::PartialEq for IPX_PATTERN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPX_PATTERN>()) == 0 }
+        self.Src == other.Src && self.Dest == other.Dest
     }
 }
 impl ::core::cmp::Eq for IPX_PATTERN {}
@@ -2627,7 +2529,7 @@ unsafe impl ::windows::core::Abi for IPX_PATTERN_0 {
 }
 impl ::core::cmp::PartialEq for IPX_PATTERN_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPX_PATTERN_0>()) == 0 }
+        self.NetworkAddress == other.NetworkAddress && self.NodeAddress == other.NodeAddress && self.Socket == other.Socket
     }
 }
 impl ::core::cmp::Eq for IPX_PATTERN_0 {}
@@ -2656,12 +2558,6 @@ impl ::core::clone::Clone for IP_PATTERN {
 unsafe impl ::windows::core::Abi for IP_PATTERN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IP_PATTERN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_PATTERN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IP_PATTERN {}
 impl ::core::default::Default for IP_PATTERN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2683,12 +2579,6 @@ impl ::core::clone::Clone for IP_PATTERN_0 {
 unsafe impl ::windows::core::Abi for IP_PATTERN_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IP_PATTERN_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_PATTERN_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IP_PATTERN_0 {}
 impl ::core::default::Default for IP_PATTERN_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2717,7 +2607,7 @@ unsafe impl ::windows::core::Abi for IP_PATTERN_0_0 {
 }
 impl ::core::cmp::PartialEq for IP_PATTERN_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_PATTERN_0_0>()) == 0 }
+        self.s_type == other.s_type && self.s_code == other.s_code && self.filler == other.filler
     }
 }
 impl ::core::cmp::Eq for IP_PATTERN_0_0 {}
@@ -2748,7 +2638,7 @@ unsafe impl ::windows::core::Abi for IP_PATTERN_0_1 {
 }
 impl ::core::cmp::PartialEq for IP_PATTERN_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_PATTERN_0_1>()) == 0 }
+        self.s_srcport == other.s_srcport && self.s_dstport == other.s_dstport
     }
 }
 impl ::core::cmp::Eq for IP_PATTERN_0_1 {}
@@ -2779,7 +2669,7 @@ unsafe impl ::windows::core::Abi for IS_ADSPEC_BODY {
 }
 impl ::core::cmp::PartialEq for IS_ADSPEC_BODY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IS_ADSPEC_BODY>()) == 0 }
+        self.adspec_mh == other.adspec_mh && self.adspec_genparms == other.adspec_genparms
     }
 }
 impl ::core::cmp::Eq for IS_ADSPEC_BODY {}
@@ -2803,12 +2693,6 @@ impl ::core::clone::Clone for IS_FLOWSPEC {
 unsafe impl ::windows::core::Abi for IS_FLOWSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IS_FLOWSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IS_FLOWSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IS_FLOWSPEC {}
 impl ::core::default::Default for IS_FLOWSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2829,12 +2713,6 @@ impl ::core::clone::Clone for IntServFlowSpec {
 unsafe impl ::windows::core::Abi for IntServFlowSpec {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IntServFlowSpec {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServFlowSpec>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IntServFlowSpec {}
 impl ::core::default::Default for IntServFlowSpec {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2856,12 +2734,6 @@ impl ::core::clone::Clone for IntServFlowSpec_0 {
 unsafe impl ::windows::core::Abi for IntServFlowSpec_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IntServFlowSpec_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServFlowSpec_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IntServFlowSpec_0 {}
 impl ::core::default::Default for IntServFlowSpec_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2890,7 +2762,7 @@ unsafe impl ::windows::core::Abi for IntServMainHdr {
 }
 impl ::core::cmp::PartialEq for IntServMainHdr {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServMainHdr>()) == 0 }
+        self.ismh_version == other.ismh_version && self.ismh_unused == other.ismh_unused && self.ismh_len32b == other.ismh_len32b
     }
 }
 impl ::core::cmp::Eq for IntServMainHdr {}
@@ -2922,7 +2794,7 @@ unsafe impl ::windows::core::Abi for IntServParmHdr {
 }
 impl ::core::cmp::PartialEq for IntServParmHdr {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServParmHdr>()) == 0 }
+        self.isph_parm_num == other.isph_parm_num && self.isph_flags == other.isph_flags && self.isph_len32b == other.isph_len32b
     }
 }
 impl ::core::cmp::Eq for IntServParmHdr {}
@@ -2954,7 +2826,7 @@ unsafe impl ::windows::core::Abi for IntServServiceHdr {
 }
 impl ::core::cmp::PartialEq for IntServServiceHdr {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServServiceHdr>()) == 0 }
+        self.issh_service == other.issh_service && self.issh_flags == other.issh_flags && self.issh_len32b == other.issh_len32b
     }
 }
 impl ::core::cmp::Eq for IntServServiceHdr {}
@@ -2978,12 +2850,6 @@ impl ::core::clone::Clone for IntServTspecBody {
 unsafe impl ::windows::core::Abi for IntServTspecBody {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IntServTspecBody {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServTspecBody>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IntServTspecBody {}
 impl ::core::default::Default for IntServTspecBody {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3004,12 +2870,6 @@ impl ::core::clone::Clone for IntServTspecBody_0 {
 unsafe impl ::windows::core::Abi for IntServTspecBody_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IntServTspecBody_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IntServTspecBody_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IntServTspecBody_0 {}
 impl ::core::default::Default for IntServTspecBody_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3036,14 +2896,6 @@ impl ::core::clone::Clone for LPMIPTABLE {
 unsafe impl ::windows::core::Abi for LPMIPTABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for LPMIPTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LPMIPTABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for LPMIPTABLE {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for LPMIPTABLE {
     fn default() -> Self {
@@ -3101,18 +2953,12 @@ impl ::core::clone::Clone for LPM_INIT_INFO {
 }
 impl ::core::fmt::Debug for LPM_INIT_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LPM_INIT_INFO").field("PcmVersionNumber", &self.PcmVersionNumber).field("ResultTimeLimit", &self.ResultTimeLimit).field("ConfiguredLpmCount", &self.ConfiguredLpmCount).field("AllocMemory", &self.AllocMemory.map(|f| f as usize)).field("FreeMemory", &self.FreeMemory.map(|f| f as usize)).field("PcmAdmitResultCallback", &self.PcmAdmitResultCallback.map(|f| f as usize)).field("GetRsvpObjectsCallback", &self.GetRsvpObjectsCallback.map(|f| f as usize)).finish()
+        f.debug_struct("LPM_INIT_INFO").field("PcmVersionNumber", &self.PcmVersionNumber).field("ResultTimeLimit", &self.ResultTimeLimit).field("ConfiguredLpmCount", &self.ConfiguredLpmCount).finish()
     }
 }
 unsafe impl ::windows::core::Abi for LPM_INIT_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LPM_INIT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LPM_INIT_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LPM_INIT_INFO {}
 impl ::core::default::Default for LPM_INIT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3141,7 +2987,7 @@ unsafe impl ::windows::core::Abi for PARAM_BUFFER {
 }
 impl ::core::cmp::PartialEq for PARAM_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAM_BUFFER>()) == 0 }
+        self.ParameterId == other.ParameterId && self.Length == other.Length && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for PARAM_BUFFER {}
@@ -3173,7 +3019,7 @@ unsafe impl ::windows::core::Abi for POLICY_DATA {
 }
 impl ::core::cmp::PartialEq for POLICY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DATA>()) == 0 }
+        self.PolicyObjHdr == other.PolicyObjHdr && self.usPeOffset == other.usPeOffset && self.usReserved == other.usReserved
     }
 }
 impl ::core::cmp::Eq for POLICY_DATA {}
@@ -3205,7 +3051,7 @@ unsafe impl ::windows::core::Abi for POLICY_DECISION {
 }
 impl ::core::cmp::PartialEq for POLICY_DECISION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DECISION>()) == 0 }
+        self.lpvResult == other.lpvResult && self.wPolicyErrCode == other.wPolicyErrCode && self.wPolicyErrValue == other.wPolicyErrValue
     }
 }
 impl ::core::cmp::Eq for POLICY_DECISION {}
@@ -3237,7 +3083,7 @@ unsafe impl ::windows::core::Abi for POLICY_ELEMENT {
 }
 impl ::core::cmp::PartialEq for POLICY_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_ELEMENT>()) == 0 }
+        self.usPeLength == other.usPeLength && self.usPeType == other.usPeType && self.ucPeData == other.ucPeData
     }
 }
 impl ::core::cmp::Eq for POLICY_ELEMENT {}
@@ -3275,7 +3121,7 @@ unsafe impl ::windows::core::Abi for QOS_DESTADDR {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for QOS_DESTADDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_DESTADDR>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.SocketAddress == other.SocketAddress && self.SocketAddressLength == other.SocketAddressLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3309,7 +3155,7 @@ unsafe impl ::windows::core::Abi for QOS_DIFFSERV {
 }
 impl ::core::cmp::PartialEq for QOS_DIFFSERV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_DIFFSERV>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.DSFieldCount == other.DSFieldCount && self.DiffservRule == other.DiffservRule
     }
 }
 impl ::core::cmp::Eq for QOS_DIFFSERV {}
@@ -3343,7 +3189,7 @@ unsafe impl ::windows::core::Abi for QOS_DIFFSERV_RULE {
 }
 impl ::core::cmp::PartialEq for QOS_DIFFSERV_RULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_DIFFSERV_RULE>()) == 0 }
+        self.InboundDSField == other.InboundDSField && self.ConformingOutboundDSField == other.ConformingOutboundDSField && self.NonConformingOutboundDSField == other.NonConformingOutboundDSField && self.ConformingUserPriority == other.ConformingUserPriority && self.NonConformingUserPriority == other.NonConformingUserPriority
     }
 }
 impl ::core::cmp::Eq for QOS_DIFFSERV_RULE {}
@@ -3374,7 +3220,7 @@ unsafe impl ::windows::core::Abi for QOS_DS_CLASS {
 }
 impl ::core::cmp::PartialEq for QOS_DS_CLASS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_DS_CLASS>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.DSField == other.DSField
     }
 }
 impl ::core::cmp::Eq for QOS_DS_CLASS {}
@@ -3406,7 +3252,7 @@ unsafe impl ::windows::core::Abi for QOS_FLOWRATE_OUTGOING {
 }
 impl ::core::cmp::PartialEq for QOS_FLOWRATE_OUTGOING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_FLOWRATE_OUTGOING>()) == 0 }
+        self.Bandwidth == other.Bandwidth && self.ShapingBehavior == other.ShapingBehavior && self.Reason == other.Reason
     }
 }
 impl ::core::cmp::Eq for QOS_FLOWRATE_OUTGOING {}
@@ -3447,7 +3293,7 @@ unsafe impl ::windows::core::Abi for QOS_FLOW_FUNDAMENTALS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for QOS_FLOW_FUNDAMENTALS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_FLOW_FUNDAMENTALS>()) == 0 }
+        self.BottleneckBandwidthSet == other.BottleneckBandwidthSet && self.BottleneckBandwidth == other.BottleneckBandwidth && self.AvailableBandwidthSet == other.AvailableBandwidthSet && self.AvailableBandwidth == other.AvailableBandwidth && self.RTTSet == other.RTTSet && self.RTT == other.RTT
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3480,7 +3326,7 @@ unsafe impl ::windows::core::Abi for QOS_FRIENDLY_NAME {
 }
 impl ::core::cmp::PartialEq for QOS_FRIENDLY_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_FRIENDLY_NAME>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.FriendlyName == other.FriendlyName
     }
 }
 impl ::core::cmp::Eq for QOS_FRIENDLY_NAME {}
@@ -3511,7 +3357,7 @@ unsafe impl ::windows::core::Abi for QOS_OBJECT_HDR {
 }
 impl ::core::cmp::PartialEq for QOS_OBJECT_HDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_OBJECT_HDR>()) == 0 }
+        self.ObjectType == other.ObjectType && self.ObjectLength == other.ObjectLength
     }
 }
 impl ::core::cmp::Eq for QOS_OBJECT_HDR {}
@@ -3544,7 +3390,7 @@ unsafe impl ::windows::core::Abi for QOS_PACKET_PRIORITY {
 }
 impl ::core::cmp::PartialEq for QOS_PACKET_PRIORITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_PACKET_PRIORITY>()) == 0 }
+        self.ConformantDSCPValue == other.ConformantDSCPValue && self.NonConformantDSCPValue == other.NonConformantDSCPValue && self.ConformantL2Value == other.ConformantL2Value && self.NonConformantL2Value == other.NonConformantL2Value
     }
 }
 impl ::core::cmp::Eq for QOS_PACKET_PRIORITY {}
@@ -3575,7 +3421,7 @@ unsafe impl ::windows::core::Abi for QOS_SD_MODE {
 }
 impl ::core::cmp::PartialEq for QOS_SD_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_SD_MODE>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.ShapeDiscardMode == other.ShapeDiscardMode
     }
 }
 impl ::core::cmp::Eq for QOS_SD_MODE {}
@@ -3606,7 +3452,7 @@ unsafe impl ::windows::core::Abi for QOS_SHAPING_RATE {
 }
 impl ::core::cmp::PartialEq for QOS_SHAPING_RATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_SHAPING_RATE>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.ShapingRate == other.ShapingRate
     }
 }
 impl ::core::cmp::Eq for QOS_SHAPING_RATE {}
@@ -3636,7 +3482,7 @@ unsafe impl ::windows::core::Abi for QOS_TCP_TRAFFIC {
 }
 impl ::core::cmp::PartialEq for QOS_TCP_TRAFFIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_TCP_TRAFFIC>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr
     }
 }
 impl ::core::cmp::Eq for QOS_TCP_TRAFFIC {}
@@ -3667,7 +3513,7 @@ unsafe impl ::windows::core::Abi for QOS_TRAFFIC_CLASS {
 }
 impl ::core::cmp::PartialEq for QOS_TRAFFIC_CLASS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_TRAFFIC_CLASS>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.TrafficClass == other.TrafficClass
     }
 }
 impl ::core::cmp::Eq for QOS_TRAFFIC_CLASS {}
@@ -3698,7 +3544,7 @@ unsafe impl ::windows::core::Abi for QOS_VERSION {
 }
 impl ::core::cmp::PartialEq for QOS_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for QOS_VERSION {}
@@ -3730,7 +3576,7 @@ unsafe impl ::windows::core::Abi for QualAppFlowSpec {
 }
 impl ::core::cmp::PartialEq for QualAppFlowSpec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QualAppFlowSpec>()) == 0 }
+        self.Q_spec_serv_hdr == other.Q_spec_serv_hdr && self.Q_spec_parm_hdr == other.Q_spec_parm_hdr && self.Q_spec_parms == other.Q_spec_parms
     }
 }
 impl ::core::cmp::Eq for QualAppFlowSpec {}
@@ -3762,7 +3608,7 @@ unsafe impl ::windows::core::Abi for QualTspec {
 }
 impl ::core::cmp::PartialEq for QualTspec {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QualTspec>()) == 0 }
+        self.qual_Tspec_serv_hdr == other.qual_Tspec_serv_hdr && self.qual_Tspec_parm_hdr == other.qual_Tspec_parm_hdr && self.qual_Tspec_parms == other.qual_Tspec_parms
     }
 }
 impl ::core::cmp::Eq for QualTspec {}
@@ -3792,7 +3638,7 @@ unsafe impl ::windows::core::Abi for QualTspecParms {
 }
 impl ::core::cmp::PartialEq for QualTspecParms {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QualTspecParms>()) == 0 }
+        self.TB_Tspec_M == other.TB_Tspec_M
     }
 }
 impl ::core::cmp::Eq for QualTspecParms {}
@@ -3823,7 +3669,7 @@ unsafe impl ::windows::core::Abi for RESV_STYLE {
 }
 impl ::core::cmp::PartialEq for RESV_STYLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESV_STYLE>()) == 0 }
+        self.style_header == other.style_header && self.style_word == other.style_word
     }
 }
 impl ::core::cmp::Eq for RESV_STYLE {}
@@ -3881,12 +3727,6 @@ impl ::core::clone::Clone for RSVP_ADSPEC {
 unsafe impl ::windows::core::Abi for RSVP_ADSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RSVP_ADSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_ADSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RSVP_ADSPEC {}
 impl ::core::default::Default for RSVP_ADSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3907,12 +3747,6 @@ impl ::core::clone::Clone for RSVP_FILTERSPEC {
 unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RSVP_FILTERSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RSVP_FILTERSPEC {}
 impl ::core::default::Default for RSVP_FILTERSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3936,12 +3770,6 @@ impl ::core::clone::Clone for RSVP_FILTERSPEC_0 {
 unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RSVP_FILTERSPEC_0 {}
 impl ::core::default::Default for RSVP_FILTERSPEC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3963,12 +3791,6 @@ impl ::core::clone::Clone for RSVP_FILTERSPEC_V4 {
 unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_V4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_V4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_V4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RSVP_FILTERSPEC_V4 {}
 impl ::core::default::Default for RSVP_FILTERSPEC_V4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3989,12 +3811,6 @@ impl ::core::clone::Clone for RSVP_FILTERSPEC_V4_GPI {
 unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_V4_GPI {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_V4_GPI {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_V4_GPI>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RSVP_FILTERSPEC_V4_GPI {}
 impl ::core::default::Default for RSVP_FILTERSPEC_V4_GPI {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4023,7 +3839,7 @@ unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_V6 {
 }
 impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_V6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_V6>()) == 0 }
+        self.Address == other.Address && self.UnUsed == other.UnUsed && self.Port == other.Port
     }
 }
 impl ::core::cmp::Eq for RSVP_FILTERSPEC_V6 {}
@@ -4055,7 +3871,7 @@ unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_V6_FLOW {
 }
 impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_V6_FLOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_V6_FLOW>()) == 0 }
+        self.Address == other.Address && self.UnUsed == other.UnUsed && self.FlowLabel == other.FlowLabel
     }
 }
 impl ::core::cmp::Eq for RSVP_FILTERSPEC_V6_FLOW {}
@@ -4086,7 +3902,7 @@ unsafe impl ::windows::core::Abi for RSVP_FILTERSPEC_V6_GPI {
 }
 impl ::core::cmp::PartialEq for RSVP_FILTERSPEC_V6_GPI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_FILTERSPEC_V6_GPI>()) == 0 }
+        self.Address == other.Address && self.GeneralPortId == other.GeneralPortId
     }
 }
 impl ::core::cmp::Eq for RSVP_FILTERSPEC_V6_GPI {}
@@ -4115,14 +3931,6 @@ unsafe impl ::windows::core::Abi for RSVP_HOP {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_HOP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_HOP>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_HOP {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_HOP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4146,14 +3954,6 @@ impl ::core::clone::Clone for RSVP_HOP_0 {
 unsafe impl ::windows::core::Abi for RSVP_HOP_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_HOP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_HOP_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_HOP_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_HOP_0 {
     fn default() -> Self {
@@ -4211,7 +4011,7 @@ unsafe impl ::windows::core::Abi for RSVP_MSG_OBJS {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for RSVP_MSG_OBJS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_MSG_OBJS>()) == 0 }
+        self.RsvpMsgType == other.RsvpMsgType && self.pRsvpSession == other.pRsvpSession && self.pRsvpFromHop == other.pRsvpFromHop && self.pRsvpToHop == other.pRsvpToHop && self.pResvStyle == other.pResvStyle && self.pRsvpScope == other.pRsvpScope && self.FlowDescCount == other.FlowDescCount && self.pFlowDescs == other.pFlowDescs && self.PdObjectCount == other.PdObjectCount && self.ppPdObjects == other.ppPdObjects && self.pErrorSpec == other.pErrorSpec && self.pAdspec == other.pAdspec
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4245,7 +4045,7 @@ unsafe impl ::windows::core::Abi for RSVP_POLICY {
 }
 impl ::core::cmp::PartialEq for RSVP_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_POLICY>()) == 0 }
+        self.Len == other.Len && self.Type == other.Type && self.Info == other.Info
     }
 }
 impl ::core::cmp::Eq for RSVP_POLICY {}
@@ -4277,7 +4077,7 @@ unsafe impl ::windows::core::Abi for RSVP_POLICY_INFO {
 }
 impl ::core::cmp::PartialEq for RSVP_POLICY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_POLICY_INFO>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.NumPolicyElement == other.NumPolicyElement && self.PolicyElement == other.PolicyElement
     }
 }
 impl ::core::cmp::Eq for RSVP_POLICY_INFO {}
@@ -4318,7 +4118,7 @@ unsafe impl ::windows::core::Abi for RSVP_RESERVE_INFO {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for RSVP_RESERVE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_RESERVE_INFO>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.Style == other.Style && self.ConfirmRequest == other.ConfirmRequest && self.PolicyElementList == other.PolicyElementList && self.NumFlowDesc == other.NumFlowDesc && self.FlowDescList == other.FlowDescList
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4349,14 +4149,6 @@ unsafe impl ::windows::core::Abi for RSVP_SCOPE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_SCOPE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_SCOPE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_SCOPE {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_SCOPE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4380,14 +4172,6 @@ impl ::core::clone::Clone for RSVP_SCOPE_0 {
 unsafe impl ::windows::core::Abi for RSVP_SCOPE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_SCOPE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_SCOPE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_SCOPE_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_SCOPE_0 {
     fn default() -> Self {
@@ -4414,14 +4198,6 @@ unsafe impl ::windows::core::Abi for RSVP_SESSION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_SESSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_SESSION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_SESSION {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_SESSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4445,14 +4221,6 @@ impl ::core::clone::Clone for RSVP_SESSION_0 {
 unsafe impl ::windows::core::Abi for RSVP_SESSION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RSVP_SESSION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_SESSION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RSVP_SESSION_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RSVP_SESSION_0 {
     fn default() -> Self {
@@ -4483,7 +4251,7 @@ unsafe impl ::windows::core::Abi for RSVP_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for RSVP_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSVP_STATUS_INFO>()) == 0 }
+        self.ObjectHdr == other.ObjectHdr && self.StatusCode == other.StatusCode && self.ExtendedStatus1 == other.ExtendedStatus1 && self.ExtendedStatus2 == other.ExtendedStatus2
     }
 }
 impl ::core::cmp::Eq for RSVP_STATUS_INFO {}
@@ -4515,7 +4283,7 @@ unsafe impl ::windows::core::Abi for RsvpObjHdr {
 }
 impl ::core::cmp::PartialEq for RsvpObjHdr {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RsvpObjHdr>()) == 0 }
+        self.obj_length == other.obj_length && self.obj_class == other.obj_class && self.obj_ctype == other.obj_ctype
     }
 }
 impl ::core::cmp::Eq for RsvpObjHdr {}
@@ -4544,14 +4312,6 @@ unsafe impl ::windows::core::Abi for Rsvp_Hop_IPv4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Rsvp_Hop_IPv4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Rsvp_Hop_IPv4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Rsvp_Hop_IPv4 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Rsvp_Hop_IPv4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4572,12 +4332,6 @@ impl ::core::clone::Clone for SENDER_TSPEC {
 unsafe impl ::windows::core::Abi for SENDER_TSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SENDER_TSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENDER_TSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SENDER_TSPEC {}
 impl ::core::default::Default for SENDER_TSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4599,12 +4353,6 @@ impl ::core::clone::Clone for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
 unsafe impl ::windows::core::Abi for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_KSR_SIGNATURE_PAYLOAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {}
 impl ::core::default::Default for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4627,12 +4375,6 @@ impl ::core::clone::Clone for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
 unsafe impl ::windows::core::Abi for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_REVOCATION_LIST_PAYLOAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_REVOCATION_LIST_PAYLOAD {}
 impl ::core::default::Default for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4658,12 +4400,6 @@ impl ::core::clone::Clone for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
 unsafe impl ::windows::core::Abi for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_SBCP_INFO_PAYLOAD_V1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {}
 impl ::core::default::Default for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4687,12 +4423,6 @@ impl ::core::clone::Clone for SIPAEVENT_SI_POLICY_PAYLOAD {
 unsafe impl ::windows::core::Abi for SIPAEVENT_SI_POLICY_PAYLOAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_SI_POLICY_PAYLOAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_SI_POLICY_PAYLOAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_SI_POLICY_PAYLOAD {}
 impl ::core::default::Default for SIPAEVENT_SI_POLICY_PAYLOAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4713,12 +4443,6 @@ impl ::core::clone::Clone for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
 unsafe impl ::windows::core::Abi for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_VSM_IDK_INFO_PAYLOAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {}
 impl ::core::default::Default for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4738,12 +4462,6 @@ impl ::core::clone::Clone for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
 unsafe impl ::windows::core::Abi for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {}
 impl ::core::default::Default for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4766,12 +4484,6 @@ impl ::core::clone::Clone for SIPAEVENT_VSM_IDK_RSA_INFO {
 unsafe impl ::windows::core::Abi for SIPAEVENT_VSM_IDK_RSA_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SIPAEVENT_VSM_IDK_RSA_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIPAEVENT_VSM_IDK_RSA_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SIPAEVENT_VSM_IDK_RSA_INFO {}
 impl ::core::default::Default for SIPAEVENT_VSM_IDK_RSA_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4795,14 +4507,6 @@ impl ::core::clone::Clone for Scope_list_ipv4 {
 unsafe impl ::windows::core::Abi for Scope_list_ipv4 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Scope_list_ipv4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Scope_list_ipv4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Scope_list_ipv4 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Scope_list_ipv4 {
     fn default() -> Self {
@@ -4831,14 +4535,6 @@ unsafe impl ::windows::core::Abi for Session_IPv4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for Session_IPv4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Session_IPv4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for Session_IPv4 {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for Session_IPv4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4862,12 +4558,6 @@ impl ::core::clone::Clone for TCG_PCClientPCREventStruct {
 unsafe impl ::windows::core::Abi for TCG_PCClientPCREventStruct {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCG_PCClientPCREventStruct {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCG_PCClientPCREventStruct>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCG_PCClientPCREventStruct {}
 impl ::core::default::Default for TCG_PCClientPCREventStruct {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4889,12 +4579,6 @@ impl ::core::clone::Clone for TCG_PCClientTaggedEventStruct {
 unsafe impl ::windows::core::Abi for TCG_PCClientTaggedEventStruct {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCG_PCClientTaggedEventStruct {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCG_PCClientTaggedEventStruct>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCG_PCClientTaggedEventStruct {}
 impl ::core::default::Default for TCG_PCClientTaggedEventStruct {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4920,21 +4604,13 @@ impl ::core::clone::Clone for TCI_CLIENT_FUNC_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for TCI_CLIENT_FUNC_LIST {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("TCI_CLIENT_FUNC_LIST").field("ClNotifyHandler", &self.ClNotifyHandler.map(|f| f as usize)).field("ClAddFlowCompleteHandler", &self.ClAddFlowCompleteHandler.map(|f| f as usize)).field("ClModifyFlowCompleteHandler", &self.ClModifyFlowCompleteHandler.map(|f| f as usize)).field("ClDeleteFlowCompleteHandler", &self.ClDeleteFlowCompleteHandler.map(|f| f as usize)).finish()
+        f.debug_struct("TCI_CLIENT_FUNC_LIST").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for TCI_CLIENT_FUNC_LIST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TCI_CLIENT_FUNC_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCI_CLIENT_FUNC_LIST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TCI_CLIENT_FUNC_LIST {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TCI_CLIENT_FUNC_LIST {
     fn default() -> Self {
@@ -4965,7 +4641,7 @@ unsafe impl ::windows::core::Abi for TC_GEN_FILTER {
 }
 impl ::core::cmp::PartialEq for TC_GEN_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TC_GEN_FILTER>()) == 0 }
+        self.AddressType == other.AddressType && self.PatternSize == other.PatternSize && self.Pattern == other.Pattern && self.Mask == other.Mask
     }
 }
 impl ::core::cmp::Eq for TC_GEN_FILTER {}
@@ -5004,7 +4680,7 @@ unsafe impl ::windows::core::Abi for TC_GEN_FLOW {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for TC_GEN_FLOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TC_GEN_FLOW>()) == 0 }
+        self.SendingFlowspec == other.SendingFlowspec && self.ReceivingFlowspec == other.ReceivingFlowspec && self.TcObjectsLength == other.TcObjectsLength && self.TcObjects == other.TcObjects
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -5045,7 +4721,7 @@ unsafe impl ::windows::core::Abi for TC_IFC_DESCRIPTOR {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for TC_IFC_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TC_IFC_DESCRIPTOR>()) == 0 }
+        self.Length == other.Length && self.pInterfaceName == other.pInterfaceName && self.pInterfaceID == other.pInterfaceID && self.AddressListDesc == other.AddressListDesc
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -5086,7 +4762,7 @@ unsafe impl ::windows::core::Abi for TC_SUPPORTED_INFO_BUFFER {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for TC_SUPPORTED_INFO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TC_SUPPORTED_INFO_BUFFER>()) == 0 }
+        self.InstanceIDLength == other.InstanceIDLength && self.InstanceID == other.InstanceID && self.InterfaceLuid == other.InterfaceLuid && self.AddrListDesc == other.AddrListDesc
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -5120,12 +4796,6 @@ impl ::core::clone::Clone for WBCL_Iterator {
 unsafe impl ::windows::core::Abi for WBCL_Iterator {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WBCL_Iterator {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WBCL_Iterator>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WBCL_Iterator {}
 impl ::core::default::Default for WBCL_Iterator {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5148,12 +4818,6 @@ impl ::core::clone::Clone for WBCL_LogHdr {
 unsafe impl ::windows::core::Abi for WBCL_LogHdr {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WBCL_LogHdr {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WBCL_LogHdr>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WBCL_LogHdr {}
 impl ::core::default::Default for WBCL_LogHdr {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -4785,7 +4785,7 @@ unsafe impl ::windows::core::Abi for AUTH_VALIDATION_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUTH_VALIDATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTH_VALIDATION_EX>()) == 0 }
+        self.Header == other.Header && self.hRasConnection == other.hRasConnection && self.wszUserName == other.wszUserName && self.wszLogonDomain == other.wszLogonDomain && self.AuthInfoSize == other.AuthInfoSize && self.AuthInfo == other.AuthInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4818,7 +4818,7 @@ unsafe impl ::windows::core::Abi for GRE_CONFIG_PARAMS0 {
 }
 impl ::core::cmp::PartialEq for GRE_CONFIG_PARAMS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GRE_CONFIG_PARAMS0>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags
     }
 }
 impl ::core::cmp::Eq for GRE_CONFIG_PARAMS0 {}
@@ -4889,7 +4889,7 @@ unsafe impl ::windows::core::Abi for IKEV2_CONFIG_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for IKEV2_CONFIG_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_CONFIG_PARAMS>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags && self.dwTunnelConfigParamFlags == other.dwTunnelConfigParamFlags && self.TunnelConfigParams == other.TunnelConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -4951,7 +4951,21 @@ unsafe impl ::windows::core::Abi for IKEV2_PROJECTION_INFO {
 }
 impl ::core::cmp::PartialEq for IKEV2_PROJECTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_PROJECTION_INFO>()) == 0 }
+        self.dwIPv4NegotiationError == other.dwIPv4NegotiationError
+            && self.wszAddress == other.wszAddress
+            && self.wszRemoteAddress == other.wszRemoteAddress
+            && self.IPv4SubInterfaceIndex == other.IPv4SubInterfaceIndex
+            && self.dwIPv6NegotiationError == other.dwIPv6NegotiationError
+            && self.bInterfaceIdentifier == other.bInterfaceIdentifier
+            && self.bRemoteInterfaceIdentifier == other.bRemoteInterfaceIdentifier
+            && self.bPrefix == other.bPrefix
+            && self.dwPrefixLength == other.dwPrefixLength
+            && self.IPv6SubInterfaceIndex == other.IPv6SubInterfaceIndex
+            && self.dwOptions == other.dwOptions
+            && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol
+            && self.dwEapTypeId == other.dwEapTypeId
+            && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm
+            && self.dwEncryptionMethod == other.dwEncryptionMethod
     }
 }
 impl ::core::cmp::Eq for IKEV2_PROJECTION_INFO {}
@@ -5013,7 +5027,22 @@ unsafe impl ::windows::core::Abi for IKEV2_PROJECTION_INFO2 {
 }
 impl ::core::cmp::PartialEq for IKEV2_PROJECTION_INFO2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_PROJECTION_INFO2>()) == 0 }
+        self.dwIPv4NegotiationError == other.dwIPv4NegotiationError
+            && self.wszAddress == other.wszAddress
+            && self.wszRemoteAddress == other.wszRemoteAddress
+            && self.IPv4SubInterfaceIndex == other.IPv4SubInterfaceIndex
+            && self.dwIPv6NegotiationError == other.dwIPv6NegotiationError
+            && self.bInterfaceIdentifier == other.bInterfaceIdentifier
+            && self.bRemoteInterfaceIdentifier == other.bRemoteInterfaceIdentifier
+            && self.bPrefix == other.bPrefix
+            && self.dwPrefixLength == other.dwPrefixLength
+            && self.IPv6SubInterfaceIndex == other.IPv6SubInterfaceIndex
+            && self.dwOptions == other.dwOptions
+            && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol
+            && self.dwEapTypeId == other.dwEapTypeId
+            && self.dwEmbeddedEAPTypeId == other.dwEmbeddedEAPTypeId
+            && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm
+            && self.dwEncryptionMethod == other.dwEncryptionMethod
     }
 }
 impl ::core::cmp::Eq for IKEV2_PROJECTION_INFO2 {}
@@ -5069,7 +5098,7 @@ unsafe impl ::windows::core::Abi for IKEV2_TUNNEL_CONFIG_PARAMS2 {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for IKEV2_TUNNEL_CONFIG_PARAMS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_TUNNEL_CONFIG_PARAMS2>()) == 0 }
+        self.dwIdleTimeout == other.dwIdleTimeout && self.dwNetworkBlackoutTime == other.dwNetworkBlackoutTime && self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSizeForRenegotiation == other.dwSaDataSizeForRenegotiation && self.dwConfigOptions == other.dwConfigOptions && self.dwTotalCertificates == other.dwTotalCertificates && self.certificateNames == other.certificateNames && self.machineCertificateName == other.machineCertificateName && self.dwEncryptionType == other.dwEncryptionType && self.customPolicy == other.customPolicy
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5133,7 +5162,7 @@ unsafe impl ::windows::core::Abi for IKEV2_TUNNEL_CONFIG_PARAMS3 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for IKEV2_TUNNEL_CONFIG_PARAMS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_TUNNEL_CONFIG_PARAMS3>()) == 0 }
+        self.dwIdleTimeout == other.dwIdleTimeout && self.dwNetworkBlackoutTime == other.dwNetworkBlackoutTime && self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSizeForRenegotiation == other.dwSaDataSizeForRenegotiation && self.dwConfigOptions == other.dwConfigOptions && self.dwTotalCertificates == other.dwTotalCertificates && self.certificateNames == other.certificateNames && self.machineCertificateName == other.machineCertificateName && self.dwEncryptionType == other.dwEncryptionType && self.customPolicy == other.customPolicy && self.dwTotalEkus == other.dwTotalEkus && self.certificateEKUs == other.certificateEKUs && self.machineCertificateHash == other.machineCertificateHash
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -5199,7 +5228,7 @@ unsafe impl ::windows::core::Abi for IKEV2_TUNNEL_CONFIG_PARAMS4 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for IKEV2_TUNNEL_CONFIG_PARAMS4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEV2_TUNNEL_CONFIG_PARAMS4>()) == 0 }
+        self.dwIdleTimeout == other.dwIdleTimeout && self.dwNetworkBlackoutTime == other.dwNetworkBlackoutTime && self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSizeForRenegotiation == other.dwSaDataSizeForRenegotiation && self.dwConfigOptions == other.dwConfigOptions && self.dwTotalCertificates == other.dwTotalCertificates && self.certificateNames == other.certificateNames && self.machineCertificateName == other.machineCertificateName && self.dwEncryptionType == other.dwEncryptionType && self.customPolicy == other.customPolicy && self.dwTotalEkus == other.dwTotalEkus && self.certificateEKUs == other.certificateEKUs && self.machineCertificateHash == other.machineCertificateHash && self.dwMmSaLifeTime == other.dwMmSaLifeTime
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -5232,7 +5261,7 @@ unsafe impl ::windows::core::Abi for L2TP_CONFIG_PARAMS0 {
 }
 impl ::core::cmp::PartialEq for L2TP_CONFIG_PARAMS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<L2TP_CONFIG_PARAMS0>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags
     }
 }
 impl ::core::cmp::Eq for L2TP_CONFIG_PARAMS0 {}
@@ -5265,7 +5294,7 @@ unsafe impl ::windows::core::Abi for L2TP_CONFIG_PARAMS1 {
 }
 impl ::core::cmp::PartialEq for L2TP_CONFIG_PARAMS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<L2TP_CONFIG_PARAMS1>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags && self.dwTunnelConfigParamFlags == other.dwTunnelConfigParamFlags && self.TunnelConfigParams == other.TunnelConfigParams
     }
 }
 impl ::core::cmp::Eq for L2TP_CONFIG_PARAMS1 {}
@@ -5299,7 +5328,7 @@ unsafe impl ::windows::core::Abi for L2TP_TUNNEL_CONFIG_PARAMS1 {
 }
 impl ::core::cmp::PartialEq for L2TP_TUNNEL_CONFIG_PARAMS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<L2TP_TUNNEL_CONFIG_PARAMS1>()) == 0 }
+        self.dwIdleTimeout == other.dwIdleTimeout && self.dwEncryptionType == other.dwEncryptionType && self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSizeForRenegotiation == other.dwSaDataSizeForRenegotiation && self.customPolicy == other.customPolicy
     }
 }
 impl ::core::cmp::Eq for L2TP_TUNNEL_CONFIG_PARAMS1 {}
@@ -5334,7 +5363,7 @@ unsafe impl ::windows::core::Abi for L2TP_TUNNEL_CONFIG_PARAMS2 {
 }
 impl ::core::cmp::PartialEq for L2TP_TUNNEL_CONFIG_PARAMS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<L2TP_TUNNEL_CONFIG_PARAMS2>()) == 0 }
+        self.dwIdleTimeout == other.dwIdleTimeout && self.dwEncryptionType == other.dwEncryptionType && self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSizeForRenegotiation == other.dwSaDataSizeForRenegotiation && self.customPolicy == other.customPolicy && self.dwMmSaLifeTime == other.dwMmSaLifeTime
     }
 }
 impl ::core::cmp::Eq for L2TP_TUNNEL_CONFIG_PARAMS2 {}
@@ -5373,7 +5402,7 @@ unsafe impl ::windows::core::Abi for MGM_IF_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MGM_IF_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MGM_IF_ENTRY>()) == 0 }
+        self.dwIfIndex == other.dwIfIndex && self.dwIfNextHopAddr == other.dwIfNextHopAddr && self.bIGMP == other.bIGMP && self.bIsEnabled == other.bIsEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5413,35 +5442,13 @@ impl ::core::clone::Clone for MPRAPI_ADMIN_DLL_CALLBACKS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::fmt::Debug for MPRAPI_ADMIN_DLL_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MPRAPI_ADMIN_DLL_CALLBACKS")
-            .field("revision", &self.revision)
-            .field("lpfnMprAdminGetIpAddressForUser", &self.lpfnMprAdminGetIpAddressForUser.map(|f| f as usize))
-            .field("lpfnMprAdminReleaseIpAddress", &self.lpfnMprAdminReleaseIpAddress.map(|f| f as usize))
-            .field("lpfnMprAdminGetIpv6AddressForUser", &self.lpfnMprAdminGetIpv6AddressForUser.map(|f| f as usize))
-            .field("lpfnMprAdminReleaseIpV6AddressForUser", &self.lpfnMprAdminReleaseIpV6AddressForUser.map(|f| f as usize))
-            .field("lpfnRasAdminAcceptNewLink", &self.lpfnRasAdminAcceptNewLink.map(|f| f as usize))
-            .field("lpfnRasAdminLinkHangupNotification", &self.lpfnRasAdminLinkHangupNotification.map(|f| f as usize))
-            .field("lpfnRasAdminTerminateDll", &self.lpfnRasAdminTerminateDll.map(|f| f as usize))
-            .field("lpfnRasAdminAcceptNewConnectionEx", &self.lpfnRasAdminAcceptNewConnectionEx.map(|f| f as usize))
-            .field("lpfnRasAdminAcceptEndpointChangeEx", &self.lpfnRasAdminAcceptEndpointChangeEx.map(|f| f as usize))
-            .field("lpfnRasAdminAcceptReauthenticationEx", &self.lpfnRasAdminAcceptReauthenticationEx.map(|f| f as usize))
-            .field("lpfnRasAdminConnectionHangupNotificationEx", &self.lpfnRasAdminConnectionHangupNotificationEx.map(|f| f as usize))
-            .field("lpfnRASValidatePreAuthenticatedConnectionEx", &self.lpfnRASValidatePreAuthenticatedConnectionEx.map(|f| f as usize))
-            .finish()
+        f.debug_struct("MPRAPI_ADMIN_DLL_CALLBACKS").field("revision", &self.revision).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 unsafe impl ::windows::core::Abi for MPRAPI_ADMIN_DLL_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MPRAPI_ADMIN_DLL_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPRAPI_ADMIN_DLL_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MPRAPI_ADMIN_DLL_CALLBACKS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MPRAPI_ADMIN_DLL_CALLBACKS {
     fn default() -> Self {
@@ -5471,7 +5478,7 @@ unsafe impl ::windows::core::Abi for MPRAPI_OBJECT_HEADER {
 }
 impl ::core::cmp::PartialEq for MPRAPI_OBJECT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPRAPI_OBJECT_HEADER>()) == 0 }
+        self.revision == other.revision && self.r#type == other.r#type && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MPRAPI_OBJECT_HEADER {}
@@ -5510,7 +5517,7 @@ unsafe impl ::windows::core::Abi for MPRAPI_TUNNEL_CONFIG_PARAMS0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPRAPI_TUNNEL_CONFIG_PARAMS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPRAPI_TUNNEL_CONFIG_PARAMS0>()) == 0 }
+        self.IkeConfigParams == other.IkeConfigParams && self.PptpConfigParams == other.PptpConfigParams && self.L2tpConfigParams == other.L2tpConfigParams && self.SstpConfigParams == other.SstpConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -5552,7 +5559,7 @@ unsafe impl ::windows::core::Abi for MPRAPI_TUNNEL_CONFIG_PARAMS1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPRAPI_TUNNEL_CONFIG_PARAMS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPRAPI_TUNNEL_CONFIG_PARAMS1>()) == 0 }
+        self.IkeConfigParams == other.IkeConfigParams && self.PptpConfigParams == other.PptpConfigParams && self.L2tpConfigParams == other.L2tpConfigParams && self.SstpConfigParams == other.SstpConfigParams && self.GREConfigParams == other.GREConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -5592,7 +5599,7 @@ unsafe impl ::windows::core::Abi for MPR_CERT_EKU {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_CERT_EKU {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_CERT_EKU>()) == 0 }
+        self.dwSize == other.dwSize && self.IsEKUOID == other.IsEKUOID && self.pwszEKU == other.pwszEKU
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5625,7 +5632,7 @@ unsafe impl ::windows::core::Abi for MPR_CREDENTIALSEX_0 {
 }
 impl ::core::cmp::PartialEq for MPR_CREDENTIALSEX_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_CREDENTIALSEX_0>()) == 0 }
+        self.dwSize == other.dwSize && self.lpbCredentialsInfo == other.lpbCredentialsInfo
     }
 }
 impl ::core::cmp::Eq for MPR_CREDENTIALSEX_0 {}
@@ -5656,7 +5663,7 @@ unsafe impl ::windows::core::Abi for MPR_CREDENTIALSEX_1 {
 }
 impl ::core::cmp::PartialEq for MPR_CREDENTIALSEX_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_CREDENTIALSEX_1>()) == 0 }
+        self.dwSize == other.dwSize && self.lpbCredentialsInfo == other.lpbCredentialsInfo
     }
 }
 impl ::core::cmp::Eq for MPR_CREDENTIALSEX_1 {}
@@ -5687,7 +5694,7 @@ unsafe impl ::windows::core::Abi for MPR_DEVICE_0 {
 }
 impl ::core::cmp::PartialEq for MPR_DEVICE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_DEVICE_0>()) == 0 }
+        self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName
     }
 }
 impl ::core::cmp::Eq for MPR_DEVICE_0 {}
@@ -5720,7 +5727,7 @@ unsafe impl ::windows::core::Abi for MPR_DEVICE_1 {
 }
 impl ::core::cmp::PartialEq for MPR_DEVICE_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_DEVICE_1>()) == 0 }
+        self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName && self.szLocalPhoneNumber == other.szLocalPhoneNumber && self.szAlternates == other.szAlternates
     }
 }
 impl ::core::cmp::Eq for MPR_DEVICE_1 {}
@@ -5756,7 +5763,7 @@ unsafe impl ::windows::core::Abi for MPR_FILTER_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_FILTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_FILTER_0>()) == 0 }
+        self.fEnable == other.fEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5796,7 +5803,7 @@ unsafe impl ::windows::core::Abi for MPR_IFTRANSPORT_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_IFTRANSPORT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_IFTRANSPORT_0>()) == 0 }
+        self.dwTransportId == other.dwTransportId && self.hIfTransport == other.hIfTransport && self.wszIfTransportName == other.wszIfTransportName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5836,7 +5843,7 @@ unsafe impl ::windows::core::Abi for MPR_IF_CUSTOMINFOEX0 {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for MPR_IF_CUSTOMINFOEX0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_IF_CUSTOMINFOEX0>()) == 0 }
+        self.Header == other.Header && self.dwFlags == other.dwFlags && self.customIkev2Config == other.customIkev2Config
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5876,7 +5883,7 @@ unsafe impl ::windows::core::Abi for MPR_IF_CUSTOMINFOEX1 {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for MPR_IF_CUSTOMINFOEX1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_IF_CUSTOMINFOEX1>()) == 0 }
+        self.Header == other.Header && self.dwFlags == other.dwFlags && self.customIkev2Config == other.customIkev2Config
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5916,7 +5923,7 @@ unsafe impl ::windows::core::Abi for MPR_IF_CUSTOMINFOEX2 {
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPR_IF_CUSTOMINFOEX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_IF_CUSTOMINFOEX2>()) == 0 }
+        self.Header == other.Header && self.dwFlags == other.dwFlags && self.customIkev2Config == other.customIkev2Config
     }
 }
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
@@ -5960,7 +5967,7 @@ unsafe impl ::windows::core::Abi for MPR_INTERFACE_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_INTERFACE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_INTERFACE_0>()) == 0 }
+        self.wszInterfaceName == other.wszInterfaceName && self.hInterface == other.hInterface && self.fEnabled == other.fEnabled && self.dwIfType == other.dwIfType && self.dwConnectionState == other.dwConnectionState && self.fUnReachabilityReasons == other.fUnReachabilityReasons && self.dwLastError == other.dwLastError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6005,7 +6012,7 @@ unsafe impl ::windows::core::Abi for MPR_INTERFACE_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_INTERFACE_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_INTERFACE_1>()) == 0 }
+        self.wszInterfaceName == other.wszInterfaceName && self.hInterface == other.hInterface && self.fEnabled == other.fEnabled && self.dwIfType == other.dwIfType && self.dwConnectionState == other.dwConnectionState && self.fUnReachabilityReasons == other.fUnReachabilityReasons && self.dwLastError == other.dwLastError && self.lpwsDialoutHoursRestriction == other.lpwsDialoutHoursRestriction
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6117,7 +6124,43 @@ unsafe impl ::windows::core::Abi for MPR_INTERFACE_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_INTERFACE_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_INTERFACE_2>()) == 0 }
+        self.wszInterfaceName == other.wszInterfaceName
+            && self.hInterface == other.hInterface
+            && self.fEnabled == other.fEnabled
+            && self.dwIfType == other.dwIfType
+            && self.dwConnectionState == other.dwConnectionState
+            && self.fUnReachabilityReasons == other.fUnReachabilityReasons
+            && self.dwLastError == other.dwLastError
+            && self.dwfOptions == other.dwfOptions
+            && self.szLocalPhoneNumber == other.szLocalPhoneNumber
+            && self.szAlternates == other.szAlternates
+            && self.ipaddr == other.ipaddr
+            && self.ipaddrDns == other.ipaddrDns
+            && self.ipaddrDnsAlt == other.ipaddrDnsAlt
+            && self.ipaddrWins == other.ipaddrWins
+            && self.ipaddrWinsAlt == other.ipaddrWinsAlt
+            && self.dwfNetProtocols == other.dwfNetProtocols
+            && self.szDeviceType == other.szDeviceType
+            && self.szDeviceName == other.szDeviceName
+            && self.szX25PadType == other.szX25PadType
+            && self.szX25Address == other.szX25Address
+            && self.szX25Facilities == other.szX25Facilities
+            && self.szX25UserData == other.szX25UserData
+            && self.dwChannels == other.dwChannels
+            && self.dwSubEntries == other.dwSubEntries
+            && self.dwDialMode == other.dwDialMode
+            && self.dwDialExtraPercent == other.dwDialExtraPercent
+            && self.dwDialExtraSampleSeconds == other.dwDialExtraSampleSeconds
+            && self.dwHangUpExtraPercent == other.dwHangUpExtraPercent
+            && self.dwHangUpExtraSampleSeconds == other.dwHangUpExtraSampleSeconds
+            && self.dwIdleDisconnectSeconds == other.dwIdleDisconnectSeconds
+            && self.dwType == other.dwType
+            && self.dwEncryptionType == other.dwEncryptionType
+            && self.dwCustomAuthKey == other.dwCustomAuthKey
+            && self.dwCustomAuthDataSize == other.dwCustomAuthDataSize
+            && self.lpbCustomAuthData == other.lpbCustomAuthData
+            && self.guidId == other.guidId
+            && self.dwVpnStrategy == other.dwVpnStrategy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6187,14 +6230,6 @@ unsafe impl ::windows::core::Abi for MPR_INTERFACE_3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for MPR_INTERFACE_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_INTERFACE_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for MPR_INTERFACE_3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for MPR_INTERFACE_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6222,7 +6257,7 @@ unsafe impl ::windows::core::Abi for MPR_IPINIP_INTERFACE_0 {
 }
 impl ::core::cmp::PartialEq for MPR_IPINIP_INTERFACE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_IPINIP_INTERFACE_0>()) == 0 }
+        self.wszFriendlyName == other.wszFriendlyName && self.Guid == other.Guid
     }
 }
 impl ::core::cmp::Eq for MPR_IPINIP_INTERFACE_0 {}
@@ -6261,7 +6296,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_SERVER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_0>()) == 0 }
+        self.fLanOnlyMode == other.fLanOnlyMode && self.dwUpTime == other.dwUpTime && self.dwTotalPorts == other.dwTotalPorts && self.dwPortsInUse == other.dwPortsInUse
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6296,7 +6331,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_1 {
 }
 impl ::core::cmp::PartialEq for MPR_SERVER_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_1>()) == 0 }
+        self.dwNumPptpPorts == other.dwNumPptpPorts && self.dwPptpPortFlags == other.dwPptpPortFlags && self.dwNumL2tpPorts == other.dwNumL2tpPorts && self.dwL2tpPortFlags == other.dwL2tpPortFlags
     }
 }
 impl ::core::cmp::Eq for MPR_SERVER_1 {}
@@ -6331,7 +6366,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_2 {
 }
 impl ::core::cmp::PartialEq for MPR_SERVER_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_2>()) == 0 }
+        self.dwNumPptpPorts == other.dwNumPptpPorts && self.dwPptpPortFlags == other.dwPptpPortFlags && self.dwNumL2tpPorts == other.dwNumL2tpPorts && self.dwL2tpPortFlags == other.dwL2tpPortFlags && self.dwNumSstpPorts == other.dwNumSstpPorts && self.dwSstpPortFlags == other.dwSstpPortFlags
     }
 }
 impl ::core::cmp::Eq for MPR_SERVER_2 {}
@@ -6373,7 +6408,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_EX0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPR_SERVER_EX0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_EX0>()) == 0 }
+        self.Header == other.Header && self.fLanOnlyMode == other.fLanOnlyMode && self.dwUpTime == other.dwUpTime && self.dwTotalPorts == other.dwTotalPorts && self.dwPortsInUse == other.dwPortsInUse && self.Reserved == other.Reserved && self.ConfigParams == other.ConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -6417,7 +6452,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_EX1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPR_SERVER_EX1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_EX1>()) == 0 }
+        self.Header == other.Header && self.fLanOnlyMode == other.fLanOnlyMode && self.dwUpTime == other.dwUpTime && self.dwTotalPorts == other.dwTotalPorts && self.dwPortsInUse == other.dwPortsInUse && self.Reserved == other.Reserved && self.ConfigParams == other.ConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -6457,7 +6492,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_SET_CONFIG_EX0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPR_SERVER_SET_CONFIG_EX0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_SET_CONFIG_EX0>()) == 0 }
+        self.Header == other.Header && self.setConfigForProtocols == other.setConfigForProtocols && self.ConfigParams == other.ConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -6497,7 +6532,7 @@ unsafe impl ::windows::core::Abi for MPR_SERVER_SET_CONFIG_EX1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for MPR_SERVER_SET_CONFIG_EX1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_SERVER_SET_CONFIG_EX1>()) == 0 }
+        self.Header == other.Header && self.setConfigForProtocols == other.setConfigForProtocols && self.ConfigParams == other.ConfigParams
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -6537,7 +6572,7 @@ unsafe impl ::windows::core::Abi for MPR_TRANSPORT_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MPR_TRANSPORT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_TRANSPORT_0>()) == 0 }
+        self.dwTransportId == other.dwTransportId && self.hTransport == other.hTransport && self.wszTransportName == other.wszTransportName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6572,14 +6607,6 @@ impl ::core::clone::Clone for MPR_VPN_TRAFFIC_SELECTOR {
 unsafe impl ::windows::core::Abi for MPR_VPN_TRAFFIC_SELECTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for MPR_VPN_TRAFFIC_SELECTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_VPN_TRAFFIC_SELECTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for MPR_VPN_TRAFFIC_SELECTOR {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for MPR_VPN_TRAFFIC_SELECTOR {
     fn default() -> Self {
@@ -6616,7 +6643,7 @@ unsafe impl ::windows::core::Abi for MPR_VPN_TRAFFIC_SELECTORS {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for MPR_VPN_TRAFFIC_SELECTORS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPR_VPN_TRAFFIC_SELECTORS>()) == 0 }
+        self.numTsi == other.numTsi && self.numTsr == other.numTsr && self.tsI == other.tsI && self.tsR == other.tsR
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -6649,7 +6676,7 @@ unsafe impl ::windows::core::Abi for PPP_ATCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_ATCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_ATCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.wszAddress == other.wszAddress
     }
 }
 impl ::core::cmp::Eq for PPP_ATCP_INFO {}
@@ -6683,7 +6710,7 @@ unsafe impl ::windows::core::Abi for PPP_CCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_CCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_CCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm && self.dwOptions == other.dwOptions && self.dwRemoteCompressionAlgorithm == other.dwRemoteCompressionAlgorithm && self.dwRemoteOptions == other.dwRemoteOptions
     }
 }
 impl ::core::cmp::Eq for PPP_CCP_INFO {}
@@ -6716,7 +6743,7 @@ unsafe impl ::windows::core::Abi for PPP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_INFO>()) == 0 }
+        self.nbf == other.nbf && self.ip == other.ip && self.ipx == other.ipx && self.at == other.at
     }
 }
 impl ::core::cmp::Eq for PPP_INFO {}
@@ -6751,7 +6778,7 @@ unsafe impl ::windows::core::Abi for PPP_INFO_2 {
 }
 impl ::core::cmp::PartialEq for PPP_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_INFO_2>()) == 0 }
+        self.nbf == other.nbf && self.ip == other.ip && self.ipx == other.ipx && self.at == other.at && self.ccp == other.ccp && self.lcp == other.lcp
     }
 }
 impl ::core::cmp::Eq for PPP_INFO_2 {}
@@ -6785,7 +6812,7 @@ unsafe impl ::windows::core::Abi for PPP_INFO_3 {
 }
 impl ::core::cmp::PartialEq for PPP_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_INFO_3>()) == 0 }
+        self.nbf == other.nbf && self.ip == other.ip && self.ipv6 == other.ipv6 && self.ccp == other.ccp && self.lcp == other.lcp
     }
 }
 impl ::core::cmp::Eq for PPP_INFO_3 {}
@@ -6817,7 +6844,7 @@ unsafe impl ::windows::core::Abi for PPP_IPCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_IPCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_IPCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.wszAddress == other.wszAddress && self.wszRemoteAddress == other.wszRemoteAddress
     }
 }
 impl ::core::cmp::Eq for PPP_IPCP_INFO {}
@@ -6851,7 +6878,7 @@ unsafe impl ::windows::core::Abi for PPP_IPCP_INFO2 {
 }
 impl ::core::cmp::PartialEq for PPP_IPCP_INFO2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_IPCP_INFO2>()) == 0 }
+        self.dwError == other.dwError && self.wszAddress == other.wszAddress && self.wszRemoteAddress == other.wszRemoteAddress && self.dwOptions == other.dwOptions && self.dwRemoteOptions == other.dwRemoteOptions
     }
 }
 impl ::core::cmp::Eq for PPP_IPCP_INFO2 {}
@@ -6889,7 +6916,7 @@ unsafe impl ::windows::core::Abi for PPP_IPV6_CP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_IPV6_CP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_IPV6_CP_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwSize == other.dwSize && self.dwError == other.dwError && self.bInterfaceIdentifier == other.bInterfaceIdentifier && self.bRemoteInterfaceIdentifier == other.bRemoteInterfaceIdentifier && self.dwOptions == other.dwOptions && self.dwRemoteOptions == other.dwRemoteOptions && self.bPrefix == other.bPrefix && self.dwPrefixLength == other.dwPrefixLength
     }
 }
 impl ::core::cmp::Eq for PPP_IPV6_CP_INFO {}
@@ -6920,7 +6947,7 @@ unsafe impl ::windows::core::Abi for PPP_IPXCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_IPXCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_IPXCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.wszAddress == other.wszAddress
     }
 }
 impl ::core::cmp::Eq for PPP_IPXCP_INFO {}
@@ -6972,7 +6999,7 @@ unsafe impl ::windows::core::Abi for PPP_LCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_LCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_LCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol && self.dwAuthenticationData == other.dwAuthenticationData && self.dwRemoteAuthenticationProtocol == other.dwRemoteAuthenticationProtocol && self.dwRemoteAuthenticationData == other.dwRemoteAuthenticationData && self.dwTerminateReason == other.dwTerminateReason && self.dwRemoteTerminateReason == other.dwRemoteTerminateReason && self.dwOptions == other.dwOptions && self.dwRemoteOptions == other.dwRemoteOptions && self.dwEapTypeId == other.dwEapTypeId && self.dwRemoteEapTypeId == other.dwRemoteEapTypeId
     }
 }
 impl ::core::cmp::Eq for PPP_LCP_INFO {}
@@ -7003,7 +7030,7 @@ unsafe impl ::windows::core::Abi for PPP_NBFCP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_NBFCP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_NBFCP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.wszWksta == other.wszWksta
     }
 }
 impl ::core::cmp::Eq for PPP_NBFCP_INFO {}
@@ -7089,7 +7116,34 @@ unsafe impl ::windows::core::Abi for PPP_PROJECTION_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_PROJECTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_PROJECTION_INFO>()) == 0 }
+        self.dwIPv4NegotiationError == other.dwIPv4NegotiationError
+            && self.wszAddress == other.wszAddress
+            && self.wszRemoteAddress == other.wszRemoteAddress
+            && self.dwIPv4Options == other.dwIPv4Options
+            && self.dwIPv4RemoteOptions == other.dwIPv4RemoteOptions
+            && self.IPv4SubInterfaceIndex == other.IPv4SubInterfaceIndex
+            && self.dwIPv6NegotiationError == other.dwIPv6NegotiationError
+            && self.bInterfaceIdentifier == other.bInterfaceIdentifier
+            && self.bRemoteInterfaceIdentifier == other.bRemoteInterfaceIdentifier
+            && self.bPrefix == other.bPrefix
+            && self.dwPrefixLength == other.dwPrefixLength
+            && self.IPv6SubInterfaceIndex == other.IPv6SubInterfaceIndex
+            && self.dwLcpError == other.dwLcpError
+            && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol
+            && self.dwAuthenticationData == other.dwAuthenticationData
+            && self.dwRemoteAuthenticationProtocol == other.dwRemoteAuthenticationProtocol
+            && self.dwRemoteAuthenticationData == other.dwRemoteAuthenticationData
+            && self.dwLcpTerminateReason == other.dwLcpTerminateReason
+            && self.dwLcpRemoteTerminateReason == other.dwLcpRemoteTerminateReason
+            && self.dwLcpOptions == other.dwLcpOptions
+            && self.dwLcpRemoteOptions == other.dwLcpRemoteOptions
+            && self.dwEapTypeId == other.dwEapTypeId
+            && self.dwRemoteEapTypeId == other.dwRemoteEapTypeId
+            && self.dwCcpError == other.dwCcpError
+            && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm
+            && self.dwCcpOptions == other.dwCcpOptions
+            && self.dwRemoteCompressionAlgorithm == other.dwRemoteCompressionAlgorithm
+            && self.dwCcpRemoteOptions == other.dwCcpRemoteOptions
     }
 }
 impl ::core::cmp::Eq for PPP_PROJECTION_INFO {}
@@ -7177,7 +7231,35 @@ unsafe impl ::windows::core::Abi for PPP_PROJECTION_INFO2 {
 }
 impl ::core::cmp::PartialEq for PPP_PROJECTION_INFO2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_PROJECTION_INFO2>()) == 0 }
+        self.dwIPv4NegotiationError == other.dwIPv4NegotiationError
+            && self.wszAddress == other.wszAddress
+            && self.wszRemoteAddress == other.wszRemoteAddress
+            && self.dwIPv4Options == other.dwIPv4Options
+            && self.dwIPv4RemoteOptions == other.dwIPv4RemoteOptions
+            && self.IPv4SubInterfaceIndex == other.IPv4SubInterfaceIndex
+            && self.dwIPv6NegotiationError == other.dwIPv6NegotiationError
+            && self.bInterfaceIdentifier == other.bInterfaceIdentifier
+            && self.bRemoteInterfaceIdentifier == other.bRemoteInterfaceIdentifier
+            && self.bPrefix == other.bPrefix
+            && self.dwPrefixLength == other.dwPrefixLength
+            && self.IPv6SubInterfaceIndex == other.IPv6SubInterfaceIndex
+            && self.dwLcpError == other.dwLcpError
+            && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol
+            && self.dwAuthenticationData == other.dwAuthenticationData
+            && self.dwRemoteAuthenticationProtocol == other.dwRemoteAuthenticationProtocol
+            && self.dwRemoteAuthenticationData == other.dwRemoteAuthenticationData
+            && self.dwLcpTerminateReason == other.dwLcpTerminateReason
+            && self.dwLcpRemoteTerminateReason == other.dwLcpRemoteTerminateReason
+            && self.dwLcpOptions == other.dwLcpOptions
+            && self.dwLcpRemoteOptions == other.dwLcpRemoteOptions
+            && self.dwEapTypeId == other.dwEapTypeId
+            && self.dwEmbeddedEAPTypeId == other.dwEmbeddedEAPTypeId
+            && self.dwRemoteEapTypeId == other.dwRemoteEapTypeId
+            && self.dwCcpError == other.dwCcpError
+            && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm
+            && self.dwCcpOptions == other.dwCcpOptions
+            && self.dwRemoteCompressionAlgorithm == other.dwRemoteCompressionAlgorithm
+            && self.dwCcpRemoteOptions == other.dwCcpRemoteOptions
     }
 }
 impl ::core::cmp::Eq for PPP_PROJECTION_INFO2 {}
@@ -7208,7 +7290,7 @@ unsafe impl ::windows::core::Abi for PPTP_CONFIG_PARAMS {
 }
 impl ::core::cmp::PartialEq for PPTP_CONFIG_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPTP_CONFIG_PARAMS>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags
     }
 }
 impl ::core::cmp::Eq for PPTP_CONFIG_PARAMS {}
@@ -7232,12 +7314,6 @@ impl ::core::clone::Clone for PROJECTION_INFO {
 unsafe impl ::windows::core::Abi for PROJECTION_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROJECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROJECTION_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROJECTION_INFO {}
 impl ::core::default::Default for PROJECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7258,12 +7334,6 @@ impl ::core::clone::Clone for PROJECTION_INFO_0 {
 unsafe impl ::windows::core::Abi for PROJECTION_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROJECTION_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROJECTION_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROJECTION_INFO_0 {}
 impl ::core::default::Default for PROJECTION_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7284,12 +7354,6 @@ impl ::core::clone::Clone for PROJECTION_INFO2 {
 unsafe impl ::windows::core::Abi for PROJECTION_INFO2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROJECTION_INFO2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROJECTION_INFO2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROJECTION_INFO2 {}
 impl ::core::default::Default for PROJECTION_INFO2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7310,12 +7374,6 @@ impl ::core::clone::Clone for PROJECTION_INFO2_0 {
 unsafe impl ::windows::core::Abi for PROJECTION_INFO2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROJECTION_INFO2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROJECTION_INFO2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROJECTION_INFO2_0 {}
 impl ::core::default::Default for PROJECTION_INFO2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7343,14 +7401,6 @@ impl ::core::clone::Clone for RASADPARAMS {
 unsafe impl ::windows::core::Abi for RASADPARAMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASADPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASADPARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASADPARAMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASADPARAMS {
     fn default() -> Self {
@@ -7387,7 +7437,7 @@ unsafe impl ::windows::core::Abi for RASAMBA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASAMBA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASAMBA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szNetBiosError == other.szNetBiosError && self.bLana == other.bLana
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7422,7 +7472,7 @@ unsafe impl ::windows::core::Abi for RASAMBW {
 }
 impl ::core::cmp::PartialEq for RASAMBW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASAMBW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szNetBiosError == other.szNetBiosError && self.bLana == other.bLana
     }
 }
 impl ::core::cmp::Eq for RASAMBW {}
@@ -7461,7 +7511,7 @@ unsafe impl ::windows::core::Abi for RASAUTODIALENTRYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASAUTODIALENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASAUTODIALENTRYA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDialingLocation == other.dwDialingLocation && self.szEntry == other.szEntry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7496,7 +7546,7 @@ unsafe impl ::windows::core::Abi for RASAUTODIALENTRYW {
 }
 impl ::core::cmp::PartialEq for RASAUTODIALENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASAUTODIALENTRYW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwDialingLocation == other.dwDialingLocation && self.szEntry == other.szEntry
     }
 }
 impl ::core::cmp::Eq for RASAUTODIALENTRYW {}
@@ -7530,7 +7580,7 @@ unsafe impl ::windows::core::Abi for RASCOMMSETTINGS {
 }
 impl ::core::cmp::PartialEq for RASCOMMSETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCOMMSETTINGS>()) == 0 }
+        self.dwSize == other.dwSize && self.bParity == other.bParity && self.bStop == other.bStop && self.bByteSize == other.bByteSize && self.bAlign == other.bAlign
     }
 }
 impl ::core::cmp::Eq for RASCOMMSETTINGS {}
@@ -7568,14 +7618,6 @@ unsafe impl ::windows::core::Abi for RASCONNA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASCONNA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCONNA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASCONNA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASCONNA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7608,14 +7650,6 @@ unsafe impl ::windows::core::Abi for RASCONNSTATUSA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RASCONNSTATUSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCONNSTATUSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RASCONNSTATUSA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RASCONNSTATUSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7647,14 +7681,6 @@ impl ::core::clone::Clone for RASCONNSTATUSW {
 unsafe impl ::windows::core::Abi for RASCONNSTATUSW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RASCONNSTATUSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCONNSTATUSW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RASCONNSTATUSW {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RASCONNSTATUSW {
     fn default() -> Self {
@@ -7689,14 +7715,6 @@ impl ::core::clone::Clone for RASCONNW {
 unsafe impl ::windows::core::Abi for RASCONNW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASCONNW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCONNW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASCONNW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASCONNW {
     fn default() -> Self {
@@ -7734,7 +7752,7 @@ unsafe impl ::windows::core::Abi for RASCREDENTIALSA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASCREDENTIALSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCREDENTIALSA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMask == other.dwMask && self.szUserName == other.szUserName && self.szPassword == other.szPassword && self.szDomain == other.szDomain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7770,7 +7788,7 @@ unsafe impl ::windows::core::Abi for RASCREDENTIALSW {
 }
 impl ::core::cmp::PartialEq for RASCREDENTIALSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCREDENTIALSW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMask == other.dwMask && self.szUserName == other.szUserName && self.szPassword == other.szPassword && self.szDomain == other.szDomain
     }
 }
 impl ::core::cmp::Eq for RASCREDENTIALSW {}
@@ -7804,7 +7822,7 @@ unsafe impl ::windows::core::Abi for RASCTRYINFO {
 }
 impl ::core::cmp::PartialEq for RASCTRYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCTRYINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCountryID == other.dwCountryID && self.dwNextCountryID == other.dwNextCountryID && self.dwCountryCode == other.dwCountryCode && self.dwCountryNameOffset == other.dwCountryNameOffset
     }
 }
 impl ::core::cmp::Eq for RASCTRYINFO {}
@@ -7832,14 +7850,6 @@ impl ::core::clone::Clone for RASCUSTOMSCRIPTEXTENSIONS {
 unsafe impl ::windows::core::Abi for RASCUSTOMSCRIPTEXTENSIONS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASCUSTOMSCRIPTEXTENSIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASCUSTOMSCRIPTEXTENSIONS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASCUSTOMSCRIPTEXTENSIONS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASCUSTOMSCRIPTEXTENSIONS {
     fn default() -> Self {
@@ -7875,7 +7885,7 @@ unsafe impl ::windows::core::Abi for RASDEVINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASDEVINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDEVINFOA>()) == 0 }
+        self.dwSize == other.dwSize && self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7909,7 +7919,7 @@ unsafe impl ::windows::core::Abi for RASDEVINFOW {
 }
 impl ::core::cmp::PartialEq for RASDEVINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDEVINFOW>()) == 0 }
+        self.dwSize == other.dwSize && self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName
     }
 }
 impl ::core::cmp::Eq for RASDEVINFOW {}
@@ -7933,12 +7943,6 @@ impl ::core::clone::Clone for RASDEVSPECIFICINFO {
 unsafe impl ::windows::core::Abi for RASDEVSPECIFICINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RASDEVSPECIFICINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDEVSPECIFICINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RASDEVSPECIFICINFO {}
 impl ::core::default::Default for RASDEVSPECIFICINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7971,14 +7975,6 @@ unsafe impl ::windows::core::Abi for RASDIALDLG {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASDIALDLG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDIALDLG>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASDIALDLG {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASDIALDLG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8009,14 +8005,6 @@ impl ::core::clone::Clone for RASDIALEXTENSIONS {
 unsafe impl ::windows::core::Abi for RASDIALEXTENSIONS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASDIALEXTENSIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDIALEXTENSIONS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASDIALEXTENSIONS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASDIALEXTENSIONS {
     fn default() -> Self {
@@ -8052,14 +8040,6 @@ unsafe impl ::windows::core::Abi for RASDIALPARAMSA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASDIALPARAMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDIALPARAMSA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASDIALPARAMSA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASDIALPARAMSA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8089,12 +8069,6 @@ impl ::core::clone::Clone for RASDIALPARAMSW {
 unsafe impl ::windows::core::Abi for RASDIALPARAMSW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RASDIALPARAMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASDIALPARAMSW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RASDIALPARAMSW {}
 impl ::core::default::Default for RASDIALPARAMSW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8115,12 +8089,6 @@ impl ::core::clone::Clone for RASEAPINFO {
 unsafe impl ::windows::core::Abi for RASEAPINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RASEAPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASEAPINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RASEAPINFO {}
 impl ::core::default::Default for RASEAPINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8155,7 +8123,7 @@ unsafe impl ::windows::core::Abi for RASEAPUSERIDENTITYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASEAPUSERIDENTITYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASEAPUSERIDENTITYA>()) == 0 }
+        self.szUserName == other.szUserName && self.dwSizeofEapInfo == other.dwSizeofEapInfo && self.pbEapInfo == other.pbEapInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8189,7 +8157,7 @@ unsafe impl ::windows::core::Abi for RASEAPUSERIDENTITYW {
 }
 impl ::core::cmp::PartialEq for RASEAPUSERIDENTITYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASEAPUSERIDENTITYW>()) == 0 }
+        self.szUserName == other.szUserName && self.dwSizeofEapInfo == other.dwSizeofEapInfo && self.pbEapInfo == other.pbEapInfo
     }
 }
 impl ::core::cmp::Eq for RASEAPUSERIDENTITYW {}
@@ -8277,14 +8245,6 @@ unsafe impl ::windows::core::Abi for RASENTRYA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RASENTRYA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RASENTRYA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RASENTRYA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8317,14 +8277,6 @@ unsafe impl ::windows::core::Abi for RASENTRYDLGA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASENTRYDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYDLGA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASENTRYDLGA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASENTRYDLGA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8356,14 +8308,6 @@ impl ::core::clone::Clone for RASENTRYDLGW {
 unsafe impl ::windows::core::Abi for RASENTRYDLGW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASENTRYDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYDLGW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASENTRYDLGW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASENTRYDLGW {
     fn default() -> Self {
@@ -8400,7 +8344,7 @@ unsafe impl ::windows::core::Abi for RASENTRYNAMEA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASENTRYNAMEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYNAMEA>()) == 0 }
+        self.dwSize == other.dwSize && self.szEntryName == other.szEntryName && self.dwFlags == other.dwFlags && self.szPhonebookPath == other.szPhonebookPath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8435,7 +8379,7 @@ unsafe impl ::windows::core::Abi for RASENTRYNAMEW {
 }
 impl ::core::cmp::PartialEq for RASENTRYNAMEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYNAMEW>()) == 0 }
+        self.dwSize == other.dwSize && self.szEntryName == other.szEntryName && self.dwFlags == other.dwFlags && self.szPhonebookPath == other.szPhonebookPath
     }
 }
 impl ::core::cmp::Eq for RASENTRYNAMEW {}
@@ -8523,14 +8467,6 @@ unsafe impl ::windows::core::Abi for RASENTRYW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RASENTRYW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASENTRYW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RASENTRYW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RASENTRYW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8569,14 +8505,6 @@ unsafe impl ::windows::core::Abi for RASIKEV2_PROJECTION_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RASIKEV2_PROJECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASIKEV2_PROJECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RASIKEV2_PROJECTION_INFO {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RASIKEV2_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8606,7 +8534,7 @@ unsafe impl ::windows::core::Abi for RASIPADDR {
 }
 impl ::core::cmp::PartialEq for RASIPADDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASIPADDR>()) == 0 }
+        self.a == other.a && self.b == other.b && self.c == other.c && self.d == other.d
     }
 }
 impl ::core::cmp::Eq for RASIPADDR {}
@@ -8638,7 +8566,7 @@ unsafe impl ::windows::core::Abi for RASIPXW {
 }
 impl ::core::cmp::PartialEq for RASIPXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASIPXW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szIpxAddress == other.szIpxAddress
     }
 }
 impl ::core::cmp::Eq for RASIPXW {}
@@ -8679,7 +8607,7 @@ unsafe impl ::windows::core::Abi for RASNOUSERA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASNOUSERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASNOUSERA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwTimeoutMs == other.dwTimeoutMs && self.szUserName == other.szUserName && self.szPassword == other.szPassword && self.szDomain == other.szDomain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8716,7 +8644,7 @@ unsafe impl ::windows::core::Abi for RASNOUSERW {
 }
 impl ::core::cmp::PartialEq for RASNOUSERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASNOUSERW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwTimeoutMs == other.dwTimeoutMs && self.szUserName == other.szUserName && self.szPassword == other.szPassword && self.szDomain == other.szDomain
     }
 }
 impl ::core::cmp::Eq for RASNOUSERW {}
@@ -8753,14 +8681,6 @@ unsafe impl ::windows::core::Abi for RASPBDLGA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASPBDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPBDLGA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASPBDLGA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASPBDLGA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8794,14 +8714,6 @@ unsafe impl ::windows::core::Abi for RASPBDLGW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RASPBDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPBDLGW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RASPBDLGW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RASPBDLGW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8833,7 +8745,7 @@ unsafe impl ::windows::core::Abi for RASPPPCCP {
 }
 impl ::core::cmp::PartialEq for RASPPPCCP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPCCP>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.dwCompressionAlgorithm == other.dwCompressionAlgorithm && self.dwOptions == other.dwOptions && self.dwServerCompressionAlgorithm == other.dwServerCompressionAlgorithm && self.dwServerOptions == other.dwServerOptions
     }
 }
 impl ::core::cmp::Eq for RASPPPCCP {}
@@ -8874,7 +8786,7 @@ unsafe impl ::windows::core::Abi for RASPPPIPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASPPPIPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPIPA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szIpAddress == other.szIpAddress && self.szServerIpAddress == other.szServerIpAddress && self.dwOptions == other.dwOptions && self.dwServerOptions == other.dwServerOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8911,7 +8823,7 @@ unsafe impl ::windows::core::Abi for RASPPPIPV6 {
 }
 impl ::core::cmp::PartialEq for RASPPPIPV6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPIPV6>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.bLocalInterfaceIdentifier == other.bLocalInterfaceIdentifier && self.bPeerInterfaceIdentifier == other.bPeerInterfaceIdentifier && self.bLocalCompressionProtocol == other.bLocalCompressionProtocol && self.bPeerCompressionProtocol == other.bPeerCompressionProtocol
     }
 }
 impl ::core::cmp::Eq for RASPPPIPV6 {}
@@ -8946,7 +8858,7 @@ unsafe impl ::windows::core::Abi for RASPPPIPW {
 }
 impl ::core::cmp::PartialEq for RASPPPIPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPIPW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szIpAddress == other.szIpAddress && self.szServerIpAddress == other.szServerIpAddress && self.dwOptions == other.dwOptions && self.dwServerOptions == other.dwServerOptions
     }
 }
 impl ::core::cmp::Eq for RASPPPIPW {}
@@ -8984,7 +8896,7 @@ unsafe impl ::windows::core::Abi for RASPPPIPXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASPPPIPXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPIPXA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.szIpxAddress == other.szIpxAddress
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9052,7 +8964,7 @@ unsafe impl ::windows::core::Abi for RASPPPLCPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASPPPLCPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPLCPA>()) == 0 }
+        self.dwSize == other.dwSize && self.fBundled == other.fBundled && self.dwError == other.dwError && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol && self.dwAuthenticationData == other.dwAuthenticationData && self.dwEapTypeId == other.dwEapTypeId && self.dwServerAuthenticationProtocol == other.dwServerAuthenticationProtocol && self.dwServerAuthenticationData == other.dwServerAuthenticationData && self.dwServerEapTypeId == other.dwServerEapTypeId && self.fMultilink == other.fMultilink && self.dwTerminateReason == other.dwTerminateReason && self.dwServerTerminateReason == other.dwServerTerminateReason && self.szReplyMessage == other.szReplyMessage && self.dwOptions == other.dwOptions && self.dwServerOptions == other.dwServerOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9120,7 +9032,7 @@ unsafe impl ::windows::core::Abi for RASPPPLCPW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASPPPLCPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPLCPW>()) == 0 }
+        self.dwSize == other.dwSize && self.fBundled == other.fBundled && self.dwError == other.dwError && self.dwAuthenticationProtocol == other.dwAuthenticationProtocol && self.dwAuthenticationData == other.dwAuthenticationData && self.dwEapTypeId == other.dwEapTypeId && self.dwServerAuthenticationProtocol == other.dwServerAuthenticationProtocol && self.dwServerAuthenticationData == other.dwServerAuthenticationData && self.dwServerEapTypeId == other.dwServerEapTypeId && self.fMultilink == other.fMultilink && self.dwTerminateReason == other.dwTerminateReason && self.dwServerTerminateReason == other.dwServerTerminateReason && self.szReplyMessage == other.szReplyMessage && self.dwOptions == other.dwOptions && self.dwServerOptions == other.dwServerOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9163,7 +9075,7 @@ unsafe impl ::windows::core::Abi for RASPPPNBFA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASPPPNBFA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPNBFA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.dwNetBiosError == other.dwNetBiosError && self.szNetBiosError == other.szNetBiosError && self.szWorkstationName == other.szWorkstationName && self.bLana == other.bLana
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9200,7 +9112,7 @@ unsafe impl ::windows::core::Abi for RASPPPNBFW {
 }
 impl ::core::cmp::PartialEq for RASPPPNBFW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPPNBFW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwError == other.dwError && self.dwNetBiosError == other.dwNetBiosError && self.szNetBiosError == other.szNetBiosError && self.szWorkstationName == other.szWorkstationName && self.bLana == other.bLana
     }
 }
 impl ::core::cmp::Eq for RASPPPNBFW {}
@@ -9250,14 +9162,6 @@ unsafe impl ::windows::core::Abi for RASPPP_PROJECTION_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RASPPP_PROJECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASPPP_PROJECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RASPPP_PROJECTION_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RASPPP_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9295,7 +9199,7 @@ unsafe impl ::windows::core::Abi for RASSUBENTRYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RASSUBENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASSUBENTRYA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwfFlags == other.dwfFlags && self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName && self.szLocalPhoneNumber == other.szLocalPhoneNumber && self.dwAlternateOffset == other.dwAlternateOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9332,7 +9236,7 @@ unsafe impl ::windows::core::Abi for RASSUBENTRYW {
 }
 impl ::core::cmp::PartialEq for RASSUBENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASSUBENTRYW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwfFlags == other.dwfFlags && self.szDeviceType == other.szDeviceType && self.szDeviceName == other.szDeviceName && self.szLocalPhoneNumber == other.szLocalPhoneNumber && self.dwAlternateOffset == other.dwAlternateOffset
     }
 }
 impl ::core::cmp::Eq for RASSUBENTRYW {}
@@ -9361,14 +9265,6 @@ unsafe impl ::windows::core::Abi for RASTUNNELENDPOINT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RASTUNNELENDPOINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASTUNNELENDPOINT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RASTUNNELENDPOINT {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RASTUNNELENDPOINT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9393,14 +9289,6 @@ impl ::core::clone::Clone for RASTUNNELENDPOINT_0 {
 unsafe impl ::windows::core::Abi for RASTUNNELENDPOINT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RASTUNNELENDPOINT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASTUNNELENDPOINT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RASTUNNELENDPOINT_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RASTUNNELENDPOINT_0 {
     fn default() -> Self {
@@ -9430,14 +9318,6 @@ impl ::core::clone::Clone for RASUPDATECONN {
 unsafe impl ::windows::core::Abi for RASUPDATECONN {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for RASUPDATECONN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RASUPDATECONN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for RASUPDATECONN {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for RASUPDATECONN {
     fn default() -> Self {
@@ -9479,7 +9359,7 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_CONNECTION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_0>()) == 0 }
+        self.hConnection == other.hConnection && self.hInterface == other.hInterface && self.dwConnectDuration == other.dwConnectDuration && self.dwInterfaceType == other.dwInterfaceType && self.dwConnectionFlags == other.dwConnectionFlags && self.wszInterfaceName == other.wszInterfaceName && self.wszUserName == other.wszUserName && self.wszLogonDomain == other.wszLogonDomain && self.wszRemoteComputer == other.wszRemoteComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9547,7 +9427,7 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_CONNECTION_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_1>()) == 0 }
+        self.hConnection == other.hConnection && self.hInterface == other.hInterface && self.PppInfo == other.PppInfo && self.dwBytesXmited == other.dwBytesXmited && self.dwBytesRcved == other.dwBytesRcved && self.dwFramesXmited == other.dwFramesXmited && self.dwFramesRcved == other.dwFramesRcved && self.dwCrcErr == other.dwCrcErr && self.dwTimeoutErr == other.dwTimeoutErr && self.dwAlignmentErr == other.dwAlignmentErr && self.dwHardwareOverrunErr == other.dwHardwareOverrunErr && self.dwFramingErr == other.dwFramingErr && self.dwBufferOverrunErr == other.dwBufferOverrunErr && self.dwCompressionRatioIn == other.dwCompressionRatioIn && self.dwCompressionRatioOut == other.dwCompressionRatioOut
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9589,7 +9469,7 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_CONNECTION_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_2>()) == 0 }
+        self.hConnection == other.hConnection && self.wszUserName == other.wszUserName && self.dwInterfaceType == other.dwInterfaceType && self.guid == other.guid && self.PppInfo2 == other.PppInfo2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9635,7 +9515,7 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_CONNECTION_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_3>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwSize == other.dwSize && self.hConnection == other.hConnection && self.wszUserName == other.wszUserName && self.dwInterfaceType == other.dwInterfaceType && self.guid == other.guid && self.PppInfo3 == other.PppInfo3 && self.rasQuarState == other.rasQuarState && self.timer == other.timer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9694,14 +9574,6 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAS_CONNECTION_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAS_CONNECTION_4 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAS_CONNECTION_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9754,14 +9626,6 @@ unsafe impl ::windows::core::Abi for RAS_CONNECTION_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAS_CONNECTION_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_CONNECTION_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAS_CONNECTION_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAS_CONNECTION_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9802,7 +9666,7 @@ unsafe impl ::windows::core::Abi for RAS_PORT_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_PORT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_PORT_0>()) == 0 }
+        self.hPort == other.hPort && self.hConnection == other.hConnection && self.dwPortCondition == other.dwPortCondition && self.dwTotalNumberOfCalls == other.dwTotalNumberOfCalls && self.dwConnectDuration == other.dwConnectDuration && self.wszPortName == other.wszPortName && self.wszMediaName == other.wszMediaName && self.wszDeviceName == other.wszDeviceName && self.wszDeviceType == other.wszDeviceType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9872,7 +9736,7 @@ unsafe impl ::windows::core::Abi for RAS_PORT_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_PORT_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_PORT_1>()) == 0 }
+        self.hPort == other.hPort && self.hConnection == other.hConnection && self.dwHardwareCondition == other.dwHardwareCondition && self.dwLineSpeed == other.dwLineSpeed && self.dwBytesXmited == other.dwBytesXmited && self.dwBytesRcved == other.dwBytesRcved && self.dwFramesXmited == other.dwFramesXmited && self.dwFramesRcved == other.dwFramesRcved && self.dwCrcErr == other.dwCrcErr && self.dwTimeoutErr == other.dwTimeoutErr && self.dwAlignmentErr == other.dwAlignmentErr && self.dwHardwareOverrunErr == other.dwHardwareOverrunErr && self.dwFramingErr == other.dwFramingErr && self.dwBufferOverrunErr == other.dwBufferOverrunErr && self.dwCompressionRatioIn == other.dwCompressionRatioIn && self.dwCompressionRatioOut == other.dwCompressionRatioOut
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9964,7 +9828,33 @@ unsafe impl ::windows::core::Abi for RAS_PORT_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_PORT_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_PORT_2>()) == 0 }
+        self.hPort == other.hPort
+            && self.hConnection == other.hConnection
+            && self.dwConn_State == other.dwConn_State
+            && self.wszPortName == other.wszPortName
+            && self.wszMediaName == other.wszMediaName
+            && self.wszDeviceName == other.wszDeviceName
+            && self.wszDeviceType == other.wszDeviceType
+            && self.dwHardwareCondition == other.dwHardwareCondition
+            && self.dwLineSpeed == other.dwLineSpeed
+            && self.dwCrcErr == other.dwCrcErr
+            && self.dwSerialOverRunErrs == other.dwSerialOverRunErrs
+            && self.dwTimeoutErr == other.dwTimeoutErr
+            && self.dwAlignmentErr == other.dwAlignmentErr
+            && self.dwHardwareOverrunErr == other.dwHardwareOverrunErr
+            && self.dwFramingErr == other.dwFramingErr
+            && self.dwBufferOverrunErr == other.dwBufferOverrunErr
+            && self.dwCompressionRatioIn == other.dwCompressionRatioIn
+            && self.dwCompressionRatioOut == other.dwCompressionRatioOut
+            && self.dwTotalErrors == other.dwTotalErrors
+            && self.ullBytesXmited == other.ullBytesXmited
+            && self.ullBytesRcved == other.ullBytesRcved
+            && self.ullFramesXmited == other.ullFramesXmited
+            && self.ullFramesRcved == other.ullFramesRcved
+            && self.ullBytesTxUncompressed == other.ullBytesTxUncompressed
+            && self.ullBytesTxCompressed == other.ullBytesTxCompressed
+            && self.ullBytesRcvUncompressed == other.ullBytesRcvUncompressed
+            && self.ullBytesRcvCompressed == other.ullBytesRcvCompressed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9996,14 +9886,6 @@ unsafe impl ::windows::core::Abi for RAS_PROJECTION_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RAS_PROJECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_PROJECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RAS_PROJECTION_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RAS_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10028,14 +9910,6 @@ impl ::core::clone::Clone for RAS_PROJECTION_INFO_0 {
 unsafe impl ::windows::core::Abi for RAS_PROJECTION_INFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for RAS_PROJECTION_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_PROJECTION_INFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for RAS_PROJECTION_INFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for RAS_PROJECTION_INFO_0 {
     fn default() -> Self {
@@ -10071,7 +9945,7 @@ unsafe impl ::windows::core::Abi for RAS_SECURITY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAS_SECURITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_SECURITY_INFO>()) == 0 }
+        self.LastError == other.LastError && self.BytesReceived == other.BytesReceived && self.DeviceName == other.DeviceName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10133,7 +10007,7 @@ unsafe impl ::windows::core::Abi for RAS_STATS {
 }
 impl ::core::cmp::PartialEq for RAS_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_STATS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwBytesXmited == other.dwBytesXmited && self.dwBytesRcved == other.dwBytesRcved && self.dwFramesXmited == other.dwFramesXmited && self.dwFramesRcved == other.dwFramesRcved && self.dwCrcErr == other.dwCrcErr && self.dwTimeoutErr == other.dwTimeoutErr && self.dwAlignmentErr == other.dwAlignmentErr && self.dwHardwareOverrunErr == other.dwHardwareOverrunErr && self.dwFramingErr == other.dwFramingErr && self.dwBufferOverrunErr == other.dwBufferOverrunErr && self.dwCompressionRatioIn == other.dwCompressionRatioIn && self.dwCompressionRatioOut == other.dwCompressionRatioOut && self.dwBps == other.dwBps && self.dwConnectDuration == other.dwConnectDuration
     }
 }
 impl ::core::cmp::Eq for RAS_STATS {}
@@ -10166,7 +10040,7 @@ unsafe impl ::windows::core::Abi for RAS_UPDATE_CONNECTION {
 }
 impl ::core::cmp::PartialEq for RAS_UPDATE_CONNECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_UPDATE_CONNECTION>()) == 0 }
+        self.Header == other.Header && self.dwIfIndex == other.dwIfIndex && self.wszLocalEndpointAddress == other.wszLocalEndpointAddress && self.wszRemoteEndpointAddress == other.wszRemoteEndpointAddress
     }
 }
 impl ::core::cmp::Eq for RAS_UPDATE_CONNECTION {}
@@ -10197,7 +10071,7 @@ unsafe impl ::windows::core::Abi for RAS_USER_0 {
 }
 impl ::core::cmp::PartialEq for RAS_USER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_USER_0>()) == 0 }
+        self.bfPrivilege == other.bfPrivilege && self.wszPhoneNumber == other.wszPhoneNumber
     }
 }
 impl ::core::cmp::Eq for RAS_USER_0 {}
@@ -10229,7 +10103,7 @@ unsafe impl ::windows::core::Abi for RAS_USER_1 {
 }
 impl ::core::cmp::PartialEq for RAS_USER_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_USER_1>()) == 0 }
+        self.bfPrivilege == other.bfPrivilege && self.wszPhoneNumber == other.wszPhoneNumber && self.bfPrivilege2 == other.bfPrivilege2
     }
 }
 impl ::core::cmp::Eq for RAS_USER_1 {}
@@ -10264,7 +10138,7 @@ unsafe impl ::windows::core::Abi for ROUTER_CUSTOM_IKEv2_POLICY0 {
 }
 impl ::core::cmp::PartialEq for ROUTER_CUSTOM_IKEv2_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROUTER_CUSTOM_IKEv2_POLICY0>()) == 0 }
+        self.dwIntegrityMethod == other.dwIntegrityMethod && self.dwEncryptionMethod == other.dwEncryptionMethod && self.dwCipherTransformConstant == other.dwCipherTransformConstant && self.dwAuthTransformConstant == other.dwAuthTransformConstant && self.dwPfsGroup == other.dwPfsGroup && self.dwDhGroup == other.dwDhGroup
     }
 }
 impl ::core::cmp::Eq for ROUTER_CUSTOM_IKEv2_POLICY0 {}
@@ -10303,7 +10177,7 @@ unsafe impl ::windows::core::Abi for ROUTER_IKEv2_IF_CUSTOM_CONFIG0 {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for ROUTER_IKEv2_IF_CUSTOM_CONFIG0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROUTER_IKEv2_IF_CUSTOM_CONFIG0>()) == 0 }
+        self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSize == other.dwSaDataSize && self.certificateName == other.certificateName && self.customPolicy == other.customPolicy
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -10345,7 +10219,7 @@ unsafe impl ::windows::core::Abi for ROUTER_IKEv2_IF_CUSTOM_CONFIG1 {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for ROUTER_IKEv2_IF_CUSTOM_CONFIG1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROUTER_IKEv2_IF_CUSTOM_CONFIG1>()) == 0 }
+        self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSize == other.dwSaDataSize && self.certificateName == other.certificateName && self.customPolicy == other.customPolicy && self.certificateHash == other.certificateHash
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -10389,7 +10263,7 @@ unsafe impl ::windows::core::Abi for ROUTER_IKEv2_IF_CUSTOM_CONFIG2 {
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for ROUTER_IKEv2_IF_CUSTOM_CONFIG2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROUTER_IKEv2_IF_CUSTOM_CONFIG2>()) == 0 }
+        self.dwSaLifeTime == other.dwSaLifeTime && self.dwSaDataSize == other.dwSaDataSize && self.certificateName == other.certificateName && self.customPolicy == other.customPolicy && self.certificateHash == other.certificateHash && self.dwMmSaLifeTime == other.dwMmSaLifeTime && self.vpnTrafficSelectors == other.vpnTrafficSelectors
     }
 }
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
@@ -10426,32 +10300,13 @@ impl ::core::clone::Clone for ROUTING_PROTOCOL_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for ROUTING_PROTOCOL_CONFIG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("ROUTING_PROTOCOL_CONFIG")
-            .field("dwCallbackFlags", &self.dwCallbackFlags)
-            .field("pfnRpfCallback", &self.pfnRpfCallback.map(|f| f as usize))
-            .field("pfnCreationAlertCallback", &self.pfnCreationAlertCallback.map(|f| f as usize))
-            .field("pfnPruneAlertCallback", &self.pfnPruneAlertCallback.map(|f| f as usize))
-            .field("pfnJoinAlertCallback", &self.pfnJoinAlertCallback.map(|f| f as usize))
-            .field("pfnWrongIfCallback", &self.pfnWrongIfCallback.map(|f| f as usize))
-            .field("pfnLocalJoinCallback", &self.pfnLocalJoinCallback.map(|f| f as usize))
-            .field("pfnLocalLeaveCallback", &self.pfnLocalLeaveCallback.map(|f| f as usize))
-            .field("pfnDisableIgmpCallback", &self.pfnDisableIgmpCallback.map(|f| f as usize))
-            .field("pfnEnableIgmpCallback", &self.pfnEnableIgmpCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("ROUTING_PROTOCOL_CONFIG").field("dwCallbackFlags", &self.dwCallbackFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for ROUTING_PROTOCOL_CONFIG {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ROUTING_PROTOCOL_CONFIG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROUTING_PROTOCOL_CONFIG>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ROUTING_PROTOCOL_CONFIG {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ROUTING_PROTOCOL_CONFIG {
     fn default() -> Self {
@@ -10490,7 +10345,7 @@ unsafe impl ::windows::core::Abi for RTM_DEST_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RTM_DEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_DEST_INFO>()) == 0 }
+        self.DestHandle == other.DestHandle && self.DestAddress == other.DestAddress && self.LastChanged == other.LastChanged && self.BelongsToViews == other.BelongsToViews && self.NumberOfViews == other.NumberOfViews && self.ViewInfo == other.ViewInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10533,7 +10388,7 @@ unsafe impl ::windows::core::Abi for RTM_DEST_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RTM_DEST_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_DEST_INFO_0>()) == 0 }
+        self.ViewId == other.ViewId && self.NumRoutes == other.NumRoutes && self.Route == other.Route && self.Owner == other.Owner && self.DestFlags == other.DestFlags && self.HoldRoute == other.HoldRoute
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10564,12 +10419,6 @@ impl ::core::fmt::Debug for RTM_ENTITY_EXPORT_METHODS {
 unsafe impl ::windows::core::Abi for RTM_ENTITY_EXPORT_METHODS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTM_ENTITY_EXPORT_METHODS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_EXPORT_METHODS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTM_ENTITY_EXPORT_METHODS {}
 impl ::core::default::Default for RTM_ENTITY_EXPORT_METHODS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10589,12 +10438,6 @@ impl ::core::clone::Clone for RTM_ENTITY_ID {
 unsafe impl ::windows::core::Abi for RTM_ENTITY_ID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTM_ENTITY_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_ID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTM_ENTITY_ID {}
 impl ::core::default::Default for RTM_ENTITY_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10615,12 +10458,6 @@ impl ::core::clone::Clone for RTM_ENTITY_ID_0 {
 unsafe impl ::windows::core::Abi for RTM_ENTITY_ID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTM_ENTITY_ID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_ID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTM_ENTITY_ID_0 {}
 impl ::core::default::Default for RTM_ENTITY_ID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10648,7 +10485,7 @@ unsafe impl ::windows::core::Abi for RTM_ENTITY_ID_0_0 {
 }
 impl ::core::cmp::PartialEq for RTM_ENTITY_ID_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_ID_0_0>()) == 0 }
+        self.EntityProtocolId == other.EntityProtocolId && self.EntityInstanceId == other.EntityInstanceId
     }
 }
 impl ::core::cmp::Eq for RTM_ENTITY_ID_0_0 {}
@@ -10673,12 +10510,6 @@ impl ::core::clone::Clone for RTM_ENTITY_INFO {
 unsafe impl ::windows::core::Abi for RTM_ENTITY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTM_ENTITY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTM_ENTITY_INFO {}
 impl ::core::default::Default for RTM_ENTITY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10707,7 +10538,7 @@ unsafe impl ::windows::core::Abi for RTM_ENTITY_METHOD_INPUT {
 }
 impl ::core::cmp::PartialEq for RTM_ENTITY_METHOD_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_METHOD_INPUT>()) == 0 }
+        self.MethodType == other.MethodType && self.InputSize == other.InputSize && self.InputData == other.InputData
     }
 }
 impl ::core::cmp::Eq for RTM_ENTITY_METHOD_INPUT {}
@@ -10740,7 +10571,7 @@ unsafe impl ::windows::core::Abi for RTM_ENTITY_METHOD_OUTPUT {
 }
 impl ::core::cmp::PartialEq for RTM_ENTITY_METHOD_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ENTITY_METHOD_OUTPUT>()) == 0 }
+        self.MethodType == other.MethodType && self.MethodStatus == other.MethodStatus && self.OutputSize == other.OutputSize && self.OutputData == other.OutputData
     }
 }
 impl ::core::cmp::Eq for RTM_ENTITY_METHOD_OUTPUT {}
@@ -10772,7 +10603,7 @@ unsafe impl ::windows::core::Abi for RTM_NET_ADDRESS {
 }
 impl ::core::cmp::PartialEq for RTM_NET_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_NET_ADDRESS>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.NumBits == other.NumBits && self.AddrBits == other.AddrBits
     }
 }
 impl ::core::cmp::Eq for RTM_NET_ADDRESS {}
@@ -10808,7 +10639,7 @@ unsafe impl ::windows::core::Abi for RTM_NEXTHOP_INFO {
 }
 impl ::core::cmp::PartialEq for RTM_NEXTHOP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_NEXTHOP_INFO>()) == 0 }
+        self.NextHopAddress == other.NextHopAddress && self.NextHopOwner == other.NextHopOwner && self.InterfaceIndex == other.InterfaceIndex && self.State == other.State && self.Flags == other.Flags && self.EntitySpecificInfo == other.EntitySpecificInfo && self.RemoteNextHop == other.RemoteNextHop
     }
 }
 impl ::core::cmp::Eq for RTM_NEXTHOP_INFO {}
@@ -10839,7 +10670,7 @@ unsafe impl ::windows::core::Abi for RTM_NEXTHOP_LIST {
 }
 impl ::core::cmp::PartialEq for RTM_NEXTHOP_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_NEXTHOP_LIST>()) == 0 }
+        self.NumNextHops == other.NumNextHops && self.NextHops == other.NextHops
     }
 }
 impl ::core::cmp::Eq for RTM_NEXTHOP_LIST {}
@@ -10870,7 +10701,7 @@ unsafe impl ::windows::core::Abi for RTM_PREF_INFO {
 }
 impl ::core::cmp::PartialEq for RTM_PREF_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_PREF_INFO>()) == 0 }
+        self.Metric == other.Metric && self.Preference == other.Preference
     }
 }
 impl ::core::cmp::Eq for RTM_PREF_INFO {}
@@ -10903,7 +10734,7 @@ unsafe impl ::windows::core::Abi for RTM_REGN_PROFILE {
 }
 impl ::core::cmp::PartialEq for RTM_REGN_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_REGN_PROFILE>()) == 0 }
+        self.MaxNextHopsInRoute == other.MaxNextHopsInRoute && self.MaxHandlesInEnum == other.MaxHandlesInEnum && self.ViewsSupported == other.ViewsSupported && self.NumberOfViews == other.NumberOfViews
     }
 }
 impl ::core::cmp::Eq for RTM_REGN_PROFILE {}
@@ -10942,7 +10773,7 @@ unsafe impl ::windows::core::Abi for RTM_ROUTE_INFO {
 }
 impl ::core::cmp::PartialEq for RTM_ROUTE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTM_ROUTE_INFO>()) == 0 }
+        self.DestHandle == other.DestHandle && self.RouteOwner == other.RouteOwner && self.Neighbour == other.Neighbour && self.State == other.State && self.Flags1 == other.Flags1 && self.Flags == other.Flags && self.PrefInfo == other.PrefInfo && self.BelongsToViews == other.BelongsToViews && self.EntitySpecificInfo == other.EntitySpecificInfo && self.NextHopsList == other.NextHopsList
     }
 }
 impl ::core::cmp::Eq for RTM_ROUTE_INFO {}
@@ -10982,7 +10813,7 @@ unsafe impl ::windows::core::Abi for SECURITY_MESSAGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_MESSAGE>()) == 0 }
+        self.dwMsgId == other.dwMsgId && self.hPort == other.hPort && self.dwError == other.dwError && self.UserName == other.UserName && self.Domain == other.Domain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11017,7 +10848,7 @@ unsafe impl ::windows::core::Abi for SOURCE_GROUP_ENTRY {
 }
 impl ::core::cmp::PartialEq for SOURCE_GROUP_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCE_GROUP_ENTRY>()) == 0 }
+        self.dwSourceAddr == other.dwSourceAddr && self.dwSourceMask == other.dwSourceMask && self.dwGroupAddr == other.dwGroupAddr && self.dwGroupMask == other.dwGroupMask
     }
 }
 impl ::core::cmp::Eq for SOURCE_GROUP_ENTRY {}
@@ -11054,7 +10885,7 @@ unsafe impl ::windows::core::Abi for SSTP_CERT_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for SSTP_CERT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSTP_CERT_INFO>()) == 0 }
+        self.isDefault == other.isDefault && self.certBlob == other.certBlob
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -11096,7 +10927,7 @@ unsafe impl ::windows::core::Abi for SSTP_CONFIG_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for SSTP_CONFIG_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSTP_CONFIG_PARAMS>()) == 0 }
+        self.dwNumPorts == other.dwNumPorts && self.dwPortFlags == other.dwPortFlags && self.isUseHttps == other.isUseHttps && self.certAlgorithm == other.certAlgorithm && self.sstpCertDetails == other.sstpCertDetails
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -11127,14 +10958,6 @@ unsafe impl ::windows::core::Abi for VPN_TS_IP_ADDRESS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for VPN_TS_IP_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VPN_TS_IP_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for VPN_TS_IP_ADDRESS {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for VPN_TS_IP_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11159,14 +10982,6 @@ impl ::core::clone::Clone for VPN_TS_IP_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for VPN_TS_IP_ADDRESS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for VPN_TS_IP_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VPN_TS_IP_ADDRESS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for VPN_TS_IP_ADDRESS_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for VPN_TS_IP_ADDRESS_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
@@ -1099,14 +1099,6 @@ unsafe impl ::windows::core::Abi for AsnAny {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AsnAny {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AsnAny>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AsnAny {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AsnAny {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1142,14 +1134,6 @@ unsafe impl ::windows::core::Abi for AsnAny_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AsnAny_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AsnAny_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AsnAny_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AsnAny_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1170,12 +1154,6 @@ impl ::core::clone::Clone for AsnObjectIdentifier {
 unsafe impl ::windows::core::Abi for AsnObjectIdentifier {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AsnObjectIdentifier {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AsnObjectIdentifier>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AsnObjectIdentifier {}
 impl ::core::default::Default for AsnObjectIdentifier {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1202,14 +1180,6 @@ unsafe impl ::windows::core::Abi for AsnOctetString {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AsnOctetString {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AsnOctetString>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AsnOctetString {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AsnOctetString {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1235,14 +1205,6 @@ unsafe impl ::windows::core::Abi for SnmpVarBind {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SnmpVarBind {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SnmpVarBind>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SnmpVarBind {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SnmpVarBind {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1267,14 +1229,6 @@ impl ::core::clone::Clone for SnmpVarBindList {
 unsafe impl ::windows::core::Abi for SnmpVarBindList {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SnmpVarBindList {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SnmpVarBindList>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SnmpVarBindList {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SnmpVarBindList {
     fn default() -> Self {
@@ -1303,7 +1257,7 @@ unsafe impl ::windows::core::Abi for smiCNTR64 {
 }
 impl ::core::cmp::PartialEq for smiCNTR64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiCNTR64>()) == 0 }
+        self.hipart == other.hipart && self.lopart == other.lopart
     }
 }
 impl ::core::cmp::Eq for smiCNTR64 {}
@@ -1334,7 +1288,7 @@ unsafe impl ::windows::core::Abi for smiOCTETS {
 }
 impl ::core::cmp::PartialEq for smiOCTETS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiOCTETS>()) == 0 }
+        self.len == other.len && self.ptr == other.ptr
     }
 }
 impl ::core::cmp::Eq for smiOCTETS {}
@@ -1365,7 +1319,7 @@ unsafe impl ::windows::core::Abi for smiOID {
 }
 impl ::core::cmp::PartialEq for smiOID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiOID>()) == 0 }
+        self.len == other.len && self.ptr == other.ptr
     }
 }
 impl ::core::cmp::Eq for smiOID {}
@@ -1389,12 +1343,6 @@ impl ::core::clone::Clone for smiVALUE {
 unsafe impl ::windows::core::Abi for smiVALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for smiVALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiVALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for smiVALUE {}
 impl ::core::default::Default for smiVALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1419,12 +1367,6 @@ impl ::core::clone::Clone for smiVALUE_0 {
 unsafe impl ::windows::core::Abi for smiVALUE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for smiVALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiVALUE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for smiVALUE_0 {}
 impl ::core::default::Default for smiVALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1461,7 +1403,7 @@ unsafe impl ::windows::core::Abi for smiVENDORINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for smiVENDORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<smiVENDORINFO>()) == 0 }
+        self.vendorName == other.vendorName && self.vendorContact == other.vendorContact && self.vendorVersionId == other.vendorVersionId && self.vendorVersionDate == other.vendorVersionDate && self.vendorEnterprise == other.vendorEnterprise
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
@@ -1331,7 +1331,7 @@ unsafe impl ::windows::core::Abi for CONNECTDLGSTRUCTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONNECTDLGSTRUCTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTDLGSTRUCTA>()) == 0 }
+        self.cbStructure == other.cbStructure && self.hwndOwner == other.hwndOwner && self.lpConnRes == other.lpConnRes && self.dwFlags == other.dwFlags && self.dwDevNum == other.dwDevNum
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1373,7 +1373,7 @@ unsafe impl ::windows::core::Abi for CONNECTDLGSTRUCTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONNECTDLGSTRUCTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTDLGSTRUCTW>()) == 0 }
+        self.cbStructure == other.cbStructure && self.hwndOwner == other.hwndOwner && self.lpConnRes == other.lpConnRes && self.dwFlags == other.dwFlags && self.dwDevNum == other.dwDevNum
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1415,7 +1415,7 @@ unsafe impl ::windows::core::Abi for DISCDLGSTRUCTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISCDLGSTRUCTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISCDLGSTRUCTA>()) == 0 }
+        self.cbStructure == other.cbStructure && self.hwndOwner == other.hwndOwner && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1457,7 +1457,7 @@ unsafe impl ::windows::core::Abi for DISCDLGSTRUCTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISCDLGSTRUCTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISCDLGSTRUCTW>()) == 0 }
+        self.cbStructure == other.cbStructure && self.hwndOwner == other.hwndOwner && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1493,7 +1493,7 @@ unsafe impl ::windows::core::Abi for NETCONNECTINFOSTRUCT {
 }
 impl ::core::cmp::PartialEq for NETCONNECTINFOSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETCONNECTINFOSTRUCT>()) == 0 }
+        self.cbStructure == other.cbStructure && self.dwFlags == other.dwFlags && self.dwSpeed == other.dwSpeed && self.dwDelay == other.dwDelay && self.dwOptDataSize == other.dwOptDataSize
     }
 }
 impl ::core::cmp::Eq for NETCONNECTINFOSTRUCT {}
@@ -1536,7 +1536,7 @@ unsafe impl ::windows::core::Abi for NETINFOSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NETINFOSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETINFOSTRUCT>()) == 0 }
+        self.cbStructure == other.cbStructure && self.dwProviderVersion == other.dwProviderVersion && self.dwStatus == other.dwStatus && self.dwCharacteristics == other.dwCharacteristics && self.dwHandle == other.dwHandle && self.wNetType == other.wNetType && self.dwPrinters == other.dwPrinters && self.dwDrives == other.dwDrives
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1575,7 +1575,7 @@ unsafe impl ::windows::core::Abi for NETRESOURCEA {
 }
 impl ::core::cmp::PartialEq for NETRESOURCEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETRESOURCEA>()) == 0 }
+        self.dwScope == other.dwScope && self.dwType == other.dwType && self.dwDisplayType == other.dwDisplayType && self.dwUsage == other.dwUsage && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.lpComment == other.lpComment && self.lpProvider == other.lpProvider
     }
 }
 impl ::core::cmp::Eq for NETRESOURCEA {}
@@ -1612,7 +1612,7 @@ unsafe impl ::windows::core::Abi for NETRESOURCEW {
 }
 impl ::core::cmp::PartialEq for NETRESOURCEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETRESOURCEW>()) == 0 }
+        self.dwScope == other.dwScope && self.dwType == other.dwType && self.dwDisplayType == other.dwDisplayType && self.dwUsage == other.dwUsage && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.lpComment == other.lpComment && self.lpProvider == other.lpProvider
     }
 }
 impl ::core::cmp::Eq for NETRESOURCEW {}
@@ -1650,7 +1650,7 @@ unsafe impl ::windows::core::Abi for NOTIFYADD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NOTIFYADD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYADD>()) == 0 }
+        self.hwndOwner == other.hwndOwner && self.NetResource == other.NetResource && self.dwAddFlags == other.dwAddFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1691,7 +1691,7 @@ unsafe impl ::windows::core::Abi for NOTIFYCANCEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NOTIFYCANCEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYCANCEL>()) == 0 }
+        self.lpName == other.lpName && self.lpProvider == other.lpProvider && self.dwFlags == other.dwFlags && self.fForce == other.fForce
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1725,7 +1725,7 @@ unsafe impl ::windows::core::Abi for NOTIFYINFO {
 }
 impl ::core::cmp::PartialEq for NOTIFYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYINFO>()) == 0 }
+        self.dwNotifyStatus == other.dwNotifyStatus && self.dwOperationStatus == other.dwOperationStatus && self.lpContext == other.lpContext
     }
 }
 impl ::core::cmp::Eq for NOTIFYINFO {}
@@ -1789,7 +1789,7 @@ unsafe impl ::windows::core::Abi for REMOTE_NAME_INFOA {
 }
 impl ::core::cmp::PartialEq for REMOTE_NAME_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REMOTE_NAME_INFOA>()) == 0 }
+        self.lpUniversalName == other.lpUniversalName && self.lpConnectionName == other.lpConnectionName && self.lpRemainingPath == other.lpRemainingPath
     }
 }
 impl ::core::cmp::Eq for REMOTE_NAME_INFOA {}
@@ -1821,7 +1821,7 @@ unsafe impl ::windows::core::Abi for REMOTE_NAME_INFOW {
 }
 impl ::core::cmp::PartialEq for REMOTE_NAME_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REMOTE_NAME_INFOW>()) == 0 }
+        self.lpUniversalName == other.lpUniversalName && self.lpConnectionName == other.lpConnectionName && self.lpRemainingPath == other.lpRemainingPath
     }
 }
 impl ::core::cmp::Eq for REMOTE_NAME_INFOW {}
@@ -1851,7 +1851,7 @@ unsafe impl ::windows::core::Abi for UNIVERSAL_NAME_INFOA {
 }
 impl ::core::cmp::PartialEq for UNIVERSAL_NAME_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNIVERSAL_NAME_INFOA>()) == 0 }
+        self.lpUniversalName == other.lpUniversalName
     }
 }
 impl ::core::cmp::Eq for UNIVERSAL_NAME_INFOA {}
@@ -1881,7 +1881,7 @@ unsafe impl ::windows::core::Abi for UNIVERSAL_NAME_INFOW {
 }
 impl ::core::cmp::PartialEq for UNIVERSAL_NAME_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNIVERSAL_NAME_INFOW>()) == 0 }
+        self.lpUniversalName == other.lpUniversalName
     }
 }
 impl ::core::cmp::Eq for UNIVERSAL_NAME_INFOW {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WebDav/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WebDav/mod.rs
@@ -166,7 +166,7 @@ unsafe impl ::windows::core::Abi for DAV_CALLBACK_AUTH_BLOB {
 }
 impl ::core::cmp::PartialEq for DAV_CALLBACK_AUTH_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DAV_CALLBACK_AUTH_BLOB>()) == 0 }
+        self.pBuffer == other.pBuffer && self.ulSize == other.ulSize && self.ulType == other.ulType
     }
 }
 impl ::core::cmp::Eq for DAV_CALLBACK_AUTH_BLOB {}
@@ -199,7 +199,7 @@ unsafe impl ::windows::core::Abi for DAV_CALLBACK_AUTH_UNP {
 }
 impl ::core::cmp::PartialEq for DAV_CALLBACK_AUTH_UNP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DAV_CALLBACK_AUTH_UNP>()) == 0 }
+        self.pszUserName == other.pszUserName && self.ulUserNameLength == other.ulUserNameLength && self.pszPassword == other.pszPassword && self.ulPasswordLength == other.ulPasswordLength
     }
 }
 impl ::core::cmp::Eq for DAV_CALLBACK_AUTH_UNP {}
@@ -238,7 +238,7 @@ unsafe impl ::windows::core::Abi for DAV_CALLBACK_CRED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DAV_CALLBACK_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DAV_CALLBACK_CRED>()) == 0 }
+        self.AuthBlob == other.AuthBlob && self.UNPBlob == other.UNPBlob && self.bAuthBlobValid == other.bAuthBlobValid && self.bSave == other.bSave
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -5235,44 +5235,13 @@ impl ::core::clone::Clone for DOT11EXT_APIS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 impl ::core::fmt::Debug for DOT11EXT_APIS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DOT11EXT_APIS")
-            .field("Dot11ExtAllocateBuffer", &self.Dot11ExtAllocateBuffer.map(|f| f as usize))
-            .field("Dot11ExtFreeBuffer", &self.Dot11ExtFreeBuffer.map(|f| f as usize))
-            .field("Dot11ExtSetProfileCustomUserData", &self.Dot11ExtSetProfileCustomUserData.map(|f| f as usize))
-            .field("Dot11ExtGetProfileCustomUserData", &self.Dot11ExtGetProfileCustomUserData.map(|f| f as usize))
-            .field("Dot11ExtSetCurrentProfile", &self.Dot11ExtSetCurrentProfile.map(|f| f as usize))
-            .field("Dot11ExtSendUIRequest", &self.Dot11ExtSendUIRequest.map(|f| f as usize))
-            .field("Dot11ExtPreAssociateCompletion", &self.Dot11ExtPreAssociateCompletion.map(|f| f as usize))
-            .field("Dot11ExtPostAssociateCompletion", &self.Dot11ExtPostAssociateCompletion.map(|f| f as usize))
-            .field("Dot11ExtSendNotification", &self.Dot11ExtSendNotification.map(|f| f as usize))
-            .field("Dot11ExtSendPacket", &self.Dot11ExtSendPacket.map(|f| f as usize))
-            .field("Dot11ExtSetEtherTypeHandling", &self.Dot11ExtSetEtherTypeHandling.map(|f| f as usize))
-            .field("Dot11ExtSetAuthAlgorithm", &self.Dot11ExtSetAuthAlgorithm.map(|f| f as usize))
-            .field("Dot11ExtSetUnicastCipherAlgorithm", &self.Dot11ExtSetUnicastCipherAlgorithm.map(|f| f as usize))
-            .field("Dot11ExtSetMulticastCipherAlgorithm", &self.Dot11ExtSetMulticastCipherAlgorithm.map(|f| f as usize))
-            .field("Dot11ExtSetDefaultKey", &self.Dot11ExtSetDefaultKey.map(|f| f as usize))
-            .field("Dot11ExtSetKeyMappingKey", &self.Dot11ExtSetKeyMappingKey.map(|f| f as usize))
-            .field("Dot11ExtSetDefaultKeyId", &self.Dot11ExtSetDefaultKeyId.map(|f| f as usize))
-            .field("Dot11ExtNicSpecificExtension", &self.Dot11ExtNicSpecificExtension.map(|f| f as usize))
-            .field("Dot11ExtSetExcludeUnencrypted", &self.Dot11ExtSetExcludeUnencrypted.map(|f| f as usize))
-            .field("Dot11ExtStartOneX", &self.Dot11ExtStartOneX.map(|f| f as usize))
-            .field("Dot11ExtStopOneX", &self.Dot11ExtStopOneX.map(|f| f as usize))
-            .field("Dot11ExtProcessSecurityPacket", &self.Dot11ExtProcessSecurityPacket.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DOT11EXT_APIS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 unsafe impl ::windows::core::Abi for DOT11EXT_APIS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
-impl ::core::cmp::PartialEq for DOT11EXT_APIS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_APIS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
-impl ::core::cmp::Eq for DOT11EXT_APIS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 impl ::core::default::Default for DOT11EXT_APIS {
     fn default() -> Self {
@@ -5300,7 +5269,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_CONNECTIVITY_PROFILE {
 }
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_CONNECTIVITY_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_CONNECTIVITY_PROFILE>()) == 0 }
+        self.pszXmlFragmentIhvConnectivity == other.pszXmlFragmentIhvConnectivity
     }
 }
 impl ::core::cmp::Eq for DOT11EXT_IHV_CONNECTIVITY_PROFILE {}
@@ -5337,7 +5306,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_DISCOVERY_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_DISCOVERY_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_DISCOVERY_PROFILE>()) == 0 }
+        self.IhvConnectivityProfile == other.IhvConnectivityProfile && self.IhvSecurityProfile == other.IhvSecurityProfile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5376,7 +5345,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_DISCOVERY_PROFILE_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_DISCOVERY_PROFILE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_DISCOVERY_PROFILE_LIST>()) == 0 }
+        self.dwCount == other.dwCount && self.pIhvDiscoveryProfiles == other.pIhvDiscoveryProfiles
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5422,41 +5391,13 @@ impl ::core::clone::Clone for DOT11EXT_IHV_HANDLERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
 impl ::core::fmt::Debug for DOT11EXT_IHV_HANDLERS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DOT11EXT_IHV_HANDLERS")
-            .field("Dot11ExtIhvDeinitService", &self.Dot11ExtIhvDeinitService.map(|f| f as usize))
-            .field("Dot11ExtIhvInitAdapter", &self.Dot11ExtIhvInitAdapter.map(|f| f as usize))
-            .field("Dot11ExtIhvDeinitAdapter", &self.Dot11ExtIhvDeinitAdapter.map(|f| f as usize))
-            .field("Dot11ExtIhvPerformPreAssociate", &self.Dot11ExtIhvPerformPreAssociate.map(|f| f as usize))
-            .field("Dot11ExtIhvAdapterReset", &self.Dot11ExtIhvAdapterReset.map(|f| f as usize))
-            .field("Dot11ExtIhvPerformPostAssociate", &self.Dot11ExtIhvPerformPostAssociate.map(|f| f as usize))
-            .field("Dot11ExtIhvStopPostAssociate", &self.Dot11ExtIhvStopPostAssociate.map(|f| f as usize))
-            .field("Dot11ExtIhvValidateProfile", &self.Dot11ExtIhvValidateProfile.map(|f| f as usize))
-            .field("Dot11ExtIhvPerformCapabilityMatch", &self.Dot11ExtIhvPerformCapabilityMatch.map(|f| f as usize))
-            .field("Dot11ExtIhvCreateDiscoveryProfiles", &self.Dot11ExtIhvCreateDiscoveryProfiles.map(|f| f as usize))
-            .field("Dot11ExtIhvProcessSessionChange", &self.Dot11ExtIhvProcessSessionChange.map(|f| f as usize))
-            .field("Dot11ExtIhvReceiveIndication", &self.Dot11ExtIhvReceiveIndication.map(|f| f as usize))
-            .field("Dot11ExtIhvReceivePacket", &self.Dot11ExtIhvReceivePacket.map(|f| f as usize))
-            .field("Dot11ExtIhvSendPacketCompletion", &self.Dot11ExtIhvSendPacketCompletion.map(|f| f as usize))
-            .field("Dot11ExtIhvIsUIRequestPending", &self.Dot11ExtIhvIsUIRequestPending.map(|f| f as usize))
-            .field("Dot11ExtIhvProcessUIResponse", &self.Dot11ExtIhvProcessUIResponse.map(|f| f as usize))
-            .field("Dot11ExtIhvQueryUIRequest", &self.Dot11ExtIhvQueryUIRequest.map(|f| f as usize))
-            .field("Dot11ExtIhvOnexIndicateResult", &self.Dot11ExtIhvOnexIndicateResult.map(|f| f as usize))
-            .field("Dot11ExtIhvControl", &self.Dot11ExtIhvControl.map(|f| f as usize))
-            .finish()
+        f.debug_struct("DOT11EXT_IHV_HANDLERS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
 unsafe impl ::windows::core::Abi for DOT11EXT_IHV_HANDLERS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
-impl ::core::cmp::PartialEq for DOT11EXT_IHV_HANDLERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_HANDLERS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
-impl ::core::cmp::Eq for DOT11EXT_IHV_HANDLERS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
 impl ::core::default::Default for DOT11EXT_IHV_HANDLERS {
     fn default() -> Self {
@@ -5493,7 +5434,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_PARAMS>()) == 0 }
+        self.dot11ExtIhvProfileParams == other.dot11ExtIhvProfileParams && self.wstrProfileName == other.wstrProfileName && self.dwProfileTypeFlags == other.dwProfileTypeFlags && self.interfaceGuid == other.interfaceGuid
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
@@ -5533,7 +5474,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_PROFILE_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_PROFILE_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_PROFILE_PARAMS>()) == 0 }
+        self.pSsidList == other.pSsidList && self.BssType == other.BssType && self.pMSSecuritySettings == other.pMSSecuritySettings
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
@@ -5572,7 +5513,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_SECURITY_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_SECURITY_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_SECURITY_PROFILE>()) == 0 }
+        self.pszXmlFragmentIhvSecurity == other.pszXmlFragmentIhvSecurity && self.bUseMSOnex == other.bUseMSOnex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5605,7 +5546,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_SSID_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_SSID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_SSID_LIST>()) == 0 }
+        self.ulCount == other.ulCount && self.SSIDs == other.SSIDs
     }
 }
 impl ::core::cmp::Eq for DOT11EXT_IHV_SSID_LIST {}
@@ -5639,7 +5580,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_IHV_UI_REQUEST {
 }
 impl ::core::cmp::PartialEq for DOT11EXT_IHV_UI_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_IHV_UI_REQUEST>()) == 0 }
+        self.dwSessionId == other.dwSessionId && self.guidUIRequest == other.guidUIRequest && self.UIPageClsid == other.UIPageClsid && self.dwByteCount == other.dwByteCount && self.pvUIRequest == other.pvUIRequest
     }
 }
 impl ::core::cmp::Eq for DOT11EXT_IHV_UI_REQUEST {}
@@ -5668,21 +5609,13 @@ impl ::core::clone::Clone for DOT11EXT_VIRTUAL_STATION_APIS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for DOT11EXT_VIRTUAL_STATION_APIS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DOT11EXT_VIRTUAL_STATION_APIS").field("Dot11ExtRequestVirtualStation", &self.Dot11ExtRequestVirtualStation.map(|f| f as usize)).field("Dot11ExtReleaseVirtualStation", &self.Dot11ExtReleaseVirtualStation.map(|f| f as usize)).field("Dot11ExtQueryVirtualStationProperties", &self.Dot11ExtQueryVirtualStationProperties.map(|f| f as usize)).field("Dot11ExtSetVirtualStationAPProperties", &self.Dot11ExtSetVirtualStationAPProperties.map(|f| f as usize)).finish()
+        f.debug_struct("DOT11EXT_VIRTUAL_STATION_APIS").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for DOT11EXT_VIRTUAL_STATION_APIS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DOT11EXT_VIRTUAL_STATION_APIS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_VIRTUAL_STATION_APIS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DOT11EXT_VIRTUAL_STATION_APIS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DOT11EXT_VIRTUAL_STATION_APIS {
     fn default() -> Self {
@@ -5721,7 +5654,7 @@ unsafe impl ::windows::core::Abi for DOT11EXT_VIRTUAL_STATION_AP_PROPERTY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11EXT_VIRTUAL_STATION_AP_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11EXT_VIRTUAL_STATION_AP_PROPERTY>()) == 0 }
+        self.dot11SSID == other.dot11SSID && self.dot11AuthAlgo == other.dot11AuthAlgo && self.dot11CipherAlgo == other.dot11CipherAlgo && self.bIsPassPhrase == other.bIsPassPhrase && self.dwKeyLength == other.dwKeyLength && self.ucKeyData == other.ucKeyData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5757,7 +5690,7 @@ unsafe impl ::windows::core::Abi for DOT11_ACCESSNETWORKOPTIONS {
 }
 impl ::core::cmp::PartialEq for DOT11_ACCESSNETWORKOPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ACCESSNETWORKOPTIONS>()) == 0 }
+        self.AccessNetworkType == other.AccessNetworkType && self.Internet == other.Internet && self.ASRA == other.ASRA && self.ESR == other.ESR && self.UESA == other.UESA
     }
 }
 impl ::core::cmp::Eq for DOT11_ACCESSNETWORKOPTIONS {}
@@ -5789,7 +5722,7 @@ unsafe impl ::windows::core::Abi for DOT11_ADAPTER {
 }
 impl ::core::cmp::PartialEq for DOT11_ADAPTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ADAPTER>()) == 0 }
+        self.gAdapterId == other.gAdapterId && self.pszDescription == other.pszDescription && self.Dot11CurrentOpMode == other.Dot11CurrentOpMode
     }
 }
 impl ::core::cmp::Eq for DOT11_ADAPTER {}
@@ -5829,7 +5762,7 @@ unsafe impl ::windows::core::Abi for DOT11_ADDITIONAL_IE {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ADDITIONAL_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ADDITIONAL_IE>()) == 0 }
+        self.Header == other.Header && self.uBeaconIEsOffset == other.uBeaconIEsOffset && self.uBeaconIEsLength == other.uBeaconIEsLength && self.uResponseIEsOffset == other.uResponseIEsOffset && self.uResponseIEsLength == other.uResponseIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -5870,7 +5803,7 @@ unsafe impl ::windows::core::Abi for DOT11_ANQP_QUERY_COMPLETE_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_ANQP_QUERY_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ANQP_QUERY_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Status == other.Status && self.hContext == other.hContext && self.uResponseLength == other.uResponseLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -5905,7 +5838,7 @@ unsafe impl ::windows::core::Abi for DOT11_AP_JOIN_REQUEST {
 }
 impl ::core::cmp::PartialEq for DOT11_AP_JOIN_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AP_JOIN_REQUEST>()) == 0 }
+        self.uJoinFailureTimeout == other.uJoinFailureTimeout && self.OperationalRateSet == other.OperationalRateSet && self.uChCenterFrequency == other.uChCenterFrequency && self.dot11BSSDescription == other.dot11BSSDescription
     }
 }
 impl ::core::cmp::Eq for DOT11_AP_JOIN_REQUEST {}
@@ -5993,7 +5926,32 @@ unsafe impl ::windows::core::Abi for DOT11_ASSOCIATION_COMPLETION_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_ASSOCIATION_COMPLETION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ASSOCIATION_COMPLETION_PARAMETERS>()) == 0 }
+        self.Header == other.Header
+            && self.MacAddr == other.MacAddr
+            && self.uStatus == other.uStatus
+            && self.bReAssocReq == other.bReAssocReq
+            && self.bReAssocResp == other.bReAssocResp
+            && self.uAssocReqOffset == other.uAssocReqOffset
+            && self.uAssocReqSize == other.uAssocReqSize
+            && self.uAssocRespOffset == other.uAssocRespOffset
+            && self.uAssocRespSize == other.uAssocRespSize
+            && self.uBeaconOffset == other.uBeaconOffset
+            && self.uBeaconSize == other.uBeaconSize
+            && self.uIHVDataOffset == other.uIHVDataOffset
+            && self.uIHVDataSize == other.uIHVDataSize
+            && self.AuthAlgo == other.AuthAlgo
+            && self.UnicastCipher == other.UnicastCipher
+            && self.MulticastCipher == other.MulticastCipher
+            && self.uActivePhyListOffset == other.uActivePhyListOffset
+            && self.uActivePhyListSize == other.uActivePhyListSize
+            && self.bFourAddressSupported == other.bFourAddressSupported
+            && self.bPortAuthorized == other.bPortAuthorized
+            && self.ucActiveQoSProtocol == other.ucActiveQoSProtocol
+            && self.DSInfo == other.DSInfo
+            && self.uEncapTableOffset == other.uEncapTableOffset
+            && self.uEncapTableSize == other.uEncapTableSize
+            && self.MulticastMgmtCipher == other.MulticastMgmtCipher
+            && self.uAssocComebackTime == other.uAssocComebackTime
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -6051,7 +6009,7 @@ unsafe impl ::windows::core::Abi for DOT11_ASSOCIATION_INFO_EX {
 }
 impl ::core::cmp::PartialEq for DOT11_ASSOCIATION_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ASSOCIATION_INFO_EX>()) == 0 }
+        self.PeerMacAddress == other.PeerMacAddress && self.BSSID == other.BSSID && self.usCapabilityInformation == other.usCapabilityInformation && self.usListenInterval == other.usListenInterval && self.ucPeerSupportedRates == other.ucPeerSupportedRates && self.usAssociationID == other.usAssociationID && self.dot11AssociationState == other.dot11AssociationState && self.dot11PowerMode == other.dot11PowerMode && self.liAssociationUpTime == other.liAssociationUpTime && self.ullNumOfTxPacketSuccesses == other.ullNumOfTxPacketSuccesses && self.ullNumOfTxPacketFailures == other.ullNumOfTxPacketFailures && self.ullNumOfRxPacketSuccesses == other.ullNumOfRxPacketSuccesses && self.ullNumOfRxPacketFailures == other.ullNumOfRxPacketFailures
     }
 }
 impl ::core::cmp::Eq for DOT11_ASSOCIATION_INFO_EX {}
@@ -6090,7 +6048,7 @@ unsafe impl ::windows::core::Abi for DOT11_ASSOCIATION_INFO_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ASSOCIATION_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ASSOCIATION_INFO_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11AssocInfo == other.dot11AssocInfo
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6131,7 +6089,7 @@ unsafe impl ::windows::core::Abi for DOT11_ASSOCIATION_PARAMS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ASSOCIATION_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ASSOCIATION_PARAMS>()) == 0 }
+        self.Header == other.Header && self.BSSID == other.BSSID && self.uAssocRequestIEsOffset == other.uAssocRequestIEsOffset && self.uAssocRequestIEsLength == other.uAssocRequestIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6173,7 +6131,7 @@ unsafe impl ::windows::core::Abi for DOT11_ASSOCIATION_START_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ASSOCIATION_START_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ASSOCIATION_START_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.MacAddr == other.MacAddr && self.SSID == other.SSID && self.uIHVDataOffset == other.uIHVDataOffset && self.uIHVDataSize == other.uIHVDataSize
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6214,7 +6172,7 @@ unsafe impl ::windows::core::Abi for DOT11_AUTH_ALGORITHM_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_AUTH_ALGORITHM_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AUTH_ALGORITHM_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.AlgorithmIds == other.AlgorithmIds
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6247,7 +6205,7 @@ unsafe impl ::windows::core::Abi for DOT11_AUTH_CIPHER_PAIR {
 }
 impl ::core::cmp::PartialEq for DOT11_AUTH_CIPHER_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AUTH_CIPHER_PAIR>()) == 0 }
+        self.AuthAlgoId == other.AuthAlgoId && self.CipherAlgoId == other.CipherAlgoId
     }
 }
 impl ::core::cmp::Eq for DOT11_AUTH_CIPHER_PAIR {}
@@ -6286,7 +6244,7 @@ unsafe impl ::windows::core::Abi for DOT11_AUTH_CIPHER_PAIR_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_AUTH_CIPHER_PAIR_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AUTH_CIPHER_PAIR_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.AuthCipherPairs == other.AuthCipherPairs
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6327,7 +6285,7 @@ unsafe impl ::windows::core::Abi for DOT11_AVAILABLE_CHANNEL_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_AVAILABLE_CHANNEL_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AVAILABLE_CHANNEL_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.uChannelNumber == other.uChannelNumber
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6368,7 +6326,7 @@ unsafe impl ::windows::core::Abi for DOT11_AVAILABLE_FREQUENCY_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_AVAILABLE_FREQUENCY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_AVAILABLE_FREQUENCY_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.uFrequencyValue == other.uFrequencyValue
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6401,7 +6359,7 @@ unsafe impl ::windows::core::Abi for DOT11_BSSID_CANDIDATE {
 }
 impl ::core::cmp::PartialEq for DOT11_BSSID_CANDIDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSSID_CANDIDATE>()) == 0 }
+        self.BSSID == other.BSSID && self.uFlags == other.uFlags
     }
 }
 impl ::core::cmp::Eq for DOT11_BSSID_CANDIDATE {}
@@ -6440,7 +6398,7 @@ unsafe impl ::windows::core::Abi for DOT11_BSSID_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_BSSID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSSID_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.BSSIDs == other.BSSIDs
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6479,7 +6437,7 @@ unsafe impl ::windows::core::Abi for DOT11_BSS_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for DOT11_BSS_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSS_DESCRIPTION>()) == 0 }
+        self.uReserved == other.uReserved && self.dot11BSSID == other.dot11BSSID && self.dot11BSSType == other.dot11BSSType && self.usBeaconPeriod == other.usBeaconPeriod && self.ullTimestamp == other.ullTimestamp && self.usCapabilityInformation == other.usCapabilityInformation && self.uBufferLength == other.uBufferLength && self.ucBuffer == other.ucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_BSS_DESCRIPTION {}
@@ -6519,14 +6477,6 @@ unsafe impl ::windows::core::Abi for DOT11_BSS_ENTRY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DOT11_BSS_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSS_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DOT11_BSS_ENTRY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DOT11_BSS_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6547,12 +6497,6 @@ impl ::core::clone::Clone for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
 unsafe impl ::windows::core::Abi for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {}
 impl ::core::default::Default for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6581,7 +6525,7 @@ unsafe impl ::windows::core::Abi for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0 {
 }
 impl ::core::cmp::PartialEq for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0>()) == 0 }
+        self.uHopPattern == other.uHopPattern && self.uHopSet == other.uHopSet && self.uDwellTime == other.uDwellTime
     }
 }
 impl ::core::cmp::Eq for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0 {}
@@ -6612,7 +6556,7 @@ unsafe impl ::windows::core::Abi for DOT11_BSS_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_BSS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BSS_LIST>()) == 0 }
+        self.uNumOfBytes == other.uNumOfBytes && self.pucBuffer == other.pucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_BSS_LIST {}
@@ -6651,7 +6595,7 @@ unsafe impl ::windows::core::Abi for DOT11_BYTE_ARRAY {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_BYTE_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_BYTE_ARRAY>()) == 0 }
+        self.Header == other.Header && self.uNumOfBytes == other.uNumOfBytes && self.uTotalNumOfBytes == other.uTotalNumOfBytes && self.ucBuffer == other.ucBuffer
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6690,7 +6634,7 @@ unsafe impl ::windows::core::Abi for DOT11_CAN_SUSTAIN_AP_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_CAN_SUSTAIN_AP_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CAN_SUSTAIN_AP_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ulReason == other.ulReason
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6723,7 +6667,7 @@ unsafe impl ::windows::core::Abi for DOT11_CHANNEL_HINT {
 }
 impl ::core::cmp::PartialEq for DOT11_CHANNEL_HINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CHANNEL_HINT>()) == 0 }
+        self.Dot11PhyType == other.Dot11PhyType && self.uChannelNumber == other.uChannelNumber
     }
 }
 impl ::core::cmp::Eq for DOT11_CHANNEL_HINT {}
@@ -6762,7 +6706,7 @@ unsafe impl ::windows::core::Abi for DOT11_CIPHER_ALGORITHM_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_CIPHER_ALGORITHM_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CIPHER_ALGORITHM_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.AlgorithmIds == other.AlgorithmIds
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6807,7 +6751,7 @@ unsafe impl ::windows::core::Abi for DOT11_CIPHER_DEFAULT_KEY_VALUE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_CIPHER_DEFAULT_KEY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CIPHER_DEFAULT_KEY_VALUE>()) == 0 }
+        self.Header == other.Header && self.uKeyIndex == other.uKeyIndex && self.AlgorithmId == other.AlgorithmId && self.MacAddr == other.MacAddr && self.bDelete == other.bDelete && self.bStatic == other.bStatic && self.usKeyLength == other.usKeyLength && self.ucKey == other.ucKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -6851,7 +6795,7 @@ unsafe impl ::windows::core::Abi for DOT11_CIPHER_KEY_MAPPING_KEY_VALUE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_CIPHER_KEY_MAPPING_KEY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CIPHER_KEY_MAPPING_KEY_VALUE>()) == 0 }
+        self.PeerMacAddr == other.PeerMacAddr && self.AlgorithmId == other.AlgorithmId && self.Direction == other.Direction && self.bDelete == other.bDelete && self.bStatic == other.bStatic && self.usKeyLength == other.usKeyLength && self.ucKey == other.ucKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6890,7 +6834,7 @@ unsafe impl ::windows::core::Abi for DOT11_CONNECTION_COMPLETION_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_CONNECTION_COMPLETION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CONNECTION_COMPLETION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uStatus == other.uStatus
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6931,7 +6875,7 @@ unsafe impl ::windows::core::Abi for DOT11_CONNECTION_START_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_CONNECTION_START_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CONNECTION_START_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.BSSType == other.BSSType && self.AdhocBSSID == other.AdhocBSSID && self.AdhocSSID == other.AdhocSSID
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -6989,7 +6933,7 @@ unsafe impl ::windows::core::Abi for DOT11_COUNTERS_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_COUNTERS_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_COUNTERS_ENTRY>()) == 0 }
+        self.uTransmittedFragmentCount == other.uTransmittedFragmentCount && self.uMulticastTransmittedFrameCount == other.uMulticastTransmittedFrameCount && self.uFailedCount == other.uFailedCount && self.uRetryCount == other.uRetryCount && self.uMultipleRetryCount == other.uMultipleRetryCount && self.uFrameDuplicateCount == other.uFrameDuplicateCount && self.uRTSSuccessCount == other.uRTSSuccessCount && self.uRTSFailureCount == other.uRTSFailureCount && self.uACKFailureCount == other.uACKFailureCount && self.uReceivedFragmentCount == other.uReceivedFragmentCount && self.uMulticastReceivedFrameCount == other.uMulticastReceivedFrameCount && self.uFCSErrorCount == other.uFCSErrorCount && self.uTransmittedFrameCount == other.uTransmittedFrameCount
     }
 }
 impl ::core::cmp::Eq for DOT11_COUNTERS_ENTRY {}
@@ -7028,7 +6972,7 @@ unsafe impl ::windows::core::Abi for DOT11_COUNTRY_OR_REGION_STRING_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_COUNTRY_OR_REGION_STRING_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_COUNTRY_OR_REGION_STRING_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.CountryOrRegionStrings == other.CountryOrRegionStrings
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7061,7 +7005,7 @@ unsafe impl ::windows::core::Abi for DOT11_CURRENT_OFFLOAD_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for DOT11_CURRENT_OFFLOAD_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CURRENT_OFFLOAD_CAPABILITY>()) == 0 }
+        self.uReserved == other.uReserved && self.uFlags == other.uFlags
     }
 }
 impl ::core::cmp::Eq for DOT11_CURRENT_OFFLOAD_CAPABILITY {}
@@ -7092,7 +7036,7 @@ unsafe impl ::windows::core::Abi for DOT11_CURRENT_OPERATION_MODE {
 }
 impl ::core::cmp::PartialEq for DOT11_CURRENT_OPERATION_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CURRENT_OPERATION_MODE>()) == 0 }
+        self.uReserved == other.uReserved && self.uCurrentOpMode == other.uCurrentOpMode
     }
 }
 impl ::core::cmp::Eq for DOT11_CURRENT_OPERATION_MODE {}
@@ -7132,7 +7076,7 @@ unsafe impl ::windows::core::Abi for DOT11_CURRENT_OPTIONAL_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_CURRENT_OPTIONAL_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_CURRENT_OPTIONAL_CAPABILITY>()) == 0 }
+        self.uReserved == other.uReserved && self.bDot11CFPollable == other.bDot11CFPollable && self.bDot11PCF == other.bDot11PCF && self.bDot11PCFMPDUTransferToPC == other.bDot11PCFMPDUTransferToPC && self.bStrictlyOrderedServiceClass == other.bStrictlyOrderedServiceClass
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7166,7 +7110,7 @@ unsafe impl ::windows::core::Abi for DOT11_DATA_RATE_MAPPING_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_DATA_RATE_MAPPING_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DATA_RATE_MAPPING_ENTRY>()) == 0 }
+        self.ucDataRateIndex == other.ucDataRateIndex && self.ucDataRateFlag == other.ucDataRateFlag && self.usDataRateValue == other.usDataRateValue
     }
 }
 impl ::core::cmp::Eq for DOT11_DATA_RATE_MAPPING_ENTRY {}
@@ -7204,7 +7148,7 @@ unsafe impl ::windows::core::Abi for DOT11_DATA_RATE_MAPPING_TABLE {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_DATA_RATE_MAPPING_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DATA_RATE_MAPPING_TABLE>()) == 0 }
+        self.Header == other.Header && self.uDataRateMappingLength == other.uDataRateMappingLength && self.DataRateMappingEntries == other.DataRateMappingEntries
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7270,7 +7214,7 @@ unsafe impl ::windows::core::Abi for DOT11_DEFAULT_WEP_OFFLOAD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_DEFAULT_WEP_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DEFAULT_WEP_OFFLOAD>()) == 0 }
+        self.uReserved == other.uReserved && self.hOffloadContext == other.hOffloadContext && self.hOffload == other.hOffload && self.dwIndex == other.dwIndex && self.dot11OffloadType == other.dot11OffloadType && self.dwAlgorithm == other.dwAlgorithm && self.uFlags == other.uFlags && self.dot11KeyDirection == other.dot11KeyDirection && self.ucMacAddress == other.ucMacAddress && self.uNumOfRWsOnMe == other.uNumOfRWsOnMe && self.dot11IV48Counters == other.dot11IV48Counters && self.usDot11RWBitMaps == other.usDot11RWBitMaps && self.usKeyLength == other.usKeyLength && self.ucKey == other.ucKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7313,7 +7257,7 @@ unsafe impl ::windows::core::Abi for DOT11_DEFAULT_WEP_UPLOAD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_DEFAULT_WEP_UPLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DEFAULT_WEP_UPLOAD>()) == 0 }
+        self.uReserved == other.uReserved && self.dot11OffloadType == other.dot11OffloadType && self.hOffload == other.hOffload && self.uNumOfRWsUsed == other.uNumOfRWsUsed && self.dot11IV48Counters == other.dot11IV48Counters && self.usDot11RWBitMaps == other.usDot11RWBitMaps
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7353,7 +7297,7 @@ unsafe impl ::windows::core::Abi for DOT11_DISASSOCIATE_PEER_REQUEST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_DISASSOCIATE_PEER_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DISASSOCIATE_PEER_REQUEST>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr && self.usReason == other.usReason
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7395,7 +7339,7 @@ unsafe impl ::windows::core::Abi for DOT11_DISASSOCIATION_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_DISASSOCIATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DISASSOCIATION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.MacAddr == other.MacAddr && self.uReason == other.uReason && self.uIHVDataOffset == other.uIHVDataOffset && self.uIHVDataSize == other.uIHVDataSize
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7434,7 +7378,7 @@ unsafe impl ::windows::core::Abi for DOT11_DIVERSITY_SELECTION_RX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_DIVERSITY_SELECTION_RX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DIVERSITY_SELECTION_RX>()) == 0 }
+        self.uAntennaListIndex == other.uAntennaListIndex && self.bDiversitySelectionRX == other.bDiversitySelectionRX
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7474,7 +7418,7 @@ unsafe impl ::windows::core::Abi for DOT11_DIVERSITY_SELECTION_RX_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_DIVERSITY_SELECTION_RX_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_DIVERSITY_SELECTION_RX_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11DiversitySelectionRx == other.dot11DiversitySelectionRx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7513,7 +7457,7 @@ unsafe impl ::windows::core::Abi for DOT11_EAP_RESULT {
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
 impl ::core::cmp::PartialEq for DOT11_EAP_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EAP_RESULT>()) == 0 }
+        self.dwFailureReasonCode == other.dwFailureReasonCode && self.pAttribArray == other.pAttribArray
     }
 }
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
@@ -7546,7 +7490,7 @@ unsafe impl ::windows::core::Abi for DOT11_ENCAP_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_ENCAP_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ENCAP_ENTRY>()) == 0 }
+        self.usEtherType == other.usEtherType && self.usEncapType == other.usEncapType
     }
 }
 impl ::core::cmp::Eq for DOT11_ENCAP_ENTRY {}
@@ -7585,7 +7529,7 @@ unsafe impl ::windows::core::Abi for DOT11_ERP_PHY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_ERP_PHY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ERP_PHY_ATTRIBUTES>()) == 0 }
+        self.HRDSSSAttributes == other.HRDSSSAttributes && self.bERPPBCCOptionImplemented == other.bERPPBCCOptionImplemented && self.bDSSSOFDMOptionImplemented == other.bDSSSOFDMOptionImplemented && self.bShortSlotTimeOptionImplemented == other.bShortSlotTimeOptionImplemented
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7651,7 +7595,20 @@ unsafe impl ::windows::core::Abi for DOT11_EXTAP_ATTRIBUTES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_EXTAP_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EXTAP_ATTRIBUTES>()) == 0 }
+        self.Header == other.Header
+            && self.uScanSSIDListSize == other.uScanSSIDListSize
+            && self.uDesiredSSIDListSize == other.uDesiredSSIDListSize
+            && self.uPrivacyExemptionListSize == other.uPrivacyExemptionListSize
+            && self.uAssociationTableSize == other.uAssociationTableSize
+            && self.uDefaultKeyTableSize == other.uDefaultKeyTableSize
+            && self.uWEPKeyValueMaxLength == other.uWEPKeyValueMaxLength
+            && self.bStrictlyOrderedServiceClassImplemented == other.bStrictlyOrderedServiceClassImplemented
+            && self.uNumSupportedCountryOrRegionStrings == other.uNumSupportedCountryOrRegionStrings
+            && self.pSupportedCountryOrRegionStrings == other.pSupportedCountryOrRegionStrings
+            && self.uInfraNumSupportedUcastAlgoPairs == other.uInfraNumSupportedUcastAlgoPairs
+            && self.pInfraSupportedUcastAlgoPairs == other.pInfraSupportedUcastAlgoPairs
+            && self.uInfraNumSupportedMcastAlgoPairs == other.uInfraNumSupportedMcastAlgoPairs
+            && self.pInfraSupportedMcastAlgoPairs == other.pInfraSupportedMcastAlgoPairs
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -7757,7 +7714,40 @@ unsafe impl ::windows::core::Abi for DOT11_EXTSTA_ATTRIBUTES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_EXTSTA_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EXTSTA_ATTRIBUTES>()) == 0 }
+        self.Header == other.Header
+            && self.uScanSSIDListSize == other.uScanSSIDListSize
+            && self.uDesiredBSSIDListSize == other.uDesiredBSSIDListSize
+            && self.uDesiredSSIDListSize == other.uDesiredSSIDListSize
+            && self.uExcludedMacAddressListSize == other.uExcludedMacAddressListSize
+            && self.uPrivacyExemptionListSize == other.uPrivacyExemptionListSize
+            && self.uKeyMappingTableSize == other.uKeyMappingTableSize
+            && self.uDefaultKeyTableSize == other.uDefaultKeyTableSize
+            && self.uWEPKeyValueMaxLength == other.uWEPKeyValueMaxLength
+            && self.uPMKIDCacheSize == other.uPMKIDCacheSize
+            && self.uMaxNumPerSTADefaultKeyTables == other.uMaxNumPerSTADefaultKeyTables
+            && self.bStrictlyOrderedServiceClassImplemented == other.bStrictlyOrderedServiceClassImplemented
+            && self.ucSupportedQoSProtocolFlags == other.ucSupportedQoSProtocolFlags
+            && self.bSafeModeImplemented == other.bSafeModeImplemented
+            && self.uNumSupportedCountryOrRegionStrings == other.uNumSupportedCountryOrRegionStrings
+            && self.pSupportedCountryOrRegionStrings == other.pSupportedCountryOrRegionStrings
+            && self.uInfraNumSupportedUcastAlgoPairs == other.uInfraNumSupportedUcastAlgoPairs
+            && self.pInfraSupportedUcastAlgoPairs == other.pInfraSupportedUcastAlgoPairs
+            && self.uInfraNumSupportedMcastAlgoPairs == other.uInfraNumSupportedMcastAlgoPairs
+            && self.pInfraSupportedMcastAlgoPairs == other.pInfraSupportedMcastAlgoPairs
+            && self.uAdhocNumSupportedUcastAlgoPairs == other.uAdhocNumSupportedUcastAlgoPairs
+            && self.pAdhocSupportedUcastAlgoPairs == other.pAdhocSupportedUcastAlgoPairs
+            && self.uAdhocNumSupportedMcastAlgoPairs == other.uAdhocNumSupportedMcastAlgoPairs
+            && self.pAdhocSupportedMcastAlgoPairs == other.pAdhocSupportedMcastAlgoPairs
+            && self.bAutoPowerSaveMode == other.bAutoPowerSaveMode
+            && self.uMaxNetworkOffloadListSize == other.uMaxNetworkOffloadListSize
+            && self.bMFPCapable == other.bMFPCapable
+            && self.uInfraNumSupportedMcastMgmtAlgoPairs == other.uInfraNumSupportedMcastMgmtAlgoPairs
+            && self.pInfraSupportedMcastMgmtAlgoPairs == other.pInfraSupportedMcastMgmtAlgoPairs
+            && self.bNeighborReportSupported == other.bNeighborReportSupported
+            && self.bAPChannelReportSupported == other.bAPChannelReportSupported
+            && self.bActionFramesSupported == other.bActionFramesSupported
+            && self.bANQPQueryOffloadSupported == other.bANQPQueryOffloadSupported
+            && self.bHESSIDConnectionSupported == other.bHESSIDConnectionSupported
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -7817,7 +7807,7 @@ unsafe impl ::windows::core::Abi for DOT11_EXTSTA_CAPABILITY {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_EXTSTA_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EXTSTA_CAPABILITY>()) == 0 }
+        self.Header == other.Header && self.uScanSSIDListSize == other.uScanSSIDListSize && self.uDesiredBSSIDListSize == other.uDesiredBSSIDListSize && self.uDesiredSSIDListSize == other.uDesiredSSIDListSize && self.uExcludedMacAddressListSize == other.uExcludedMacAddressListSize && self.uPrivacyExemptionListSize == other.uPrivacyExemptionListSize && self.uKeyMappingTableSize == other.uKeyMappingTableSize && self.uDefaultKeyTableSize == other.uDefaultKeyTableSize && self.uWEPKeyValueMaxLength == other.uWEPKeyValueMaxLength && self.uPMKIDCacheSize == other.uPMKIDCacheSize && self.uMaxNumPerSTADefaultKeyTables == other.uMaxNumPerSTADefaultKeyTables
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7875,7 +7865,7 @@ unsafe impl ::windows::core::Abi for DOT11_EXTSTA_RECV_CONTEXT {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_EXTSTA_RECV_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EXTSTA_RECV_CONTEXT>()) == 0 }
+        self.Header == other.Header && self.uReceiveFlags == other.uReceiveFlags && self.uPhyId == other.uPhyId && self.uChCenterFrequency == other.uChCenterFrequency && self.usNumberOfMPDUsReceived == other.usNumberOfMPDUsReceived && self.lRSSI == other.lRSSI && self.ucDataRate == other.ucDataRate && self.uSizeMediaSpecificInfo == other.uSizeMediaSpecificInfo && self.pvMediaSpecificInfo == other.pvMediaSpecificInfo && self.ullTimestamp == other.ullTimestamp
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7918,7 +7908,7 @@ unsafe impl ::windows::core::Abi for DOT11_EXTSTA_SEND_CONTEXT {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_EXTSTA_SEND_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_EXTSTA_SEND_CONTEXT>()) == 0 }
+        self.Header == other.Header && self.usExemptionActionType == other.usExemptionActionType && self.uPhyId == other.uPhyId && self.uDelayedSleepValue == other.uDelayedSleepValue && self.pvMediaSpecificInfo == other.pvMediaSpecificInfo && self.uSendFlags == other.uSendFlags
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -7951,7 +7941,7 @@ unsafe impl ::windows::core::Abi for DOT11_FRAGMENT_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for DOT11_FRAGMENT_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_FRAGMENT_DESCRIPTOR>()) == 0 }
+        self.uOffset == other.uOffset && self.uLength == other.uLength
     }
 }
 impl ::core::cmp::Eq for DOT11_FRAGMENT_DESCRIPTOR {}
@@ -7992,7 +7982,7 @@ unsafe impl ::windows::core::Abi for DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMP
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8035,7 +8025,7 @@ unsafe impl ::windows::core::Abi for DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8078,7 +8068,7 @@ unsafe impl ::windows::core::Abi for DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8111,7 +8101,7 @@ unsafe impl ::windows::core::Abi for DOT11_HOPPING_PATTERN_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_HOPPING_PATTERN_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_HOPPING_PATTERN_ENTRY>()) == 0 }
+        self.uHoppingPatternIndex == other.uHoppingPatternIndex && self.uRandomTableFieldNumber == other.uRandomTableFieldNumber
     }
 }
 impl ::core::cmp::Eq for DOT11_HOPPING_PATTERN_ENTRY {}
@@ -8143,7 +8133,7 @@ unsafe impl ::windows::core::Abi for DOT11_HOPPING_PATTERN_ENTRY_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_HOPPING_PATTERN_ENTRY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_HOPPING_PATTERN_ENTRY_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11HoppingPatternEntry == other.dot11HoppingPatternEntry
     }
 }
 impl ::core::cmp::Eq for DOT11_HOPPING_PATTERN_ENTRY_LIST {}
@@ -8182,7 +8172,7 @@ unsafe impl ::windows::core::Abi for DOT11_HRDSSS_PHY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_HRDSSS_PHY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_HRDSSS_PHY_ATTRIBUTES>()) == 0 }
+        self.bShortPreambleOptionImplemented == other.bShortPreambleOptionImplemented && self.bPBCCOptionImplemented == other.bPBCCOptionImplemented && self.bChannelAgilityPresent == other.bChannelAgilityPresent && self.uHRCCAModeSupported == other.uHRCCAModeSupported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8223,7 +8213,7 @@ unsafe impl ::windows::core::Abi for DOT11_IBSS_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_IBSS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_IBSS_PARAMS>()) == 0 }
+        self.Header == other.Header && self.bJoinOnly == other.bJoinOnly && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -8256,7 +8246,7 @@ unsafe impl ::windows::core::Abi for DOT11_IHV_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for DOT11_IHV_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_IHV_VERSION_INFO>()) == 0 }
+        self.dwVerMin == other.dwVerMin && self.dwVerMax == other.dwVerMax
     }
 }
 impl ::core::cmp::Eq for DOT11_IHV_VERSION_INFO {}
@@ -8326,7 +8316,7 @@ unsafe impl ::windows::core::Abi for DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS 
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr && self.uStatus == other.uStatus && self.ucErrorSource == other.ucErrorSource && self.bReAssocReq == other.bReAssocReq && self.bReAssocResp == other.bReAssocResp && self.uAssocReqOffset == other.uAssocReqOffset && self.uAssocReqSize == other.uAssocReqSize && self.uAssocRespOffset == other.uAssocRespOffset && self.uAssocRespSize == other.uAssocRespSize && self.AuthAlgo == other.AuthAlgo && self.UnicastCipher == other.UnicastCipher && self.MulticastCipher == other.MulticastCipher && self.uActivePhyListOffset == other.uActivePhyListOffset && self.uActivePhyListSize == other.uActivePhyListSize && self.uBeaconOffset == other.uBeaconOffset && self.uBeaconSize == other.uBeaconSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -8369,7 +8359,7 @@ unsafe impl ::windows::core::Abi for DOT11_INCOMING_ASSOC_DECISION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_INCOMING_ASSOC_DECISION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INCOMING_ASSOC_DECISION>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr && self.bAccept == other.bAccept && self.usReasonCode == other.usReasonCode && self.uAssocResponseIEsOffset == other.uAssocResponseIEsOffset && self.uAssocResponseIEsLength == other.uAssocResponseIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -8413,7 +8403,7 @@ unsafe impl ::windows::core::Abi for DOT11_INCOMING_ASSOC_DECISION_V2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_INCOMING_ASSOC_DECISION_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INCOMING_ASSOC_DECISION_V2>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr && self.bAccept == other.bAccept && self.usReasonCode == other.usReasonCode && self.uAssocResponseIEsOffset == other.uAssocResponseIEsOffset && self.uAssocResponseIEsLength == other.uAssocResponseIEsLength && self.WFDStatus == other.WFDStatus
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -8455,7 +8445,7 @@ unsafe impl ::windows::core::Abi for DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAM
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr && self.bReAssocReq == other.bReAssocReq && self.uAssocReqOffset == other.uAssocReqOffset && self.uAssocReqSize == other.uAssocReqSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -8494,7 +8484,7 @@ unsafe impl ::windows::core::Abi for DOT11_INCOMING_ASSOC_STARTED_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_INCOMING_ASSOC_STARTED_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INCOMING_ASSOC_STARTED_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerMacAddr == other.PeerMacAddr
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8538,7 +8528,7 @@ unsafe impl ::windows::core::Abi for DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARA
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.ReceiverAddress == other.ReceiverAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8581,7 +8571,7 @@ unsafe impl ::windows::core::Abi for DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PAR
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ReceiverDeviceAddress == other.ReceiverDeviceAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8614,7 +8604,7 @@ unsafe impl ::windows::core::Abi for DOT11_IV48_COUNTER {
 }
 impl ::core::cmp::PartialEq for DOT11_IV48_COUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_IV48_COUNTER>()) == 0 }
+        self.uIV32Counter == other.uIV32Counter && self.usIV16Counter == other.usIV16Counter
     }
 }
 impl ::core::cmp::Eq for DOT11_IV48_COUNTER {}
@@ -8647,7 +8637,7 @@ unsafe impl ::windows::core::Abi for DOT11_JOIN_REQUEST {
 }
 impl ::core::cmp::PartialEq for DOT11_JOIN_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_JOIN_REQUEST>()) == 0 }
+        self.uJoinFailureTimeout == other.uJoinFailureTimeout && self.OperationalRateSet == other.OperationalRateSet && self.uChCenterFrequency == other.uChCenterFrequency && self.dot11BSSDescription == other.dot11BSSDescription
     }
 }
 impl ::core::cmp::Eq for DOT11_JOIN_REQUEST {}
@@ -8679,7 +8669,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_BIP {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_BIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_BIP>()) == 0 }
+        self.ucIPN == other.ucIPN && self.ulBIPKeyLength == other.ulBIPKeyLength && self.ucBIPKey == other.ucBIPKey
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_BIP {}
@@ -8711,7 +8701,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_BIP_GMAC_256 {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_BIP_GMAC_256 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_BIP_GMAC_256>()) == 0 }
+        self.ucIPN == other.ucIPN && self.ulBIPGmac256KeyLength == other.ulBIPGmac256KeyLength && self.ucBIPGmac256Key == other.ucBIPGmac256Key
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_BIP_GMAC_256 {}
@@ -8743,7 +8733,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_CCMP {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_CCMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_CCMP>()) == 0 }
+        self.ucIV48Counter == other.ucIV48Counter && self.ulCCMPKeyLength == other.ulCCMPKeyLength && self.ucCCMPKey == other.ucCCMPKey
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_CCMP {}
@@ -8775,7 +8765,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_GCMP {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_GCMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_GCMP>()) == 0 }
+        self.ucIV48Counter == other.ucIV48Counter && self.ulGCMPKeyLength == other.ulGCMPKeyLength && self.ucGCMPKey == other.ucGCMPKey
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_GCMP {}
@@ -8807,7 +8797,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_GCMP_256 {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_GCMP_256 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_GCMP_256>()) == 0 }
+        self.ucIV48Counter == other.ucIV48Counter && self.ulGCMP256KeyLength == other.ulGCMP256KeyLength && self.ucGCMP256Key == other.ucGCMP256Key
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_GCMP_256 {}
@@ -8840,7 +8830,7 @@ unsafe impl ::windows::core::Abi for DOT11_KEY_ALGO_TKIP_MIC {
 }
 impl ::core::cmp::PartialEq for DOT11_KEY_ALGO_TKIP_MIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_KEY_ALGO_TKIP_MIC>()) == 0 }
+        self.ucIV48Counter == other.ucIV48Counter && self.ulTKIPKeyLength == other.ulTKIPKeyLength && self.ulMICKeyLength == other.ulMICKeyLength && self.ucTKIPMICKeys == other.ucTKIPMICKeys
     }
 }
 impl ::core::cmp::Eq for DOT11_KEY_ALGO_TKIP_MIC {}
@@ -8871,7 +8861,7 @@ unsafe impl ::windows::core::Abi for DOT11_LINK_QUALITY_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_LINK_QUALITY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_LINK_QUALITY_ENTRY>()) == 0 }
+        self.PeerMacAddr == other.PeerMacAddr && self.ucLinkQuality == other.ucLinkQuality
     }
 }
 impl ::core::cmp::Eq for DOT11_LINK_QUALITY_ENTRY {}
@@ -8909,7 +8899,7 @@ unsafe impl ::windows::core::Abi for DOT11_LINK_QUALITY_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_LINK_QUALITY_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_LINK_QUALITY_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uLinkQualityListSize == other.uLinkQualityListSize && self.uLinkQualityListOffset == other.uLinkQualityListOffset
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -8950,7 +8940,7 @@ unsafe impl ::windows::core::Abi for DOT11_MAC_ADDRESS_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_MAC_ADDRESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MAC_ADDRESS_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.MacAddrs == other.MacAddrs
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9010,7 +9000,20 @@ unsafe impl ::windows::core::Abi for DOT11_MAC_FRAME_STATISTICS {
 }
 impl ::core::cmp::PartialEq for DOT11_MAC_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MAC_FRAME_STATISTICS>()) == 0 }
+        self.ullTransmittedFrameCount == other.ullTransmittedFrameCount
+            && self.ullReceivedFrameCount == other.ullReceivedFrameCount
+            && self.ullTransmittedFailureFrameCount == other.ullTransmittedFailureFrameCount
+            && self.ullReceivedFailureFrameCount == other.ullReceivedFailureFrameCount
+            && self.ullWEPExcludedCount == other.ullWEPExcludedCount
+            && self.ullTKIPLocalMICFailures == other.ullTKIPLocalMICFailures
+            && self.ullTKIPReplays == other.ullTKIPReplays
+            && self.ullTKIPICVErrorCount == other.ullTKIPICVErrorCount
+            && self.ullCCMPReplays == other.ullCCMPReplays
+            && self.ullCCMPDecryptErrors == other.ullCCMPDecryptErrors
+            && self.ullWEPUndecryptableCount == other.ullWEPUndecryptableCount
+            && self.ullWEPICVErrorCount == other.ullWEPICVErrorCount
+            && self.ullDecryptSuccessCount == other.ullDecryptSuccessCount
+            && self.ullDecryptFailureCount == other.ullDecryptFailureCount
     }
 }
 impl ::core::cmp::Eq for DOT11_MAC_FRAME_STATISTICS {}
@@ -9042,7 +9045,7 @@ unsafe impl ::windows::core::Abi for DOT11_MAC_INFO {
 }
 impl ::core::cmp::PartialEq for DOT11_MAC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MAC_INFO>()) == 0 }
+        self.uReserved == other.uReserved && self.uNdisPortNumber == other.uNdisPortNumber && self.MacAddr == other.MacAddr
     }
 }
 impl ::core::cmp::Eq for DOT11_MAC_INFO {}
@@ -9079,7 +9082,7 @@ unsafe impl ::windows::core::Abi for DOT11_MAC_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_MAC_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MAC_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uOpmodeMask == other.uOpmodeMask
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9120,7 +9123,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_CALLBACK_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_CALLBACK_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_CALLBACK_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.dot11ManufacturingCallbackType == other.dot11ManufacturingCallbackType && self.uStatus == other.uStatus && self.pvContext == other.pvContext
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9154,7 +9157,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_A
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_ADC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_ADC>()) == 0 }
+        self.Dot11Band == other.Dot11Band && self.uChannel == other.uChannel && self.ADCPowerLevel == other.ADCPowerLevel
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_ADC {}
@@ -9193,7 +9196,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX>()) == 0 }
+        self.bEnabled == other.bEnabled && self.Dot11Band == other.Dot11Band && self.uChannel == other.uChannel && self.PowerLevel == other.PowerLevel
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9236,7 +9239,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_FUNCTIONAL_TEST_TX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_FUNCTIONAL_TEST_TX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_FUNCTIONAL_TEST_TX>()) == 0 }
+        self.bEnable == other.bEnable && self.bOpenLoop == other.bOpenLoop && self.Dot11Band == other.Dot11Band && self.uChannel == other.uChannel && self.uSetPowerLevel == other.uSetPowerLevel && self.ADCPowerLevel == other.ADCPowerLevel
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9280,7 +9283,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_SELF_TEST_QUERY_RESULTS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_SELF_TEST_QUERY_RESULTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_SELF_TEST_QUERY_RESULTS>()) == 0 }
+        self.SelfTestType == other.SelfTestType && self.uTestID == other.uTestID && self.bResult == other.bResult && self.uPinFailedBitMask == other.uPinFailedBitMask && self.pvContext == other.pvContext && self.uBytesWrittenOut == other.uBytesWrittenOut && self.ucBufferOut == other.ucBufferOut
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9317,7 +9320,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS>()) == 0 }
+        self.SelfTestType == other.SelfTestType && self.uTestID == other.uTestID && self.uPinBitMask == other.uPinBitMask && self.pvContext == other.pvContext && self.uBufferLength == other.uBufferLength && self.ucBufferIn == other.ucBufferIn
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {}
@@ -9349,7 +9352,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_TEST {
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_TEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_TEST>()) == 0 }
+        self.dot11ManufacturingTestType == other.dot11ManufacturingTestType && self.uBufferLength == other.uBufferLength && self.ucBuffer == other.ucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_TEST {}
@@ -9383,7 +9386,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_TEST_QUERY_DATA {
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_TEST_QUERY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_TEST_QUERY_DATA>()) == 0 }
+        self.uKey == other.uKey && self.uOffset == other.uOffset && self.uBufferLength == other.uBufferLength && self.uBytesRead == other.uBytesRead && self.ucBufferOut == other.ucBufferOut
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_TEST_QUERY_DATA {}
@@ -9416,7 +9419,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_TEST_SET_DATA {
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_TEST_SET_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_TEST_SET_DATA>()) == 0 }
+        self.uKey == other.uKey && self.uOffset == other.uOffset && self.uBufferLength == other.uBufferLength && self.ucBufferIn == other.ucBufferIn
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_TEST_SET_DATA {}
@@ -9447,7 +9450,7 @@ unsafe impl ::windows::core::Abi for DOT11_MANUFACTURING_TEST_SLEEP {
 }
 impl ::core::cmp::PartialEq for DOT11_MANUFACTURING_TEST_SLEEP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MANUFACTURING_TEST_SLEEP>()) == 0 }
+        self.uSleepTime == other.uSleepTime && self.pvContext == other.pvContext
     }
 }
 impl ::core::cmp::Eq for DOT11_MANUFACTURING_TEST_SLEEP {}
@@ -9479,7 +9482,7 @@ unsafe impl ::windows::core::Abi for DOT11_MD_CAPABILITY_ENTRY_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_MD_CAPABILITY_ENTRY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MD_CAPABILITY_ENTRY_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11MDCapabilityEntry == other.dot11MDCapabilityEntry
     }
 }
 impl ::core::cmp::Eq for DOT11_MD_CAPABILITY_ENTRY_LIST {}
@@ -9517,7 +9520,7 @@ unsafe impl ::windows::core::Abi for DOT11_MPDU_MAX_LENGTH_INDICATION {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_MPDU_MAX_LENGTH_INDICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MPDU_MAX_LENGTH_INDICATION>()) == 0 }
+        self.Header == other.Header && self.uPhyId == other.uPhyId && self.uMPDUMaxLength == other.uMPDUMaxLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9561,7 +9564,7 @@ unsafe impl ::windows::core::Abi for DOT11_MSONEX_RESULT_PARAMS {
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
 impl ::core::cmp::PartialEq for DOT11_MSONEX_RESULT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MSONEX_RESULT_PARAMS>()) == 0 }
+        self.Dot11OnexAuthStatus == other.Dot11OnexAuthStatus && self.Dot11OneXReasonCode == other.Dot11OneXReasonCode && self.pbMPPESendKey == other.pbMPPESendKey && self.dwMPPESendKeyLen == other.dwMPPESendKeyLen && self.pbMPPERecvKey == other.pbMPPERecvKey && self.dwMPPERecvKeyLen == other.dwMPPERecvKeyLen && self.pDot11EapResult == other.pDot11EapResult
     }
 }
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
@@ -9604,7 +9607,7 @@ unsafe impl ::windows::core::Abi for DOT11_MSSECURITY_SETTINGS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
 impl ::core::cmp::PartialEq for DOT11_MSSECURITY_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MSSECURITY_SETTINGS>()) == 0 }
+        self.dot11AuthAlgorithm == other.dot11AuthAlgorithm && self.dot11CipherAlgorithm == other.dot11CipherAlgorithm && self.fOneXEnabled == other.fOneXEnabled && self.eapMethodType == other.eapMethodType && self.dwEapConnectionDataLen == other.dwEapConnectionDataLen && self.pEapConnectionData == other.pEapConnectionData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
@@ -9639,7 +9642,7 @@ unsafe impl ::windows::core::Abi for DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY>()) == 0 }
+        self.uMultiDomainCapabilityIndex == other.uMultiDomainCapabilityIndex && self.uFirstChannelNumber == other.uFirstChannelNumber && self.uNumberOfChannels == other.uNumberOfChannels && self.lMaximumTransmitPowerLevel == other.lMaximumTransmitPowerLevel
     }
 }
 impl ::core::cmp::Eq for DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {}
@@ -9670,7 +9673,7 @@ unsafe impl ::windows::core::Abi for DOT11_NETWORK {
 }
 impl ::core::cmp::PartialEq for DOT11_NETWORK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_NETWORK>()) == 0 }
+        self.dot11Ssid == other.dot11Ssid && self.dot11BssType == other.dot11BssType
     }
 }
 impl ::core::cmp::Eq for DOT11_NETWORK {}
@@ -9702,7 +9705,7 @@ unsafe impl ::windows::core::Abi for DOT11_NETWORK_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_NETWORK_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_NETWORK_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.Network == other.Network
     }
 }
 impl ::core::cmp::Eq for DOT11_NETWORK_LIST {}
@@ -9734,7 +9737,7 @@ unsafe impl ::windows::core::Abi for DOT11_NIC_SPECIFIC_EXTENSION {
 }
 impl ::core::cmp::PartialEq for DOT11_NIC_SPECIFIC_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_NIC_SPECIFIC_EXTENSION>()) == 0 }
+        self.uBufferLength == other.uBufferLength && self.uTotalBufferLength == other.uTotalBufferLength && self.ucBuffer == other.ucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_NIC_SPECIFIC_EXTENSION {}
@@ -9764,7 +9767,7 @@ unsafe impl ::windows::core::Abi for DOT11_OFDM_PHY_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DOT11_OFDM_PHY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OFDM_PHY_ATTRIBUTES>()) == 0 }
+        self.uFrequencyBandsSupported == other.uFrequencyBandsSupported
     }
 }
 impl ::core::cmp::Eq for DOT11_OFDM_PHY_ATTRIBUTES {}
@@ -9800,7 +9803,7 @@ unsafe impl ::windows::core::Abi for DOT11_OFFLOAD_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for DOT11_OFFLOAD_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OFFLOAD_CAPABILITY>()) == 0 }
+        self.uReserved == other.uReserved && self.uFlags == other.uFlags && self.uSupportedWEPAlgorithms == other.uSupportedWEPAlgorithms && self.uNumOfReplayWindows == other.uNumOfReplayWindows && self.uMaxWEPKeyMappingLength == other.uMaxWEPKeyMappingLength && self.uSupportedAuthAlgorithms == other.uSupportedAuthAlgorithms && self.uMaxAuthKeyMappingLength == other.uMaxAuthKeyMappingLength
     }
 }
 impl ::core::cmp::Eq for DOT11_OFFLOAD_CAPABILITY {}
@@ -9833,7 +9836,7 @@ unsafe impl ::windows::core::Abi for DOT11_OFFLOAD_NETWORK {
 }
 impl ::core::cmp::PartialEq for DOT11_OFFLOAD_NETWORK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OFFLOAD_NETWORK>()) == 0 }
+        self.Ssid == other.Ssid && self.UnicastCipher == other.UnicastCipher && self.AuthAlgo == other.AuthAlgo && self.Dot11ChannelHints == other.Dot11ChannelHints
     }
 }
 impl ::core::cmp::Eq for DOT11_OFFLOAD_NETWORK {}
@@ -9875,7 +9878,7 @@ unsafe impl ::windows::core::Abi for DOT11_OFFLOAD_NETWORK_LIST_INFO {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_OFFLOAD_NETWORK_LIST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OFFLOAD_NETWORK_LIST_INFO>()) == 0 }
+        self.Header == other.Header && self.ulFlags == other.ulFlags && self.FastScanPeriod == other.FastScanPeriod && self.FastScanIterations == other.FastScanIterations && self.SlowScanPeriod == other.SlowScanPeriod && self.uNumOfEntries == other.uNumOfEntries && self.offloadNetworkList == other.offloadNetworkList
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9914,7 +9917,7 @@ unsafe impl ::windows::core::Abi for DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Status == other.Status
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -9947,7 +9950,7 @@ unsafe impl ::windows::core::Abi for DOT11_OI {
 }
 impl ::core::cmp::PartialEq for DOT11_OI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OI>()) == 0 }
+        self.OILength == other.OILength && self.OI == other.OI
     }
 }
 impl ::core::cmp::Eq for DOT11_OI {}
@@ -9982,7 +9985,7 @@ unsafe impl ::windows::core::Abi for DOT11_OPERATION_MODE_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for DOT11_OPERATION_MODE_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OPERATION_MODE_CAPABILITY>()) == 0 }
+        self.uReserved == other.uReserved && self.uMajorVersion == other.uMajorVersion && self.uMinorVersion == other.uMinorVersion && self.uNumOfTXBuffers == other.uNumOfTXBuffers && self.uNumOfRXBuffers == other.uNumOfRXBuffers && self.uOpModeCapability == other.uOpModeCapability
     }
 }
 impl ::core::cmp::Eq for DOT11_OPERATION_MODE_CAPABILITY {}
@@ -10021,7 +10024,7 @@ unsafe impl ::windows::core::Abi for DOT11_OPTIONAL_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_OPTIONAL_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_OPTIONAL_CAPABILITY>()) == 0 }
+        self.uReserved == other.uReserved && self.bDot11PCF == other.bDot11PCF && self.bDot11PCFMPDUTransferToPC == other.bDot11PCFMPDUTransferToPC && self.bStrictlyOrderedServiceClass == other.bStrictlyOrderedServiceClass
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10085,7 +10088,7 @@ unsafe impl ::windows::core::Abi for DOT11_PEER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_PEER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PEER_INFO>()) == 0 }
+        self.MacAddress == other.MacAddress && self.usCapabilityInformation == other.usCapabilityInformation && self.AuthAlgo == other.AuthAlgo && self.UnicastCipherAlgo == other.UnicastCipherAlgo && self.MulticastCipherAlgo == other.MulticastCipherAlgo && self.bWpsEnabled == other.bWpsEnabled && self.usListenInterval == other.usListenInterval && self.ucSupportedRates == other.ucSupportedRates && self.usAssociationID == other.usAssociationID && self.AssociationState == other.AssociationState && self.PowerMode == other.PowerMode && self.liAssociationUpTime == other.liAssociationUpTime && self.Statistics == other.Statistics
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10126,7 +10129,7 @@ unsafe impl ::windows::core::Abi for DOT11_PEER_INFO_LIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_PEER_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PEER_INFO_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.PeerInfo == other.PeerInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -10163,7 +10166,7 @@ unsafe impl ::windows::core::Abi for DOT11_PEER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for DOT11_PEER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PEER_STATISTICS>()) == 0 }
+        self.ullDecryptSuccessCount == other.ullDecryptSuccessCount && self.ullDecryptFailureCount == other.ullDecryptFailureCount && self.ullTxPacketSuccessCount == other.ullTxPacketSuccessCount && self.ullTxPacketFailureCount == other.ullTxPacketFailureCount && self.ullRxPacketSuccessCount == other.ullRxPacketSuccessCount && self.ullRxPacketFailureCount == other.ullRxPacketFailureCount
     }
 }
 impl ::core::cmp::Eq for DOT11_PEER_STATISTICS {}
@@ -10197,7 +10200,7 @@ unsafe impl ::windows::core::Abi for DOT11_PER_MSDU_COUNTERS {
 }
 impl ::core::cmp::PartialEq for DOT11_PER_MSDU_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PER_MSDU_COUNTERS>()) == 0 }
+        self.uTransmittedFragmentCount == other.uTransmittedFragmentCount && self.uRetryCount == other.uRetryCount && self.uRTSSuccessCount == other.uRTSSuccessCount && self.uRTSFailureCount == other.uRTSFailureCount && self.uACKFailureCount == other.uACKFailureCount
     }
 }
 impl ::core::cmp::Eq for DOT11_PER_MSDU_COUNTERS {}
@@ -10238,14 +10241,6 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_ATTRIBUTES {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
-impl ::core::cmp::PartialEq for DOT11_PHY_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_ATTRIBUTES>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
-impl ::core::cmp::Eq for DOT11_PHY_ATTRIBUTES {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::default::Default for DOT11_PHY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10271,14 +10266,6 @@ impl ::core::clone::Clone for DOT11_PHY_ATTRIBUTES_0 {
 unsafe impl ::windows::core::Abi for DOT11_PHY_ATTRIBUTES_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
-impl ::core::cmp::PartialEq for DOT11_PHY_ATTRIBUTES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_ATTRIBUTES_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
-impl ::core::cmp::Eq for DOT11_PHY_ATTRIBUTES_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::default::Default for DOT11_PHY_ATTRIBUTES_0 {
     fn default() -> Self {
@@ -10342,7 +10329,24 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_FRAME_STATISTICS {
 }
 impl ::core::cmp::PartialEq for DOT11_PHY_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_FRAME_STATISTICS>()) == 0 }
+        self.ullTransmittedFrameCount == other.ullTransmittedFrameCount
+            && self.ullMulticastTransmittedFrameCount == other.ullMulticastTransmittedFrameCount
+            && self.ullFailedCount == other.ullFailedCount
+            && self.ullRetryCount == other.ullRetryCount
+            && self.ullMultipleRetryCount == other.ullMultipleRetryCount
+            && self.ullMaxTXLifetimeExceededCount == other.ullMaxTXLifetimeExceededCount
+            && self.ullTransmittedFragmentCount == other.ullTransmittedFragmentCount
+            && self.ullRTSSuccessCount == other.ullRTSSuccessCount
+            && self.ullRTSFailureCount == other.ullRTSFailureCount
+            && self.ullACKFailureCount == other.ullACKFailureCount
+            && self.ullReceivedFrameCount == other.ullReceivedFrameCount
+            && self.ullMulticastReceivedFrameCount == other.ullMulticastReceivedFrameCount
+            && self.ullPromiscuousReceivedFrameCount == other.ullPromiscuousReceivedFrameCount
+            && self.ullMaxRXLifetimeExceededCount == other.ullMaxRXLifetimeExceededCount
+            && self.ullFrameDuplicateCount == other.ullFrameDuplicateCount
+            && self.ullReceivedFragmentCount == other.ullReceivedFragmentCount
+            && self.ullPromiscuousReceivedFragmentCount == other.ullPromiscuousReceivedFragmentCount
+            && self.ullFCSErrorCount == other.ullFCSErrorCount
     }
 }
 impl ::core::cmp::Eq for DOT11_PHY_FRAME_STATISTICS {}
@@ -10372,14 +10376,6 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::PartialEq for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::Eq for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::default::Default for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10404,14 +10400,6 @@ impl ::core::clone::Clone for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::PartialEq for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl ::core::cmp::Eq for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {}
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::default::Default for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
     fn default() -> Self {
@@ -10448,7 +10436,7 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_ID_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PHY_ID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_ID_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11PhyId == other.dot11PhyId
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -10489,7 +10477,7 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_STATE_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_PHY_STATE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_STATE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uPhyId == other.uPhyId && self.bHardwarePhyState == other.bHardwarePhyState && self.bSoftwarePhyState == other.bSoftwarePhyState
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -10534,7 +10522,7 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_TYPE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_PHY_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_TYPE_INFO>()) == 0 }
+        self.dot11PhyType == other.dot11PhyType && self.bUseParameters == other.bUseParameters && self.uProbeDelay == other.uProbeDelay && self.uMinChannelTime == other.uMinChannelTime && self.uMaxChannelTime == other.uMaxChannelTime && self.ChDescriptionType == other.ChDescriptionType && self.uChannelListSize == other.uChannelListSize && self.ucChannelListBuffer == other.ucChannelListBuffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10575,7 +10563,7 @@ unsafe impl ::windows::core::Abi for DOT11_PHY_TYPE_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PHY_TYPE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PHY_TYPE_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11PhyType == other.dot11PhyType
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -10615,7 +10603,7 @@ unsafe impl ::windows::core::Abi for DOT11_PMKID_CANDIDATE_LIST_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PMKID_CANDIDATE_LIST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PMKID_CANDIDATE_LIST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uCandidateListSize == other.uCandidateListSize && self.uCandidateListOffset == other.uCandidateListOffset
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -10649,7 +10637,7 @@ unsafe impl ::windows::core::Abi for DOT11_PMKID_ENTRY {
 }
 impl ::core::cmp::PartialEq for DOT11_PMKID_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PMKID_ENTRY>()) == 0 }
+        self.BSSID == other.BSSID && self.PMKID == other.PMKID && self.uFlags == other.uFlags
     }
 }
 impl ::core::cmp::Eq for DOT11_PMKID_ENTRY {}
@@ -10688,7 +10676,7 @@ unsafe impl ::windows::core::Abi for DOT11_PMKID_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PMKID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PMKID_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.PMKIDs == other.PMKIDs
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -10729,7 +10717,7 @@ unsafe impl ::windows::core::Abi for DOT11_PORT_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_PORT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PORT_STATE>()) == 0 }
+        self.PeerMacAddress == other.PeerMacAddress && self.uSessionId == other.uSessionId && self.bPortControlled == other.bPortControlled && self.bPortAuthorized == other.bPortAuthorized
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10769,7 +10757,7 @@ unsafe impl ::windows::core::Abi for DOT11_PORT_STATE_NOTIFICATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_PORT_STATE_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PORT_STATE_NOTIFICATION>()) == 0 }
+        self.Header == other.Header && self.PeerMac == other.PeerMac && self.bOpen == other.bOpen
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -10808,7 +10796,7 @@ unsafe impl ::windows::core::Abi for DOT11_POWER_MGMT_AUTO_MODE_ENABLED_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_POWER_MGMT_AUTO_MODE_ENABLED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_POWER_MGMT_AUTO_MODE_ENABLED_INFO>()) == 0 }
+        self.Header == other.Header && self.bEnabled == other.bEnabled
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -10850,7 +10838,7 @@ unsafe impl ::windows::core::Abi for DOT11_POWER_MGMT_MODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_POWER_MGMT_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_POWER_MGMT_MODE>()) == 0 }
+        self.dot11PowerMode == other.dot11PowerMode && self.uPowerSaveLevel == other.uPowerSaveLevel && self.usListenInterval == other.usListenInterval && self.usAID == other.usAID && self.bReceiveDTIMs == other.bReceiveDTIMs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10891,7 +10879,7 @@ unsafe impl ::windows::core::Abi for DOT11_POWER_MGMT_MODE_STATUS_INFO {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_POWER_MGMT_MODE_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_POWER_MGMT_MODE_STATUS_INFO>()) == 0 }
+        self.Header == other.Header && self.PowerSaveMode == other.PowerSaveMode && self.uPowerSaveLevel == other.uPowerSaveLevel && self.Reason == other.Reason
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -10925,7 +10913,7 @@ unsafe impl ::windows::core::Abi for DOT11_PRIVACY_EXEMPTION {
 }
 impl ::core::cmp::PartialEq for DOT11_PRIVACY_EXEMPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PRIVACY_EXEMPTION>()) == 0 }
+        self.usEtherType == other.usEtherType && self.usExemptionActionType == other.usExemptionActionType && self.usExemptionPacketType == other.usExemptionPacketType
     }
 }
 impl ::core::cmp::Eq for DOT11_PRIVACY_EXEMPTION {}
@@ -10964,7 +10952,7 @@ unsafe impl ::windows::core::Abi for DOT11_PRIVACY_EXEMPTION_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PRIVACY_EXEMPTION_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PRIVACY_EXEMPTION_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.PrivacyExemptionEntries == other.PrivacyExemptionEntries
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11008,7 +10996,7 @@ unsafe impl ::windows::core::Abi for DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMP
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.ReceiverAddress == other.ReceiverAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11051,7 +11039,7 @@ unsafe impl ::windows::core::Abi for DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COM
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ReceiverDeviceAddress == other.ReceiverDeviceAddress && self.DialogToken == other.DialogToken && self.Status == other.Status && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11090,7 +11078,7 @@ unsafe impl ::windows::core::Abi for DOT11_QOS_PARAMS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_QOS_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_QOS_PARAMS>()) == 0 }
+        self.Header == other.Header && self.ucEnabledQoSProtocolFlags == other.ucEnabledQoSProtocolFlags
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11124,7 +11112,7 @@ unsafe impl ::windows::core::Abi for DOT11_QOS_TX_DURATION {
 }
 impl ::core::cmp::PartialEq for DOT11_QOS_TX_DURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_QOS_TX_DURATION>()) == 0 }
+        self.uNominalMSDUSize == other.uNominalMSDUSize && self.uMinPHYRate == other.uMinPHYRate && self.uDuration == other.uDuration
     }
 }
 impl ::core::cmp::Eq for DOT11_QOS_TX_DURATION {}
@@ -11156,7 +11144,7 @@ unsafe impl ::windows::core::Abi for DOT11_QOS_TX_MEDIUM_TIME {
 }
 impl ::core::cmp::PartialEq for DOT11_QOS_TX_MEDIUM_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_QOS_TX_MEDIUM_TIME>()) == 0 }
+        self.dot11PeerAddress == other.dot11PeerAddress && self.ucQoSPriority == other.ucQoSPriority && self.uMediumTimeAdmited == other.uMediumTimeAdmited
     }
 }
 impl ::core::cmp::Eq for DOT11_QOS_TX_MEDIUM_TIME {}
@@ -11187,7 +11175,7 @@ unsafe impl ::windows::core::Abi for DOT11_RATE_SET {
 }
 impl ::core::cmp::PartialEq for DOT11_RATE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RATE_SET>()) == 0 }
+        self.uRateSetLength == other.uRateSetLength && self.ucRateSet == other.ucRateSet
     }
 }
 impl ::core::cmp::Eq for DOT11_RATE_SET {}
@@ -11227,7 +11215,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11270,7 +11258,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAM
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11313,7 +11301,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARA
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.ResponseContext == other.ResponseContext && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11357,7 +11345,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_INVITATION_REQUEST_PARAMETER
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_INVITATION_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_INVITATION_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.TransmitterDeviceAddress == other.TransmitterDeviceAddress && self.BSSID == other.BSSID && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11400,7 +11388,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETE
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.TransmitterDeviceAddress == other.TransmitterDeviceAddress && self.BSSID == other.BSSID && self.DialogToken == other.DialogToken && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11444,7 +11432,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.TransmitterDeviceAddress == other.TransmitterDeviceAddress && self.BSSID == other.BSSID && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11487,7 +11475,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.TransmitterDeviceAddress == other.TransmitterDeviceAddress && self.BSSID == other.BSSID && self.DialogToken == other.DialogToken && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11571,7 +11559,29 @@ unsafe impl ::windows::core::Abi for DOT11_RECV_EXTENSION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_RECV_EXTENSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECV_EXTENSION_INFO>()) == 0 }
+        self.uVersion == other.uVersion
+            && self.pvReserved == other.pvReserved
+            && self.dot11PhyType == other.dot11PhyType
+            && self.uChCenterFrequency == other.uChCenterFrequency
+            && self.lRSSI == other.lRSSI
+            && self.lRSSIMin == other.lRSSIMin
+            && self.lRSSIMax == other.lRSSIMax
+            && self.uRSSI == other.uRSSI
+            && self.ucPriority == other.ucPriority
+            && self.ucDataRate == other.ucDataRate
+            && self.ucPeerMacAddress == other.ucPeerMacAddress
+            && self.dwExtendedStatus == other.dwExtendedStatus
+            && self.hWEPOffloadContext == other.hWEPOffloadContext
+            && self.hAuthOffloadContext == other.hAuthOffloadContext
+            && self.usWEPAppliedMask == other.usWEPAppliedMask
+            && self.usWPAMSDUPriority == other.usWPAMSDUPriority
+            && self.dot11LowestIV48Counter == other.dot11LowestIV48Counter
+            && self.usDot11LeftRWBitMap == other.usDot11LeftRWBitMap
+            && self.dot11HighestIV48Counter == other.dot11HighestIV48Counter
+            && self.usDot11RightRWBitMap == other.usDot11RightRWBitMap
+            && self.usNumberOfMPDUsReceived == other.usNumberOfMPDUsReceived
+            && self.usNumberOfFragments == other.usNumberOfFragments
+            && self.pNdisPackets == other.pNdisPackets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11651,7 +11661,27 @@ unsafe impl ::windows::core::Abi for DOT11_RECV_EXTENSION_INFO_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_RECV_EXTENSION_INFO_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECV_EXTENSION_INFO_V2>()) == 0 }
+        self.uVersion == other.uVersion
+            && self.pvReserved == other.pvReserved
+            && self.dot11PhyType == other.dot11PhyType
+            && self.uChCenterFrequency == other.uChCenterFrequency
+            && self.lRSSI == other.lRSSI
+            && self.uRSSI == other.uRSSI
+            && self.ucPriority == other.ucPriority
+            && self.ucDataRate == other.ucDataRate
+            && self.ucPeerMacAddress == other.ucPeerMacAddress
+            && self.dwExtendedStatus == other.dwExtendedStatus
+            && self.hWEPOffloadContext == other.hWEPOffloadContext
+            && self.hAuthOffloadContext == other.hAuthOffloadContext
+            && self.usWEPAppliedMask == other.usWEPAppliedMask
+            && self.usWPAMSDUPriority == other.usWPAMSDUPriority
+            && self.dot11LowestIV48Counter == other.dot11LowestIV48Counter
+            && self.usDot11LeftRWBitMap == other.usDot11LeftRWBitMap
+            && self.dot11HighestIV48Counter == other.dot11HighestIV48Counter
+            && self.usDot11RightRWBitMap == other.usDot11RightRWBitMap
+            && self.usNumberOfMPDUsReceived == other.usNumberOfMPDUsReceived
+            && self.usNumberOfFragments == other.usNumberOfFragments
+            && self.pNdisPackets == other.pNdisPackets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11685,7 +11715,7 @@ unsafe impl ::windows::core::Abi for DOT11_RECV_SENSITIVITY {
 }
 impl ::core::cmp::PartialEq for DOT11_RECV_SENSITIVITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECV_SENSITIVITY>()) == 0 }
+        self.ucDataRate == other.ucDataRate && self.lRSSIMin == other.lRSSIMin && self.lRSSIMax == other.lRSSIMax
     }
 }
 impl ::core::cmp::Eq for DOT11_RECV_SENSITIVITY {}
@@ -11711,12 +11741,6 @@ impl ::core::clone::Clone for DOT11_RECV_SENSITIVITY_LIST {
 unsafe impl ::windows::core::Abi for DOT11_RECV_SENSITIVITY_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DOT11_RECV_SENSITIVITY_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECV_SENSITIVITY_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DOT11_RECV_SENSITIVITY_LIST {}
 impl ::core::default::Default for DOT11_RECV_SENSITIVITY_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11737,12 +11761,6 @@ impl ::core::clone::Clone for DOT11_RECV_SENSITIVITY_LIST_0 {
 unsafe impl ::windows::core::Abi for DOT11_RECV_SENSITIVITY_LIST_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DOT11_RECV_SENSITIVITY_LIST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RECV_SENSITIVITY_LIST_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DOT11_RECV_SENSITIVITY_LIST_0 {}
 impl ::core::default::Default for DOT11_RECV_SENSITIVITY_LIST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11771,7 +11789,7 @@ unsafe impl ::windows::core::Abi for DOT11_REG_DOMAINS_SUPPORT_VALUE {
 }
 impl ::core::cmp::PartialEq for DOT11_REG_DOMAINS_SUPPORT_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_REG_DOMAINS_SUPPORT_VALUE>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11RegDomainValue == other.dot11RegDomainValue
     }
 }
 impl ::core::cmp::Eq for DOT11_REG_DOMAINS_SUPPORT_VALUE {}
@@ -11802,7 +11820,7 @@ unsafe impl ::windows::core::Abi for DOT11_REG_DOMAIN_VALUE {
 }
 impl ::core::cmp::PartialEq for DOT11_REG_DOMAIN_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_REG_DOMAIN_VALUE>()) == 0 }
+        self.uRegDomainsSupportIndex == other.uRegDomainsSupportIndex && self.uRegDomainsSupportValue == other.uRegDomainsSupportValue
     }
 }
 impl ::core::cmp::Eq for DOT11_REG_DOMAIN_VALUE {}
@@ -11840,7 +11858,7 @@ unsafe impl ::windows::core::Abi for DOT11_RESET_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_RESET_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RESET_REQUEST>()) == 0 }
+        self.dot11ResetType == other.dot11ResetType && self.dot11MacAddress == other.dot11MacAddress && self.bSetDefaultMIB == other.bSetDefaultMIB
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11879,7 +11897,7 @@ unsafe impl ::windows::core::Abi for DOT11_ROAMING_COMPLETION_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ROAMING_COMPLETION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ROAMING_COMPLETION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.uStatus == other.uStatus
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11920,7 +11938,7 @@ unsafe impl ::windows::core::Abi for DOT11_ROAMING_START_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_ROAMING_START_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_ROAMING_START_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.AdhocBSSID == other.AdhocBSSID && self.AdhocSSID == other.AdhocSSID && self.uRoamingReason == other.uRoamingReason
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -11954,7 +11972,7 @@ unsafe impl ::windows::core::Abi for DOT11_RSSI_RANGE {
 }
 impl ::core::cmp::PartialEq for DOT11_RSSI_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_RSSI_RANGE>()) == 0 }
+        self.dot11PhyType == other.dot11PhyType && self.uRSSIMin == other.uRSSIMin && self.uRSSIMax == other.uRSSIMax
     }
 }
 impl ::core::cmp::Eq for DOT11_RSSI_RANGE {}
@@ -12016,7 +12034,7 @@ unsafe impl ::windows::core::Abi for DOT11_SCAN_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_SCAN_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SCAN_REQUEST>()) == 0 }
+        self.dot11BSSType == other.dot11BSSType && self.dot11BSSID == other.dot11BSSID && self.dot11SSID == other.dot11SSID && self.dot11ScanType == other.dot11ScanType && self.bRestrictedScan == other.bRestrictedScan && self.bUseRequestIE == other.bUseRequestIE && self.uRequestIDsOffset == other.uRequestIDsOffset && self.uNumOfRequestIDs == other.uNumOfRequestIDs && self.uPhyTypesOffset == other.uPhyTypesOffset && self.uNumOfPhyTypes == other.uNumOfPhyTypes && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength && self.ucBuffer == other.ucBuffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12082,7 +12100,7 @@ unsafe impl ::windows::core::Abi for DOT11_SCAN_REQUEST_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_SCAN_REQUEST_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SCAN_REQUEST_V2>()) == 0 }
+        self.dot11BSSType == other.dot11BSSType && self.dot11BSSID == other.dot11BSSID && self.dot11ScanType == other.dot11ScanType && self.bRestrictedScan == other.bRestrictedScan && self.udot11SSIDsOffset == other.udot11SSIDsOffset && self.uNumOfdot11SSIDs == other.uNumOfdot11SSIDs && self.bUseRequestIE == other.bUseRequestIE && self.uRequestIDsOffset == other.uRequestIDsOffset && self.uNumOfRequestIDs == other.uNumOfRequestIDs && self.uPhyTypeInfosOffset == other.uPhyTypeInfosOffset && self.uNumOfPhyTypeInfos == other.uNumOfPhyTypeInfos && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength && self.ucBuffer == other.ucBuffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12109,12 +12127,6 @@ impl ::core::clone::Clone for DOT11_SECURITY_PACKET_HEADER {
 unsafe impl ::windows::core::Abi for DOT11_SECURITY_PACKET_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DOT11_SECURITY_PACKET_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SECURITY_PACKET_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DOT11_SECURITY_PACKET_HEADER {}
 impl ::core::default::Default for DOT11_SECURITY_PACKET_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12169,7 +12181,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARA
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.ResponseContext == other.ResponseContext && self.uSendTimeout == other.uSendTimeout && self.Status == other.Status && self.GroupCapability == other.GroupCapability && self.GroupID == other.GroupID && self.bUseGroupID == other.bUseGroupID && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -12227,7 +12239,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETER
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.uSendTimeout == other.uSendTimeout && self.GroupOwnerIntent == other.GroupOwnerIntent && self.MinimumConfigTimeout == other.MinimumConfigTimeout && self.IntendedInterfaceAddress == other.IntendedInterfaceAddress && self.GroupCapability == other.GroupCapability && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -12293,7 +12305,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETE
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.PeerDeviceAddress == other.PeerDeviceAddress && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uSendTimeout == other.uSendTimeout && self.Status == other.Status && self.GroupOwnerIntent == other.GroupOwnerIntent && self.MinimumConfigTimeout == other.MinimumConfigTimeout && self.IntendedInterfaceAddress == other.IntendedInterfaceAddress && self.GroupCapability == other.GroupCapability && self.GroupID == other.GroupID && self.bUseGroupID == other.bUseGroupID && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -12359,7 +12371,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_INVITATION_REQUEST_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_SEND_INVITATION_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_INVITATION_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.DialogToken == other.DialogToken && self.PeerDeviceAddress == other.PeerDeviceAddress && self.uSendTimeout == other.uSendTimeout && self.MinimumConfigTimeout == other.MinimumConfigTimeout && self.InvitationFlags == other.InvitationFlags && self.GroupBSSID == other.GroupBSSID && self.bUseGroupBSSID == other.bUseGroupBSSID && self.OperatingChannel == other.OperatingChannel && self.bUseSpecifiedOperatingChannel == other.bUseSpecifiedOperatingChannel && self.GroupID == other.GroupID && self.bLocalGO == other.bLocalGO && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -12423,7 +12435,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_INVITATION_RESPONSE_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_SEND_INVITATION_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_INVITATION_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ReceiverDeviceAddress == other.ReceiverDeviceAddress && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uSendTimeout == other.uSendTimeout && self.Status == other.Status && self.MinimumConfigTimeout == other.MinimumConfigTimeout && self.GroupBSSID == other.GroupBSSID && self.bUseGroupBSSID == other.bUseGroupBSSID && self.OperatingChannel == other.OperatingChannel && self.bUseSpecifiedOperatingChannel == other.bUseSpecifiedOperatingChannel && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -12469,7 +12481,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARA
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.DialogToken == other.DialogToken && self.PeerDeviceAddress == other.PeerDeviceAddress && self.uSendTimeout == other.uSendTimeout && self.GroupCapability == other.GroupCapability && self.GroupID == other.GroupID && self.bUseGroupID == other.bUseGroupID && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -12513,7 +12525,7 @@ unsafe impl ::windows::core::Abi for DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PAR
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ReceiverDeviceAddress == other.ReceiverDeviceAddress && self.DialogToken == other.DialogToken && self.RequestContext == other.RequestContext && self.uSendTimeout == other.uSendTimeout && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -12546,7 +12558,7 @@ unsafe impl ::windows::core::Abi for DOT11_SSID {
 }
 impl ::core::cmp::PartialEq for DOT11_SSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SSID>()) == 0 }
+        self.uSSIDLength == other.uSSIDLength && self.ucSSID == other.ucSSID
     }
 }
 impl ::core::cmp::Eq for DOT11_SSID {}
@@ -12585,7 +12597,7 @@ unsafe impl ::windows::core::Abi for DOT11_SSID_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_SSID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SSID_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.SSIDs == other.SSIDs
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -12620,7 +12632,7 @@ unsafe impl ::windows::core::Abi for DOT11_START_REQUEST {
 }
 impl ::core::cmp::PartialEq for DOT11_START_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_START_REQUEST>()) == 0 }
+        self.uStartFailureTimeout == other.uStartFailureTimeout && self.OperationalRateSet == other.OperationalRateSet && self.uChCenterFrequency == other.uChCenterFrequency && self.dot11BSSDescription == other.dot11BSSDescription
     }
 }
 impl ::core::cmp::Eq for DOT11_START_REQUEST {}
@@ -12662,7 +12674,7 @@ unsafe impl ::windows::core::Abi for DOT11_STATISTICS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_STATISTICS>()) == 0 }
+        self.Header == other.Header && self.ullFourWayHandshakeFailures == other.ullFourWayHandshakeFailures && self.ullTKIPCounterMeasuresInvoked == other.ullTKIPCounterMeasuresInvoked && self.ullReserved == other.ullReserved && self.MacUcastCounters == other.MacUcastCounters && self.MacMcastCounters == other.MacMcastCounters && self.PhyCounters == other.PhyCounters
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -12695,7 +12707,7 @@ unsafe impl ::windows::core::Abi for DOT11_STATUS_INDICATION {
 }
 impl ::core::cmp::PartialEq for DOT11_STATUS_INDICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_STATUS_INDICATION>()) == 0 }
+        self.uStatusType == other.uStatusType && self.ndisStatus == other.ndisStatus
     }
 }
 impl ::core::cmp::Eq for DOT11_STATUS_INDICATION {}
@@ -12732,7 +12744,7 @@ unsafe impl ::windows::core::Abi for DOT11_STOP_AP_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_STOP_AP_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_STOP_AP_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.ulReason == other.ulReason
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -12771,7 +12783,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_ANTENNA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_ANTENNA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_ANTENNA>()) == 0 }
+        self.uAntennaListIndex == other.uAntennaListIndex && self.bSupportedAntenna == other.bSupportedAntenna
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12811,7 +12823,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_ANTENNA_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_ANTENNA_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_ANTENNA_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11SupportedAntenna == other.dot11SupportedAntenna
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12844,7 +12856,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_DATA_RATES_VALUE {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_DATA_RATES_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_DATA_RATES_VALUE>()) == 0 }
+        self.ucSupportedTxDataRatesValue == other.ucSupportedTxDataRatesValue && self.ucSupportedRxDataRatesValue == other.ucSupportedRxDataRatesValue
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_DATA_RATES_VALUE {}
@@ -12875,7 +12887,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_DATA_RATES_VALUE_V2 {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_DATA_RATES_VALUE_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_DATA_RATES_VALUE_V2>()) == 0 }
+        self.ucSupportedTxDataRatesValue == other.ucSupportedTxDataRatesValue && self.ucSupportedRxDataRatesValue == other.ucSupportedRxDataRatesValue
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_DATA_RATES_VALUE_V2 {}
@@ -12905,7 +12917,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_DSSS_CHANNEL {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_DSSS_CHANNEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_DSSS_CHANNEL>()) == 0 }
+        self.uChannel == other.uChannel
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_DSSS_CHANNEL {}
@@ -12937,7 +12949,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_DSSS_CHANNEL_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_DSSS_CHANNEL_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_DSSS_CHANNEL_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11SupportedDSSSChannel == other.dot11SupportedDSSSChannel
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_DSSS_CHANNEL_LIST {}
@@ -12967,7 +12979,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_OFDM_FREQUENCY {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_OFDM_FREQUENCY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_OFDM_FREQUENCY>()) == 0 }
+        self.uCenterFrequency == other.uCenterFrequency
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_OFDM_FREQUENCY {}
@@ -12999,7 +13011,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_OFDM_FREQUENCY_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_OFDM_FREQUENCY_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_OFDM_FREQUENCY_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11SupportedOFDMFrequency == other.dot11SupportedOFDMFrequency
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_OFDM_FREQUENCY_LIST {}
@@ -13031,7 +13043,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_PHY_TYPES {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_PHY_TYPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_PHY_TYPES>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11PHYType == other.dot11PHYType
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_PHY_TYPES {}
@@ -13062,7 +13074,7 @@ unsafe impl ::windows::core::Abi for DOT11_SUPPORTED_POWER_LEVELS {
 }
 impl ::core::cmp::PartialEq for DOT11_SUPPORTED_POWER_LEVELS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_SUPPORTED_POWER_LEVELS>()) == 0 }
+        self.uNumOfSupportedPowerLevels == other.uNumOfSupportedPowerLevels && self.uTxPowerLevelValues == other.uTxPowerLevelValues
     }
 }
 impl ::core::cmp::Eq for DOT11_SUPPORTED_POWER_LEVELS {}
@@ -13101,7 +13113,7 @@ unsafe impl ::windows::core::Abi for DOT11_TKIPMIC_FAILURE_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_TKIPMIC_FAILURE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_TKIPMIC_FAILURE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.bDefaultKeyFailure == other.bDefaultKeyFailure && self.uKeyIndex == other.uKeyIndex && self.PeerMac == other.PeerMac
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -13135,7 +13147,7 @@ unsafe impl ::windows::core::Abi for DOT11_UPDATE_IE {
 }
 impl ::core::cmp::PartialEq for DOT11_UPDATE_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_UPDATE_IE>()) == 0 }
+        self.dot11UpdateIEOp == other.dot11UpdateIEOp && self.uBufferLength == other.uBufferLength && self.ucBuffer == other.ucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_UPDATE_IE {}
@@ -13166,7 +13178,7 @@ unsafe impl ::windows::core::Abi for DOT11_VENUEINFO {
 }
 impl ::core::cmp::PartialEq for DOT11_VENUEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_VENUEINFO>()) == 0 }
+        self.VenueGroup == other.VenueGroup && self.VenueType == other.VenueType
     }
 }
 impl ::core::cmp::Eq for DOT11_VENUEINFO {}
@@ -13204,7 +13216,7 @@ unsafe impl ::windows::core::Abi for DOT11_VWIFI_ATTRIBUTES {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_VWIFI_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_VWIFI_ATTRIBUTES>()) == 0 }
+        self.Header == other.Header && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.Combinations == other.Combinations
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13245,7 +13257,7 @@ unsafe impl ::windows::core::Abi for DOT11_VWIFI_COMBINATION {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_VWIFI_COMBINATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_VWIFI_COMBINATION>()) == 0 }
+        self.Header == other.Header && self.uNumInfrastructure == other.uNumInfrastructure && self.uNumAdhoc == other.uNumAdhoc && self.uNumSoftAP == other.uNumSoftAP
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13287,7 +13299,7 @@ unsafe impl ::windows::core::Abi for DOT11_VWIFI_COMBINATION_V2 {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_VWIFI_COMBINATION_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_VWIFI_COMBINATION_V2>()) == 0 }
+        self.Header == other.Header && self.uNumInfrastructure == other.uNumInfrastructure && self.uNumAdhoc == other.uNumAdhoc && self.uNumSoftAP == other.uNumSoftAP && self.uNumVirtualStation == other.uNumVirtualStation
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13330,7 +13342,7 @@ unsafe impl ::windows::core::Abi for DOT11_VWIFI_COMBINATION_V3 {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_VWIFI_COMBINATION_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_VWIFI_COMBINATION_V3>()) == 0 }
+        self.Header == other.Header && self.uNumInfrastructure == other.uNumInfrastructure && self.uNumAdhoc == other.uNumAdhoc && self.uNumSoftAP == other.uNumSoftAP && self.uNumVirtualStation == other.uNumVirtualStation && self.uNumWFDGroup == other.uNumWFDGroup
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13398,7 +13410,7 @@ unsafe impl ::windows::core::Abi for DOT11_WEP_OFFLOAD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_WEP_OFFLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WEP_OFFLOAD>()) == 0 }
+        self.uReserved == other.uReserved && self.hOffloadContext == other.hOffloadContext && self.hOffload == other.hOffload && self.dot11OffloadType == other.dot11OffloadType && self.dwAlgorithm == other.dwAlgorithm && self.bRowIsOutbound == other.bRowIsOutbound && self.bUseDefault == other.bUseDefault && self.uFlags == other.uFlags && self.ucMacAddress == other.ucMacAddress && self.uNumOfRWsOnPeer == other.uNumOfRWsOnPeer && self.uNumOfRWsOnMe == other.uNumOfRWsOnMe && self.dot11IV48Counters == other.dot11IV48Counters && self.usDot11RWBitMaps == other.usDot11RWBitMaps && self.usKeyLength == other.usKeyLength && self.ucKey == other.ucKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13441,7 +13453,7 @@ unsafe impl ::windows::core::Abi for DOT11_WEP_UPLOAD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_WEP_UPLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WEP_UPLOAD>()) == 0 }
+        self.uReserved == other.uReserved && self.dot11OffloadType == other.dot11OffloadType && self.hOffload == other.hOffload && self.uNumOfRWsUsed == other.uNumOfRWsUsed && self.dot11IV48Counters == other.dot11IV48Counters && self.usDot11RWBitMaps == other.usDot11RWBitMaps
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13485,7 +13497,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_ADDITIONAL_IE {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_ADDITIONAL_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_ADDITIONAL_IE>()) == 0 }
+        self.Header == other.Header && self.uBeaconIEsOffset == other.uBeaconIEsOffset && self.uBeaconIEsLength == other.uBeaconIEsLength && self.uProbeResponseIEsOffset == other.uProbeResponseIEsOffset && self.uProbeResponseIEsLength == other.uProbeResponseIEsLength && self.uDefaultRequestIEsOffset == other.uDefaultRequestIEsOffset && self.uDefaultRequestIEsLength == other.uDefaultRequestIEsLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13520,7 +13532,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR>()) == 0 }
+        self.AdvertisementID == other.AdvertisementID && self.ConfigMethods == other.ConfigMethods && self.ServiceNameLength == other.ServiceNameLength && self.ServiceName == other.ServiceName
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR {}
@@ -13551,7 +13563,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_ADVERTISED_SERVICE_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_ADVERTISED_SERVICE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_ADVERTISED_SERVICE_LIST>()) == 0 }
+        self.ServiceCount == other.ServiceCount && self.AdvertisedService == other.AdvertisedService
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_ADVERTISED_SERVICE_LIST {}
@@ -13582,7 +13594,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_ADVERTISEMENT_ID {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_ADVERTISEMENT_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_ADVERTISEMENT_ID>()) == 0 }
+        self.AdvertisementID == other.AdvertisementID && self.ServiceAddress == other.ServiceAddress
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_ADVERTISEMENT_ID {}
@@ -13648,7 +13660,21 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_ATTRIBUTES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_ATTRIBUTES>()) == 0 }
+        self.Header == other.Header
+            && self.uNumConcurrentGORole == other.uNumConcurrentGORole
+            && self.uNumConcurrentClientRole == other.uNumConcurrentClientRole
+            && self.WPSVersionsSupported == other.WPSVersionsSupported
+            && self.bServiceDiscoverySupported == other.bServiceDiscoverySupported
+            && self.bClientDiscoverabilitySupported == other.bClientDiscoverabilitySupported
+            && self.bInfrastructureManagementSupported == other.bInfrastructureManagementSupported
+            && self.uMaxSecondaryDeviceTypeListSize == other.uMaxSecondaryDeviceTypeListSize
+            && self.DeviceAddress == other.DeviceAddress
+            && self.uInterfaceAddressListCount == other.uInterfaceAddressListCount
+            && self.pInterfaceAddressList == other.pInterfaceAddressList
+            && self.uNumSupportedCountryOrRegionStrings == other.uNumSupportedCountryOrRegionStrings
+            && self.pSupportedCountryOrRegionStrings == other.pSupportedCountryOrRegionStrings
+            && self.uDiscoveryFilterListSize == other.uDiscoveryFilterListSize
+            && self.uGORoleClientTableSize == other.uGORoleClientTableSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -13682,7 +13708,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_CHANNEL {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_CHANNEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_CHANNEL>()) == 0 }
+        self.CountryRegionString == other.CountryRegionString && self.OperatingClass == other.OperatingClass && self.ChannelNumber == other.ChannelNumber
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_CHANNEL {}
@@ -13713,7 +13739,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_CONFIGURATION_TIMEOUT {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_CONFIGURATION_TIMEOUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_CONFIGURATION_TIMEOUT>()) == 0 }
+        self.GOTimeout == other.GOTimeout && self.ClientTimeout == other.ClientTimeout
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_CONFIGURATION_TIMEOUT {}
@@ -13765,7 +13791,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DEVICE_CAPABILITY_CONFIG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_DEVICE_CAPABILITY_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DEVICE_CAPABILITY_CONFIG>()) == 0 }
+        self.Header == other.Header && self.bServiceDiscoveryEnabled == other.bServiceDiscoveryEnabled && self.bClientDiscoverabilityEnabled == other.bClientDiscoverabilityEnabled && self.bConcurrentOperationSupported == other.bConcurrentOperationSupported && self.bInfrastructureManagementEnabled == other.bInfrastructureManagementEnabled && self.bDeviceLimitReached == other.bDeviceLimitReached && self.bInvitationProcedureEnabled == other.bInvitationProcedureEnabled && self.WPSVersionsEnabled == other.WPSVersionsEnabled
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -13805,12 +13831,6 @@ impl ::core::clone::Clone for DOT11_WFD_DEVICE_ENTRY {
 unsafe impl ::windows::core::Abi for DOT11_WFD_DEVICE_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DOT11_WFD_DEVICE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DEVICE_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DOT11_WFD_DEVICE_ENTRY {}
 impl ::core::default::Default for DOT11_WFD_DEVICE_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13847,7 +13867,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DEVICE_INFO {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DEVICE_INFO>()) == 0 }
+        self.Header == other.Header && self.DeviceAddress == other.DeviceAddress && self.ConfigMethods == other.ConfigMethods && self.PrimaryDeviceType == other.PrimaryDeviceType && self.DeviceName == other.DeviceName
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13886,7 +13906,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DEVICE_LISTEN_CHANNEL {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_DEVICE_LISTEN_CHANNEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DEVICE_LISTEN_CHANNEL>()) == 0 }
+        self.Header == other.Header && self.ChannelNumber == other.ChannelNumber
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13920,7 +13940,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DEVICE_TYPE {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_DEVICE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DEVICE_TYPE>()) == 0 }
+        self.CategoryID == other.CategoryID && self.SubCategoryID == other.SubCategoryID && self.OUI == other.OUI
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_DEVICE_TYPE {}
@@ -13961,7 +13981,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.Status == other.Status && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.uListOffset == other.uListOffset && self.uListLength == other.uListLength
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -13995,7 +14015,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DISCOVER_DEVICE_FILTER {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_DISCOVER_DEVICE_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DISCOVER_DEVICE_FILTER>()) == 0 }
+        self.DeviceID == other.DeviceID && self.ucBitmask == other.ucBitmask && self.GroupSSID == other.GroupSSID
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_DISCOVER_DEVICE_FILTER {}
@@ -14039,7 +14059,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_DISCOVER_REQUEST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_DISCOVER_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_DISCOVER_REQUEST>()) == 0 }
+        self.Header == other.Header && self.DiscoverType == other.DiscoverType && self.ScanType == other.ScanType && self.uDiscoverTimeout == other.uDiscoverTimeout && self.uDeviceFilterListOffset == other.uDeviceFilterListOffset && self.uNumDeviceFilters == other.uNumDeviceFilters && self.uIEsOffset == other.uIEsOffset && self.uIEsLength == other.uIEsLength && self.bForceScanLegacyNetworks == other.bForceScanLegacyNetworks
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -14071,7 +14091,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GO_INTENT {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_GO_INTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GO_INTENT>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_GO_INTENT {}
@@ -14102,7 +14122,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GROUP_ID {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_GROUP_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GROUP_ID>()) == 0 }
+        self.DeviceAddress == other.DeviceAddress && self.SSID == other.SSID
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_GROUP_ID {}
@@ -14142,7 +14162,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GROUP_JOIN_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_GROUP_JOIN_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GROUP_JOIN_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.GOOperatingChannel == other.GOOperatingChannel && self.GOConfigTime == other.GOConfigTime && self.bInGroupFormation == other.bInGroupFormation && self.bWaitForWPSReady == other.bWaitForWPSReady
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -14194,7 +14214,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG>()) == 0 }
+        self.Header == other.Header && self.bPersistentGroupEnabled == other.bPersistentGroupEnabled && self.bIntraBSSDistributionSupported == other.bIntraBSSDistributionSupported && self.bCrossConnectionSupported == other.bCrossConnectionSupported && self.bPersistentReconnectSupported == other.bPersistentReconnectSupported && self.bGroupFormationEnabled == other.bGroupFormationEnabled && self.uMaximumGroupLimit == other.uMaximumGroupLimit
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -14248,7 +14268,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_V2 
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
 impl ::core::cmp::PartialEq for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_V2>()) == 0 }
+        self.Header == other.Header && self.bPersistentGroupEnabled == other.bPersistentGroupEnabled && self.bIntraBSSDistributionSupported == other.bIntraBSSDistributionSupported && self.bCrossConnectionSupported == other.bCrossConnectionSupported && self.bPersistentReconnectSupported == other.bPersistentReconnectSupported && self.bGroupFormationEnabled == other.bGroupFormationEnabled && self.uMaximumGroupLimit == other.uMaximumGroupLimit && self.bEapolKeyIpAddressAllocationSupported == other.bEapolKeyIpAddressAllocationSupported
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_NetworkManagement_Ndis"))]
@@ -14287,7 +14307,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_GROUP_START_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_GROUP_START_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_GROUP_START_PARAMETERS>()) == 0 }
+        self.Header == other.Header && self.AdvertisedOperatingChannel == other.AdvertisedOperatingChannel
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -14319,7 +14339,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_INVITATION_FLAGS {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_INVITATION_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_INVITATION_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_INVITATION_FLAGS {}
@@ -14358,7 +14378,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST>()) == 0 }
+        self.Header == other.Header && self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.SecondaryDeviceTypes == other.SecondaryDeviceTypes
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -14391,7 +14411,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_SERVICE_HASH_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_SERVICE_HASH_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_SERVICE_HASH_LIST>()) == 0 }
+        self.ServiceHashCount == other.ServiceHashCount && self.ServiceHash == other.ServiceHash
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_SERVICE_HASH_LIST {}
@@ -14422,7 +14442,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_SESSION_ID {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_SESSION_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_SESSION_ID>()) == 0 }
+        self.SessionID == other.SessionID && self.SessionAddress == other.SessionAddress
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_SESSION_ID {}
@@ -14453,7 +14473,7 @@ unsafe impl ::windows::core::Abi for DOT11_WFD_SESSION_INFO {
 }
 impl ::core::cmp::PartialEq for DOT11_WFD_SESSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WFD_SESSION_INFO>()) == 0 }
+        self.uSessionInfoLength == other.uSessionInfoLength && self.ucSessionInfo == other.ucSessionInfo
     }
 }
 impl ::core::cmp::Eq for DOT11_WFD_SESSION_INFO {}
@@ -14487,7 +14507,7 @@ unsafe impl ::windows::core::Abi for DOT11_WME_AC_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DOT11_WME_AC_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WME_AC_PARAMETERS>()) == 0 }
+        self.ucAccessCategoryIndex == other.ucAccessCategoryIndex && self.ucAIFSN == other.ucAIFSN && self.ucECWmin == other.ucECWmin && self.ucECWmax == other.ucECWmax && self.usTXOPLimit == other.usTXOPLimit
     }
 }
 impl ::core::cmp::Eq for DOT11_WME_AC_PARAMETERS {}
@@ -14519,7 +14539,7 @@ unsafe impl ::windows::core::Abi for DOT11_WME_AC_PARAMETERS_LIST {
 }
 impl ::core::cmp::PartialEq for DOT11_WME_AC_PARAMETERS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WME_AC_PARAMETERS_LIST>()) == 0 }
+        self.uNumOfEntries == other.uNumOfEntries && self.uTotalNumOfEntries == other.uTotalNumOfEntries && self.dot11WMEACParameters == other.dot11WMEACParameters
     }
 }
 impl ::core::cmp::Eq for DOT11_WME_AC_PARAMETERS_LIST {}
@@ -14554,7 +14574,7 @@ unsafe impl ::windows::core::Abi for DOT11_WME_UPDATE_IE {
 }
 impl ::core::cmp::PartialEq for DOT11_WME_UPDATE_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WME_UPDATE_IE>()) == 0 }
+        self.uParamElemMinBeaconIntervals == other.uParamElemMinBeaconIntervals && self.uWMEInfoElemOffset == other.uWMEInfoElemOffset && self.uWMEInfoElemLength == other.uWMEInfoElemLength && self.uWMEParamElemOffset == other.uWMEParamElemOffset && self.uWMEParamElemLength == other.uWMEParamElemLength && self.ucBuffer == other.ucBuffer
     }
 }
 impl ::core::cmp::Eq for DOT11_WME_UPDATE_IE {}
@@ -14593,7 +14613,7 @@ unsafe impl ::windows::core::Abi for DOT11_WPA_TSC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOT11_WPA_TSC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WPA_TSC>()) == 0 }
+        self.uReserved == other.uReserved && self.dot11OffloadType == other.dot11OffloadType && self.hOffload == other.hOffload && self.dot11IV48Counter == other.dot11IV48Counter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14626,7 +14646,7 @@ unsafe impl ::windows::core::Abi for DOT11_WPS_DEVICE_NAME {
 }
 impl ::core::cmp::PartialEq for DOT11_WPS_DEVICE_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOT11_WPS_DEVICE_NAME>()) == 0 }
+        self.uDeviceNameLength == other.uDeviceNameLength && self.ucDeviceName == other.ucDeviceName
     }
 }
 impl ::core::cmp::Eq for DOT11_WPS_DEVICE_NAME {}
@@ -14660,7 +14680,7 @@ unsafe impl ::windows::core::Abi for L2_NOTIFICATION_DATA {
 }
 impl ::core::cmp::PartialEq for L2_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<L2_NOTIFICATION_DATA>()) == 0 }
+        self.NotificationSource == other.NotificationSource && self.NotificationCode == other.NotificationCode && self.InterfaceGuid == other.InterfaceGuid && self.dwDataSize == other.dwDataSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for L2_NOTIFICATION_DATA {}
@@ -14718,7 +14738,7 @@ unsafe impl ::windows::core::Abi for ONEX_AUTH_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ONEX_AUTH_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_AUTH_PARAMS>()) == 0 }
+        self.fUpdatePending == other.fUpdatePending && self.oneXConnProfile == other.oneXConnProfile && self.authIdentity == other.authIdentity && self.dwQuarantineState == other.dwQuarantineState && self._bitfield == other._bitfield && self.dwSessionId == other.dwSessionId && self.hUserToken == other.hUserToken && self.OneXUserProfile == other.OneXUserProfile && self.Identity == other.Identity && self.UserName == other.UserName && self.Domain == other.Domain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14764,7 +14784,7 @@ unsafe impl ::windows::core::Abi for ONEX_EAP_ERROR {
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
 impl ::core::cmp::PartialEq for ONEX_EAP_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_EAP_ERROR>()) == 0 }
+        self.dwWinError == other.dwWinError && self.r#type == other.r#type && self.dwReasonCode == other.dwReasonCode && self.rootCauseGuid == other.rootCauseGuid && self.repairGuid == other.repairGuid && self.helpLinkGuid == other.helpLinkGuid && self._bitfield == other._bitfield && self.RootCauseString == other.RootCauseString && self.RepairString == other.RepairString
     }
 }
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
@@ -14807,7 +14827,7 @@ unsafe impl ::windows::core::Abi for ONEX_RESULT_UPDATE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ONEX_RESULT_UPDATE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_RESULT_UPDATE_DATA>()) == 0 }
+        self.oneXStatus == other.oneXStatus && self.BackendSupport == other.BackendSupport && self.fBackendEngaged == other.fBackendEngaged && self._bitfield == other._bitfield && self.authParams == other.authParams && self.eapError == other.eapError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14841,7 +14861,7 @@ unsafe impl ::windows::core::Abi for ONEX_STATUS {
 }
 impl ::core::cmp::PartialEq for ONEX_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_STATUS>()) == 0 }
+        self.authStatus == other.authStatus && self.dwReason == other.dwReason && self.dwError == other.dwError
     }
 }
 impl ::core::cmp::Eq for ONEX_STATUS {}
@@ -14874,7 +14894,7 @@ unsafe impl ::windows::core::Abi for ONEX_USER_INFO {
 }
 impl ::core::cmp::PartialEq for ONEX_USER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_USER_INFO>()) == 0 }
+        self.authIdentity == other.authIdentity && self._bitfield == other._bitfield && self.UserName == other.UserName && self.DomainName == other.DomainName
     }
 }
 impl ::core::cmp::Eq for ONEX_USER_INFO {}
@@ -14905,7 +14925,7 @@ unsafe impl ::windows::core::Abi for ONEX_VARIABLE_BLOB {
 }
 impl ::core::cmp::PartialEq for ONEX_VARIABLE_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ONEX_VARIABLE_BLOB>()) == 0 }
+        self.dwSize == other.dwSize && self.dwOffset == other.dwOffset
     }
 }
 impl ::core::cmp::Eq for ONEX_VARIABLE_BLOB {}
@@ -14939,7 +14959,7 @@ unsafe impl ::windows::core::Abi for WDIAG_IHV_WLAN_ID {
 }
 impl ::core::cmp::PartialEq for WDIAG_IHV_WLAN_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDIAG_IHV_WLAN_ID>()) == 0 }
+        self.strProfileName == other.strProfileName && self.Ssid == other.Ssid && self.BssType == other.BssType && self.dwFlags == other.dwFlags && self.dwReasonCode == other.dwReasonCode
     }
 }
 impl ::core::cmp::Eq for WDIAG_IHV_WLAN_ID {}
@@ -14977,7 +14997,7 @@ unsafe impl ::windows::core::Abi for WFDSVC_CONNECTION_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WFDSVC_CONNECTION_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WFDSVC_CONNECTION_CAPABILITY>()) == 0 }
+        self.bNew == other.bNew && self.bClient == other.bClient && self.bGO == other.bGO
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15010,7 +15030,7 @@ unsafe impl ::windows::core::Abi for WFD_GROUP_ID {
 }
 impl ::core::cmp::PartialEq for WFD_GROUP_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WFD_GROUP_ID>()) == 0 }
+        self.DeviceAddress == other.DeviceAddress && self.GroupSSID == other.GroupSSID
     }
 }
 impl ::core::cmp::Eq for WFD_GROUP_ID {}
@@ -15047,7 +15067,7 @@ unsafe impl ::windows::core::Abi for WLAN_ASSOCIATION_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for WLAN_ASSOCIATION_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_ASSOCIATION_ATTRIBUTES>()) == 0 }
+        self.dot11Ssid == other.dot11Ssid && self.dot11BssType == other.dot11BssType && self.dot11Bssid == other.dot11Bssid && self.dot11PhyType == other.dot11PhyType && self.uDot11PhyIndex == other.uDot11PhyIndex && self.wlanSignalQuality == other.wlanSignalQuality && self.ulRxRate == other.ulRxRate && self.ulTxRate == other.ulTxRate
     }
 }
 impl ::core::cmp::Eq for WLAN_ASSOCIATION_ATTRIBUTES {}
@@ -15078,7 +15098,7 @@ unsafe impl ::windows::core::Abi for WLAN_AUTH_CIPHER_PAIR_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_AUTH_CIPHER_PAIR_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_AUTH_CIPHER_PAIR_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.pAuthCipherPairList == other.pAuthCipherPairList
     }
 }
 impl ::core::cmp::Eq for WLAN_AUTH_CIPHER_PAIR_LIST {}
@@ -15144,7 +15164,7 @@ unsafe impl ::windows::core::Abi for WLAN_AVAILABLE_NETWORK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_AVAILABLE_NETWORK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_AVAILABLE_NETWORK>()) == 0 }
+        self.strProfileName == other.strProfileName && self.dot11Ssid == other.dot11Ssid && self.dot11BssType == other.dot11BssType && self.uNumberOfBssids == other.uNumberOfBssids && self.bNetworkConnectable == other.bNetworkConnectable && self.wlanNotConnectableReason == other.wlanNotConnectableReason && self.uNumberOfPhyTypes == other.uNumberOfPhyTypes && self.dot11PhyTypes == other.dot11PhyTypes && self.bMorePhyTypes == other.bMorePhyTypes && self.wlanSignalQuality == other.wlanSignalQuality && self.bSecurityEnabled == other.bSecurityEnabled && self.dot11DefaultAuthAlgorithm == other.dot11DefaultAuthAlgorithm && self.dot11DefaultCipherAlgorithm == other.dot11DefaultCipherAlgorithm && self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15184,7 +15204,7 @@ unsafe impl ::windows::core::Abi for WLAN_AVAILABLE_NETWORK_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_AVAILABLE_NETWORK_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_AVAILABLE_NETWORK_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.Network == other.Network
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15224,7 +15244,7 @@ unsafe impl ::windows::core::Abi for WLAN_AVAILABLE_NETWORK_LIST_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_AVAILABLE_NETWORK_LIST_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_AVAILABLE_NETWORK_LIST_V2>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.Network == other.Network
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15298,7 +15318,24 @@ unsafe impl ::windows::core::Abi for WLAN_AVAILABLE_NETWORK_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_AVAILABLE_NETWORK_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_AVAILABLE_NETWORK_V2>()) == 0 }
+        self.strProfileName == other.strProfileName
+            && self.dot11Ssid == other.dot11Ssid
+            && self.dot11BssType == other.dot11BssType
+            && self.uNumberOfBssids == other.uNumberOfBssids
+            && self.bNetworkConnectable == other.bNetworkConnectable
+            && self.wlanNotConnectableReason == other.wlanNotConnectableReason
+            && self.uNumberOfPhyTypes == other.uNumberOfPhyTypes
+            && self.dot11PhyTypes == other.dot11PhyTypes
+            && self.bMorePhyTypes == other.bMorePhyTypes
+            && self.wlanSignalQuality == other.wlanSignalQuality
+            && self.bSecurityEnabled == other.bSecurityEnabled
+            && self.dot11DefaultAuthAlgorithm == other.dot11DefaultAuthAlgorithm
+            && self.dot11DefaultCipherAlgorithm == other.dot11DefaultCipherAlgorithm
+            && self.dwFlags == other.dwFlags
+            && self.AccessNetworkOptions == other.AccessNetworkOptions
+            && self.dot11HESSID == other.dot11HESSID
+            && self.VenueInfo == other.VenueInfo
+            && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15368,7 +15405,7 @@ unsafe impl ::windows::core::Abi for WLAN_BSS_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_BSS_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_BSS_ENTRY>()) == 0 }
+        self.dot11Ssid == other.dot11Ssid && self.uPhyId == other.uPhyId && self.dot11Bssid == other.dot11Bssid && self.dot11BssType == other.dot11BssType && self.dot11BssPhyType == other.dot11BssPhyType && self.lRssi == other.lRssi && self.uLinkQuality == other.uLinkQuality && self.bInRegDomain == other.bInRegDomain && self.usBeaconPeriod == other.usBeaconPeriod && self.ullTimestamp == other.ullTimestamp && self.ullHostTimestamp == other.ullHostTimestamp && self.usCapabilityInformation == other.usCapabilityInformation && self.ulChCenterFrequency == other.ulChCenterFrequency && self.wlanRateSet == other.wlanRateSet && self.ulIeOffset == other.ulIeOffset && self.ulIeSize == other.ulIeSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15408,7 +15445,7 @@ unsafe impl ::windows::core::Abi for WLAN_BSS_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_BSS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_BSS_LIST>()) == 0 }
+        self.dwTotalSize == other.dwTotalSize && self.dwNumberOfItems == other.dwNumberOfItems && self.wlanBssEntries == other.wlanBssEntries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15450,7 +15487,7 @@ unsafe impl ::windows::core::Abi for WLAN_CONNECTION_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_CONNECTION_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_CONNECTION_ATTRIBUTES>()) == 0 }
+        self.isState == other.isState && self.wlanConnectionMode == other.wlanConnectionMode && self.strProfileName == other.strProfileName && self.wlanAssociationAttributes == other.wlanAssociationAttributes && self.wlanSecurityAttributes == other.wlanSecurityAttributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15495,7 +15532,7 @@ unsafe impl ::windows::core::Abi for WLAN_CONNECTION_NOTIFICATION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_CONNECTION_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_CONNECTION_NOTIFICATION_DATA>()) == 0 }
+        self.wlanConnectionMode == other.wlanConnectionMode && self.strProfileName == other.strProfileName && self.dot11Ssid == other.dot11Ssid && self.dot11BssType == other.dot11BssType && self.bSecurityEnabled == other.bSecurityEnabled && self.wlanReasonCode == other.wlanReasonCode && self.dwFlags == other.dwFlags && self.strProfileXml == other.strProfileXml
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15538,7 +15575,7 @@ unsafe impl ::windows::core::Abi for WLAN_CONNECTION_PARAMETERS {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for WLAN_CONNECTION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_CONNECTION_PARAMETERS>()) == 0 }
+        self.wlanConnectionMode == other.wlanConnectionMode && self.strProfile == other.strProfile && self.pDot11Ssid == other.pDot11Ssid && self.pDesiredBssidList == other.pDesiredBssidList && self.dot11BssType == other.dot11BssType && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -15583,7 +15620,7 @@ unsafe impl ::windows::core::Abi for WLAN_CONNECTION_PARAMETERS_V2 {
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 impl ::core::cmp::PartialEq for WLAN_CONNECTION_PARAMETERS_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_CONNECTION_PARAMETERS_V2>()) == 0 }
+        self.wlanConnectionMode == other.wlanConnectionMode && self.strProfile == other.strProfile && self.pDot11Ssid == other.pDot11Ssid && self.pDot11Hessid == other.pDot11Hessid && self.pDesiredBssidList == other.pDesiredBssidList && self.dot11BssType == other.dot11BssType && self.dwFlags == other.dwFlags && self.pDot11AccessNetworkOptions == other.pDot11AccessNetworkOptions
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -15616,7 +15653,7 @@ unsafe impl ::windows::core::Abi for WLAN_COUNTRY_OR_REGION_STRING_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_COUNTRY_OR_REGION_STRING_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_COUNTRY_OR_REGION_STRING_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.pCountryOrRegionStringList == other.pCountryOrRegionStringList
     }
 }
 impl ::core::cmp::Eq for WLAN_COUNTRY_OR_REGION_STRING_LIST {}
@@ -15648,7 +15685,7 @@ unsafe impl ::windows::core::Abi for WLAN_DEVICE_SERVICE_GUID_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_DEVICE_SERVICE_GUID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_DEVICE_SERVICE_GUID_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.DeviceService == other.DeviceService
     }
 }
 impl ::core::cmp::Eq for WLAN_DEVICE_SERVICE_GUID_LIST {}
@@ -15681,7 +15718,7 @@ unsafe impl ::windows::core::Abi for WLAN_DEVICE_SERVICE_NOTIFICATION_DATA {
 }
 impl ::core::cmp::PartialEq for WLAN_DEVICE_SERVICE_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_DEVICE_SERVICE_NOTIFICATION_DATA>()) == 0 }
+        self.DeviceService == other.DeviceService && self.dwOpCode == other.dwOpCode && self.dwDataSize == other.dwDataSize && self.DataBlob == other.DataBlob
     }
 }
 impl ::core::cmp::Eq for WLAN_DEVICE_SERVICE_NOTIFICATION_DATA {}
@@ -15712,7 +15749,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS>()) == 0 }
+        self.hostedNetworkSSID == other.hostedNetworkSSID && self.dwMaxNumberOfPeers == other.dwMaxNumberOfPeers
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS {}
@@ -15744,7 +15781,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE 
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE>()) == 0 }
+        self.OldState == other.OldState && self.NewState == other.NewState && self.PeerStateChangeReason == other.PeerStateChangeReason
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE {}
@@ -15775,7 +15812,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_PEER_STATE {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_PEER_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_PEER_STATE>()) == 0 }
+        self.PeerMacAddress == other.PeerMacAddress && self.PeerAuthState == other.PeerAuthState
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_PEER_STATE {}
@@ -15806,7 +15843,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_RADIO_STATE {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_RADIO_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_RADIO_STATE>()) == 0 }
+        self.dot11SoftwareRadioState == other.dot11SoftwareRadioState && self.dot11HardwareRadioState == other.dot11HardwareRadioState
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_RADIO_STATE {}
@@ -15837,7 +15874,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_SECURITY_SETTINGS {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_SECURITY_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_SECURITY_SETTINGS>()) == 0 }
+        self.dot11AuthAlgo == other.dot11AuthAlgo && self.dot11CipherAlgo == other.dot11CipherAlgo
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_SECURITY_SETTINGS {}
@@ -15869,7 +15906,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_STATE_CHANGE {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_STATE_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_STATE_CHANGE>()) == 0 }
+        self.OldState == other.OldState && self.NewState == other.NewState && self.StateChangeReason == other.StateChangeReason
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_STATE_CHANGE {}
@@ -15905,7 +15942,7 @@ unsafe impl ::windows::core::Abi for WLAN_HOSTED_NETWORK_STATUS {
 }
 impl ::core::cmp::PartialEq for WLAN_HOSTED_NETWORK_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_HOSTED_NETWORK_STATUS>()) == 0 }
+        self.HostedNetworkState == other.HostedNetworkState && self.IPDeviceID == other.IPDeviceID && self.wlanHostedNetworkBSSID == other.wlanHostedNetworkBSSID && self.dot11PhyType == other.dot11PhyType && self.ulChannelFrequency == other.ulChannelFrequency && self.dwNumberOfPeers == other.dwNumberOfPeers && self.PeerList == other.PeerList
     }
 }
 impl ::core::cmp::Eq for WLAN_HOSTED_NETWORK_STATUS {}
@@ -15946,7 +15983,7 @@ unsafe impl ::windows::core::Abi for WLAN_INTERFACE_CAPABILITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_INTERFACE_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_INTERFACE_CAPABILITY>()) == 0 }
+        self.interfaceType == other.interfaceType && self.bDot11DSupported == other.bDot11DSupported && self.dwMaxDesiredSsidListSize == other.dwMaxDesiredSsidListSize && self.dwMaxDesiredBssidListSize == other.dwMaxDesiredBssidListSize && self.dwNumberOfSupportedPhys == other.dwNumberOfSupportedPhys && self.dot11PhyTypes == other.dot11PhyTypes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15980,7 +16017,7 @@ unsafe impl ::windows::core::Abi for WLAN_INTERFACE_INFO {
 }
 impl ::core::cmp::PartialEq for WLAN_INTERFACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_INTERFACE_INFO>()) == 0 }
+        self.InterfaceGuid == other.InterfaceGuid && self.strInterfaceDescription == other.strInterfaceDescription && self.isState == other.isState
     }
 }
 impl ::core::cmp::Eq for WLAN_INTERFACE_INFO {}
@@ -16012,7 +16049,7 @@ unsafe impl ::windows::core::Abi for WLAN_INTERFACE_INFO_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_INTERFACE_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_INTERFACE_INFO_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.InterfaceInfo == other.InterfaceInfo
     }
 }
 impl ::core::cmp::Eq for WLAN_INTERFACE_INFO_LIST {}
@@ -16066,7 +16103,7 @@ unsafe impl ::windows::core::Abi for WLAN_MAC_FRAME_STATISTICS {
 }
 impl ::core::cmp::PartialEq for WLAN_MAC_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_MAC_FRAME_STATISTICS>()) == 0 }
+        self.ullTransmittedFrameCount == other.ullTransmittedFrameCount && self.ullReceivedFrameCount == other.ullReceivedFrameCount && self.ullWEPExcludedCount == other.ullWEPExcludedCount && self.ullTKIPLocalMICFailures == other.ullTKIPLocalMICFailures && self.ullTKIPReplays == other.ullTKIPReplays && self.ullTKIPICVErrorCount == other.ullTKIPICVErrorCount && self.ullCCMPReplays == other.ullCCMPReplays && self.ullCCMPDecryptErrors == other.ullCCMPDecryptErrors && self.ullWEPUndecryptableCount == other.ullWEPUndecryptableCount && self.ullWEPICVErrorCount == other.ullWEPICVErrorCount && self.ullDecryptSuccessCount == other.ullDecryptSuccessCount && self.ullDecryptFailureCount == other.ullDecryptFailureCount
     }
 }
 impl ::core::cmp::Eq for WLAN_MAC_FRAME_STATISTICS {}
@@ -16110,7 +16147,7 @@ unsafe impl ::windows::core::Abi for WLAN_MSM_NOTIFICATION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_MSM_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_MSM_NOTIFICATION_DATA>()) == 0 }
+        self.wlanConnectionMode == other.wlanConnectionMode && self.strProfileName == other.strProfileName && self.dot11Ssid == other.dot11Ssid && self.dot11BssType == other.dot11BssType && self.dot11MacAddr == other.dot11MacAddr && self.bSecurityEnabled == other.bSecurityEnabled && self.bFirstPeer == other.bFirstPeer && self.bLastPeer == other.bLastPeer && self.wlanReasonCode == other.wlanReasonCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16178,7 +16215,24 @@ unsafe impl ::windows::core::Abi for WLAN_PHY_FRAME_STATISTICS {
 }
 impl ::core::cmp::PartialEq for WLAN_PHY_FRAME_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_PHY_FRAME_STATISTICS>()) == 0 }
+        self.ullTransmittedFrameCount == other.ullTransmittedFrameCount
+            && self.ullMulticastTransmittedFrameCount == other.ullMulticastTransmittedFrameCount
+            && self.ullFailedCount == other.ullFailedCount
+            && self.ullRetryCount == other.ullRetryCount
+            && self.ullMultipleRetryCount == other.ullMultipleRetryCount
+            && self.ullMaxTXLifetimeExceededCount == other.ullMaxTXLifetimeExceededCount
+            && self.ullTransmittedFragmentCount == other.ullTransmittedFragmentCount
+            && self.ullRTSSuccessCount == other.ullRTSSuccessCount
+            && self.ullRTSFailureCount == other.ullRTSFailureCount
+            && self.ullACKFailureCount == other.ullACKFailureCount
+            && self.ullReceivedFrameCount == other.ullReceivedFrameCount
+            && self.ullMulticastReceivedFrameCount == other.ullMulticastReceivedFrameCount
+            && self.ullPromiscuousReceivedFrameCount == other.ullPromiscuousReceivedFrameCount
+            && self.ullMaxRXLifetimeExceededCount == other.ullMaxRXLifetimeExceededCount
+            && self.ullFrameDuplicateCount == other.ullFrameDuplicateCount
+            && self.ullReceivedFragmentCount == other.ullReceivedFragmentCount
+            && self.ullPromiscuousReceivedFragmentCount == other.ullPromiscuousReceivedFragmentCount
+            && self.ullFCSErrorCount == other.ullFCSErrorCount
     }
 }
 impl ::core::cmp::Eq for WLAN_PHY_FRAME_STATISTICS {}
@@ -16210,7 +16264,7 @@ unsafe impl ::windows::core::Abi for WLAN_PHY_RADIO_STATE {
 }
 impl ::core::cmp::PartialEq for WLAN_PHY_RADIO_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_PHY_RADIO_STATE>()) == 0 }
+        self.dwPhyIndex == other.dwPhyIndex && self.dot11SoftwareRadioState == other.dot11SoftwareRadioState && self.dot11HardwareRadioState == other.dot11HardwareRadioState
     }
 }
 impl ::core::cmp::Eq for WLAN_PHY_RADIO_STATE {}
@@ -16241,7 +16295,7 @@ unsafe impl ::windows::core::Abi for WLAN_PROFILE_INFO {
 }
 impl ::core::cmp::PartialEq for WLAN_PROFILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_PROFILE_INFO>()) == 0 }
+        self.strProfileName == other.strProfileName && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for WLAN_PROFILE_INFO {}
@@ -16273,7 +16327,7 @@ unsafe impl ::windows::core::Abi for WLAN_PROFILE_INFO_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_PROFILE_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_PROFILE_INFO_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.dwIndex == other.dwIndex && self.ProfileInfo == other.ProfileInfo
     }
 }
 impl ::core::cmp::Eq for WLAN_PROFILE_INFO_LIST {}
@@ -16304,7 +16358,7 @@ unsafe impl ::windows::core::Abi for WLAN_RADIO_STATE {
 }
 impl ::core::cmp::PartialEq for WLAN_RADIO_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_RADIO_STATE>()) == 0 }
+        self.dwNumberOfPhys == other.dwNumberOfPhys && self.PhyRadioState == other.PhyRadioState
     }
 }
 impl ::core::cmp::Eq for WLAN_RADIO_STATE {}
@@ -16335,7 +16389,7 @@ unsafe impl ::windows::core::Abi for WLAN_RATE_SET {
 }
 impl ::core::cmp::PartialEq for WLAN_RATE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_RATE_SET>()) == 0 }
+        self.uRateSetLength == other.uRateSetLength && self.usRateSet == other.usRateSet
     }
 }
 impl ::core::cmp::Eq for WLAN_RATE_SET {}
@@ -16366,7 +16420,7 @@ unsafe impl ::windows::core::Abi for WLAN_RAW_DATA {
 }
 impl ::core::cmp::PartialEq for WLAN_RAW_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_RAW_DATA>()) == 0 }
+        self.dwDataSize == other.dwDataSize && self.DataBlob == other.DataBlob
     }
 }
 impl ::core::cmp::Eq for WLAN_RAW_DATA {}
@@ -16398,7 +16452,7 @@ unsafe impl ::windows::core::Abi for WLAN_RAW_DATA_LIST {
 }
 impl ::core::cmp::PartialEq for WLAN_RAW_DATA_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_RAW_DATA_LIST>()) == 0 }
+        self.dwTotalSize == other.dwTotalSize && self.dwNumberOfItems == other.dwNumberOfItems && self.DataList == other.DataList
     }
 }
 impl ::core::cmp::Eq for WLAN_RAW_DATA_LIST {}
@@ -16429,7 +16483,7 @@ unsafe impl ::windows::core::Abi for WLAN_RAW_DATA_LIST_0 {
 }
 impl ::core::cmp::PartialEq for WLAN_RAW_DATA_LIST_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_RAW_DATA_LIST_0>()) == 0 }
+        self.dwDataOffset == other.dwDataOffset && self.dwDataSize == other.dwDataSize
     }
 }
 impl ::core::cmp::Eq for WLAN_RAW_DATA_LIST_0 {}
@@ -16468,7 +16522,7 @@ unsafe impl ::windows::core::Abi for WLAN_SECURITY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLAN_SECURITY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_SECURITY_ATTRIBUTES>()) == 0 }
+        self.bSecurityEnabled == other.bSecurityEnabled && self.bOneXEnabled == other.bOneXEnabled && self.dot11AuthAlgorithm == other.dot11AuthAlgorithm && self.dot11CipherAlgorithm == other.dot11CipherAlgorithm
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16506,7 +16560,7 @@ unsafe impl ::windows::core::Abi for WLAN_STATISTICS {
 }
 impl ::core::cmp::PartialEq for WLAN_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLAN_STATISTICS>()) == 0 }
+        self.ullFourWayHandshakeFailures == other.ullFourWayHandshakeFailures && self.ullTKIPCounterMeasuresInvoked == other.ullTKIPCounterMeasuresInvoked && self.ullReserved == other.ullReserved && self.MacUcastCounters == other.MacUcastCounters && self.MacMcastCounters == other.MacMcastCounters && self.dwNumberOfPhys == other.dwNumberOfPhys && self.PhyCounters == other.PhyCounters
     }
 }
 impl ::core::cmp::Eq for WLAN_STATISTICS {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
@@ -1127,12 +1127,6 @@ impl ::core::clone::Clone for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
 unsafe impl ::windows::core::Abi for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {}
 impl ::core::default::Default for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1162,7 +1156,7 @@ unsafe impl ::windows::core::Abi for WCN_VENDOR_EXTENSION_SPEC {
 }
 impl ::core::cmp::PartialEq for WCN_VENDOR_EXTENSION_SPEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCN_VENDOR_EXTENSION_SPEC>()) == 0 }
+        self.VendorId == other.VendorId && self.SubType == other.SubType && self.Index == other.Index && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WCN_VENDOR_EXTENSION_SPEC {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectionManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectionManager/mod.rs
@@ -261,7 +261,7 @@ unsafe impl ::windows::core::Abi for NET_INTERFACE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for NET_INTERFACE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_INTERFACE_CONTEXT>()) == 0 }
+        self.InterfaceIndex == other.InterfaceIndex && self.ConfigurationName == other.ConfigurationName
     }
 }
 impl ::core::cmp::Eq for NET_INTERFACE_CONTEXT {}
@@ -299,7 +299,7 @@ unsafe impl ::windows::core::Abi for NET_INTERFACE_CONTEXT_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NET_INTERFACE_CONTEXT_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NET_INTERFACE_CONTEXT_TABLE>()) == 0 }
+        self.InterfaceContextHandle == other.InterfaceContextHandle && self.NumberOfEntries == other.NumberOfEntries && self.InterfaceContextArray == other.InterfaceContextArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -339,7 +339,7 @@ unsafe impl ::windows::core::Abi for WCM_BILLING_CYCLE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCM_BILLING_CYCLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_BILLING_CYCLE_INFO>()) == 0 }
+        self.StartDate == other.StartDate && self.Duration == other.Duration && self.Reset == other.Reset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -372,7 +372,7 @@ unsafe impl ::windows::core::Abi for WCM_CONNECTION_COST_DATA {
 }
 impl ::core::cmp::PartialEq for WCM_CONNECTION_COST_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_CONNECTION_COST_DATA>()) == 0 }
+        self.ConnectionCost == other.ConnectionCost && self.CostSource == other.CostSource
     }
 }
 impl ::core::cmp::Eq for WCM_CONNECTION_COST_DATA {}
@@ -414,7 +414,7 @@ unsafe impl ::windows::core::Abi for WCM_DATAPLAN_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCM_DATAPLAN_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_DATAPLAN_STATUS>()) == 0 }
+        self.UsageData == other.UsageData && self.DataLimitInMegabytes == other.DataLimitInMegabytes && self.InboundBandwidthInKbps == other.InboundBandwidthInKbps && self.OutboundBandwidthInKbps == other.OutboundBandwidthInKbps && self.BillingCycle == other.BillingCycle && self.MaxTransferSizeInMegabytes == other.MaxTransferSizeInMegabytes && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -453,7 +453,7 @@ unsafe impl ::windows::core::Abi for WCM_POLICY_VALUE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCM_POLICY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_POLICY_VALUE>()) == 0 }
+        self.fValue == other.fValue && self.fIsGroupPolicy == other.fIsGroupPolicy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -487,7 +487,7 @@ unsafe impl ::windows::core::Abi for WCM_PROFILE_INFO {
 }
 impl ::core::cmp::PartialEq for WCM_PROFILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_PROFILE_INFO>()) == 0 }
+        self.strProfileName == other.strProfileName && self.AdapterGUID == other.AdapterGUID && self.Media == other.Media
     }
 }
 impl ::core::cmp::Eq for WCM_PROFILE_INFO {}
@@ -518,7 +518,7 @@ unsafe impl ::windows::core::Abi for WCM_PROFILE_INFO_LIST {
 }
 impl ::core::cmp::PartialEq for WCM_PROFILE_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_PROFILE_INFO_LIST>()) == 0 }
+        self.dwNumberOfItems == other.dwNumberOfItems && self.ProfileInfo == other.ProfileInfo
     }
 }
 impl ::core::cmp::Eq for WCM_PROFILE_INFO_LIST {}
@@ -554,7 +554,7 @@ unsafe impl ::windows::core::Abi for WCM_TIME_INTERVAL {
 }
 impl ::core::cmp::PartialEq for WCM_TIME_INTERVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_TIME_INTERVAL>()) == 0 }
+        self.wYear == other.wYear && self.wMonth == other.wMonth && self.wDay == other.wDay && self.wHour == other.wHour && self.wMinute == other.wMinute && self.wSecond == other.wSecond && self.wMilliseconds == other.wMilliseconds
     }
 }
 impl ::core::cmp::Eq for WCM_TIME_INTERVAL {}
@@ -591,7 +591,7 @@ unsafe impl ::windows::core::Abi for WCM_USAGE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCM_USAGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCM_USAGE_DATA>()) == 0 }
+        self.UsageInMegabytes == other.UsageInMegabytes && self.LastSyncTime == other.LastSyncTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
@@ -4952,12 +4952,6 @@ impl ::core::clone::Clone for FWPM_ACTION0 {
 unsafe impl ::windows::core::Abi for FWPM_ACTION0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FWPM_ACTION0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_ACTION0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FWPM_ACTION0 {}
 impl ::core::default::Default for FWPM_ACTION0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4978,12 +4972,6 @@ impl ::core::clone::Clone for FWPM_ACTION0_0 {
 unsafe impl ::windows::core::Abi for FWPM_ACTION0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FWPM_ACTION0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_ACTION0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FWPM_ACTION0_0 {}
 impl ::core::default::Default for FWPM_ACTION0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5016,7 +5004,7 @@ unsafe impl ::windows::core::Abi for FWPM_CALLOUT0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CALLOUT0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CALLOUT0>()) == 0 }
+        self.calloutKey == other.calloutKey && self.displayData == other.displayData && self.flags == other.flags && self.providerKey == other.providerKey && self.providerData == other.providerData && self.applicableLayer == other.applicableLayer && self.calloutId == other.calloutId
     }
 }
 impl ::core::cmp::Eq for FWPM_CALLOUT0 {}
@@ -5048,7 +5036,7 @@ unsafe impl ::windows::core::Abi for FWPM_CALLOUT_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CALLOUT_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CALLOUT_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.calloutKey == other.calloutKey && self.calloutId == other.calloutId
     }
 }
 impl ::core::cmp::Eq for FWPM_CALLOUT_CHANGE0 {}
@@ -5079,7 +5067,7 @@ unsafe impl ::windows::core::Abi for FWPM_CALLOUT_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CALLOUT_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CALLOUT_ENUM_TEMPLATE0>()) == 0 }
+        self.providerKey == other.providerKey && self.layerKey == other.layerKey
     }
 }
 impl ::core::cmp::Eq for FWPM_CALLOUT_ENUM_TEMPLATE0 {}
@@ -5111,7 +5099,7 @@ unsafe impl ::windows::core::Abi for FWPM_CALLOUT_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CALLOUT_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CALLOUT_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_CALLOUT_SUBSCRIPTION0 {}
@@ -5139,14 +5127,6 @@ impl ::core::clone::Clone for FWPM_CLASSIFY_OPTION0 {
 unsafe impl ::windows::core::Abi for FWPM_CLASSIFY_OPTION0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_CLASSIFY_OPTION0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CLASSIFY_OPTION0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_CLASSIFY_OPTION0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_CLASSIFY_OPTION0 {
     fn default() -> Self {
@@ -5181,7 +5161,7 @@ unsafe impl ::windows::core::Abi for FWPM_CLASSIFY_OPTIONS0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_CLASSIFY_OPTIONS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CLASSIFY_OPTIONS0>()) == 0 }
+        self.numOptions == other.numOptions && self.options == other.options
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -5224,14 +5204,6 @@ unsafe impl ::windows::core::Abi for FWPM_CONNECTION0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FWPM_CONNECTION0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CONNECTION0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FWPM_CONNECTION0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FWPM_CONNECTION0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5257,14 +5229,6 @@ unsafe impl ::windows::core::Abi for FWPM_CONNECTION0_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FWPM_CONNECTION0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CONNECTION0_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FWPM_CONNECTION0_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FWPM_CONNECTION0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5289,14 +5253,6 @@ impl ::core::clone::Clone for FWPM_CONNECTION0_1 {
 unsafe impl ::windows::core::Abi for FWPM_CONNECTION0_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FWPM_CONNECTION0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CONNECTION0_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FWPM_CONNECTION0_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FWPM_CONNECTION0_1 {
     fn default() -> Self {
@@ -5325,7 +5281,7 @@ unsafe impl ::windows::core::Abi for FWPM_CONNECTION_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CONNECTION_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CONNECTION_ENUM_TEMPLATE0>()) == 0 }
+        self.connectionId == other.connectionId && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for FWPM_CONNECTION_ENUM_TEMPLATE0 {}
@@ -5357,7 +5313,7 @@ unsafe impl ::windows::core::Abi for FWPM_CONNECTION_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_CONNECTION_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_CONNECTION_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_CONNECTION_SUBSCRIPTION0 {}
@@ -5388,7 +5344,7 @@ unsafe impl ::windows::core::Abi for FWPM_DISPLAY_DATA0 {
 }
 impl ::core::cmp::PartialEq for FWPM_DISPLAY_DATA0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_DISPLAY_DATA0>()) == 0 }
+        self.name == other.name && self.description == other.description
     }
 }
 impl ::core::cmp::Eq for FWPM_DISPLAY_DATA0 {}
@@ -5420,7 +5376,7 @@ unsafe impl ::windows::core::Abi for FWPM_FIELD0 {
 }
 impl ::core::cmp::PartialEq for FWPM_FIELD0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FIELD0>()) == 0 }
+        self.fieldKey == other.fieldKey && self.r#type == other.r#type && self.dataType == other.dataType
     }
 }
 impl ::core::cmp::Eq for FWPM_FIELD0 {}
@@ -5462,14 +5418,6 @@ unsafe impl ::windows::core::Abi for FWPM_FILTER0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_FILTER0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_FILTER0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_FILTER0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5494,14 +5442,6 @@ impl ::core::clone::Clone for FWPM_FILTER0_0 {
 unsafe impl ::windows::core::Abi for FWPM_FILTER0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_FILTER0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_FILTER0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_FILTER0_0 {
     fn default() -> Self {
@@ -5531,7 +5471,7 @@ unsafe impl ::windows::core::Abi for FWPM_FILTER_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_FILTER_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.filterKey == other.filterKey && self.filterId == other.filterId
     }
 }
 impl ::core::cmp::Eq for FWPM_FILTER_CHANGE0 {}
@@ -5560,14 +5500,6 @@ impl ::core::clone::Clone for FWPM_FILTER_CONDITION0 {
 unsafe impl ::windows::core::Abi for FWPM_FILTER_CONDITION0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_FILTER_CONDITION0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER_CONDITION0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_FILTER_CONDITION0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_FILTER_CONDITION0 {
     fn default() -> Self {
@@ -5609,7 +5541,7 @@ unsafe impl ::windows::core::Abi for FWPM_FILTER_ENUM_TEMPLATE0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_FILTER_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER_ENUM_TEMPLATE0>()) == 0 }
+        self.providerKey == other.providerKey && self.layerKey == other.layerKey && self.enumType == other.enumType && self.flags == other.flags && self.providerContextTemplate == other.providerContextTemplate && self.numFilterConditions == other.numFilterConditions && self.filterCondition == other.filterCondition && self.actionMask == other.actionMask && self.calloutKey == other.calloutKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -5649,7 +5581,7 @@ unsafe impl ::windows::core::Abi for FWPM_FILTER_SUBSCRIPTION0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_FILTER_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_FILTER_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -5687,7 +5619,7 @@ unsafe impl ::windows::core::Abi for FWPM_LAYER0 {
 }
 impl ::core::cmp::PartialEq for FWPM_LAYER0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_LAYER0>()) == 0 }
+        self.layerKey == other.layerKey && self.displayData == other.displayData && self.flags == other.flags && self.numFields == other.numFields && self.field == other.field && self.defaultSubLayerKey == other.defaultSubLayerKey && self.layerId == other.layerId
     }
 }
 impl ::core::cmp::Eq for FWPM_LAYER0 {}
@@ -5717,7 +5649,7 @@ unsafe impl ::windows::core::Abi for FWPM_LAYER_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_LAYER_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_LAYER_ENUM_TEMPLATE0>()) == 0 }
+        self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for FWPM_LAYER_ENUM_TEMPLATE0 {}
@@ -5751,7 +5683,7 @@ unsafe impl ::windows::core::Abi for FWPM_LAYER_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for FWPM_LAYER_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_LAYER_STATISTICS0>()) == 0 }
+        self.layerId == other.layerId && self.classifyPermitCount == other.classifyPermitCount && self.classifyBlockCount == other.classifyBlockCount && self.classifyVetoCount == other.classifyVetoCount && self.numCacheEntries == other.numCacheEntries
     }
 }
 impl ::core::cmp::Eq for FWPM_LAYER_STATISTICS0 {}
@@ -5780,14 +5712,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT0 {
     fn default() -> Self {
@@ -5818,14 +5742,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5851,14 +5767,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT1 {
     fn default() -> Self {
@@ -5889,14 +5797,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT1_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT1_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5922,14 +5822,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT2 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT2 {
     fn default() -> Self {
@@ -5964,14 +5856,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5997,14 +5881,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT3 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT3 {
     fn default() -> Self {
@@ -6039,14 +5915,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT3_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT3_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT3_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6072,14 +5940,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT4 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT4 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT4>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT4 {
     fn default() -> Self {
@@ -6114,14 +5974,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT4_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT4_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT4_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT4_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT4_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6147,14 +5999,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT5 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT5 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT5>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT5 {
     fn default() -> Self {
@@ -6190,14 +6034,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT5_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT5_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT5_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT5_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT5_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6232,7 +6068,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CAPABILITY_ALLOW0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CAPABILITY_ALLOW0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CAPABILITY_ALLOW0>()) == 0 }
+        self.networkCapabilityId == other.networkCapabilityId && self.filterId == other.filterId && self.isLoopback == other.isLoopback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6272,7 +6108,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CAPABILITY_DROP0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CAPABILITY_DROP0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CAPABILITY_DROP0>()) == 0 }
+        self.networkCapabilityId == other.networkCapabilityId && self.filterId == other.filterId && self.isLoopback == other.isLoopback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6316,7 +6152,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CLASSIFY_ALLOW0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CLASSIFY_ALLOW0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CLASSIFY_ALLOW0>()) == 0 }
+        self.filterId == other.filterId && self.layerId == other.layerId && self.reauthReason == other.reauthReason && self.originalProfile == other.originalProfile && self.currentProfile == other.currentProfile && self.msFwpDirection == other.msFwpDirection && self.isLoopback == other.isLoopback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6349,7 +6185,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CLASSIFY_DROP0 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CLASSIFY_DROP0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CLASSIFY_DROP0>()) == 0 }
+        self.filterId == other.filterId && self.layerId == other.layerId
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_CLASSIFY_DROP0 {}
@@ -6391,7 +6227,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CLASSIFY_DROP1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CLASSIFY_DROP1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CLASSIFY_DROP1>()) == 0 }
+        self.filterId == other.filterId && self.layerId == other.layerId && self.reauthReason == other.reauthReason && self.originalProfile == other.originalProfile && self.currentProfile == other.currentProfile && self.msFwpDirection == other.msFwpDirection && self.isLoopback == other.isLoopback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6449,7 +6285,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CLASSIFY_DROP2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CLASSIFY_DROP2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CLASSIFY_DROP2>()) == 0 }
+        self.filterId == other.filterId && self.layerId == other.layerId && self.reauthReason == other.reauthReason && self.originalProfile == other.originalProfile && self.currentProfile == other.currentProfile && self.msFwpDirection == other.msFwpDirection && self.isLoopback == other.isLoopback && self.vSwitchId == other.vSwitchId && self.vSwitchSourcePort == other.vSwitchSourcePort && self.vSwitchDestinationPort == other.vSwitchDestinationPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6525,7 +6361,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_CLASSIFY_DROP_MAC0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_CLASSIFY_DROP_MAC0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_CLASSIFY_DROP_MAC0>()) == 0 }
+        self.localMacAddr == other.localMacAddr && self.remoteMacAddr == other.remoteMacAddr && self.mediaType == other.mediaType && self.ifType == other.ifType && self.etherType == other.etherType && self.ndisPortNumber == other.ndisPortNumber && self.reserved == other.reserved && self.vlanTag == other.vlanTag && self.ifLuid == other.ifLuid && self.filterId == other.filterId && self.layerId == other.layerId && self.reauthReason == other.reauthReason && self.originalProfile == other.originalProfile && self.currentProfile == other.currentProfile && self.msFwpDirection == other.msFwpDirection && self.isLoopback == other.isLoopback && self.vSwitchId == other.vSwitchId && self.vSwitchSourcePort == other.vSwitchSourcePort && self.vSwitchDestinationPort == other.vSwitchDestinationPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6566,7 +6402,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_ENUM_TEMPLATE0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_ENUM_TEMPLATE0>()) == 0 }
+        self.startTime == other.startTime && self.endTime == other.endTime && self.numFilterConditions == other.numFilterConditions && self.filterCondition == other.filterCondition
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -6606,14 +6442,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6639,14 +6467,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6671,14 +6491,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER0_1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER0_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER0_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER0_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER0_1 {
     fn default() -> Self {
@@ -6715,14 +6527,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6747,14 +6551,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER1_0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1_0 {
     fn default() -> Self {
@@ -6781,14 +6577,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6812,14 +6600,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER1_2 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1_2 {
     fn default() -> Self {
@@ -6846,14 +6626,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1_2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1_2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6877,14 +6649,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER1_2_0_0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_2_0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_2_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_2_0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER1_2_0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER1_2_0_0 {
     fn default() -> Self {
@@ -6926,7 +6690,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER1_2_0_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER1_2_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER1_2_0_0_0>()) == 0 }
+        self.reserved2 == other.reserved2 && self.reserved3 == other.reserved3 && self.reserved4 == other.reserved4 && self.reserved5 == other.reserved5 && self.reserved6 == other.reserved6 && self.reserved7 == other.reserved7 && self.reserved8 == other.reserved8 && self.reserved9 == other.reserved9 && self.reserved10 == other.reserved10
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -6968,14 +6732,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7001,14 +6757,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7033,14 +6781,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER2_1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER2_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER2_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER2_1 {
     fn default() -> Self {
@@ -7081,14 +6821,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7114,14 +6846,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER3_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER3_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER3_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7146,14 +6870,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_HEADER3_1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_HEADER3_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_HEADER3_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_HEADER3_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_HEADER3_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_HEADER3_1 {
     fn default() -> Self {
@@ -7189,7 +6905,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_EM_FAILURE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_EM_FAILURE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_EM_FAILURE0>()) == 0 }
+        self.failureErrorCode == other.failureErrorCode && self.failurePoint == other.failurePoint && self.flags == other.flags && self.emState == other.emState && self.saRole == other.saRole && self.emAuthMethod == other.emAuthMethod && self.endCertHash == other.endCertHash && self.mmId == other.mmId && self.qmFilterId == other.qmFilterId
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_EM_FAILURE0 {}
@@ -7251,7 +6967,22 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_EM_FAILURE1 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_EM_FAILURE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_EM_FAILURE1>()) == 0 }
+        self.failureErrorCode == other.failureErrorCode
+            && self.failurePoint == other.failurePoint
+            && self.flags == other.flags
+            && self.emState == other.emState
+            && self.saRole == other.saRole
+            && self.emAuthMethod == other.emAuthMethod
+            && self.endCertHash == other.endCertHash
+            && self.mmId == other.mmId
+            && self.qmFilterId == other.qmFilterId
+            && self.localPrincipalNameForAuth == other.localPrincipalNameForAuth
+            && self.remotePrincipalNameForAuth == other.remotePrincipalNameForAuth
+            && self.numLocalPrincipalGroupSids == other.numLocalPrincipalGroupSids
+            && self.localPrincipalGroupSids == other.localPrincipalGroupSids
+            && self.numRemotePrincipalGroupSids == other.numRemotePrincipalGroupSids
+            && self.remotePrincipalGroupSids == other.remotePrincipalGroupSids
+            && self.saTrafficType == other.saTrafficType
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_EM_FAILURE1 {}
@@ -7290,7 +7021,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_MM_FAILURE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_MM_FAILURE0>()) == 0 }
+        self.failureErrorCode == other.failureErrorCode && self.failurePoint == other.failurePoint && self.flags == other.flags && self.keyingModuleType == other.keyingModuleType && self.mmState == other.mmState && self.saRole == other.saRole && self.mmAuthMethod == other.mmAuthMethod && self.endCertHash == other.endCertHash && self.mmId == other.mmId && self.mmFilterId == other.mmFilterId
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE0 {}
@@ -7352,7 +7083,22 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_MM_FAILURE1 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_MM_FAILURE1>()) == 0 }
+        self.failureErrorCode == other.failureErrorCode
+            && self.failurePoint == other.failurePoint
+            && self.flags == other.flags
+            && self.keyingModuleType == other.keyingModuleType
+            && self.mmState == other.mmState
+            && self.saRole == other.saRole
+            && self.mmAuthMethod == other.mmAuthMethod
+            && self.endCertHash == other.endCertHash
+            && self.mmId == other.mmId
+            && self.mmFilterId == other.mmFilterId
+            && self.localPrincipalNameForAuth == other.localPrincipalNameForAuth
+            && self.remotePrincipalNameForAuth == other.remotePrincipalNameForAuth
+            && self.numLocalPrincipalGroupSids == other.numLocalPrincipalGroupSids
+            && self.localPrincipalGroupSids == other.localPrincipalGroupSids
+            && self.numRemotePrincipalGroupSids == other.numRemotePrincipalGroupSids
+            && self.remotePrincipalGroupSids == other.remotePrincipalGroupSids
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE1 {}
@@ -7416,7 +7162,23 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_MM_FAILURE2 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_MM_FAILURE2>()) == 0 }
+        self.failureErrorCode == other.failureErrorCode
+            && self.failurePoint == other.failurePoint
+            && self.flags == other.flags
+            && self.keyingModuleType == other.keyingModuleType
+            && self.mmState == other.mmState
+            && self.saRole == other.saRole
+            && self.mmAuthMethod == other.mmAuthMethod
+            && self.endCertHash == other.endCertHash
+            && self.mmId == other.mmId
+            && self.mmFilterId == other.mmFilterId
+            && self.localPrincipalNameForAuth == other.localPrincipalNameForAuth
+            && self.remotePrincipalNameForAuth == other.remotePrincipalNameForAuth
+            && self.numLocalPrincipalGroupSids == other.numLocalPrincipalGroupSids
+            && self.localPrincipalGroupSids == other.localPrincipalGroupSids
+            && self.numRemotePrincipalGroupSids == other.numRemotePrincipalGroupSids
+            && self.remotePrincipalGroupSids == other.remotePrincipalGroupSids
+            && self.providerContextKey == other.providerContextKey
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_MM_FAILURE2 {}
@@ -7452,14 +7214,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7484,14 +7238,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7515,14 +7261,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
     fn default() -> Self {
@@ -7558,14 +7296,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7589,14 +7319,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
     fn default() -> Self {
@@ -7622,14 +7344,6 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7653,12 +7367,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IPSEC_DOSP_DROP0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {}
 impl ::core::default::Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7679,12 +7387,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {}
 impl ::core::default::Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7705,12 +7407,6 @@ impl ::core::clone::Clone for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
 unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {}
 impl ::core::default::Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7741,7 +7437,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_IPSEC_KERNEL_DROP0 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_IPSEC_KERNEL_DROP0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_IPSEC_KERNEL_DROP0>()) == 0 }
+        self.failureStatus == other.failureStatus && self.direction == other.direction && self.spi == other.spi && self.filterId == other.filterId && self.layerId == other.layerId
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_IPSEC_KERNEL_DROP0 {}
@@ -7771,7 +7467,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0 {
 }
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0>()) == 0 }
+        self.spi == other.spi
     }
 }
 impl ::core::cmp::Eq for FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0 {}
@@ -7809,7 +7505,7 @@ unsafe impl ::windows::core::Abi for FWPM_NET_EVENT_SUBSCRIPTION0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_NET_EVENT_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_NET_EVENT_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -7845,7 +7541,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER0>()) == 0 }
+        self.providerKey == other.providerKey && self.displayData == other.displayData && self.flags == other.flags && self.providerData == other.providerData && self.serviceName == other.serviceName
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER0 {}
@@ -7876,7 +7572,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.providerKey == other.providerKey
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_CHANGE0 {}
@@ -7911,14 +7607,6 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7951,14 +7639,6 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7989,14 +7669,6 @@ impl ::core::clone::Clone for FWPM_PROVIDER_CONTEXT1 {
 unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT1 {
     fn default() -> Self {
@@ -8033,14 +7705,6 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT1_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT1_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8071,14 +7735,6 @@ impl ::core::clone::Clone for FWPM_PROVIDER_CONTEXT2 {
 unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT2 {
     fn default() -> Self {
@@ -8116,14 +7772,6 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8154,14 +7802,6 @@ impl ::core::clone::Clone for FWPM_PROVIDER_CONTEXT3 {
 unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT3 {
     fn default() -> Self {
@@ -8199,14 +7839,6 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT3_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT3_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT3_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWPM_PROVIDER_CONTEXT3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8235,7 +7867,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.providerContextKey == other.providerContextKey && self.providerContextId == other.providerContextId
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT_CHANGE0 {}
@@ -8266,7 +7898,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0>()) == 0 }
+        self.providerKey == other.providerKey && self.providerContextType == other.providerContextType
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0 {}
@@ -8298,7 +7930,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {}
@@ -8328,7 +7960,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_ENUM_TEMPLATE0>()) == 0 }
+        self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_ENUM_TEMPLATE0 {}
@@ -8360,7 +7992,7 @@ unsafe impl ::windows::core::Abi for FWPM_PROVIDER_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_PROVIDER_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_PROVIDER_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_PROVIDER_SUBSCRIPTION0 {}
@@ -8403,7 +8035,7 @@ unsafe impl ::windows::core::Abi for FWPM_SESSION0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWPM_SESSION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SESSION0>()) == 0 }
+        self.sessionKey == other.sessionKey && self.displayData == other.displayData && self.flags == other.flags && self.txnWaitTimeoutInMSec == other.txnWaitTimeoutInMSec && self.processId == other.processId && self.sid == other.sid && self.username == other.username && self.kernelMode == other.kernelMode
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -8435,7 +8067,7 @@ unsafe impl ::windows::core::Abi for FWPM_SESSION_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SESSION_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SESSION_ENUM_TEMPLATE0>()) == 0 }
+        self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for FWPM_SESSION_ENUM_TEMPLATE0 {}
@@ -8537,7 +8169,42 @@ unsafe impl ::windows::core::Abi for FWPM_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for FWPM_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_STATISTICS0>()) == 0 }
+        self.numLayerStatistics == other.numLayerStatistics
+            && self.layerStatistics == other.layerStatistics
+            && self.inboundAllowedConnectionsV4 == other.inboundAllowedConnectionsV4
+            && self.inboundBlockedConnectionsV4 == other.inboundBlockedConnectionsV4
+            && self.outboundAllowedConnectionsV4 == other.outboundAllowedConnectionsV4
+            && self.outboundBlockedConnectionsV4 == other.outboundBlockedConnectionsV4
+            && self.inboundAllowedConnectionsV6 == other.inboundAllowedConnectionsV6
+            && self.inboundBlockedConnectionsV6 == other.inboundBlockedConnectionsV6
+            && self.outboundAllowedConnectionsV6 == other.outboundAllowedConnectionsV6
+            && self.outboundBlockedConnectionsV6 == other.outboundBlockedConnectionsV6
+            && self.inboundActiveConnectionsV4 == other.inboundActiveConnectionsV4
+            && self.outboundActiveConnectionsV4 == other.outboundActiveConnectionsV4
+            && self.inboundActiveConnectionsV6 == other.inboundActiveConnectionsV6
+            && self.outboundActiveConnectionsV6 == other.outboundActiveConnectionsV6
+            && self.reauthDirInbound == other.reauthDirInbound
+            && self.reauthDirOutbound == other.reauthDirOutbound
+            && self.reauthFamilyV4 == other.reauthFamilyV4
+            && self.reauthFamilyV6 == other.reauthFamilyV6
+            && self.reauthProtoOther == other.reauthProtoOther
+            && self.reauthProtoIPv4 == other.reauthProtoIPv4
+            && self.reauthProtoIPv6 == other.reauthProtoIPv6
+            && self.reauthProtoICMP == other.reauthProtoICMP
+            && self.reauthProtoICMP6 == other.reauthProtoICMP6
+            && self.reauthProtoUDP == other.reauthProtoUDP
+            && self.reauthProtoTCP == other.reauthProtoTCP
+            && self.reauthReasonPolicyChange == other.reauthReasonPolicyChange
+            && self.reauthReasonNewArrivalInterface == other.reauthReasonNewArrivalInterface
+            && self.reauthReasonNewNextHopInterface == other.reauthReasonNewNextHopInterface
+            && self.reauthReasonProfileCrossing == other.reauthReasonProfileCrossing
+            && self.reauthReasonClassifyCompletion == other.reauthReasonClassifyCompletion
+            && self.reauthReasonIPSecPropertiesChanged == other.reauthReasonIPSecPropertiesChanged
+            && self.reauthReasonMidStreamInspection == other.reauthReasonMidStreamInspection
+            && self.reauthReasonSocketPropertyChanged == other.reauthReasonSocketPropertyChanged
+            && self.reauthReasonNewInboundMCastBCastPacket == other.reauthReasonNewInboundMCastBCastPacket
+            && self.reauthReasonEDPPolicyChanged == other.reauthReasonEDPPolicyChanged
+            && self.reauthReasonProxyHandleChanged == other.reauthReasonProxyHandleChanged
     }
 }
 impl ::core::cmp::Eq for FWPM_STATISTICS0 {}
@@ -8572,7 +8239,7 @@ unsafe impl ::windows::core::Abi for FWPM_SUBLAYER0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SUBLAYER0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SUBLAYER0>()) == 0 }
+        self.subLayerKey == other.subLayerKey && self.displayData == other.displayData && self.flags == other.flags && self.providerKey == other.providerKey && self.providerData == other.providerData && self.weight == other.weight
     }
 }
 impl ::core::cmp::Eq for FWPM_SUBLAYER0 {}
@@ -8603,7 +8270,7 @@ unsafe impl ::windows::core::Abi for FWPM_SUBLAYER_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SUBLAYER_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SUBLAYER_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.subLayerKey == other.subLayerKey
     }
 }
 impl ::core::cmp::Eq for FWPM_SUBLAYER_CHANGE0 {}
@@ -8633,7 +8300,7 @@ unsafe impl ::windows::core::Abi for FWPM_SUBLAYER_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SUBLAYER_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SUBLAYER_ENUM_TEMPLATE0>()) == 0 }
+        self.providerKey == other.providerKey
     }
 }
 impl ::core::cmp::Eq for FWPM_SUBLAYER_ENUM_TEMPLATE0 {}
@@ -8665,7 +8332,7 @@ unsafe impl ::windows::core::Abi for FWPM_SUBLAYER_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SUBLAYER_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SUBLAYER_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_SUBLAYER_SUBSCRIPTION0 {}
@@ -8696,7 +8363,7 @@ unsafe impl ::windows::core::Abi for FWPM_SYSTEM_PORTS0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SYSTEM_PORTS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SYSTEM_PORTS0>()) == 0 }
+        self.numTypes == other.numTypes && self.types == other.types
     }
 }
 impl ::core::cmp::Eq for FWPM_SYSTEM_PORTS0 {}
@@ -8728,7 +8395,7 @@ unsafe impl ::windows::core::Abi for FWPM_SYSTEM_PORTS_BY_TYPE0 {
 }
 impl ::core::cmp::PartialEq for FWPM_SYSTEM_PORTS_BY_TYPE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_SYSTEM_PORTS_BY_TYPE0>()) == 0 }
+        self.r#type == other.r#type && self.numPorts == other.numPorts && self.ports == other.ports
     }
 }
 impl ::core::cmp::Eq for FWPM_SYSTEM_PORTS_BY_TYPE0 {}
@@ -8758,14 +8425,6 @@ unsafe impl ::windows::core::Abi for FWPM_VSWITCH_EVENT0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FWPM_VSWITCH_EVENT0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_VSWITCH_EVENT0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FWPM_VSWITCH_EVENT0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FWPM_VSWITCH_EVENT0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8790,14 +8449,6 @@ impl ::core::clone::Clone for FWPM_VSWITCH_EVENT0_0 {
 unsafe impl ::windows::core::Abi for FWPM_VSWITCH_EVENT0_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FWPM_VSWITCH_EVENT0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_VSWITCH_EVENT0_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FWPM_VSWITCH_EVENT0_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FWPM_VSWITCH_EVENT0_0 {
     fn default() -> Self {
@@ -8832,7 +8483,7 @@ unsafe impl ::windows::core::Abi for FWPM_VSWITCH_EVENT0_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_VSWITCH_EVENT0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_VSWITCH_EVENT0_0_0>()) == 0 }
+        self.numvSwitchFilterExtensions == other.numvSwitchFilterExtensions && self.vSwitchFilterExtensions == other.vSwitchFilterExtensions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8872,7 +8523,7 @@ unsafe impl ::windows::core::Abi for FWPM_VSWITCH_EVENT0_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FWPM_VSWITCH_EVENT0_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_VSWITCH_EVENT0_0_1>()) == 0 }
+        self.inRequiredPosition == other.inRequiredPosition && self.numvSwitchFilterExtensions == other.numvSwitchFilterExtensions && self.vSwitchFilterExtensions == other.vSwitchFilterExtensions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8905,7 +8556,7 @@ unsafe impl ::windows::core::Abi for FWPM_VSWITCH_EVENT_SUBSCRIPTION0 {
 }
 impl ::core::cmp::PartialEq for FWPM_VSWITCH_EVENT_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWPM_VSWITCH_EVENT_SUBSCRIPTION0>()) == 0 }
+        self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 impl ::core::cmp::Eq for FWPM_VSWITCH_EVENT_SUBSCRIPTION0 {}
@@ -8935,7 +8586,7 @@ unsafe impl ::windows::core::Abi for FWP_BYTE_ARRAY16 {
 }
 impl ::core::cmp::PartialEq for FWP_BYTE_ARRAY16 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_BYTE_ARRAY16>()) == 0 }
+        self.byteArray16 == other.byteArray16
     }
 }
 impl ::core::cmp::Eq for FWP_BYTE_ARRAY16 {}
@@ -8965,7 +8616,7 @@ unsafe impl ::windows::core::Abi for FWP_BYTE_ARRAY6 {
 }
 impl ::core::cmp::PartialEq for FWP_BYTE_ARRAY6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_BYTE_ARRAY6>()) == 0 }
+        self.byteArray6 == other.byteArray6
     }
 }
 impl ::core::cmp::Eq for FWP_BYTE_ARRAY6 {}
@@ -8996,7 +8647,7 @@ unsafe impl ::windows::core::Abi for FWP_BYTE_BLOB {
 }
 impl ::core::cmp::PartialEq for FWP_BYTE_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_BYTE_BLOB>()) == 0 }
+        self.size == other.size && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for FWP_BYTE_BLOB {}
@@ -9024,14 +8675,6 @@ impl ::core::clone::Clone for FWP_CONDITION_VALUE0 {
 unsafe impl ::windows::core::Abi for FWP_CONDITION_VALUE0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWP_CONDITION_VALUE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_CONDITION_VALUE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWP_CONDITION_VALUE0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWP_CONDITION_VALUE0 {
     fn default() -> Self {
@@ -9077,14 +8720,6 @@ unsafe impl ::windows::core::Abi for FWP_CONDITION_VALUE0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWP_CONDITION_VALUE0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_CONDITION_VALUE0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWP_CONDITION_VALUE0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWP_CONDITION_VALUE0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9109,14 +8744,6 @@ impl ::core::clone::Clone for FWP_RANGE0 {
 unsafe impl ::windows::core::Abi for FWP_RANGE0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWP_RANGE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_RANGE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWP_RANGE0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWP_RANGE0 {
     fn default() -> Self {
@@ -9153,7 +8780,7 @@ unsafe impl ::windows::core::Abi for FWP_TOKEN_INFORMATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for FWP_TOKEN_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_TOKEN_INFORMATION>()) == 0 }
+        self.sidCount == other.sidCount && self.sids == other.sids && self.restrictedSidCount == other.restrictedSidCount && self.restrictedSids == other.restrictedSids
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -9186,7 +8813,7 @@ unsafe impl ::windows::core::Abi for FWP_V4_ADDR_AND_MASK {
 }
 impl ::core::cmp::PartialEq for FWP_V4_ADDR_AND_MASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_V4_ADDR_AND_MASK>()) == 0 }
+        self.addr == other.addr && self.mask == other.mask
     }
 }
 impl ::core::cmp::Eq for FWP_V4_ADDR_AND_MASK {}
@@ -9217,7 +8844,7 @@ unsafe impl ::windows::core::Abi for FWP_V6_ADDR_AND_MASK {
 }
 impl ::core::cmp::PartialEq for FWP_V6_ADDR_AND_MASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_V6_ADDR_AND_MASK>()) == 0 }
+        self.addr == other.addr && self.prefixLength == other.prefixLength
     }
 }
 impl ::core::cmp::Eq for FWP_V6_ADDR_AND_MASK {}
@@ -9245,14 +8872,6 @@ impl ::core::clone::Clone for FWP_VALUE0 {
 unsafe impl ::windows::core::Abi for FWP_VALUE0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWP_VALUE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_VALUE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWP_VALUE0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWP_VALUE0 {
     fn default() -> Self {
@@ -9295,14 +8914,6 @@ unsafe impl ::windows::core::Abi for FWP_VALUE0_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for FWP_VALUE0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FWP_VALUE0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for FWP_VALUE0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for FWP_VALUE0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9323,12 +8934,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD0 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD0 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9353,12 +8958,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD0_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD0_0 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9379,12 +8978,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD1 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD1 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9410,12 +9003,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD1_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD1_0 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9436,12 +9023,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD2 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD2 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9468,12 +9049,6 @@ impl ::core::clone::Clone for IKEEXT_AUTHENTICATION_METHOD2_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_AUTHENTICATION_METHOD2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_AUTHENTICATION_METHOD2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_AUTHENTICATION_METHOD2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_AUTHENTICATION_METHOD2_0 {}
 impl ::core::default::Default for IKEEXT_AUTHENTICATION_METHOD2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9497,12 +9072,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION0 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9524,12 +9093,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9557,7 +9120,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0>()) == 0 }
+        self.inboundRootArraySize == other.inboundRootArraySize && self.inboundRootArray == other.inboundRootArray
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {}
@@ -9582,12 +9145,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9615,7 +9172,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0>()) == 0 }
+        self.outboundRootArraySize == other.outboundRootArraySize && self.outboundRootArray == other.outboundRootArray
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {}
@@ -9643,12 +9200,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION1 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9670,12 +9221,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9703,7 +9248,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0>()) == 0 }
+        self.inboundRootArraySize == other.inboundRootArraySize && self.inboundRootArray == other.inboundRootArray
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {}
@@ -9728,12 +9273,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION1_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9761,7 +9300,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0>()) == 0 }
+        self.outboundRootArraySize == other.outboundRootArraySize && self.outboundRootArray == other.outboundRootArray
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {}
@@ -9789,12 +9328,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9816,12 +9349,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9849,7 +9376,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0>()) == 0 }
+        self.inboundRootArraySize == other.inboundRootArraySize && self.inboundRootCriteria == other.inboundRootCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {}
@@ -9880,7 +9407,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1>()) == 0 }
+        self.inboundEnterpriseStoreArraySize == other.inboundEnterpriseStoreArraySize && self.inboundEnterpriseStoreCriteria == other.inboundEnterpriseStoreCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1 {}
@@ -9911,7 +9438,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2>()) == 0 }
+        self.inboundRootStoreArraySize == other.inboundRootStoreArraySize && self.inboundTrustedRootStoreCriteria == other.inboundTrustedRootStoreCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {}
@@ -9936,12 +9463,6 @@ impl ::core::clone::Clone for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {}
 impl ::core::default::Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9969,7 +9490,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0>()) == 0 }
+        self.outboundRootArraySize == other.outboundRootArraySize && self.outboundRootCriteria == other.outboundRootCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {}
@@ -10000,7 +9521,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1>()) == 0 }
+        self.outboundEnterpriseStoreArraySize == other.outboundEnterpriseStoreArraySize && self.outboundEnterpriseStoreCriteria == other.outboundEnterpriseStoreCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1 {}
@@ -10031,7 +9552,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2>()) == 0 }
+        self.outboundRootStoreArraySize == other.outboundRootStoreArraySize && self.outboundTrustedRootStoreCriteria == other.outboundTrustedRootStoreCriteria
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {}
@@ -10063,7 +9584,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_CREDENTIAL0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_CREDENTIAL0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_CREDENTIAL0>()) == 0 }
+        self.subjectName == other.subjectName && self.certHash == other.certHash && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_CREDENTIAL0 {}
@@ -10096,7 +9617,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_CREDENTIAL1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_CREDENTIAL1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_CREDENTIAL1>()) == 0 }
+        self.subjectName == other.subjectName && self.certHash == other.certHash && self.flags == other.flags && self.certificate == other.certificate
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_CREDENTIAL1 {}
@@ -10130,7 +9651,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERTIFICATE_CRITERIA0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERTIFICATE_CRITERIA0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERTIFICATE_CRITERIA0>()) == 0 }
+        self.certData == other.certData && self.certHash == other.certHash && self.eku == other.eku && self.name == other.name && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERTIFICATE_CRITERIA0 {}
@@ -10161,7 +9682,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERT_EKUS0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERT_EKUS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERT_EKUS0>()) == 0 }
+        self.numEku == other.numEku && self.eku == other.eku
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERT_EKUS0 {}
@@ -10192,7 +9713,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERT_NAME0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERT_NAME0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERT_NAME0>()) == 0 }
+        self.nameType == other.nameType && self.certName == other.certName
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERT_NAME0 {}
@@ -10223,7 +9744,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CERT_ROOT_CONFIG0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CERT_ROOT_CONFIG0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CERT_ROOT_CONFIG0>()) == 0 }
+        self.certData == other.certData && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CERT_ROOT_CONFIG0 {}
@@ -10255,7 +9776,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CIPHER_ALGORITHM0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CIPHER_ALGORITHM0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CIPHER_ALGORITHM0>()) == 0 }
+        self.algoIdentifier == other.algoIdentifier && self.keyLen == other.keyLen && self.rounds == other.rounds
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CIPHER_ALGORITHM0 {}
@@ -10289,7 +9810,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_COMMON_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_COMMON_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_COMMON_STATISTICS0>()) == 0 }
+        self.v4Statistics == other.v4Statistics && self.v6Statistics == other.v6Statistics && self.totalPacketsReceived == other.totalPacketsReceived && self.totalInvalidPacketsReceived == other.totalInvalidPacketsReceived && self.currentQueuedWorkitems == other.currentQueuedWorkitems
     }
 }
 impl ::core::cmp::Eq for IKEEXT_COMMON_STATISTICS0 {}
@@ -10323,7 +9844,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_COMMON_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_COMMON_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_COMMON_STATISTICS1>()) == 0 }
+        self.v4Statistics == other.v4Statistics && self.v6Statistics == other.v6Statistics && self.totalPacketsReceived == other.totalPacketsReceived && self.totalInvalidPacketsReceived == other.totalInvalidPacketsReceived && self.currentQueuedWorkitems == other.currentQueuedWorkitems
     }
 }
 impl ::core::cmp::Eq for IKEEXT_COMMON_STATISTICS1 {}
@@ -10354,7 +9875,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_COOKIE_PAIR0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_COOKIE_PAIR0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_COOKIE_PAIR0>()) == 0 }
+        self.initiator == other.initiator && self.responder == other.responder
     }
 }
 impl ::core::cmp::Eq for IKEEXT_COOKIE_PAIR0 {}
@@ -10379,12 +9900,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL0 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10406,12 +9921,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL0_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL0_0 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10433,12 +9942,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL1 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10460,12 +9963,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL1_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL1_0 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10487,12 +9984,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL2 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL2 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10514,12 +10005,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL2_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL2_0 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10547,7 +10032,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIALS0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CREDENTIALS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIALS0>()) == 0 }
+        self.numCredentials == other.numCredentials && self.credentials == other.credentials
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CREDENTIALS0 {}
@@ -10578,7 +10063,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIALS1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CREDENTIALS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIALS1>()) == 0 }
+        self.numCredentials == other.numCredentials && self.credentials == other.credentials
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CREDENTIALS1 {}
@@ -10609,7 +10094,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIALS2 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_CREDENTIALS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIALS2>()) == 0 }
+        self.numCredentials == other.numCredentials && self.credentials == other.credentials
     }
 }
 impl ::core::cmp::Eq for IKEEXT_CREDENTIALS2 {}
@@ -10633,12 +10118,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL_PAIR0 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL_PAIR0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL_PAIR0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL_PAIR0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL_PAIR0 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL_PAIR0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10659,12 +10138,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL_PAIR1 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL_PAIR1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL_PAIR1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL_PAIR1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL_PAIR1 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL_PAIR1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10685,12 +10158,6 @@ impl ::core::clone::Clone for IKEEXT_CREDENTIAL_PAIR2 {
 unsafe impl ::windows::core::Abi for IKEEXT_CREDENTIAL_PAIR2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_CREDENTIAL_PAIR2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_CREDENTIAL_PAIR2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_CREDENTIAL_PAIR2 {}
 impl ::core::default::Default for IKEEXT_CREDENTIAL_PAIR2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10717,7 +10184,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_EAP_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_EAP_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_EAP_AUTHENTICATION0>()) == 0 }
+        self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_EAP_AUTHENTICATION0 {}
@@ -10749,7 +10216,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_EM_POLICY0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_EM_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_EM_POLICY0>()) == 0 }
+        self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType
     }
 }
 impl ::core::cmp::Eq for IKEEXT_EM_POLICY0 {}
@@ -10781,7 +10248,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_EM_POLICY1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_EM_POLICY1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_EM_POLICY1>()) == 0 }
+        self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType
     }
 }
 impl ::core::cmp::Eq for IKEEXT_EM_POLICY1 {}
@@ -10813,7 +10280,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_EM_POLICY2 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_EM_POLICY2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_EM_POLICY2>()) == 0 }
+        self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType
     }
 }
 impl ::core::cmp::Eq for IKEEXT_EM_POLICY2 {}
@@ -10843,7 +10310,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_INTEGRITY_ALGORITHM0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_INTEGRITY_ALGORITHM0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_INTEGRITY_ALGORITHM0>()) == 0 }
+        self.algoIdentifier == other.algoIdentifier
     }
 }
 impl ::core::cmp::Eq for IKEEXT_INTEGRITY_ALGORITHM0 {}
@@ -10877,7 +10344,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_IPV6_CGA_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_IPV6_CGA_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_IPV6_CGA_AUTHENTICATION0>()) == 0 }
+        self.keyContainerName == other.keyContainerName && self.cspName == other.cspName && self.cspType == other.cspType && self.cgaModifier == other.cgaModifier && self.cgaCollisionCount == other.cgaCollisionCount
     }
 }
 impl ::core::cmp::Eq for IKEEXT_IPV6_CGA_AUTHENTICATION0 {}
@@ -10908,7 +10375,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTIC
 }
 impl ::core::cmp::PartialEq for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0>()) == 0 }
+        self.totalSocketReceiveFailures == other.totalSocketReceiveFailures && self.totalSocketSendFailures == other.totalSocketSendFailures
     }
 }
 impl ::core::cmp::Eq for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0 {}
@@ -10939,7 +10406,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTIC
 }
 impl ::core::cmp::PartialEq for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1>()) == 0 }
+        self.totalSocketReceiveFailures == other.totalSocketReceiveFailures && self.totalSocketSendFailures == other.totalSocketSendFailures
     }
 }
 impl ::core::cmp::Eq for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1 {}
@@ -11005,7 +10472,24 @@ unsafe impl ::windows::core::Abi for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATIS
 }
 impl ::core::cmp::PartialEq for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS0>()) == 0 }
+        self.currentActiveMainModes == other.currentActiveMainModes
+            && self.totalMainModesStarted == other.totalMainModesStarted
+            && self.totalSuccessfulMainModes == other.totalSuccessfulMainModes
+            && self.totalFailedMainModes == other.totalFailedMainModes
+            && self.totalResponderMainModes == other.totalResponderMainModes
+            && self.currentNewResponderMainModes == other.currentNewResponderMainModes
+            && self.currentActiveQuickModes == other.currentActiveQuickModes
+            && self.totalQuickModesStarted == other.totalQuickModesStarted
+            && self.totalSuccessfulQuickModes == other.totalSuccessfulQuickModes
+            && self.totalFailedQuickModes == other.totalFailedQuickModes
+            && self.totalAcquires == other.totalAcquires
+            && self.totalReinitAcquires == other.totalReinitAcquires
+            && self.currentActiveExtendedModes == other.currentActiveExtendedModes
+            && self.totalExtendedModesStarted == other.totalExtendedModesStarted
+            && self.totalSuccessfulExtendedModes == other.totalSuccessfulExtendedModes
+            && self.totalFailedExtendedModes == other.totalFailedExtendedModes
+            && self.totalImpersonationExtendedModes == other.totalImpersonationExtendedModes
+            && self.totalImpersonationMainModes == other.totalImpersonationMainModes
     }
 }
 impl ::core::cmp::Eq for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS0 {}
@@ -11071,7 +10555,24 @@ unsafe impl ::windows::core::Abi for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATIS
 }
 impl ::core::cmp::PartialEq for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1>()) == 0 }
+        self.currentActiveMainModes == other.currentActiveMainModes
+            && self.totalMainModesStarted == other.totalMainModesStarted
+            && self.totalSuccessfulMainModes == other.totalSuccessfulMainModes
+            && self.totalFailedMainModes == other.totalFailedMainModes
+            && self.totalResponderMainModes == other.totalResponderMainModes
+            && self.currentNewResponderMainModes == other.currentNewResponderMainModes
+            && self.currentActiveQuickModes == other.currentActiveQuickModes
+            && self.totalQuickModesStarted == other.totalQuickModesStarted
+            && self.totalSuccessfulQuickModes == other.totalSuccessfulQuickModes
+            && self.totalFailedQuickModes == other.totalFailedQuickModes
+            && self.totalAcquires == other.totalAcquires
+            && self.totalReinitAcquires == other.totalReinitAcquires
+            && self.currentActiveExtendedModes == other.currentActiveExtendedModes
+            && self.totalExtendedModesStarted == other.totalExtendedModesStarted
+            && self.totalSuccessfulExtendedModes == other.totalSuccessfulExtendedModes
+            && self.totalFailedExtendedModes == other.totalFailedExtendedModes
+            && self.totalImpersonationExtendedModes == other.totalImpersonationExtendedModes
+            && self.totalImpersonationMainModes == other.totalImpersonationMainModes
     }
 }
 impl ::core::cmp::Eq for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1 {}
@@ -11101,7 +10602,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_KERBEROS_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_KERBEROS_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_KERBEROS_AUTHENTICATION0>()) == 0 }
+        self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_KERBEROS_AUTHENTICATION0 {}
@@ -11132,7 +10633,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_KERBEROS_AUTHENTICATION1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_KERBEROS_AUTHENTICATION1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_KERBEROS_AUTHENTICATION1>()) == 0 }
+        self.flags == other.flags && self.proxyServer == other.proxyServer
     }
 }
 impl ::core::cmp::Eq for IKEEXT_KERBEROS_AUTHENTICATION1 {}
@@ -11167,7 +10668,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_KEYMODULE_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_KEYMODULE_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_KEYMODULE_STATISTICS0>()) == 0 }
+        self.v4Statistics == other.v4Statistics && self.v6Statistics == other.v6Statistics && self.errorFrequencyTable == other.errorFrequencyTable && self.mainModeNegotiationTime == other.mainModeNegotiationTime && self.quickModeNegotiationTime == other.quickModeNegotiationTime && self.extendedModeNegotiationTime == other.extendedModeNegotiationTime
     }
 }
 impl ::core::cmp::Eq for IKEEXT_KEYMODULE_STATISTICS0 {}
@@ -11202,7 +10703,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_KEYMODULE_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_KEYMODULE_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_KEYMODULE_STATISTICS1>()) == 0 }
+        self.v4Statistics == other.v4Statistics && self.v6Statistics == other.v6Statistics && self.errorFrequencyTable == other.errorFrequencyTable && self.mainModeNegotiationTime == other.mainModeNegotiationTime && self.quickModeNegotiationTime == other.quickModeNegotiationTime && self.extendedModeNegotiationTime == other.extendedModeNegotiationTime
     }
 }
 impl ::core::cmp::Eq for IKEEXT_KEYMODULE_STATISTICS1 {}
@@ -11232,7 +10733,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_NAME_CREDENTIAL0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_NAME_CREDENTIAL0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_NAME_CREDENTIAL0>()) == 0 }
+        self.principalName == other.principalName
     }
 }
 impl ::core::cmp::Eq for IKEEXT_NAME_CREDENTIAL0 {}
@@ -11262,7 +10763,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_NTLM_V2_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_NTLM_V2_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_NTLM_V2_AUTHENTICATION0>()) == 0 }
+        self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_NTLM_V2_AUTHENTICATION0 {}
@@ -11299,7 +10800,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_POLICY0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_POLICY0>()) == 0 }
+        self.softExpirationTime == other.softExpirationTime && self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType && self.numIkeProposals == other.numIkeProposals && self.ikeProposals == other.ikeProposals && self.flags == other.flags && self.maxDynamicFilters == other.maxDynamicFilters
     }
 }
 impl ::core::cmp::Eq for IKEEXT_POLICY0 {}
@@ -11347,7 +10848,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_POLICY1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_POLICY1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_POLICY1>()) == 0 }
+        self.softExpirationTime == other.softExpirationTime && self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType && self.numIkeProposals == other.numIkeProposals && self.ikeProposals == other.ikeProposals && self.flags == other.flags && self.maxDynamicFilters == other.maxDynamicFilters && self.retransmitDurationSecs == other.retransmitDurationSecs
     }
 }
 impl ::core::cmp::Eq for IKEEXT_POLICY1 {}
@@ -11395,7 +10896,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_POLICY2 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_POLICY2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_POLICY2>()) == 0 }
+        self.softExpirationTime == other.softExpirationTime && self.numAuthenticationMethods == other.numAuthenticationMethods && self.authenticationMethods == other.authenticationMethods && self.initiatorImpersonationType == other.initiatorImpersonationType && self.numIkeProposals == other.numIkeProposals && self.ikeProposals == other.ikeProposals && self.flags == other.flags && self.maxDynamicFilters == other.maxDynamicFilters && self.retransmitDurationSecs == other.retransmitDurationSecs
     }
 }
 impl ::core::cmp::Eq for IKEEXT_POLICY2 {}
@@ -11425,7 +10926,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_PRESHARED_KEY_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_PRESHARED_KEY_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_PRESHARED_KEY_AUTHENTICATION0>()) == 0 }
+        self.presharedKey == other.presharedKey
     }
 }
 impl ::core::cmp::Eq for IKEEXT_PRESHARED_KEY_AUTHENTICATION0 {}
@@ -11456,7 +10957,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_PRESHARED_KEY_AUTHENTICATION1>()) == 0 }
+        self.presharedKey == other.presharedKey && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {}
@@ -11490,7 +10991,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_PROPOSAL0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_PROPOSAL0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_PROPOSAL0>()) == 0 }
+        self.cipherAlgorithm == other.cipherAlgorithm && self.integrityAlgorithm == other.integrityAlgorithm && self.maxLifetimeSeconds == other.maxLifetimeSeconds && self.dhGroup == other.dhGroup && self.quickModeLimit == other.quickModeLimit
     }
 }
 impl ::core::cmp::Eq for IKEEXT_PROPOSAL0 {}
@@ -11520,7 +11021,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_RESERVED_AUTHENTICATION0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_RESERVED_AUTHENTICATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_RESERVED_AUTHENTICATION0>()) == 0 }
+        self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IKEEXT_RESERVED_AUTHENTICATION0 {}
@@ -11552,12 +11053,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS0 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS0 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11577,12 +11072,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS0_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS0_0 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11612,12 +11101,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS1 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS1 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11637,12 +11120,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS1_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS1_0 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11672,12 +11149,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS2 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS2 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11697,12 +11168,6 @@ impl ::core::clone::Clone for IKEEXT_SA_DETAILS2_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_DETAILS2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_SA_DETAILS2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_DETAILS2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_SA_DETAILS2_0 {}
 impl ::core::default::Default for IKEEXT_SA_DETAILS2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11728,14 +11193,6 @@ impl ::core::clone::Clone for IKEEXT_SA_ENUM_TEMPLATE0 {
 unsafe impl ::windows::core::Abi for IKEEXT_SA_ENUM_TEMPLATE0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IKEEXT_SA_ENUM_TEMPLATE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_SA_ENUM_TEMPLATE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IKEEXT_SA_ENUM_TEMPLATE0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IKEEXT_SA_ENUM_TEMPLATE0 {
     fn default() -> Self {
@@ -11765,7 +11222,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_STATISTICS0>()) == 0 }
+        self.ikeStatistics == other.ikeStatistics && self.authipStatistics == other.authipStatistics && self.commonStatistics == other.commonStatistics
     }
 }
 impl ::core::cmp::Eq for IKEEXT_STATISTICS0 {}
@@ -11798,7 +11255,7 @@ unsafe impl ::windows::core::Abi for IKEEXT_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IKEEXT_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_STATISTICS1>()) == 0 }
+        self.ikeStatistics == other.ikeStatistics && self.authipStatistics == other.authipStatistics && self.ikeV2Statistics == other.ikeV2Statistics && self.commonStatistics == other.commonStatistics
     }
 }
 impl ::core::cmp::Eq for IKEEXT_STATISTICS1 {}
@@ -11824,12 +11281,6 @@ impl ::core::clone::Clone for IKEEXT_TRAFFIC0 {
 unsafe impl ::windows::core::Abi for IKEEXT_TRAFFIC0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_TRAFFIC0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_TRAFFIC0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_TRAFFIC0 {}
 impl ::core::default::Default for IKEEXT_TRAFFIC0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11850,12 +11301,6 @@ impl ::core::clone::Clone for IKEEXT_TRAFFIC0_0 {
 unsafe impl ::windows::core::Abi for IKEEXT_TRAFFIC0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_TRAFFIC0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_TRAFFIC0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_TRAFFIC0_0 {}
 impl ::core::default::Default for IKEEXT_TRAFFIC0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11876,12 +11321,6 @@ impl ::core::clone::Clone for IKEEXT_TRAFFIC0_1 {
 unsafe impl ::windows::core::Abi for IKEEXT_TRAFFIC0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKEEXT_TRAFFIC0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKEEXT_TRAFFIC0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKEEXT_TRAFFIC0_1 {}
 impl ::core::default::Default for IKEEXT_TRAFFIC0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11911,7 +11350,7 @@ unsafe impl ::windows::core::Abi for IPSEC_ADDRESS_INFO0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_ADDRESS_INFO0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_ADDRESS_INFO0>()) == 0 }
+        self.numV4Addresses == other.numV4Addresses && self.v4Addresses == other.v4Addresses && self.numV6Addresses == other.numV6Addresses && self.v6Addresses == other.v6Addresses
     }
 }
 impl ::core::cmp::Eq for IPSEC_ADDRESS_INFO0 {}
@@ -11959,7 +11398,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0>()) == 0 }
+        self.invalidSpisOnInbound == other.invalidSpisOnInbound && self.decryptionFailuresOnInbound == other.decryptionFailuresOnInbound && self.authenticationFailuresOnInbound == other.authenticationFailuresOnInbound && self.udpEspValidationFailuresOnInbound == other.udpEspValidationFailuresOnInbound && self.replayCheckFailuresOnInbound == other.replayCheckFailuresOnInbound && self.invalidClearTextInbound == other.invalidClearTextInbound && self.saNotInitializedOnInbound == other.saNotInitializedOnInbound && self.receiveOverIncorrectSaInbound == other.receiveOverIncorrectSaInbound && self.secureReceivesNotMatchingFilters == other.secureReceivesNotMatchingFilters
     }
 }
 impl ::core::cmp::Eq for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0 {}
@@ -12009,7 +11448,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1>()) == 0 }
+        self.invalidSpisOnInbound == other.invalidSpisOnInbound && self.decryptionFailuresOnInbound == other.decryptionFailuresOnInbound && self.authenticationFailuresOnInbound == other.authenticationFailuresOnInbound && self.udpEspValidationFailuresOnInbound == other.udpEspValidationFailuresOnInbound && self.replayCheckFailuresOnInbound == other.replayCheckFailuresOnInbound && self.invalidClearTextInbound == other.invalidClearTextInbound && self.saNotInitializedOnInbound == other.saNotInitializedOnInbound && self.receiveOverIncorrectSaInbound == other.receiveOverIncorrectSaInbound && self.secureReceivesNotMatchingFilters == other.secureReceivesNotMatchingFilters && self.totalDropPacketsInbound == other.totalDropPacketsInbound
     }
 }
 impl ::core::cmp::Eq for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1 {}
@@ -12045,7 +11484,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AGGREGATE_SA_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AGGREGATE_SA_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AGGREGATE_SA_STATISTICS0>()) == 0 }
+        self.activeSas == other.activeSas && self.pendingSaNegotiations == other.pendingSaNegotiations && self.totalSasAdded == other.totalSasAdded && self.totalSasDeleted == other.totalSasDeleted && self.successfulRekeys == other.successfulRekeys && self.activeTunnels == other.activeTunnels && self.offloadedSas == other.offloadedSas
     }
 }
 impl ::core::cmp::Eq for IPSEC_AGGREGATE_SA_STATISTICS0 {}
@@ -12078,7 +11517,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AH_DROP_PACKET_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AH_DROP_PACKET_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AH_DROP_PACKET_STATISTICS0>()) == 0 }
+        self.invalidSpisOnInbound == other.invalidSpisOnInbound && self.authenticationFailuresOnInbound == other.authenticationFailuresOnInbound && self.replayCheckFailuresOnInbound == other.replayCheckFailuresOnInbound && self.saNotInitializedOnInbound == other.saNotInitializedOnInbound
     }
 }
 impl ::core::cmp::Eq for IPSEC_AH_DROP_PACKET_STATISTICS0 {}
@@ -12109,7 +11548,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AUTH_AND_CIPHER_TRANSFORM0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AUTH_AND_CIPHER_TRANSFORM0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AUTH_AND_CIPHER_TRANSFORM0>()) == 0 }
+        self.authTransform == other.authTransform && self.cipherTransform == other.cipherTransform
     }
 }
 impl ::core::cmp::Eq for IPSEC_AUTH_AND_CIPHER_TRANSFORM0 {}
@@ -12140,7 +11579,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AUTH_TRANSFORM0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AUTH_TRANSFORM0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AUTH_TRANSFORM0>()) == 0 }
+        self.authTransformId == other.authTransformId && self.cryptoModuleId == other.cryptoModuleId
     }
 }
 impl ::core::cmp::Eq for IPSEC_AUTH_TRANSFORM0 {}
@@ -12171,7 +11610,7 @@ unsafe impl ::windows::core::Abi for IPSEC_AUTH_TRANSFORM_ID0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_AUTH_TRANSFORM_ID0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_AUTH_TRANSFORM_ID0>()) == 0 }
+        self.authType == other.authType && self.authConfig == other.authConfig
     }
 }
 impl ::core::cmp::Eq for IPSEC_AUTH_TRANSFORM_ID0 {}
@@ -12202,7 +11641,7 @@ unsafe impl ::windows::core::Abi for IPSEC_CIPHER_TRANSFORM0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_CIPHER_TRANSFORM0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_CIPHER_TRANSFORM0>()) == 0 }
+        self.cipherTransformId == other.cipherTransformId && self.cryptoModuleId == other.cryptoModuleId
     }
 }
 impl ::core::cmp::Eq for IPSEC_CIPHER_TRANSFORM0 {}
@@ -12233,7 +11672,7 @@ unsafe impl ::windows::core::Abi for IPSEC_CIPHER_TRANSFORM_ID0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_CIPHER_TRANSFORM_ID0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_CIPHER_TRANSFORM_ID0>()) == 0 }
+        self.cipherType == other.cipherType && self.cipherConfig == other.cipherConfig
     }
 }
 impl ::core::cmp::Eq for IPSEC_CIPHER_TRANSFORM_ID0 {}
@@ -12307,7 +11746,28 @@ unsafe impl ::windows::core::Abi for IPSEC_DOSP_OPTIONS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_DOSP_OPTIONS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_DOSP_OPTIONS0>()) == 0 }
+        self.stateIdleTimeoutSeconds == other.stateIdleTimeoutSeconds
+            && self.perIPRateLimitQueueIdleTimeoutSeconds == other.perIPRateLimitQueueIdleTimeoutSeconds
+            && self.ipV6IPsecUnauthDscp == other.ipV6IPsecUnauthDscp
+            && self.ipV6IPsecUnauthRateLimitBytesPerSec == other.ipV6IPsecUnauthRateLimitBytesPerSec
+            && self.ipV6IPsecUnauthPerIPRateLimitBytesPerSec == other.ipV6IPsecUnauthPerIPRateLimitBytesPerSec
+            && self.ipV6IPsecAuthDscp == other.ipV6IPsecAuthDscp
+            && self.ipV6IPsecAuthRateLimitBytesPerSec == other.ipV6IPsecAuthRateLimitBytesPerSec
+            && self.icmpV6Dscp == other.icmpV6Dscp
+            && self.icmpV6RateLimitBytesPerSec == other.icmpV6RateLimitBytesPerSec
+            && self.ipV6FilterExemptDscp == other.ipV6FilterExemptDscp
+            && self.ipV6FilterExemptRateLimitBytesPerSec == other.ipV6FilterExemptRateLimitBytesPerSec
+            && self.defBlockExemptDscp == other.defBlockExemptDscp
+            && self.defBlockExemptRateLimitBytesPerSec == other.defBlockExemptRateLimitBytesPerSec
+            && self.maxStateEntries == other.maxStateEntries
+            && self.maxPerIPRateLimitQueues == other.maxPerIPRateLimitQueues
+            && self.flags == other.flags
+            && self.numPublicIFLuids == other.numPublicIFLuids
+            && self.publicIFLuids == other.publicIFLuids
+            && self.numInternalIFLuids == other.numInternalIFLuids
+            && self.internalIFLuids == other.internalIFLuids
+            && self.publicV6AddrMask == other.publicV6AddrMask
+            && self.internalV6AddrMask == other.internalV6AddrMask
     }
 }
 impl ::core::cmp::Eq for IPSEC_DOSP_OPTIONS0 {}
@@ -12341,7 +11801,7 @@ unsafe impl ::windows::core::Abi for IPSEC_DOSP_STATE0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_DOSP_STATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_DOSP_STATE0>()) == 0 }
+        self.publicHostV6Addr == other.publicHostV6Addr && self.internalHostV6Addr == other.internalHostV6Addr && self.totalInboundIPv6IPsecAuthPackets == other.totalInboundIPv6IPsecAuthPackets && self.totalOutboundIPv6IPsecAuthPackets == other.totalOutboundIPv6IPsecAuthPackets && self.durationSecs == other.durationSecs
     }
 }
 impl ::core::cmp::Eq for IPSEC_DOSP_STATE0 {}
@@ -12372,7 +11832,7 @@ unsafe impl ::windows::core::Abi for IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_DOSP_STATE_ENUM_TEMPLATE0>()) == 0 }
+        self.publicV6AddrMask == other.publicV6AddrMask && self.internalV6AddrMask == other.internalV6AddrMask
     }
 }
 impl ::core::cmp::Eq for IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {}
@@ -12438,7 +11898,24 @@ unsafe impl ::windows::core::Abi for IPSEC_DOSP_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_DOSP_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_DOSP_STATISTICS0>()) == 0 }
+        self.totalStateEntriesCreated == other.totalStateEntriesCreated
+            && self.currentStateEntries == other.currentStateEntries
+            && self.totalInboundAllowedIPv6IPsecUnauthPkts == other.totalInboundAllowedIPv6IPsecUnauthPkts
+            && self.totalInboundRatelimitDiscardedIPv6IPsecUnauthPkts == other.totalInboundRatelimitDiscardedIPv6IPsecUnauthPkts
+            && self.totalInboundPerIPRatelimitDiscardedIPv6IPsecUnauthPkts == other.totalInboundPerIPRatelimitDiscardedIPv6IPsecUnauthPkts
+            && self.totalInboundOtherDiscardedIPv6IPsecUnauthPkts == other.totalInboundOtherDiscardedIPv6IPsecUnauthPkts
+            && self.totalInboundAllowedIPv6IPsecAuthPkts == other.totalInboundAllowedIPv6IPsecAuthPkts
+            && self.totalInboundRatelimitDiscardedIPv6IPsecAuthPkts == other.totalInboundRatelimitDiscardedIPv6IPsecAuthPkts
+            && self.totalInboundOtherDiscardedIPv6IPsecAuthPkts == other.totalInboundOtherDiscardedIPv6IPsecAuthPkts
+            && self.totalInboundAllowedICMPv6Pkts == other.totalInboundAllowedICMPv6Pkts
+            && self.totalInboundRatelimitDiscardedICMPv6Pkts == other.totalInboundRatelimitDiscardedICMPv6Pkts
+            && self.totalInboundAllowedIPv6FilterExemptPkts == other.totalInboundAllowedIPv6FilterExemptPkts
+            && self.totalInboundRatelimitDiscardedIPv6FilterExemptPkts == other.totalInboundRatelimitDiscardedIPv6FilterExemptPkts
+            && self.totalInboundDiscardedIPv6FilterBlockPkts == other.totalInboundDiscardedIPv6FilterBlockPkts
+            && self.totalInboundAllowedDefBlockExemptPkts == other.totalInboundAllowedDefBlockExemptPkts
+            && self.totalInboundRatelimitDiscardedDefBlockExemptPkts == other.totalInboundRatelimitDiscardedDefBlockExemptPkts
+            && self.totalInboundDiscardedDefBlockPkts == other.totalInboundDiscardedDefBlockPkts
+            && self.currentInboundIPv6IPsecUnauthPerIPRateLimitQueues == other.currentInboundIPv6IPsecUnauthPerIPRateLimitQueues
     }
 }
 impl ::core::cmp::Eq for IPSEC_DOSP_STATISTICS0 {}
@@ -12472,7 +11949,7 @@ unsafe impl ::windows::core::Abi for IPSEC_ESP_DROP_PACKET_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_ESP_DROP_PACKET_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_ESP_DROP_PACKET_STATISTICS0>()) == 0 }
+        self.invalidSpisOnInbound == other.invalidSpisOnInbound && self.decryptionFailuresOnInbound == other.decryptionFailuresOnInbound && self.authenticationFailuresOnInbound == other.authenticationFailuresOnInbound && self.replayCheckFailuresOnInbound == other.replayCheckFailuresOnInbound && self.saNotInitializedOnInbound == other.saNotInitializedOnInbound
     }
 }
 impl ::core::cmp::Eq for IPSEC_ESP_DROP_PACKET_STATISTICS0 {}
@@ -12498,12 +11975,6 @@ impl ::core::clone::Clone for IPSEC_GETSPI0 {
 unsafe impl ::windows::core::Abi for IPSEC_GETSPI0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_GETSPI0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_GETSPI0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_GETSPI0 {}
 impl ::core::default::Default for IPSEC_GETSPI0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12523,12 +11994,6 @@ impl ::core::clone::Clone for IPSEC_GETSPI0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_GETSPI0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_GETSPI0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_GETSPI0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_GETSPI0_0 {}
 impl ::core::default::Default for IPSEC_GETSPI0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12551,12 +12016,6 @@ impl ::core::clone::Clone for IPSEC_GETSPI1 {
 unsafe impl ::windows::core::Abi for IPSEC_GETSPI1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_GETSPI1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_GETSPI1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_GETSPI1 {}
 impl ::core::default::Default for IPSEC_GETSPI1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12576,12 +12035,6 @@ impl ::core::clone::Clone for IPSEC_GETSPI1_0 {
 unsafe impl ::windows::core::Abi for IPSEC_GETSPI1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_GETSPI1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_GETSPI1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_GETSPI1_0 {}
 impl ::core::default::Default for IPSEC_GETSPI1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12613,7 +12066,7 @@ unsafe impl ::windows::core::Abi for IPSEC_ID0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_ID0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_ID0>()) == 0 }
+        self.mmTargetName == other.mmTargetName && self.emTargetName == other.emTargetName && self.numTokens == other.numTokens && self.tokens == other.tokens && self.explicitCredentials == other.explicitCredentials && self.logonId == other.logonId
     }
 }
 impl ::core::cmp::Eq for IPSEC_ID0 {}
@@ -12644,7 +12097,7 @@ unsafe impl ::windows::core::Abi for IPSEC_KEYING_POLICY0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_KEYING_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_KEYING_POLICY0>()) == 0 }
+        self.numKeyMods == other.numKeyMods && self.keyModKeys == other.keyModKeys
     }
 }
 impl ::core::cmp::Eq for IPSEC_KEYING_POLICY0 {}
@@ -12676,7 +12129,7 @@ unsafe impl ::windows::core::Abi for IPSEC_KEYING_POLICY1 {
 }
 impl ::core::cmp::PartialEq for IPSEC_KEYING_POLICY1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_KEYING_POLICY1>()) == 0 }
+        self.numKeyMods == other.numKeyMods && self.keyModKeys == other.keyModKeys && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IPSEC_KEYING_POLICY1 {}
@@ -12707,7 +12160,7 @@ unsafe impl ::windows::core::Abi for IPSEC_KEYMODULE_STATE0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_KEYMODULE_STATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_KEYMODULE_STATE0>()) == 0 }
+        self.keyModuleKey == other.keyModuleKey && self.stateBlob == other.stateBlob
     }
 }
 impl ::core::cmp::Eq for IPSEC_KEYMODULE_STATE0 {}
@@ -12740,7 +12193,7 @@ unsafe impl ::windows::core::Abi for IPSEC_KEY_MANAGER0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_KEY_MANAGER0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_KEY_MANAGER0>()) == 0 }
+        self.keyManagerKey == other.keyManagerKey && self.displayData == other.displayData && self.flags == other.flags && self.keyDictationTimeoutHint == other.keyDictationTimeoutHint
     }
 }
 impl ::core::cmp::Eq for IPSEC_KEY_MANAGER0 {}
@@ -12770,21 +12223,13 @@ impl ::core::clone::Clone for IPSEC_KEY_MANAGER_CALLBACKS0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::fmt::Debug for IPSEC_KEY_MANAGER_CALLBACKS0 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("IPSEC_KEY_MANAGER_CALLBACKS0").field("reserved", &self.reserved).field("flags", &self.flags).field("keyDictationCheck", &self.keyDictationCheck.map(|f| f as usize)).field("keyDictation", &self.keyDictation.map(|f| f as usize)).field("keyNotify", &self.keyNotify.map(|f| f as usize)).finish()
+        f.debug_struct("IPSEC_KEY_MANAGER_CALLBACKS0").field("reserved", &self.reserved).field("flags", &self.flags).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 unsafe impl ::windows::core::Abi for IPSEC_KEY_MANAGER_CALLBACKS0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_KEY_MANAGER_CALLBACKS0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_KEY_MANAGER_CALLBACKS0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_KEY_MANAGER_CALLBACKS0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_KEY_MANAGER_CALLBACKS0 {
     fn default() -> Self {
@@ -12815,7 +12260,7 @@ unsafe impl ::windows::core::Abi for IPSEC_PROPOSAL0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_PROPOSAL0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_PROPOSAL0>()) == 0 }
+        self.lifetime == other.lifetime && self.numSaTransforms == other.numSaTransforms && self.saTransforms == other.saTransforms && self.pfsGroup == other.pfsGroup
     }
 }
 impl ::core::cmp::Eq for IPSEC_PROPOSAL0 {}
@@ -12840,12 +12285,6 @@ impl ::core::clone::Clone for IPSEC_SA0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA0 {}
 impl ::core::default::Default for IPSEC_SA0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12869,12 +12308,6 @@ impl ::core::clone::Clone for IPSEC_SA0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA0_0 {}
 impl ::core::default::Default for IPSEC_SA0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12902,7 +12335,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0>()) == 0 }
+        self.saCipherInformation == other.saCipherInformation && self.saAuthInformation == other.saAuthInformation
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {}
@@ -12933,7 +12366,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_AUTH_INFORMATION0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_AUTH_INFORMATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_AUTH_INFORMATION0>()) == 0 }
+        self.authTransform == other.authTransform && self.authKey == other.authKey
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_AUTH_INFORMATION0 {}
@@ -12969,12 +12402,6 @@ impl ::core::clone::Clone for IPSEC_SA_BUNDLE0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_BUNDLE0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_BUNDLE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_BUNDLE0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_BUNDLE0 {}
 impl ::core::default::Default for IPSEC_SA_BUNDLE0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12994,12 +12421,6 @@ impl ::core::clone::Clone for IPSEC_SA_BUNDLE0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_BUNDLE0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_BUNDLE0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_BUNDLE0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_BUNDLE0_0 {}
 impl ::core::default::Default for IPSEC_SA_BUNDLE0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13034,12 +12455,6 @@ impl ::core::clone::Clone for IPSEC_SA_BUNDLE1 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_BUNDLE1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_BUNDLE1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_BUNDLE1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_BUNDLE1 {}
 impl ::core::default::Default for IPSEC_SA_BUNDLE1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13059,12 +12474,6 @@ impl ::core::clone::Clone for IPSEC_SA_BUNDLE1_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_BUNDLE1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_BUNDLE1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_BUNDLE1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_BUNDLE1_0 {}
 impl ::core::default::Default for IPSEC_SA_BUNDLE1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13092,7 +12501,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_CIPHER_INFORMATION0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_CIPHER_INFORMATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CIPHER_INFORMATION0>()) == 0 }
+        self.cipherTransform == other.cipherTransform && self.cipherKey == other.cipherKey
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_CIPHER_INFORMATION0 {}
@@ -13130,7 +12539,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_CONTEXT0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for IPSEC_SA_CONTEXT0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CONTEXT0>()) == 0 }
+        self.saContextId == other.saContextId && self.inboundSa == other.inboundSa && self.outboundSa == other.outboundSa
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -13170,7 +12579,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_CONTEXT1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for IPSEC_SA_CONTEXT1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CONTEXT1>()) == 0 }
+        self.saContextId == other.saContextId && self.inboundSa == other.inboundSa && self.outboundSa == other.outboundSa
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -13203,7 +12612,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_CONTEXT_CHANGE0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_CONTEXT_CHANGE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CONTEXT_CHANGE0>()) == 0 }
+        self.changeType == other.changeType && self.saContextId == other.saContextId
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_CONTEXT_CHANGE0 {}
@@ -13231,14 +12640,6 @@ impl ::core::clone::Clone for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CONTEXT_ENUM_TEMPLATE0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
     fn default() -> Self {
@@ -13274,7 +12675,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_CONTEXT_SUBSCRIPTION0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for IPSEC_SA_CONTEXT_SUBSCRIPTION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_CONTEXT_SUBSCRIPTION0>()) == 0 }
+        self.enumTemplate == other.enumTemplate && self.flags == other.flags && self.sessionKey == other.sessionKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -13309,14 +12710,6 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_DETAILS0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_SA_DETAILS0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_DETAILS0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_SA_DETAILS0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_SA_DETAILS0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13340,14 +12733,6 @@ impl ::core::clone::Clone for IPSEC_SA_DETAILS0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_DETAILS0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_SA_DETAILS0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_DETAILS0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_SA_DETAILS0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_SA_DETAILS0_0 {
     fn default() -> Self {
@@ -13379,14 +12764,6 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_DETAILS1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_SA_DETAILS1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_DETAILS1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_SA_DETAILS1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_SA_DETAILS1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13410,14 +12787,6 @@ impl ::core::clone::Clone for IPSEC_SA_DETAILS1_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_DETAILS1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for IPSEC_SA_DETAILS1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_DETAILS1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for IPSEC_SA_DETAILS1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for IPSEC_SA_DETAILS1_0 {
     fn default() -> Self {
@@ -13445,7 +12814,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_ENUM_TEMPLATE0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_ENUM_TEMPLATE0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_ENUM_TEMPLATE0>()) == 0 }
+        self.saDirection == other.saDirection
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_ENUM_TEMPLATE0 {}
@@ -13476,7 +12845,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_IDLE_TIMEOUT0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_IDLE_TIMEOUT0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_IDLE_TIMEOUT0>()) == 0 }
+        self.idleTimeoutSeconds == other.idleTimeoutSeconds && self.idleTimeoutSecondsFailOver == other.idleTimeoutSecondsFailOver
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_IDLE_TIMEOUT0 {}
@@ -13508,7 +12877,7 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_LIFETIME0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_SA_LIFETIME0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_LIFETIME0>()) == 0 }
+        self.lifetimeSeconds == other.lifetimeSeconds && self.lifetimeKilobytes == other.lifetimeKilobytes && self.lifetimePackets == other.lifetimePackets
     }
 }
 impl ::core::cmp::Eq for IPSEC_SA_LIFETIME0 {}
@@ -13532,12 +12901,6 @@ impl ::core::clone::Clone for IPSEC_SA_TRANSFORM0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_TRANSFORM0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_TRANSFORM0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_TRANSFORM0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_TRANSFORM0 {}
 impl ::core::default::Default for IPSEC_SA_TRANSFORM0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13561,12 +12924,6 @@ impl ::core::clone::Clone for IPSEC_SA_TRANSFORM0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_SA_TRANSFORM0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_SA_TRANSFORM0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_SA_TRANSFORM0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_SA_TRANSFORM0_0 {}
 impl ::core::default::Default for IPSEC_SA_TRANSFORM0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13598,7 +12955,7 @@ unsafe impl ::windows::core::Abi for IPSEC_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_STATISTICS0>()) == 0 }
+        self.aggregateSaStatistics == other.aggregateSaStatistics && self.espDropPacketStatistics == other.espDropPacketStatistics && self.ahDropPacketStatistics == other.ahDropPacketStatistics && self.aggregateDropPacketStatistics == other.aggregateDropPacketStatistics && self.inboundTrafficStatistics == other.inboundTrafficStatistics && self.outboundTrafficStatistics == other.outboundTrafficStatistics
     }
 }
 impl ::core::cmp::Eq for IPSEC_STATISTICS0 {}
@@ -13633,7 +12990,7 @@ unsafe impl ::windows::core::Abi for IPSEC_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IPSEC_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_STATISTICS1>()) == 0 }
+        self.aggregateSaStatistics == other.aggregateSaStatistics && self.espDropPacketStatistics == other.espDropPacketStatistics && self.ahDropPacketStatistics == other.ahDropPacketStatistics && self.aggregateDropPacketStatistics == other.aggregateDropPacketStatistics && self.inboundTrafficStatistics == other.inboundTrafficStatistics && self.outboundTrafficStatistics == other.outboundTrafficStatistics
     }
 }
 impl ::core::cmp::Eq for IPSEC_STATISTICS1 {}
@@ -13666,7 +13023,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TOKEN0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TOKEN0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TOKEN0>()) == 0 }
+        self.r#type == other.r#type && self.principal == other.principal && self.mode == other.mode && self.token == other.token
     }
 }
 impl ::core::cmp::Eq for IPSEC_TOKEN0 {}
@@ -13694,12 +13051,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC0 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC0 {}
 impl ::core::default::Default for IPSEC_TRAFFIC0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13720,12 +13071,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC0_0 {}
 impl ::core::default::Default for IPSEC_TRAFFIC0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13746,12 +13091,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC0_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC0_1 {}
 impl ::core::default::Default for IPSEC_TRAFFIC0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13772,12 +13111,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC0_2 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC0_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC0_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC0_2 {}
 impl ::core::default::Default for IPSEC_TRAFFIC0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13806,12 +13139,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC1 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC1 {}
 impl ::core::default::Default for IPSEC_TRAFFIC1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13832,12 +13159,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC1_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC1_0 {}
 impl ::core::default::Default for IPSEC_TRAFFIC1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13858,12 +13179,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC1_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC1_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC1_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC1_1 {}
 impl ::core::default::Default for IPSEC_TRAFFIC1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13884,12 +13199,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC1_2 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC1_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC1_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC1_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC1_2 {}
 impl ::core::default::Default for IPSEC_TRAFFIC1_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13914,12 +13223,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC_SELECTOR0 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_SELECTOR0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_SELECTOR0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_SELECTOR0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC_SELECTOR0 {}
 impl ::core::default::Default for IPSEC_TRAFFIC_SELECTOR0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13940,12 +13243,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC_SELECTOR0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_SELECTOR0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_SELECTOR0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_SELECTOR0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC_SELECTOR0_0 {}
 impl ::core::default::Default for IPSEC_TRAFFIC_SELECTOR0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13966,12 +13263,6 @@ impl ::core::clone::Clone for IPSEC_TRAFFIC_SELECTOR0_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_SELECTOR0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_SELECTOR0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_SELECTOR0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TRAFFIC_SELECTOR0_1 {}
 impl ::core::default::Default for IPSEC_TRAFFIC_SELECTOR0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14002,7 +13293,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_SELECTOR_POLICY0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_SELECTOR_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_SELECTOR_POLICY0>()) == 0 }
+        self.flags == other.flags && self.numLocalTrafficSelectors == other.numLocalTrafficSelectors && self.localTrafficSelectors == other.localTrafficSelectors && self.numRemoteTrafficSelectors == other.numRemoteTrafficSelectors && self.remoteTrafficSelectors == other.remoteTrafficSelectors
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRAFFIC_SELECTOR_POLICY0 {}
@@ -14037,7 +13328,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_STATISTICS0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_STATISTICS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_STATISTICS0>()) == 0 }
+        self.encryptedByteCount == other.encryptedByteCount && self.authenticatedAHByteCount == other.authenticatedAHByteCount && self.authenticatedESPByteCount == other.authenticatedESPByteCount && self.transportByteCount == other.transportByteCount && self.tunnelByteCount == other.tunnelByteCount && self.offloadByteCount == other.offloadByteCount
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRAFFIC_STATISTICS0 {}
@@ -14073,7 +13364,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRAFFIC_STATISTICS1 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRAFFIC_STATISTICS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRAFFIC_STATISTICS1>()) == 0 }
+        self.encryptedByteCount == other.encryptedByteCount && self.authenticatedAHByteCount == other.authenticatedAHByteCount && self.authenticatedESPByteCount == other.authenticatedESPByteCount && self.transportByteCount == other.transportByteCount && self.tunnelByteCount == other.tunnelByteCount && self.offloadByteCount == other.offloadByteCount && self.totalSuccessfulPackets == other.totalSuccessfulPackets
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRAFFIC_STATISTICS1 {}
@@ -14108,7 +13399,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRANSPORT_POLICY0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRANSPORT_POLICY0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRANSPORT_POLICY0>()) == 0 }
+        self.numIpsecProposals == other.numIpsecProposals && self.ipsecProposals == other.ipsecProposals && self.flags == other.flags && self.ndAllowClearTimeoutSeconds == other.ndAllowClearTimeoutSeconds && self.saIdleTimeout == other.saIdleTimeout && self.emPolicy == other.emPolicy
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRANSPORT_POLICY0 {}
@@ -14143,7 +13434,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRANSPORT_POLICY1 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRANSPORT_POLICY1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRANSPORT_POLICY1>()) == 0 }
+        self.numIpsecProposals == other.numIpsecProposals && self.ipsecProposals == other.ipsecProposals && self.flags == other.flags && self.ndAllowClearTimeoutSeconds == other.ndAllowClearTimeoutSeconds && self.saIdleTimeout == other.saIdleTimeout && self.emPolicy == other.emPolicy
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRANSPORT_POLICY1 {}
@@ -14178,7 +13469,7 @@ unsafe impl ::windows::core::Abi for IPSEC_TRANSPORT_POLICY2 {
 }
 impl ::core::cmp::PartialEq for IPSEC_TRANSPORT_POLICY2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TRANSPORT_POLICY2>()) == 0 }
+        self.numIpsecProposals == other.numIpsecProposals && self.ipsecProposals == other.ipsecProposals && self.flags == other.flags && self.ndAllowClearTimeoutSeconds == other.ndAllowClearTimeoutSeconds && self.saIdleTimeout == other.saIdleTimeout && self.emPolicy == other.emPolicy
     }
 }
 impl ::core::cmp::Eq for IPSEC_TRANSPORT_POLICY2 {}
@@ -14202,12 +13493,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINT0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINT0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINT0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINT0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINT0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINT0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14228,12 +13513,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINT0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINT0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINT0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINT0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINT0_0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINT0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14255,12 +13534,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14281,12 +13554,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS0_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS0_0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14307,12 +13574,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS0_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS0_1 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14335,12 +13596,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS1 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS1 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14361,12 +13616,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS1_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS1_0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14387,12 +13636,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS1_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS1_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS1_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS1_1 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14418,12 +13661,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS2 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS2 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14444,12 +13681,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS2_0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS2_0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14470,12 +13701,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_ENDPOINTS2_1 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_ENDPOINTS2_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_ENDPOINTS2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_ENDPOINTS2_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_ENDPOINTS2_1 {}
 impl ::core::default::Default for IPSEC_TUNNEL_ENDPOINTS2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14500,12 +13725,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_POLICY0 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_POLICY0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_POLICY0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_POLICY0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_POLICY0 {}
 impl ::core::default::Default for IPSEC_TUNNEL_POLICY0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14530,12 +13749,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_POLICY1 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_POLICY1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_POLICY1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_POLICY1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_POLICY1 {}
 impl ::core::default::Default for IPSEC_TUNNEL_POLICY1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14561,12 +13774,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_POLICY2 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_POLICY2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_POLICY2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_POLICY2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_POLICY2 {}
 impl ::core::default::Default for IPSEC_TUNNEL_POLICY2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14595,12 +13802,6 @@ impl ::core::clone::Clone for IPSEC_TUNNEL_POLICY3 {
 unsafe impl ::windows::core::Abi for IPSEC_TUNNEL_POLICY3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPSEC_TUNNEL_POLICY3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_TUNNEL_POLICY3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPSEC_TUNNEL_POLICY3 {}
 impl ::core::default::Default for IPSEC_TUNNEL_POLICY3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14628,7 +13829,7 @@ unsafe impl ::windows::core::Abi for IPSEC_V4_UDP_ENCAPSULATION0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_V4_UDP_ENCAPSULATION0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_V4_UDP_ENCAPSULATION0>()) == 0 }
+        self.localUdpEncapPort == other.localUdpEncapPort && self.remoteUdpEncapPort == other.remoteUdpEncapPort
     }
 }
 impl ::core::cmp::Eq for IPSEC_V4_UDP_ENCAPSULATION0 {}
@@ -14659,7 +13860,7 @@ unsafe impl ::windows::core::Abi for IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {
 }
 impl ::core::cmp::PartialEq for IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPSEC_VIRTUAL_IF_TUNNEL_INFO0>()) == 0 }
+        self.virtualIfTunnelId == other.virtualIfTunnelId && self.trafficSelectorId == other.trafficSelectorId
     }
 }
 impl ::core::cmp::Eq for IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -5208,7 +5208,7 @@ unsafe impl ::windows::core::Abi for FW_DYNAMIC_KEYWORD_ADDRESS0 {
 }
 impl ::core::cmp::PartialEq for FW_DYNAMIC_KEYWORD_ADDRESS0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FW_DYNAMIC_KEYWORD_ADDRESS0>()) == 0 }
+        self.id == other.id && self.keyword == other.keyword && self.flags == other.flags && self.addresses == other.addresses
     }
 }
 impl ::core::cmp::Eq for FW_DYNAMIC_KEYWORD_ADDRESS0 {}
@@ -5241,7 +5241,7 @@ unsafe impl ::windows::core::Abi for FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {
 }
 impl ::core::cmp::PartialEq for FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FW_DYNAMIC_KEYWORD_ADDRESS_DATA0>()) == 0 }
+        self.dynamicKeywordAddress == other.dynamicKeywordAddress && self.next == other.next && self.schemaVersion == other.schemaVersion && self.originType == other.originType
     }
 }
 impl ::core::cmp::Eq for FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {}
@@ -5272,7 +5272,7 @@ unsafe impl ::windows::core::Abi for INET_FIREWALL_AC_BINARIES {
 }
 impl ::core::cmp::PartialEq for INET_FIREWALL_AC_BINARIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_FIREWALL_AC_BINARIES>()) == 0 }
+        self.count == other.count && self.binaries == other.binaries
     }
 }
 impl ::core::cmp::Eq for INET_FIREWALL_AC_BINARIES {}
@@ -5309,7 +5309,7 @@ unsafe impl ::windows::core::Abi for INET_FIREWALL_AC_CAPABILITIES {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for INET_FIREWALL_AC_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_FIREWALL_AC_CAPABILITIES>()) == 0 }
+        self.count == other.count && self.capabilities == other.capabilities
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -5344,14 +5344,6 @@ unsafe impl ::windows::core::Abi for INET_FIREWALL_AC_CHANGE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for INET_FIREWALL_AC_CHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_FIREWALL_AC_CHANGE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for INET_FIREWALL_AC_CHANGE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for INET_FIREWALL_AC_CHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5376,14 +5368,6 @@ impl ::core::clone::Clone for INET_FIREWALL_AC_CHANGE_0 {
 unsafe impl ::windows::core::Abi for INET_FIREWALL_AC_CHANGE_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for INET_FIREWALL_AC_CHANGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_FIREWALL_AC_CHANGE_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for INET_FIREWALL_AC_CHANGE_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for INET_FIREWALL_AC_CHANGE_0 {
     fn default() -> Self {
@@ -5425,7 +5409,7 @@ unsafe impl ::windows::core::Abi for INET_FIREWALL_APP_CONTAINER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for INET_FIREWALL_APP_CONTAINER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_FIREWALL_APP_CONTAINER>()) == 0 }
+        self.appContainerSid == other.appContainerSid && self.userSid == other.userSid && self.appContainerName == other.appContainerName && self.displayName == other.displayName && self.description == other.description && self.capabilities == other.capabilities && self.binaries == other.binaries && self.workingDirectory == other.workingDirectory && self.packageFullName == other.packageFullName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -5464,7 +5448,7 @@ unsafe impl ::windows::core::Abi for NETCON_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for NETCON_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETCON_PROPERTIES>()) == 0 }
+        self.guidId == other.guidId && self.pszwName == other.pszwName && self.pszwDeviceName == other.pszwDeviceName && self.Status == other.Status && self.MediaType == other.MediaType && self.dwCharacter == other.dwCharacter && self.clsidThisObject == other.clsidThisObject && self.clsidUiObject == other.clsidUiObject
     }
 }
 impl ::core::cmp::Eq for NETCON_PROPERTIES {}

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/mod.rs
@@ -135,14 +135,6 @@ unsafe impl ::windows::core::Abi for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_CUSTOMER_ADDRESS_CHANGE_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -166,14 +158,6 @@ impl ::core::clone::Clone for WNV_IP_ADDRESS {
 unsafe impl ::windows::core::Abi for WNV_IP_ADDRESS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_IP_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_IP_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_IP_ADDRESS {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_IP_ADDRESS {
     fn default() -> Self {
@@ -200,14 +184,6 @@ impl ::core::clone::Clone for WNV_IP_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for WNV_IP_ADDRESS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_IP_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_IP_ADDRESS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_IP_ADDRESS_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_IP_ADDRESS_0 {
     fn default() -> Self {
@@ -238,7 +214,7 @@ unsafe impl ::windows::core::Abi for WNV_NOTIFICATION_PARAM {
 }
 impl ::core::cmp::PartialEq for WNV_NOTIFICATION_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_NOTIFICATION_PARAM>()) == 0 }
+        self.Header == other.Header && self.NotificationType == other.NotificationType && self.PendingNotifications == other.PendingNotifications && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for WNV_NOTIFICATION_PARAM {}
@@ -267,14 +243,6 @@ unsafe impl ::windows::core::Abi for WNV_OBJECT_CHANGE_PARAM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_OBJECT_CHANGE_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_OBJECT_CHANGE_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_OBJECT_CHANGE_PARAM {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_OBJECT_CHANGE_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -299,14 +267,6 @@ impl ::core::clone::Clone for WNV_OBJECT_CHANGE_PARAM_0 {
 unsafe impl ::windows::core::Abi for WNV_OBJECT_CHANGE_PARAM_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_OBJECT_CHANGE_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_OBJECT_CHANGE_PARAM_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_OBJECT_CHANGE_PARAM_0 {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_OBJECT_CHANGE_PARAM_0 {
     fn default() -> Self {
@@ -336,7 +296,7 @@ unsafe impl ::windows::core::Abi for WNV_OBJECT_HEADER {
 }
 impl ::core::cmp::PartialEq for WNV_OBJECT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_OBJECT_HEADER>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for WNV_OBJECT_HEADER {}
@@ -368,14 +328,6 @@ unsafe impl ::windows::core::Abi for WNV_POLICY_MISMATCH_PARAM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_POLICY_MISMATCH_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_POLICY_MISMATCH_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_POLICY_MISMATCH_PARAM {}
-#[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_POLICY_MISMATCH_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -401,14 +353,6 @@ impl ::core::clone::Clone for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
 unsafe impl ::windows::core::Abi for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_PROVIDER_ADDRESS_CHANGE_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
     fn default() -> Self {
@@ -439,14 +383,6 @@ impl ::core::clone::Clone for WNV_REDIRECT_PARAM {
 unsafe impl ::windows::core::Abi for WNV_REDIRECT_PARAM {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::PartialEq for WNV_REDIRECT_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNV_REDIRECT_PARAM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl ::core::cmp::Eq for WNV_REDIRECT_PARAM {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::default::Default for WNV_REDIRECT_PARAM {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -13745,7 +13745,7 @@ unsafe impl ::windows::core::Abi for ADSPROPERROR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADSPROPERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADSPROPERROR>()) == 0 }
+        self.hwndPage == other.hwndPage && self.pszPageTitle == other.pszPageTitle && self.pszObjPath == other.pszObjPath && self.pszObjClass == other.pszObjClass && self.hr == other.hr && self.pszError == other.pszError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13817,14 +13817,6 @@ unsafe impl ::windows::core::Abi for ADSVALUE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ADSVALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADSVALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ADSVALUE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ADSVALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13875,14 +13867,6 @@ unsafe impl ::windows::core::Abi for ADSVALUE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ADSVALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADSVALUE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ADSVALUE_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ADSVALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13919,7 +13903,7 @@ unsafe impl ::windows::core::Abi for ADS_ATTR_DEF {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADS_ATTR_DEF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_ATTR_DEF>()) == 0 }
+        self.pszAttrName == other.pszAttrName && self.dwADsType == other.dwADsType && self.dwMinRange == other.dwMinRange && self.dwMaxRange == other.dwMaxRange && self.fMultiValued == other.fMultiValued
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13961,7 +13945,7 @@ unsafe impl ::windows::core::Abi for ADS_ATTR_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADS_ATTR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_ATTR_INFO>()) == 0 }
+        self.pszAttrName == other.pszAttrName && self.dwControlCode == other.dwControlCode && self.dwADsType == other.dwADsType && self.pADsValues == other.pADsValues && self.dwNumValues == other.dwNumValues
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13994,7 +13978,7 @@ unsafe impl ::windows::core::Abi for ADS_BACKLINK {
 }
 impl ::core::cmp::PartialEq for ADS_BACKLINK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_BACKLINK>()) == 0 }
+        self.RemoteID == other.RemoteID && self.ObjectName == other.ObjectName
     }
 }
 impl ::core::cmp::Eq for ADS_BACKLINK {}
@@ -14025,7 +14009,7 @@ unsafe impl ::windows::core::Abi for ADS_CASEIGNORE_LIST {
 }
 impl ::core::cmp::PartialEq for ADS_CASEIGNORE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_CASEIGNORE_LIST>()) == 0 }
+        self.Next == other.Next && self.String == other.String
     }
 }
 impl ::core::cmp::Eq for ADS_CASEIGNORE_LIST {}
@@ -14081,7 +14065,7 @@ unsafe impl ::windows::core::Abi for ADS_CLASS_DEF {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADS_CLASS_DEF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_CLASS_DEF>()) == 0 }
+        self.pszClassName == other.pszClassName && self.dwMandatoryAttrs == other.dwMandatoryAttrs && self.ppszMandatoryAttrs == other.ppszMandatoryAttrs && self.optionalAttrs == other.optionalAttrs && self.ppszOptionalAttrs == other.ppszOptionalAttrs && self.dwNamingAttrs == other.dwNamingAttrs && self.ppszNamingAttrs == other.ppszNamingAttrs && self.dwSuperClasses == other.dwSuperClasses && self.ppszSuperClasses == other.ppszSuperClasses && self.fIsContainer == other.fIsContainer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14115,7 +14099,7 @@ unsafe impl ::windows::core::Abi for ADS_DN_WITH_BINARY {
 }
 impl ::core::cmp::PartialEq for ADS_DN_WITH_BINARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_DN_WITH_BINARY>()) == 0 }
+        self.dwLength == other.dwLength && self.lpBinaryValue == other.lpBinaryValue && self.pszDNString == other.pszDNString
     }
 }
 impl ::core::cmp::Eq for ADS_DN_WITH_BINARY {}
@@ -14146,7 +14130,7 @@ unsafe impl ::windows::core::Abi for ADS_DN_WITH_STRING {
 }
 impl ::core::cmp::PartialEq for ADS_DN_WITH_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_DN_WITH_STRING>()) == 0 }
+        self.pszStringValue == other.pszStringValue && self.pszDNString == other.pszDNString
     }
 }
 impl ::core::cmp::Eq for ADS_DN_WITH_STRING {}
@@ -14177,7 +14161,7 @@ unsafe impl ::windows::core::Abi for ADS_EMAIL {
 }
 impl ::core::cmp::PartialEq for ADS_EMAIL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_EMAIL>()) == 0 }
+        self.Address == other.Address && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for ADS_EMAIL {}
@@ -14209,7 +14193,7 @@ unsafe impl ::windows::core::Abi for ADS_FAXNUMBER {
 }
 impl ::core::cmp::PartialEq for ADS_FAXNUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_FAXNUMBER>()) == 0 }
+        self.TelephoneNumber == other.TelephoneNumber && self.NumberOfBits == other.NumberOfBits && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for ADS_FAXNUMBER {}
@@ -14240,7 +14224,7 @@ unsafe impl ::windows::core::Abi for ADS_HOLD {
 }
 impl ::core::cmp::PartialEq for ADS_HOLD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_HOLD>()) == 0 }
+        self.ObjectName == other.ObjectName && self.Amount == other.Amount
     }
 }
 impl ::core::cmp::Eq for ADS_HOLD {}
@@ -14272,7 +14256,7 @@ unsafe impl ::windows::core::Abi for ADS_NETADDRESS {
 }
 impl ::core::cmp::PartialEq for ADS_NETADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_NETADDRESS>()) == 0 }
+        self.AddressType == other.AddressType && self.AddressLength == other.AddressLength && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for ADS_NETADDRESS {}
@@ -14303,7 +14287,7 @@ unsafe impl ::windows::core::Abi for ADS_NT_SECURITY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for ADS_NT_SECURITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_NT_SECURITY_DESCRIPTOR>()) == 0 }
+        self.dwLength == other.dwLength && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for ADS_NT_SECURITY_DESCRIPTOR {}
@@ -14337,7 +14321,7 @@ unsafe impl ::windows::core::Abi for ADS_OBJECT_INFO {
 }
 impl ::core::cmp::PartialEq for ADS_OBJECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_OBJECT_INFO>()) == 0 }
+        self.pszRDN == other.pszRDN && self.pszObjectDN == other.pszObjectDN && self.pszParentDN == other.pszParentDN && self.pszSchemaDN == other.pszSchemaDN && self.pszClassName == other.pszClassName
     }
 }
 impl ::core::cmp::Eq for ADS_OBJECT_INFO {}
@@ -14369,7 +14353,7 @@ unsafe impl ::windows::core::Abi for ADS_OCTET_LIST {
 }
 impl ::core::cmp::PartialEq for ADS_OCTET_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_OCTET_LIST>()) == 0 }
+        self.Next == other.Next && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for ADS_OCTET_LIST {}
@@ -14400,7 +14384,7 @@ unsafe impl ::windows::core::Abi for ADS_OCTET_STRING {
 }
 impl ::core::cmp::PartialEq for ADS_OCTET_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_OCTET_STRING>()) == 0 }
+        self.dwLength == other.dwLength && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for ADS_OCTET_STRING {}
@@ -14432,7 +14416,7 @@ unsafe impl ::windows::core::Abi for ADS_PATH {
 }
 impl ::core::cmp::PartialEq for ADS_PATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_PATH>()) == 0 }
+        self.Type == other.Type && self.VolumeName == other.VolumeName && self.Path == other.Path
     }
 }
 impl ::core::cmp::Eq for ADS_PATH {}
@@ -14462,7 +14446,7 @@ unsafe impl ::windows::core::Abi for ADS_POSTALADDRESS {
 }
 impl ::core::cmp::PartialEq for ADS_POSTALADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_POSTALADDRESS>()) == 0 }
+        self.PostalAddress == other.PostalAddress
     }
 }
 impl ::core::cmp::Eq for ADS_POSTALADDRESS {}
@@ -14493,7 +14477,7 @@ unsafe impl ::windows::core::Abi for ADS_PROV_SPECIFIC {
 }
 impl ::core::cmp::PartialEq for ADS_PROV_SPECIFIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_PROV_SPECIFIC>()) == 0 }
+        self.dwLength == other.dwLength && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for ADS_PROV_SPECIFIC {}
@@ -14527,7 +14511,7 @@ unsafe impl ::windows::core::Abi for ADS_REPLICAPOINTER {
 }
 impl ::core::cmp::PartialEq for ADS_REPLICAPOINTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_REPLICAPOINTER>()) == 0 }
+        self.ServerName == other.ServerName && self.ReplicaType == other.ReplicaType && self.ReplicaNumber == other.ReplicaNumber && self.Count == other.Count && self.ReplicaAddressHints == other.ReplicaAddressHints
     }
 }
 impl ::core::cmp::Eq for ADS_REPLICAPOINTER {}
@@ -14556,14 +14540,6 @@ impl ::core::clone::Clone for ADS_SEARCHPREF_INFO {
 unsafe impl ::windows::core::Abi for ADS_SEARCHPREF_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ADS_SEARCHPREF_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_SEARCHPREF_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ADS_SEARCHPREF_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ADS_SEARCHPREF_INFO {
     fn default() -> Self {
@@ -14601,7 +14577,7 @@ unsafe impl ::windows::core::Abi for ADS_SEARCH_COLUMN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADS_SEARCH_COLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_SEARCH_COLUMN>()) == 0 }
+        self.pszAttrName == other.pszAttrName && self.dwADsType == other.dwADsType && self.pADsValues == other.pADsValues && self.dwNumValues == other.dwNumValues && self.hReserved == other.hReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14673,7 +14649,7 @@ unsafe impl ::windows::core::Abi for ADS_SORTKEY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADS_SORTKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_SORTKEY>()) == 0 }
+        self.pszAttrType == other.pszAttrType && self.pszReserved == other.pszReserved && self.fReverseorder == other.fReverseorder
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14706,7 +14682,7 @@ unsafe impl ::windows::core::Abi for ADS_TIMESTAMP {
 }
 impl ::core::cmp::PartialEq for ADS_TIMESTAMP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_TIMESTAMP>()) == 0 }
+        self.WholeSeconds == other.WholeSeconds && self.EventID == other.EventID
     }
 }
 impl ::core::cmp::Eq for ADS_TIMESTAMP {}
@@ -14738,7 +14714,7 @@ unsafe impl ::windows::core::Abi for ADS_TYPEDNAME {
 }
 impl ::core::cmp::PartialEq for ADS_TYPEDNAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_TYPEDNAME>()) == 0 }
+        self.ObjectName == other.ObjectName && self.Level == other.Level && self.Interval == other.Interval
     }
 }
 impl ::core::cmp::Eq for ADS_TYPEDNAME {}
@@ -14774,7 +14750,7 @@ unsafe impl ::windows::core::Abi for ADS_VLV {
 }
 impl ::core::cmp::PartialEq for ADS_VLV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADS_VLV>()) == 0 }
+        self.dwBeforeCount == other.dwBeforeCount && self.dwAfterCount == other.dwAfterCount && self.dwOffset == other.dwOffset && self.dwContentCount == other.dwContentCount && self.pszTarget == other.pszTarget && self.dwContextIDLength == other.dwContextIDLength && self.lpContextID == other.lpContextID
     }
 }
 impl ::core::cmp::Eq for ADS_VLV {}
@@ -14814,7 +14790,7 @@ unsafe impl ::windows::core::Abi for CQFORM {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for CQFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CQFORM>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.clsid == other.clsid && self.hIcon == other.hIcon && self.pszTitle == other.pszTitle
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -14849,21 +14825,13 @@ impl ::core::clone::Clone for CQPAGE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for CQPAGE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CQPAGE").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("pPageProc", &self.pPageProc.map(|f| f as usize)).field("hInstance", &self.hInstance).field("idPageName", &self.idPageName).field("idPageTemplate", &self.idPageTemplate).field("pDlgProc", &self.pDlgProc.map(|f| f as usize)).field("lParam", &self.lParam).finish()
+        f.debug_struct("CQPAGE").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hInstance", &self.hInstance).field("idPageName", &self.idPageName).field("idPageTemplate", &self.idPageTemplate).field("lParam", &self.lParam).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for CQPAGE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CQPAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CQPAGE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CQPAGE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CQPAGE {
     fn default() -> Self {
@@ -14905,7 +14873,7 @@ unsafe impl ::windows::core::Abi for DOMAINDESC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOMAINDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOMAINDESC>()) == 0 }
+        self.pszName == other.pszName && self.pszPath == other.pszPath && self.pszNCName == other.pszNCName && self.pszTrustParent == other.pszTrustParent && self.pszObjectClass == other.pszObjectClass && self.ulFlags == other.ulFlags && self.fDownLevel == other.fDownLevel && self.pdChildList == other.pdChildList && self.pdNextSibling == other.pdNextSibling
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14945,7 +14913,7 @@ unsafe impl ::windows::core::Abi for DOMAIN_CONTROLLER_INFOA {
 }
 impl ::core::cmp::PartialEq for DOMAIN_CONTROLLER_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOMAIN_CONTROLLER_INFOA>()) == 0 }
+        self.DomainControllerName == other.DomainControllerName && self.DomainControllerAddress == other.DomainControllerAddress && self.DomainControllerAddressType == other.DomainControllerAddressType && self.DomainGuid == other.DomainGuid && self.DomainName == other.DomainName && self.DnsForestName == other.DnsForestName && self.Flags == other.Flags && self.DcSiteName == other.DcSiteName && self.ClientSiteName == other.ClientSiteName
     }
 }
 impl ::core::cmp::Eq for DOMAIN_CONTROLLER_INFOA {}
@@ -14983,7 +14951,7 @@ unsafe impl ::windows::core::Abi for DOMAIN_CONTROLLER_INFOW {
 }
 impl ::core::cmp::PartialEq for DOMAIN_CONTROLLER_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOMAIN_CONTROLLER_INFOW>()) == 0 }
+        self.DomainControllerName == other.DomainControllerName && self.DomainControllerAddress == other.DomainControllerAddress && self.DomainControllerAddressType == other.DomainControllerAddressType && self.DomainGuid == other.DomainGuid && self.DomainName == other.DomainName && self.DnsForestName == other.DnsForestName && self.Flags == other.Flags && self.DcSiteName == other.DcSiteName && self.ClientSiteName == other.ClientSiteName
     }
 }
 impl ::core::cmp::Eq for DOMAIN_CONTROLLER_INFOW {}
@@ -15021,7 +14989,7 @@ unsafe impl ::windows::core::Abi for DOMAIN_TREE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DOMAIN_TREE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOMAIN_TREE>()) == 0 }
+        self.dsSize == other.dsSize && self.dwCount == other.dwCount && self.aDomains == other.aDomains
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15062,7 +15030,7 @@ unsafe impl ::windows::core::Abi for DSA_NEWOBJ_DISPINFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for DSA_NEWOBJ_DISPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSA_NEWOBJ_DISPINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.hObjClassIcon == other.hObjClassIcon && self.lpszWizTitle == other.lpszWizTitle && self.lpszContDisplayName == other.lpszContDisplayName
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -15108,7 +15076,7 @@ unsafe impl ::windows::core::Abi for DSBITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSBITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBITEMA>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pszADsPath == other.pszADsPath && self.pszClass == other.pszClass && self.dwMask == other.dwMask && self.dwState == other.dwState && self.dwStateMask == other.dwStateMask && self.szDisplayName == other.szDisplayName && self.szIconLocation == other.szIconLocation && self.iIconResID == other.iIconResID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15148,7 +15116,7 @@ unsafe impl ::windows::core::Abi for DSBITEMW {
 }
 impl ::core::cmp::PartialEq for DSBITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBITEMW>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pszADsPath == other.pszADsPath && self.pszClass == other.pszClass && self.dwMask == other.dwMask && self.dwState == other.dwState && self.dwStateMask == other.dwStateMask && self.szDisplayName == other.szDisplayName && self.szIconLocation == other.szIconLocation && self.iIconResID == other.iIconResID
     }
 }
 impl ::core::cmp::Eq for DSBITEMW {}
@@ -15197,7 +15165,6 @@ impl ::core::fmt::Debug for DSBROWSEINFOA {
             .field("pszPath", &self.pszPath)
             .field("cchPath", &self.cchPath)
             .field("dwFlags", &self.dwFlags)
-            .field("pfnCallback", &self.pfnCallback.map(|f| f as usize))
             .field("lParam", &self.lParam)
             .field("dwReturnFormat", &self.dwReturnFormat)
             .field("pUserName", &self.pUserName)
@@ -15211,14 +15178,6 @@ impl ::core::fmt::Debug for DSBROWSEINFOA {
 unsafe impl ::windows::core::Abi for DSBROWSEINFOA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::PartialEq for DSBROWSEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBROWSEINFOA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::Eq for DSBROWSEINFOA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::default::Default for DSBROWSEINFOA {
     fn default() -> Self {
@@ -15265,7 +15224,6 @@ impl ::core::fmt::Debug for DSBROWSEINFOW {
             .field("pszPath", &self.pszPath)
             .field("cchPath", &self.cchPath)
             .field("dwFlags", &self.dwFlags)
-            .field("pfnCallback", &self.pfnCallback.map(|f| f as usize))
             .field("lParam", &self.lParam)
             .field("dwReturnFormat", &self.dwReturnFormat)
             .field("pUserName", &self.pUserName)
@@ -15279,14 +15237,6 @@ impl ::core::fmt::Debug for DSBROWSEINFOW {
 unsafe impl ::windows::core::Abi for DSBROWSEINFOW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::PartialEq for DSBROWSEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSBROWSEINFOW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::Eq for DSBROWSEINFOW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::default::Default for DSBROWSEINFOW {
     fn default() -> Self {
@@ -15318,7 +15268,7 @@ unsafe impl ::windows::core::Abi for DSCLASSCREATIONINFO {
 }
 impl ::core::cmp::PartialEq for DSCLASSCREATIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCLASSCREATIONINFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.clsidWizardDialog == other.clsidWizardDialog && self.clsidWizardPrimaryPage == other.clsidWizardPrimaryPage && self.cWizardExtensions == other.cWizardExtensions && self.aWizardExtensions == other.aWizardExtensions
     }
 }
 impl ::core::cmp::Eq for DSCLASSCREATIONINFO {}
@@ -15353,7 +15303,7 @@ unsafe impl ::windows::core::Abi for DSCOLUMN {
 }
 impl ::core::cmp::PartialEq for DSCOLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSCOLUMN>()) == 0 }
+        self.dwFlags == other.dwFlags && self.fmt == other.fmt && self.cx == other.cx && self.idsName == other.idsName && self.offsetProperty == other.offsetProperty && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for DSCOLUMN {}
@@ -15389,7 +15339,7 @@ unsafe impl ::windows::core::Abi for DSDISPLAYSPECOPTIONS {
 }
 impl ::core::cmp::PartialEq for DSDISPLAYSPECOPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSDISPLAYSPECOPTIONS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.offsetAttribPrefix == other.offsetAttribPrefix && self.offsetUserName == other.offsetUserName && self.offsetPassword == other.offsetPassword && self.offsetServer == other.offsetServer && self.offsetServerConfigPath == other.offsetServerConfigPath
     }
 }
 impl ::core::cmp::Eq for DSDISPLAYSPECOPTIONS {}
@@ -15422,7 +15372,7 @@ unsafe impl ::windows::core::Abi for DSOBJECT {
 }
 impl ::core::cmp::PartialEq for DSOBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOBJECT>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwProviderFlags == other.dwProviderFlags && self.offsetName == other.offsetName && self.offsetClass == other.offsetClass
     }
 }
 impl ::core::cmp::Eq for DSOBJECT {}
@@ -15454,7 +15404,7 @@ unsafe impl ::windows::core::Abi for DSOBJECTNAMES {
 }
 impl ::core::cmp::PartialEq for DSOBJECTNAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOBJECTNAMES>()) == 0 }
+        self.clsidNamespace == other.clsidNamespace && self.cItems == other.cItems && self.aObjects == other.aObjects
     }
 }
 impl ::core::cmp::Eq for DSOBJECTNAMES {}
@@ -15485,7 +15435,7 @@ unsafe impl ::windows::core::Abi for DSOP_FILTER_FLAGS {
 }
 impl ::core::cmp::PartialEq for DSOP_FILTER_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOP_FILTER_FLAGS>()) == 0 }
+        self.Uplevel == other.Uplevel && self.flDownlevel == other.flDownlevel
     }
 }
 impl ::core::cmp::Eq for DSOP_FILTER_FLAGS {}
@@ -15521,7 +15471,7 @@ unsafe impl ::windows::core::Abi for DSOP_INIT_INFO {
 }
 impl ::core::cmp::PartialEq for DSOP_INIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOP_INIT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pwzTargetComputer == other.pwzTargetComputer && self.cDsScopeInfos == other.cDsScopeInfos && self.aDsScopeInfos == other.aDsScopeInfos && self.flOptions == other.flOptions && self.cAttributesToFetch == other.cAttributesToFetch && self.apwzAttributeNames == other.apwzAttributeNames
     }
 }
 impl ::core::cmp::Eq for DSOP_INIT_INFO {}
@@ -15557,7 +15507,7 @@ unsafe impl ::windows::core::Abi for DSOP_SCOPE_INIT_INFO {
 }
 impl ::core::cmp::PartialEq for DSOP_SCOPE_INIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOP_SCOPE_INIT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.flType == other.flType && self.flScope == other.flScope && self.FilterFlags == other.FilterFlags && self.pwzDcName == other.pwzDcName && self.pwzADsPath == other.pwzADsPath && self.hr == other.hr
     }
 }
 impl ::core::cmp::Eq for DSOP_SCOPE_INIT_INFO {}
@@ -15589,7 +15539,7 @@ unsafe impl ::windows::core::Abi for DSOP_UPLEVEL_FILTER_FLAGS {
 }
 impl ::core::cmp::PartialEq for DSOP_UPLEVEL_FILTER_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSOP_UPLEVEL_FILTER_FLAGS>()) == 0 }
+        self.flBothModes == other.flBothModes && self.flMixedModeOnly == other.flMixedModeOnly && self.flNativeModeOnly == other.flNativeModeOnly
     }
 }
 impl ::core::cmp::Eq for DSOP_UPLEVEL_FILTER_FLAGS {}
@@ -15619,7 +15569,7 @@ unsafe impl ::windows::core::Abi for DSPROPERTYPAGEINFO {
 }
 impl ::core::cmp::PartialEq for DSPROPERTYPAGEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSPROPERTYPAGEINFO>()) == 0 }
+        self.offsetString == other.offsetString
     }
 }
 impl ::core::cmp::Eq for DSPROPERTYPAGEINFO {}
@@ -15651,7 +15601,7 @@ unsafe impl ::windows::core::Abi for DSQUERYCLASSLIST {
 }
 impl ::core::cmp::PartialEq for DSQUERYCLASSLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSQUERYCLASSLIST>()) == 0 }
+        self.cbStruct == other.cbStruct && self.cClasses == other.cClasses && self.offsetClass == other.offsetClass
     }
 }
 impl ::core::cmp::Eq for DSQUERYCLASSLIST {}
@@ -15687,7 +15637,7 @@ unsafe impl ::windows::core::Abi for DSQUERYINITPARAMS {
 }
 impl ::core::cmp::PartialEq for DSQUERYINITPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSQUERYINITPARAMS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.pDefaultScope == other.pDefaultScope && self.pDefaultSaveLocation == other.pDefaultSaveLocation && self.pUserName == other.pUserName && self.pPassword == other.pPassword && self.pServer == other.pServer
     }
 }
 impl ::core::cmp::Eq for DSQUERYINITPARAMS {}
@@ -15729,7 +15679,7 @@ unsafe impl ::windows::core::Abi for DSQUERYPARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DSQUERYPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSQUERYPARAMS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.hInstance == other.hInstance && self.offsetQuery == other.offsetQuery && self.iColumns == other.iColumns && self.dwReserved == other.dwReserved && self.aColumns == other.aColumns
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15761,7 +15711,7 @@ unsafe impl ::windows::core::Abi for DSROLE_OPERATION_STATE_INFO {
 }
 impl ::core::cmp::PartialEq for DSROLE_OPERATION_STATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSROLE_OPERATION_STATE_INFO>()) == 0 }
+        self.OperationState == other.OperationState
     }
 }
 impl ::core::cmp::Eq for DSROLE_OPERATION_STATE_INFO {}
@@ -15796,7 +15746,7 @@ unsafe impl ::windows::core::Abi for DSROLE_PRIMARY_DOMAIN_INFO_BASIC {
 }
 impl ::core::cmp::PartialEq for DSROLE_PRIMARY_DOMAIN_INFO_BASIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSROLE_PRIMARY_DOMAIN_INFO_BASIC>()) == 0 }
+        self.MachineRole == other.MachineRole && self.Flags == other.Flags && self.DomainNameFlat == other.DomainNameFlat && self.DomainNameDns == other.DomainNameDns && self.DomainForestName == other.DomainForestName && self.DomainGuid == other.DomainGuid
     }
 }
 impl ::core::cmp::Eq for DSROLE_PRIMARY_DOMAIN_INFO_BASIC {}
@@ -15827,7 +15777,7 @@ unsafe impl ::windows::core::Abi for DSROLE_UPGRADE_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for DSROLE_UPGRADE_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSROLE_UPGRADE_STATUS_INFO>()) == 0 }
+        self.OperationState == other.OperationState && self.PreviousServerState == other.PreviousServerState
     }
 }
 impl ::core::cmp::Eq for DSROLE_UPGRADE_STATUS_INFO {}
@@ -15869,7 +15819,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_1A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_1A>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15913,7 +15863,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_1W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_1W>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15979,7 +15929,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_2A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_2A>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.SiteObjectName == other.SiteObjectName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.NtdsDsaObjectName == other.NtdsDsaObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled && self.fIsGc == other.fIsGc && self.SiteObjectGuid == other.SiteObjectGuid && self.ComputerObjectGuid == other.ComputerObjectGuid && self.ServerObjectGuid == other.ServerObjectGuid && self.NtdsDsaObjectGuid == other.NtdsDsaObjectGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16045,7 +15995,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_2W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_2W>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.SiteObjectName == other.SiteObjectName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.NtdsDsaObjectName == other.NtdsDsaObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled && self.fIsGc == other.fIsGc && self.SiteObjectGuid == other.SiteObjectGuid && self.ComputerObjectGuid == other.ComputerObjectGuid && self.ServerObjectGuid == other.ServerObjectGuid && self.NtdsDsaObjectGuid == other.NtdsDsaObjectGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16113,7 +16063,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_3A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_3A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_3A>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.SiteObjectName == other.SiteObjectName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.NtdsDsaObjectName == other.NtdsDsaObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled && self.fIsGc == other.fIsGc && self.fIsRodc == other.fIsRodc && self.SiteObjectGuid == other.SiteObjectGuid && self.ComputerObjectGuid == other.ComputerObjectGuid && self.ServerObjectGuid == other.ServerObjectGuid && self.NtdsDsaObjectGuid == other.NtdsDsaObjectGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16181,7 +16131,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_CONTROLLER_INFO_3W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_CONTROLLER_INFO_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_CONTROLLER_INFO_3W>()) == 0 }
+        self.NetbiosName == other.NetbiosName && self.DnsHostName == other.DnsHostName && self.SiteName == other.SiteName && self.SiteObjectName == other.SiteObjectName && self.ComputerObjectName == other.ComputerObjectName && self.ServerObjectName == other.ServerObjectName && self.NtdsDsaObjectName == other.NtdsDsaObjectName && self.fIsPdc == other.fIsPdc && self.fDsEnabled == other.fDsEnabled && self.fIsGc == other.fIsGc && self.fIsRodc == other.fIsRodc && self.SiteObjectGuid == other.SiteObjectGuid && self.ComputerObjectGuid == other.ComputerObjectGuid && self.ServerObjectGuid == other.ServerObjectGuid && self.NtdsDsaObjectGuid == other.NtdsDsaObjectGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16226,7 +16176,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_TRUSTSA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_TRUSTSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_TRUSTSA>()) == 0 }
+        self.NetbiosDomainName == other.NetbiosDomainName && self.DnsDomainName == other.DnsDomainName && self.Flags == other.Flags && self.ParentIndex == other.ParentIndex && self.TrustType == other.TrustType && self.TrustAttributes == other.TrustAttributes && self.DomainSid == other.DomainSid && self.DomainGuid == other.DomainGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16271,7 +16221,7 @@ unsafe impl ::windows::core::Abi for DS_DOMAIN_TRUSTSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_DOMAIN_TRUSTSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_DOMAIN_TRUSTSW>()) == 0 }
+        self.NetbiosDomainName == other.NetbiosDomainName && self.DnsDomainName == other.DnsDomainName && self.Flags == other.Flags && self.ParentIndex == other.ParentIndex && self.TrustType == other.TrustType && self.TrustAttributes == other.TrustAttributes && self.DomainSid == other.DomainSid && self.DomainGuid == other.DomainGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16304,7 +16254,7 @@ unsafe impl ::windows::core::Abi for DS_NAME_RESULTA {
 }
 impl ::core::cmp::PartialEq for DS_NAME_RESULTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_NAME_RESULTA>()) == 0 }
+        self.cItems == other.cItems && self.rItems == other.rItems
     }
 }
 impl ::core::cmp::Eq for DS_NAME_RESULTA {}
@@ -16335,7 +16285,7 @@ unsafe impl ::windows::core::Abi for DS_NAME_RESULTW {
 }
 impl ::core::cmp::PartialEq for DS_NAME_RESULTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_NAME_RESULTW>()) == 0 }
+        self.cItems == other.cItems && self.rItems == other.rItems
     }
 }
 impl ::core::cmp::Eq for DS_NAME_RESULTW {}
@@ -16367,7 +16317,7 @@ unsafe impl ::windows::core::Abi for DS_NAME_RESULT_ITEMA {
 }
 impl ::core::cmp::PartialEq for DS_NAME_RESULT_ITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_NAME_RESULT_ITEMA>()) == 0 }
+        self.status == other.status && self.pDomain == other.pDomain && self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DS_NAME_RESULT_ITEMA {}
@@ -16399,7 +16349,7 @@ unsafe impl ::windows::core::Abi for DS_NAME_RESULT_ITEMW {
 }
 impl ::core::cmp::PartialEq for DS_NAME_RESULT_ITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_NAME_RESULT_ITEMW>()) == 0 }
+        self.status == other.status && self.pDomain == other.pDomain && self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DS_NAME_RESULT_ITEMW {}
@@ -16440,7 +16390,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_META_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_META_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_META_DATA>()) == 0 }
+        self.pszAttributeName == other.pszAttributeName && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16484,7 +16434,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_META_DATA_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_META_DATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_META_DATA_2>()) == 0 }
+        self.pszAttributeName == other.pszAttributeName && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.pszLastOriginatingDsaDN == other.pszLastOriginatingDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16528,7 +16478,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_META_DATA_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_META_DATA_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_META_DATA_BLOB>()) == 0 }
+        self.oszAttributeName == other.oszAttributeName && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.oszLastOriginatingDsaDN == other.oszLastOriginatingDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16568,7 +16518,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_VALUE_META_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_VALUE_META_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_VALUE_META_DATA>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwEnumerationContext == other.dwEnumerationContext && self.rgMetaData == other.rgMetaData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16608,7 +16558,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_VALUE_META_DATA_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_VALUE_META_DATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_VALUE_META_DATA_2>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwEnumerationContext == other.dwEnumerationContext && self.rgMetaData == other.rgMetaData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16648,7 +16598,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_ATTR_VALUE_META_DATA_EXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_ATTR_VALUE_META_DATA_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_ATTR_VALUE_META_DATA_EXT>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwEnumerationContext == other.dwEnumerationContext && self.rgMetaData == other.rgMetaData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16681,7 +16631,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSOR {
 }
 impl ::core::cmp::PartialEq for DS_REPL_CURSOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSOR>()) == 0 }
+        self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID && self.usnAttributeFilter == other.usnAttributeFilter
     }
 }
 impl ::core::cmp::Eq for DS_REPL_CURSOR {}
@@ -16713,7 +16663,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSORS {
 }
 impl ::core::cmp::PartialEq for DS_REPL_CURSORS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSORS>()) == 0 }
+        self.cNumCursors == other.cNumCursors && self.dwReserved == other.dwReserved && self.rgCursor == other.rgCursor
     }
 }
 impl ::core::cmp::Eq for DS_REPL_CURSORS {}
@@ -16751,7 +16701,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSORS_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_CURSORS_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSORS_2>()) == 0 }
+        self.cNumCursors == other.cNumCursors && self.dwEnumerationContext == other.dwEnumerationContext && self.rgCursor == other.rgCursor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16791,7 +16741,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSORS_3W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_CURSORS_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSORS_3W>()) == 0 }
+        self.cNumCursors == other.cNumCursors && self.dwEnumerationContext == other.dwEnumerationContext && self.rgCursor == other.rgCursor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16831,7 +16781,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSOR_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_CURSOR_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSOR_2>()) == 0 }
+        self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID && self.usnAttributeFilter == other.usnAttributeFilter && self.ftimeLastSyncSuccess == other.ftimeLastSyncSuccess
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16872,7 +16822,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSOR_3W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_CURSOR_3W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSOR_3W>()) == 0 }
+        self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID && self.usnAttributeFilter == other.usnAttributeFilter && self.ftimeLastSyncSuccess == other.ftimeLastSyncSuccess && self.pszSourceDsaDN == other.pszSourceDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16913,7 +16863,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_CURSOR_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_CURSOR_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_CURSOR_BLOB>()) == 0 }
+        self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID && self.usnAttributeFilter == other.usnAttributeFilter && self.ftimeLastSyncSuccess == other.ftimeLastSyncSuccess && self.oszSourceDsaDN == other.oszSourceDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16953,7 +16903,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_KCC_DSA_FAILURESW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_KCC_DSA_FAILURESW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_KCC_DSA_FAILURESW>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwReserved == other.dwReserved && self.rgDsaFailure == other.rgDsaFailure
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16995,7 +16945,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_KCC_DSA_FAILUREW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_KCC_DSA_FAILUREW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_KCC_DSA_FAILUREW>()) == 0 }
+        self.pszDsaDN == other.pszDsaDN && self.uuidDsaObjGuid == other.uuidDsaObjGuid && self.ftimeFirstFailure == other.ftimeFirstFailure && self.cNumFailures == other.cNumFailures && self.dwLastResult == other.dwLastResult
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17037,7 +16987,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_KCC_DSA_FAILUREW_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_KCC_DSA_FAILUREW_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_KCC_DSA_FAILUREW_BLOB>()) == 0 }
+        self.oszDsaDN == other.oszDsaDN && self.uuidDsaObjGuid == other.uuidDsaObjGuid && self.ftimeFirstFailure == other.ftimeFirstFailure && self.cNumFailures == other.cNumFailures && self.dwLastResult == other.dwLastResult
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17077,7 +17027,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_NEIGHBORSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_NEIGHBORSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_NEIGHBORSW>()) == 0 }
+        self.cNumNeighbors == other.cNumNeighbors && self.dwReserved == other.dwReserved && self.rgNeighbor == other.rgNeighbor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17147,7 +17097,22 @@ unsafe impl ::windows::core::Abi for DS_REPL_NEIGHBORW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_NEIGHBORW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_NEIGHBORW>()) == 0 }
+        self.pszNamingContext == other.pszNamingContext
+            && self.pszSourceDsaDN == other.pszSourceDsaDN
+            && self.pszSourceDsaAddress == other.pszSourceDsaAddress
+            && self.pszAsyncIntersiteTransportDN == other.pszAsyncIntersiteTransportDN
+            && self.dwReplicaFlags == other.dwReplicaFlags
+            && self.dwReserved == other.dwReserved
+            && self.uuidNamingContextObjGuid == other.uuidNamingContextObjGuid
+            && self.uuidSourceDsaObjGuid == other.uuidSourceDsaObjGuid
+            && self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID
+            && self.uuidAsyncIntersiteTransportObjGuid == other.uuidAsyncIntersiteTransportObjGuid
+            && self.usnLastObjChangeSynced == other.usnLastObjChangeSynced
+            && self.usnAttributeFilter == other.usnAttributeFilter
+            && self.ftimeLastSyncSuccess == other.ftimeLastSyncSuccess
+            && self.ftimeLastSyncAttempt == other.ftimeLastSyncAttempt
+            && self.dwLastSyncResult == other.dwLastSyncResult
+            && self.cNumConsecutiveSyncFailures == other.cNumConsecutiveSyncFailures
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17217,7 +17182,22 @@ unsafe impl ::windows::core::Abi for DS_REPL_NEIGHBORW_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_NEIGHBORW_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_NEIGHBORW_BLOB>()) == 0 }
+        self.oszNamingContext == other.oszNamingContext
+            && self.oszSourceDsaDN == other.oszSourceDsaDN
+            && self.oszSourceDsaAddress == other.oszSourceDsaAddress
+            && self.oszAsyncIntersiteTransportDN == other.oszAsyncIntersiteTransportDN
+            && self.dwReplicaFlags == other.dwReplicaFlags
+            && self.dwReserved == other.dwReserved
+            && self.uuidNamingContextObjGuid == other.uuidNamingContextObjGuid
+            && self.uuidSourceDsaObjGuid == other.uuidSourceDsaObjGuid
+            && self.uuidSourceDsaInvocationID == other.uuidSourceDsaInvocationID
+            && self.uuidAsyncIntersiteTransportObjGuid == other.uuidAsyncIntersiteTransportObjGuid
+            && self.usnLastObjChangeSynced == other.usnLastObjChangeSynced
+            && self.usnAttributeFilter == other.usnAttributeFilter
+            && self.ftimeLastSyncSuccess == other.ftimeLastSyncSuccess
+            && self.ftimeLastSyncAttempt == other.ftimeLastSyncAttempt
+            && self.dwLastSyncResult == other.dwLastSyncResult
+            && self.cNumConsecutiveSyncFailures == other.cNumConsecutiveSyncFailures
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17257,7 +17237,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_OBJ_META_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_OBJ_META_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_OBJ_META_DATA>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwReserved == other.dwReserved && self.rgMetaData == other.rgMetaData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17297,7 +17277,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_OBJ_META_DATA_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_OBJ_META_DATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_OBJ_META_DATA_2>()) == 0 }
+        self.cNumEntries == other.cNumEntries && self.dwReserved == other.dwReserved && self.rgMetaData == other.rgMetaData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17344,7 +17324,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_OPW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_OPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_OPW>()) == 0 }
+        self.ftimeEnqueued == other.ftimeEnqueued && self.ulSerialNumber == other.ulSerialNumber && self.ulPriority == other.ulPriority && self.OpType == other.OpType && self.ulOptions == other.ulOptions && self.pszNamingContext == other.pszNamingContext && self.pszDsaDN == other.pszDsaDN && self.pszDsaAddress == other.pszDsaAddress && self.uuidNamingContextObjGuid == other.uuidNamingContextObjGuid && self.uuidDsaObjGuid == other.uuidDsaObjGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17391,7 +17371,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_OPW_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_OPW_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_OPW_BLOB>()) == 0 }
+        self.ftimeEnqueued == other.ftimeEnqueued && self.ulSerialNumber == other.ulSerialNumber && self.ulPriority == other.ulPriority && self.OpType == other.OpType && self.ulOptions == other.ulOptions && self.oszNamingContext == other.oszNamingContext && self.oszDsaDN == other.oszDsaDN && self.oszDsaAddress == other.oszDsaAddress && self.uuidNamingContextObjGuid == other.uuidNamingContextObjGuid && self.uuidDsaObjGuid == other.uuidDsaObjGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17431,7 +17411,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_PENDING_OPSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_PENDING_OPSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_PENDING_OPSW>()) == 0 }
+        self.ftimeCurrentOpStarted == other.ftimeCurrentOpStarted && self.cNumPendingOps == other.cNumPendingOps && self.rgPendingOp == other.rgPendingOp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17475,7 +17455,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_QUEUE_STATISTICSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_QUEUE_STATISTICSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_QUEUE_STATISTICSW>()) == 0 }
+        self.ftimeCurrentOpStarted == other.ftimeCurrentOpStarted && self.cNumPendingOps == other.cNumPendingOps && self.ftimeOldestSync == other.ftimeOldestSync && self.ftimeOldestAdd == other.ftimeOldestAdd && self.ftimeOldestMod == other.ftimeOldestMod && self.ftimeOldestDel == other.ftimeOldestDel && self.ftimeOldestUpdRefs == other.ftimeOldestUpdRefs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17535,7 +17515,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_VALUE_META_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_VALUE_META_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_VALUE_META_DATA>()) == 0 }
+        self.pszAttributeName == other.pszAttributeName && self.pszObjectDn == other.pszObjectDn && self.cbData == other.cbData && self.pbData == other.pbData && self.ftimeDeleted == other.ftimeDeleted && self.ftimeCreated == other.ftimeCreated && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17597,7 +17577,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_VALUE_META_DATA_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_VALUE_META_DATA_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_VALUE_META_DATA_2>()) == 0 }
+        self.pszAttributeName == other.pszAttributeName && self.pszObjectDn == other.pszObjectDn && self.cbData == other.cbData && self.pbData == other.pbData && self.ftimeDeleted == other.ftimeDeleted && self.ftimeCreated == other.ftimeCreated && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.pszLastOriginatingDsaDN == other.pszLastOriginatingDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17659,7 +17639,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_VALUE_META_DATA_BLOB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_VALUE_META_DATA_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_VALUE_META_DATA_BLOB>()) == 0 }
+        self.oszAttributeName == other.oszAttributeName && self.oszObjectDn == other.oszObjectDn && self.cbData == other.cbData && self.obData == other.obData && self.ftimeDeleted == other.ftimeDeleted && self.ftimeCreated == other.ftimeCreated && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.oszLastOriginatingDsaDN == other.oszLastOriginatingDsaDN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17727,7 +17707,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_VALUE_META_DATA_BLOB_EXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_VALUE_META_DATA_BLOB_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_VALUE_META_DATA_BLOB_EXT>()) == 0 }
+        self.oszAttributeName == other.oszAttributeName && self.oszObjectDn == other.oszObjectDn && self.cbData == other.cbData && self.obData == other.obData && self.ftimeDeleted == other.ftimeDeleted && self.ftimeCreated == other.ftimeCreated && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.oszLastOriginatingDsaDN == other.oszLastOriginatingDsaDN && self.dwUserIdentifier == other.dwUserIdentifier && self.dwPriorLinkState == other.dwPriorLinkState && self.dwCurrentLinkState == other.dwCurrentLinkState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17795,7 +17775,7 @@ unsafe impl ::windows::core::Abi for DS_REPL_VALUE_META_DATA_EXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DS_REPL_VALUE_META_DATA_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPL_VALUE_META_DATA_EXT>()) == 0 }
+        self.pszAttributeName == other.pszAttributeName && self.pszObjectDn == other.pszObjectDn && self.cbData == other.cbData && self.pbData == other.pbData && self.ftimeDeleted == other.ftimeDeleted && self.ftimeCreated == other.ftimeCreated && self.dwVersion == other.dwVersion && self.ftimeLastOriginatingChange == other.ftimeLastOriginatingChange && self.uuidLastOriginatingDsaInvocationID == other.uuidLastOriginatingDsaInvocationID && self.usnOriginatingChange == other.usnOriginatingChange && self.usnLocalChange == other.usnLocalChange && self.pszLastOriginatingDsaDN == other.pszLastOriginatingDsaDN && self.dwUserIdentifier == other.dwUserIdentifier && self.dwPriorLinkState == other.dwPriorLinkState && self.dwCurrentLinkState == other.dwCurrentLinkState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17830,7 +17810,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_ERRINFOA {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_ERRINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_ERRINFOA>()) == 0 }
+        self.pszSvrId == other.pszSvrId && self.error == other.error && self.dwWin32Err == other.dwWin32Err && self.pszSrcId == other.pszSrcId
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_ERRINFOA {}
@@ -17863,7 +17843,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_ERRINFOW {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_ERRINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_ERRINFOW>()) == 0 }
+        self.pszSvrId == other.pszSvrId && self.error == other.error && self.dwWin32Err == other.dwWin32Err && self.pszSrcId == other.pszSrcId
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_ERRINFOW {}
@@ -17897,7 +17877,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_SYNCA {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_SYNCA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_SYNCA>()) == 0 }
+        self.pszSrcId == other.pszSrcId && self.pszDstId == other.pszDstId && self.pszNC == other.pszNC && self.pguidSrc == other.pguidSrc && self.pguidDst == other.pguidDst
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_SYNCA {}
@@ -17931,7 +17911,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_SYNCW {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_SYNCW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_SYNCW>()) == 0 }
+        self.pszSrcId == other.pszSrcId && self.pszDstId == other.pszDstId && self.pszNC == other.pszNC && self.pguidSrc == other.pguidSrc && self.pguidDst == other.pguidDst
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_SYNCW {}
@@ -17963,7 +17943,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_UPDATEA {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_UPDATEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_UPDATEA>()) == 0 }
+        self.event == other.event && self.pErrInfo == other.pErrInfo && self.pSync == other.pSync
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_UPDATEA {}
@@ -17995,7 +17975,7 @@ unsafe impl ::windows::core::Abi for DS_REPSYNCALL_UPDATEW {
 }
 impl ::core::cmp::PartialEq for DS_REPSYNCALL_UPDATEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_REPSYNCALL_UPDATEW>()) == 0 }
+        self.event == other.event && self.pErrInfo == other.pErrInfo && self.pSync == other.pSync
     }
 }
 impl ::core::cmp::Eq for DS_REPSYNCALL_UPDATEW {}
@@ -18027,7 +18007,7 @@ unsafe impl ::windows::core::Abi for DS_SCHEMA_GUID_MAPA {
 }
 impl ::core::cmp::PartialEq for DS_SCHEMA_GUID_MAPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_SCHEMA_GUID_MAPA>()) == 0 }
+        self.guid == other.guid && self.guidType == other.guidType && self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DS_SCHEMA_GUID_MAPA {}
@@ -18059,7 +18039,7 @@ unsafe impl ::windows::core::Abi for DS_SCHEMA_GUID_MAPW {
 }
 impl ::core::cmp::PartialEq for DS_SCHEMA_GUID_MAPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_SCHEMA_GUID_MAPW>()) == 0 }
+        self.guid == other.guid && self.guidType == other.guidType && self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for DS_SCHEMA_GUID_MAPW {}
@@ -18100,7 +18080,7 @@ unsafe impl ::windows::core::Abi for DS_SELECTION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for DS_SELECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_SELECTION>()) == 0 }
+        self.pwzName == other.pwzName && self.pwzADsPath == other.pwzADsPath && self.pwzClass == other.pwzClass && self.pwzUPN == other.pwzUPN && self.pvarFetchedAttributes == other.pvarFetchedAttributes && self.flScopeType == other.flScopeType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -18140,7 +18120,7 @@ unsafe impl ::windows::core::Abi for DS_SELECTION_LIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for DS_SELECTION_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_SELECTION_LIST>()) == 0 }
+        self.cItems == other.cItems && self.cFetchedAttributes == other.cFetchedAttributes && self.aDsSelection == other.aDsSelection
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -18173,7 +18153,7 @@ unsafe impl ::windows::core::Abi for DS_SITE_COST_INFO {
 }
 impl ::core::cmp::PartialEq for DS_SITE_COST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DS_SITE_COST_INFO>()) == 0 }
+        self.errorCode == other.errorCode && self.cost == other.cost
     }
 }
 impl ::core::cmp::Eq for DS_SITE_COST_INFO {}
@@ -18245,14 +18225,6 @@ unsafe impl ::windows::core::Abi for OPENQUERYWINDOW {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::PartialEq for OPENQUERYWINDOW {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.clsidHandler == other.clsidHandler && self.pHandlerParameters == other.pHandlerParameters && self.clsidDefaultForm == other.clsidDefaultForm && self.pPersistQuery == other.pPersistQuery && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::Eq for OPENQUERYWINDOW {}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::default::Default for OPENQUERYWINDOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18275,14 +18247,6 @@ impl ::core::clone::Clone for OPENQUERYWINDOW_0 {
 unsafe impl ::windows::core::Abi for OPENQUERYWINDOW_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::PartialEq for OPENQUERYWINDOW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENQUERYWINDOW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::Eq for OPENQUERYWINDOW_0 {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::default::Default for OPENQUERYWINDOW_0 {
     fn default() -> Self {
@@ -18313,7 +18277,7 @@ unsafe impl ::windows::core::Abi for SCHEDULE {
 }
 impl ::core::cmp::PartialEq for SCHEDULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHEDULE>()) == 0 }
+        self.Size == other.Size && self.Bandwidth == other.Bandwidth && self.NumberOfSchedules == other.NumberOfSchedules && self.Schedules == other.Schedules
     }
 }
 impl ::core::cmp::Eq for SCHEDULE {}
@@ -18344,7 +18308,7 @@ unsafe impl ::windows::core::Abi for SCHEDULE_HEADER {
 }
 impl ::core::cmp::PartialEq for SCHEDULE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHEDULE_HEADER>()) == 0 }
+        self.Type == other.Type && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for SCHEDULE_HEADER {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
@@ -4174,12 +4174,6 @@ impl ::core::clone::Clone for BG_AUTH_CREDENTIALS {
 unsafe impl ::windows::core::Abi for BG_AUTH_CREDENTIALS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BG_AUTH_CREDENTIALS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_AUTH_CREDENTIALS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BG_AUTH_CREDENTIALS {}
 impl ::core::default::Default for BG_AUTH_CREDENTIALS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4199,12 +4193,6 @@ impl ::core::clone::Clone for BG_AUTH_CREDENTIALS_UNION {
 unsafe impl ::windows::core::Abi for BG_AUTH_CREDENTIALS_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BG_AUTH_CREDENTIALS_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_AUTH_CREDENTIALS_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BG_AUTH_CREDENTIALS_UNION {}
 impl ::core::default::Default for BG_AUTH_CREDENTIALS_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4232,7 +4220,7 @@ unsafe impl ::windows::core::Abi for BG_BASIC_CREDENTIALS {
 }
 impl ::core::cmp::PartialEq for BG_BASIC_CREDENTIALS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_BASIC_CREDENTIALS>()) == 0 }
+        self.UserName == other.UserName && self.Password == other.Password
     }
 }
 impl ::core::cmp::Eq for BG_BASIC_CREDENTIALS {}
@@ -4263,7 +4251,7 @@ unsafe impl ::windows::core::Abi for BG_FILE_INFO {
 }
 impl ::core::cmp::PartialEq for BG_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_FILE_INFO>()) == 0 }
+        self.RemoteName == other.RemoteName && self.LocalName == other.LocalName
     }
 }
 impl ::core::cmp::Eq for BG_FILE_INFO {}
@@ -4301,7 +4289,7 @@ unsafe impl ::windows::core::Abi for BG_FILE_PROGRESS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BG_FILE_PROGRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_FILE_PROGRESS>()) == 0 }
+        self.BytesTotal == other.BytesTotal && self.BytesTransferred == other.BytesTransferred && self.Completed == other.Completed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4334,7 +4322,7 @@ unsafe impl ::windows::core::Abi for BG_FILE_RANGE {
 }
 impl ::core::cmp::PartialEq for BG_FILE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_FILE_RANGE>()) == 0 }
+        self.InitialOffset == other.InitialOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for BG_FILE_RANGE {}
@@ -4367,7 +4355,7 @@ unsafe impl ::windows::core::Abi for BG_JOB_PROGRESS {
 }
 impl ::core::cmp::PartialEq for BG_JOB_PROGRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_JOB_PROGRESS>()) == 0 }
+        self.BytesTotal == other.BytesTotal && self.BytesTransferred == other.BytesTransferred && self.FilesTotal == other.FilesTotal && self.FilesTransferred == other.FilesTransferred
     }
 }
 impl ::core::cmp::Eq for BG_JOB_PROGRESS {}
@@ -4398,7 +4386,7 @@ unsafe impl ::windows::core::Abi for BG_JOB_REPLY_PROGRESS {
 }
 impl ::core::cmp::PartialEq for BG_JOB_REPLY_PROGRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_JOB_REPLY_PROGRESS>()) == 0 }
+        self.BytesTotal == other.BytesTotal && self.BytesTransferred == other.BytesTransferred
     }
 }
 impl ::core::cmp::Eq for BG_JOB_REPLY_PROGRESS {}
@@ -4436,7 +4424,7 @@ unsafe impl ::windows::core::Abi for BG_JOB_TIMES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BG_JOB_TIMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BG_JOB_TIMES>()) == 0 }
+        self.CreationTime == other.CreationTime && self.ModificationTime == other.ModificationTime && self.TransferCompletionTime == other.TransferCompletionTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4461,12 +4449,6 @@ impl ::core::clone::Clone for BITS_FILE_PROPERTY_VALUE {
 unsafe impl ::windows::core::Abi for BITS_FILE_PROPERTY_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BITS_FILE_PROPERTY_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITS_FILE_PROPERTY_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for BITS_FILE_PROPERTY_VALUE {}
 impl ::core::default::Default for BITS_FILE_PROPERTY_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4494,14 +4476,6 @@ impl ::core::clone::Clone for BITS_JOB_PROPERTY_VALUE {
 unsafe impl ::windows::core::Abi for BITS_JOB_PROPERTY_VALUE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for BITS_JOB_PROPERTY_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITS_JOB_PROPERTY_VALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for BITS_JOB_PROPERTY_VALUE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for BITS_JOB_PROPERTY_VALUE {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -13413,37 +13413,13 @@ impl ::core::clone::Clone for CLRES_CALLBACK_FUNCTION_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CLRES_CALLBACK_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CLRES_CALLBACK_FUNCTION_TABLE")
-            .field("LogEvent", &self.LogEvent.map(|f| f as usize))
-            .field("SetResourceStatusEx", &self.SetResourceStatusEx.map(|f| f as usize))
-            .field("SetResourceLockedMode", &self.SetResourceLockedMode.map(|f| f as usize))
-            .field("SignalFailure", &self.SignalFailure.map(|f| f as usize))
-            .field("SetResourceInMemoryNodeLocalProperties", &self.SetResourceInMemoryNodeLocalProperties.map(|f| f as usize))
-            .field("EndControlCall", &self.EndControlCall.map(|f| f as usize))
-            .field("EndTypeControlCall", &self.EndTypeControlCall.map(|f| f as usize))
-            .field("ExtendControlCall", &self.ExtendControlCall.map(|f| f as usize))
-            .field("ExtendTypeControlCall", &self.ExtendTypeControlCall.map(|f| f as usize))
-            .field("RaiseResTypeNotification", &self.RaiseResTypeNotification.map(|f| f as usize))
-            .field("ChangeResourceProcessForDumps", &self.ChangeResourceProcessForDumps.map(|f| f as usize))
-            .field("ChangeResTypeProcessForDumps", &self.ChangeResTypeProcessForDumps.map(|f| f as usize))
-            .field("SetInternalState", &self.SetInternalState.map(|f| f as usize))
-            .field("SetResourceLockedModeEx", &self.SetResourceLockedModeEx.map(|f| f as usize))
-            .field("RequestDump", &self.RequestDump.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CLRES_CALLBACK_FUNCTION_TABLE").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CLRES_CALLBACK_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CLRES_CALLBACK_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_CALLBACK_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CLRES_CALLBACK_FUNCTION_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CLRES_CALLBACK_FUNCTION_TABLE {
     fn default() -> Self {
@@ -13471,14 +13447,6 @@ unsafe impl ::windows::core::Abi for CLRES_FUNCTION_TABLE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_FUNCTION_TABLE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_FUNCTION_TABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13505,14 +13473,6 @@ impl ::core::clone::Clone for CLRES_FUNCTION_TABLE_0 {
 unsafe impl ::windows::core::Abi for CLRES_FUNCTION_TABLE_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_FUNCTION_TABLE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_FUNCTION_TABLE_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_FUNCTION_TABLE_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_FUNCTION_TABLE_0 {
     fn default() -> Self {
@@ -13546,33 +13506,13 @@ impl ::core::clone::Clone for CLRES_V1_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::fmt::Debug for CLRES_V1_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CLRES_V1_FUNCTIONS")
-            .field("Open", &self.Open.map(|f| f as usize))
-            .field("Close", &self.Close.map(|f| f as usize))
-            .field("Online", &self.Online.map(|f| f as usize))
-            .field("Offline", &self.Offline.map(|f| f as usize))
-            .field("Terminate", &self.Terminate.map(|f| f as usize))
-            .field("LooksAlive", &self.LooksAlive.map(|f| f as usize))
-            .field("IsAlive", &self.IsAlive.map(|f| f as usize))
-            .field("Arbitrate", &self.Arbitrate.map(|f| f as usize))
-            .field("Release", &self.Release.map(|f| f as usize))
-            .field("ResourceControl", &self.ResourceControl.map(|f| f as usize))
-            .field("ResourceTypeControl", &self.ResourceTypeControl.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CLRES_V1_FUNCTIONS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 unsafe impl ::windows::core::Abi for CLRES_V1_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_V1_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_V1_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_V1_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_V1_FUNCTIONS {
     fn default() -> Self {
@@ -13607,34 +13547,13 @@ impl ::core::clone::Clone for CLRES_V2_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::fmt::Debug for CLRES_V2_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CLRES_V2_FUNCTIONS")
-            .field("Open", &self.Open.map(|f| f as usize))
-            .field("Close", &self.Close.map(|f| f as usize))
-            .field("Online", &self.Online.map(|f| f as usize))
-            .field("Offline", &self.Offline.map(|f| f as usize))
-            .field("Terminate", &self.Terminate.map(|f| f as usize))
-            .field("LooksAlive", &self.LooksAlive.map(|f| f as usize))
-            .field("IsAlive", &self.IsAlive.map(|f| f as usize))
-            .field("Arbitrate", &self.Arbitrate.map(|f| f as usize))
-            .field("Release", &self.Release.map(|f| f as usize))
-            .field("ResourceControl", &self.ResourceControl.map(|f| f as usize))
-            .field("ResourceTypeControl", &self.ResourceTypeControl.map(|f| f as usize))
-            .field("Cancel", &self.Cancel.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CLRES_V2_FUNCTIONS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 unsafe impl ::windows::core::Abi for CLRES_V2_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_V2_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_V2_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_V2_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_V2_FUNCTIONS {
     fn default() -> Self {
@@ -13669,34 +13588,13 @@ impl ::core::clone::Clone for CLRES_V3_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::fmt::Debug for CLRES_V3_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CLRES_V3_FUNCTIONS")
-            .field("Open", &self.Open.map(|f| f as usize))
-            .field("Close", &self.Close.map(|f| f as usize))
-            .field("Online", &self.Online.map(|f| f as usize))
-            .field("Offline", &self.Offline.map(|f| f as usize))
-            .field("Terminate", &self.Terminate.map(|f| f as usize))
-            .field("LooksAlive", &self.LooksAlive.map(|f| f as usize))
-            .field("IsAlive", &self.IsAlive.map(|f| f as usize))
-            .field("Arbitrate", &self.Arbitrate.map(|f| f as usize))
-            .field("Release", &self.Release.map(|f| f as usize))
-            .field("BeginResourceControl", &self.BeginResourceControl.map(|f| f as usize))
-            .field("BeginResourceTypeControl", &self.BeginResourceTypeControl.map(|f| f as usize))
-            .field("Cancel", &self.Cancel.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CLRES_V3_FUNCTIONS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 unsafe impl ::windows::core::Abi for CLRES_V3_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_V3_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_V3_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_V3_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_V3_FUNCTIONS {
     fn default() -> Self {
@@ -13733,36 +13631,13 @@ impl ::core::clone::Clone for CLRES_V4_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::fmt::Debug for CLRES_V4_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CLRES_V4_FUNCTIONS")
-            .field("Open", &self.Open.map(|f| f as usize))
-            .field("Close", &self.Close.map(|f| f as usize))
-            .field("Online", &self.Online.map(|f| f as usize))
-            .field("Offline", &self.Offline.map(|f| f as usize))
-            .field("Terminate", &self.Terminate.map(|f| f as usize))
-            .field("LooksAlive", &self.LooksAlive.map(|f| f as usize))
-            .field("IsAlive", &self.IsAlive.map(|f| f as usize))
-            .field("Arbitrate", &self.Arbitrate.map(|f| f as usize))
-            .field("Release", &self.Release.map(|f| f as usize))
-            .field("BeginResourceControl", &self.BeginResourceControl.map(|f| f as usize))
-            .field("BeginResourceTypeControl", &self.BeginResourceTypeControl.map(|f| f as usize))
-            .field("Cancel", &self.Cancel.map(|f| f as usize))
-            .field("BeginResourceControlAsUser", &self.BeginResourceControlAsUser.map(|f| f as usize))
-            .field("BeginResourceTypeControlAsUser", &self.BeginResourceTypeControlAsUser.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CLRES_V4_FUNCTIONS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 unsafe impl ::windows::core::Abi for CLRES_V4_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for CLRES_V4_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLRES_V4_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for CLRES_V4_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for CLRES_V4_FUNCTIONS {
     fn default() -> Self {
@@ -13798,7 +13673,7 @@ unsafe impl ::windows::core::Abi for CLUSCTL_GROUP_GET_LAST_MOVE_TIME_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUSCTL_GROUP_GET_LAST_MOVE_TIME_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSCTL_GROUP_GET_LAST_MOVE_TIME_OUTPUT>()) == 0 }
+        self.GetTickCount64 == other.GetTickCount64 && self.GetSystemTime == other.GetSystemTime && self.NodeId == other.NodeId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13832,7 +13707,7 @@ unsafe impl ::windows::core::Abi for CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT
 }
 impl ::core::cmp::PartialEq for CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVersion == other.dwVersion && self.eReason == other.eReason
     }
 }
 impl ::core::cmp::Eq for CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT {}
@@ -13863,7 +13738,7 @@ unsafe impl ::windows::core::Abi for CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE
 }
 impl ::core::cmp::PartialEq for CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INPUT>()) == 0 }
+        self.dwFlags == other.dwFlags && self.guidPoolFilter == other.guidPoolFilter
     }
 }
 impl ::core::cmp::Eq for CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INPUT {}
@@ -13887,12 +13762,6 @@ impl ::core::clone::Clone for CLUSPROP_BINARY {
 unsafe impl ::windows::core::Abi for CLUSPROP_BINARY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_BINARY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_BINARY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_BINARY {}
 impl ::core::default::Default for CLUSPROP_BINARY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13944,14 +13813,6 @@ unsafe impl ::windows::core::Abi for CLUSPROP_BUFFER_HELPER {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for CLUSPROP_BUFFER_HELPER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_BUFFER_HELPER>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for CLUSPROP_BUFFER_HELPER {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for CLUSPROP_BUFFER_HELPER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13972,12 +13833,6 @@ impl ::core::clone::Clone for CLUSPROP_DWORD {
 unsafe impl ::windows::core::Abi for CLUSPROP_DWORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_DWORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_DWORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_DWORD {}
 impl ::core::default::Default for CLUSPROP_DWORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14003,14 +13858,6 @@ unsafe impl ::windows::core::Abi for CLUSPROP_FILETIME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CLUSPROP_FILETIME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_FILETIME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CLUSPROP_FILETIME {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CLUSPROP_FILETIME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14031,12 +13878,6 @@ impl ::core::clone::Clone for CLUSPROP_FTSET_INFO {
 unsafe impl ::windows::core::Abi for CLUSPROP_FTSET_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_FTSET_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_FTSET_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_FTSET_INFO {}
 impl ::core::default::Default for CLUSPROP_FTSET_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14057,12 +13898,6 @@ impl ::core::clone::Clone for CLUSPROP_LARGE_INTEGER {
 unsafe impl ::windows::core::Abi for CLUSPROP_LARGE_INTEGER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_LARGE_INTEGER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_LARGE_INTEGER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_LARGE_INTEGER {}
 impl ::core::default::Default for CLUSPROP_LARGE_INTEGER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14083,12 +13918,6 @@ impl ::core::clone::Clone for CLUSPROP_LIST {
 unsafe impl ::windows::core::Abi for CLUSPROP_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_LIST {}
 impl ::core::default::Default for CLUSPROP_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14109,12 +13938,6 @@ impl ::core::clone::Clone for CLUSPROP_LONG {
 unsafe impl ::windows::core::Abi for CLUSPROP_LONG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_LONG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_LONG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_LONG {}
 impl ::core::default::Default for CLUSPROP_LONG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14135,12 +13958,6 @@ impl ::core::clone::Clone for CLUSPROP_PARTITION_INFO {
 unsafe impl ::windows::core::Abi for CLUSPROP_PARTITION_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_PARTITION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_PARTITION_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_PARTITION_INFO {}
 impl ::core::default::Default for CLUSPROP_PARTITION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14161,12 +13978,6 @@ impl ::core::clone::Clone for CLUSPROP_PARTITION_INFO_EX {
 unsafe impl ::windows::core::Abi for CLUSPROP_PARTITION_INFO_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_PARTITION_INFO_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_PARTITION_INFO_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_PARTITION_INFO_EX {}
 impl ::core::default::Default for CLUSPROP_PARTITION_INFO_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14187,12 +13998,6 @@ impl ::core::clone::Clone for CLUSPROP_PARTITION_INFO_EX2 {
 unsafe impl ::windows::core::Abi for CLUSPROP_PARTITION_INFO_EX2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_PARTITION_INFO_EX2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_PARTITION_INFO_EX2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_PARTITION_INFO_EX2 {}
 impl ::core::default::Default for CLUSPROP_PARTITION_INFO_EX2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14214,12 +14019,6 @@ impl ::core::clone::Clone for CLUSPROP_REQUIRED_DEPENDENCY {
 unsafe impl ::windows::core::Abi for CLUSPROP_REQUIRED_DEPENDENCY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_REQUIRED_DEPENDENCY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_REQUIRED_DEPENDENCY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_REQUIRED_DEPENDENCY {}
 impl ::core::default::Default for CLUSPROP_REQUIRED_DEPENDENCY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14240,12 +14039,6 @@ impl ::core::clone::Clone for CLUSPROP_RESOURCE_CLASS {
 unsafe impl ::windows::core::Abi for CLUSPROP_RESOURCE_CLASS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_RESOURCE_CLASS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_RESOURCE_CLASS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_RESOURCE_CLASS {}
 impl ::core::default::Default for CLUSPROP_RESOURCE_CLASS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14266,12 +14059,6 @@ impl ::core::clone::Clone for CLUSPROP_RESOURCE_CLASS_INFO {
 unsafe impl ::windows::core::Abi for CLUSPROP_RESOURCE_CLASS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_RESOURCE_CLASS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_RESOURCE_CLASS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_RESOURCE_CLASS_INFO {}
 impl ::core::default::Default for CLUSPROP_RESOURCE_CLASS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14292,12 +14079,6 @@ impl ::core::clone::Clone for CLUSPROP_SCSI_ADDRESS {
 unsafe impl ::windows::core::Abi for CLUSPROP_SCSI_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_SCSI_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SCSI_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_SCSI_ADDRESS {}
 impl ::core::default::Default for CLUSPROP_SCSI_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14322,14 +14103,6 @@ impl ::core::clone::Clone for CLUSPROP_SECURITY_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for CLUSPROP_SECURITY_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::PartialEq for CLUSPROP_SECURITY_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SECURITY_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::Eq for CLUSPROP_SECURITY_DESCRIPTOR {}
 #[cfg(feature = "Win32_System_SystemServices")]
 impl ::core::default::Default for CLUSPROP_SECURITY_DESCRIPTOR {
     fn default() -> Self {
@@ -14356,14 +14129,6 @@ unsafe impl ::windows::core::Abi for CLUSPROP_SECURITY_DESCRIPTOR_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::PartialEq for CLUSPROP_SECURITY_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SECURITY_DESCRIPTOR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::Eq for CLUSPROP_SECURITY_DESCRIPTOR_0 {}
-#[cfg(feature = "Win32_System_SystemServices")]
 impl ::core::default::Default for CLUSPROP_SECURITY_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14384,12 +14149,6 @@ impl ::core::clone::Clone for CLUSPROP_SYNTAX {
 unsafe impl ::windows::core::Abi for CLUSPROP_SYNTAX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_SYNTAX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SYNTAX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_SYNTAX {}
 impl ::core::default::Default for CLUSPROP_SYNTAX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14417,7 +14176,7 @@ unsafe impl ::windows::core::Abi for CLUSPROP_SYNTAX_0 {
 }
 impl ::core::cmp::PartialEq for CLUSPROP_SYNTAX_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SYNTAX_0>()) == 0 }
+        self.wFormat == other.wFormat && self.wType == other.wType
     }
 }
 impl ::core::cmp::Eq for CLUSPROP_SYNTAX_0 {}
@@ -14441,12 +14200,6 @@ impl ::core::clone::Clone for CLUSPROP_SZ {
 unsafe impl ::windows::core::Abi for CLUSPROP_SZ {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_SZ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_SZ>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_SZ {}
 impl ::core::default::Default for CLUSPROP_SZ {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14467,12 +14220,6 @@ impl ::core::clone::Clone for CLUSPROP_ULARGE_INTEGER {
 unsafe impl ::windows::core::Abi for CLUSPROP_ULARGE_INTEGER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_ULARGE_INTEGER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_ULARGE_INTEGER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_ULARGE_INTEGER {}
 impl ::core::default::Default for CLUSPROP_ULARGE_INTEGER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14493,12 +14240,6 @@ impl ::core::clone::Clone for CLUSPROP_VALUE {
 unsafe impl ::windows::core::Abi for CLUSPROP_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_VALUE {}
 impl ::core::default::Default for CLUSPROP_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14519,12 +14260,6 @@ impl ::core::clone::Clone for CLUSPROP_WORD {
 unsafe impl ::windows::core::Abi for CLUSPROP_WORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSPROP_WORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSPROP_WORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSPROP_WORD {}
 impl ::core::default::Default for CLUSPROP_WORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14571,7 +14306,7 @@ unsafe impl ::windows::core::Abi for CLUSTERVERSIONINFO {
 }
 impl ::core::cmp::PartialEq for CLUSTERVERSIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTERVERSIONINFO>()) == 0 }
+        self.dwVersionInfoSize == other.dwVersionInfoSize && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.BuildNumber == other.BuildNumber && self.szVendorId == other.szVendorId && self.szCSDVersion == other.szCSDVersion && self.dwClusterHighestVersion == other.dwClusterHighestVersion && self.dwClusterLowestVersion == other.dwClusterLowestVersion && self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for CLUSTERVERSIONINFO {}
@@ -14606,7 +14341,7 @@ unsafe impl ::windows::core::Abi for CLUSTERVERSIONINFO_NT4 {
 }
 impl ::core::cmp::PartialEq for CLUSTERVERSIONINFO_NT4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTERVERSIONINFO_NT4>()) == 0 }
+        self.dwVersionInfoSize == other.dwVersionInfoSize && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.BuildNumber == other.BuildNumber && self.szVendorId == other.szVendorId && self.szCSDVersion == other.szCSDVersion
     }
 }
 impl ::core::cmp::Eq for CLUSTERVERSIONINFO_NT4 {}
@@ -14645,7 +14380,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_AVAILABILITY_SET_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUSTER_AVAILABILITY_SET_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_AVAILABILITY_SET_CONFIG>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwUpdateDomains == other.dwUpdateDomains && self.dwFaultDomains == other.dwFaultDomains && self.bReserveSpareNode == other.bReserveSpareNode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14681,7 +14416,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_BATCH_COMMAND {
 }
 impl ::core::cmp::PartialEq for CLUSTER_BATCH_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_BATCH_COMMAND>()) == 0 }
+        self.Command == other.Command && self.dwOptions == other.dwOptions && self.wzName == other.wzName && self.lpData == other.lpData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for CLUSTER_BATCH_COMMAND {}
@@ -14712,7 +14447,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_CREATE_GROUP_INFO {
 }
 impl ::core::cmp::PartialEq for CLUSTER_CREATE_GROUP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_CREATE_GROUP_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.groupType == other.groupType
     }
 }
 impl ::core::cmp::Eq for CLUSTER_CREATE_GROUP_INFO {}
@@ -14747,7 +14482,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_ENUM_ITEM {
 }
 impl ::core::cmp::PartialEq for CLUSTER_ENUM_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_ENUM_ITEM>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwType == other.dwType && self.cbId == other.cbId && self.lpszId == other.lpszId && self.cbName == other.cbName && self.lpszName == other.lpszName
     }
 }
 impl ::core::cmp::Eq for CLUSTER_ENUM_ITEM {}
@@ -14803,7 +14538,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_GROUP_ENUM_ITEM {
 }
 impl ::core::cmp::PartialEq for CLUSTER_GROUP_ENUM_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_GROUP_ENUM_ITEM>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbId == other.cbId && self.lpszId == other.lpszId && self.cbName == other.cbName && self.lpszName == other.lpszName && self.state == other.state && self.cbOwnerNode == other.cbOwnerNode && self.lpszOwnerNode == other.lpszOwnerNode && self.dwFlags == other.dwFlags && self.cbProperties == other.cbProperties && self.pProperties == other.pProperties && self.cbRoProperties == other.cbRoProperties && self.pRoProperties == other.pRoProperties
     }
 }
 impl ::core::cmp::Eq for CLUSTER_GROUP_ENUM_ITEM {}
@@ -14839,7 +14574,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_HEALTH_FAULT {
 }
 impl ::core::cmp::PartialEq for CLUSTER_HEALTH_FAULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_HEALTH_FAULT>()) == 0 }
+        self.Id == other.Id && self.ErrorType == other.ErrorType && self.ErrorCode == other.ErrorCode && self.Description == other.Description && self.Provider == other.Provider && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for CLUSTER_HEALTH_FAULT {}
@@ -14870,7 +14605,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_HEALTH_FAULT_ARRAY {
 }
 impl ::core::cmp::PartialEq for CLUSTER_HEALTH_FAULT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_HEALTH_FAULT_ARRAY>()) == 0 }
+        self.numFaults == other.numFaults && self.faults == other.faults
     }
 }
 impl ::core::cmp::Eq for CLUSTER_HEALTH_FAULT_ARRAY {}
@@ -14901,7 +14636,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_IP_ENTRY {
 }
 impl ::core::cmp::PartialEq for CLUSTER_IP_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_IP_ENTRY>()) == 0 }
+        self.lpszIpAddress == other.lpszIpAddress && self.dwPrefixLength == other.dwPrefixLength
     }
 }
 impl ::core::cmp::Eq for CLUSTER_IP_ENTRY {}
@@ -14939,7 +14674,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_MEMBERSHIP_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUSTER_MEMBERSHIP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_MEMBERSHIP_INFO>()) == 0 }
+        self.HasQuorum == other.HasQuorum && self.UpnodesSize == other.UpnodesSize && self.Upnodes == other.Upnodes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14976,7 +14711,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_READ_BATCH_COMMAND {
 }
 impl ::core::cmp::PartialEq for CLUSTER_READ_BATCH_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_READ_BATCH_COMMAND>()) == 0 }
+        self.Command == other.Command && self.dwOptions == other.dwOptions && self.wzSubkeyName == other.wzSubkeyName && self.wzValueName == other.wzValueName && self.lpData == other.lpData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for CLUSTER_READ_BATCH_COMMAND {}
@@ -15032,7 +14767,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_RESOURCE_ENUM_ITEM {
 }
 impl ::core::cmp::PartialEq for CLUSTER_RESOURCE_ENUM_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_RESOURCE_ENUM_ITEM>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbId == other.cbId && self.lpszId == other.lpszId && self.cbName == other.cbName && self.lpszName == other.lpszName && self.cbOwnerGroupName == other.cbOwnerGroupName && self.lpszOwnerGroupName == other.lpszOwnerGroupName && self.cbOwnerGroupId == other.cbOwnerGroupId && self.lpszOwnerGroupId == other.lpszOwnerGroupId && self.cbProperties == other.cbProperties && self.pProperties == other.pProperties && self.cbRoProperties == other.cbRoProperties && self.pRoProperties == other.pRoProperties
     }
 }
 impl ::core::cmp::Eq for CLUSTER_RESOURCE_ENUM_ITEM {}
@@ -15070,7 +14805,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_SET_PASSWORD_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUSTER_SET_PASSWORD_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SET_PASSWORD_STATUS>()) == 0 }
+        self.NodeId == other.NodeId && self.SetAttempted == other.SetAttempted && self.ReturnStatus == other.ReturnStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15096,12 +14831,6 @@ impl ::core::clone::Clone for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
 unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {}
 impl ::core::default::Default for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15122,12 +14851,6 @@ impl ::core::clone::Clone for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
 unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_INPUT {}
 impl ::core::default::Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15155,7 +14878,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAM
 }
 impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAME>()) == 0 }
+        self.NewVolumeName == other.NewVolumeName && self.NewVolumeGuid == other.NewVolumeGuid
     }
 }
 impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAME {}
@@ -15185,7 +14908,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {
 }
 impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME>()) == 0 }
+        self.NewVolumeName == other.NewVolumeName
     }
 }
 impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {}
@@ -15209,12 +14932,6 @@ impl ::core::clone::Clone for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
 unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {}
 impl ::core::default::Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15237,12 +14954,6 @@ impl ::core::clone::Clone for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
 unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {}
 impl ::core::default::Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15271,7 +14982,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_STATE_INFO {
 }
 impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_STATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_STATE_INFO>()) == 0 }
+        self.szVolumeName == other.szVolumeName && self.szNodeName == other.szNodeName && self.VolumeState == other.VolumeState
     }
 }
 impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_STATE_INFO {}
@@ -15306,7 +15017,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_SHARED_VOLUME_STATE_INFO_EX {
 }
 impl ::core::cmp::PartialEq for CLUSTER_SHARED_VOLUME_STATE_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_SHARED_VOLUME_STATE_INFO_EX>()) == 0 }
+        self.szVolumeName == other.szVolumeName && self.szNodeName == other.szNodeName && self.VolumeState == other.VolumeState && self.szVolumeFriendlyName == other.szVolumeFriendlyName && self.RedirectedIOReason == other.RedirectedIOReason && self.VolumeRedirectedIOReason == other.VolumeRedirectedIOReason
     }
 }
 impl ::core::cmp::Eq for CLUSTER_SHARED_VOLUME_STATE_INFO_EX {}
@@ -15336,7 +15047,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_VALIDATE_CSV_FILENAME {
 }
 impl ::core::cmp::PartialEq for CLUSTER_VALIDATE_CSV_FILENAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_VALIDATE_CSV_FILENAME>()) == 0 }
+        self.szFileName == other.szFileName
     }
 }
 impl ::core::cmp::Eq for CLUSTER_VALIDATE_CSV_FILENAME {}
@@ -15366,7 +15077,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_VALIDATE_DIRECTORY {
 }
 impl ::core::cmp::PartialEq for CLUSTER_VALIDATE_DIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_VALIDATE_DIRECTORY>()) == 0 }
+        self.szPath == other.szPath
     }
 }
 impl ::core::cmp::Eq for CLUSTER_VALIDATE_DIRECTORY {}
@@ -15396,7 +15107,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_VALIDATE_NETNAME {
 }
 impl ::core::cmp::PartialEq for CLUSTER_VALIDATE_NETNAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_VALIDATE_NETNAME>()) == 0 }
+        self.szNetworkName == other.szNetworkName
     }
 }
 impl ::core::cmp::Eq for CLUSTER_VALIDATE_NETNAME {}
@@ -15426,7 +15137,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_VALIDATE_PATH {
 }
 impl ::core::cmp::PartialEq for CLUSTER_VALIDATE_PATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_VALIDATE_PATH>()) == 0 }
+        self.szPath == other.szPath
     }
 }
 impl ::core::cmp::Eq for CLUSTER_VALIDATE_PATH {}
@@ -15459,7 +15170,7 @@ unsafe impl ::windows::core::Abi for CLUS_CHKDSK_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_CHKDSK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CHKDSK_INFO>()) == 0 }
+        self.PartitionNumber == other.PartitionNumber && self.ChkdskState == other.ChkdskState && self.FileIdCount == other.FileIdCount && self.FileIdList == other.FileIdList
     }
 }
 impl ::core::cmp::Eq for CLUS_CHKDSK_INFO {}
@@ -15489,7 +15200,7 @@ unsafe impl ::windows::core::Abi for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT
 }
 impl ::core::cmp::PartialEq for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT>()) == 0 }
+        self.FileServerName == other.FileServerName
     }
 }
 impl ::core::cmp::Eq for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT {}
@@ -15519,7 +15230,7 @@ unsafe impl ::windows::core::Abi for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPU
 }
 impl ::core::cmp::PartialEq for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT>()) == 0 }
+        self.FileServerName == other.FileServerName
     }
 }
 impl ::core::cmp::Eq for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT {}
@@ -15556,7 +15267,7 @@ unsafe impl ::windows::core::Abi for CLUS_CSV_MAINTENANCE_MODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_CSV_MAINTENANCE_MODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CSV_MAINTENANCE_MODE_INFO>()) == 0 }
+        self.InMaintenance == other.InMaintenance && self.VolumeName == other.VolumeName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15593,7 +15304,7 @@ unsafe impl ::windows::core::Abi for CLUS_CSV_VOLUME_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_CSV_VOLUME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CSV_VOLUME_INFO>()) == 0 }
+        self.VolumeOffset == other.VolumeOffset && self.PartitionNumber == other.PartitionNumber && self.FaultState == other.FaultState && self.BackupState == other.BackupState && self.szVolumeFriendlyName == other.szVolumeFriendlyName && self.szVolumeName == other.szVolumeName
     }
 }
 impl ::core::cmp::Eq for CLUS_CSV_VOLUME_INFO {}
@@ -15625,7 +15336,7 @@ unsafe impl ::windows::core::Abi for CLUS_CSV_VOLUME_NAME {
 }
 impl ::core::cmp::PartialEq for CLUS_CSV_VOLUME_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_CSV_VOLUME_NAME>()) == 0 }
+        self.VolumeOffset == other.VolumeOffset && self.szVolumeName == other.szVolumeName && self.szRootPath == other.szRootPath
     }
 }
 impl ::core::cmp::Eq for CLUS_CSV_VOLUME_NAME {}
@@ -15656,7 +15367,7 @@ unsafe impl ::windows::core::Abi for CLUS_DISK_NUMBER_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_DISK_NUMBER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_DISK_NUMBER_INFO>()) == 0 }
+        self.DiskNumber == other.DiskNumber && self.BytesPerSector == other.BytesPerSector
     }
 }
 impl ::core::cmp::Eq for CLUS_DISK_NUMBER_INFO {}
@@ -15693,7 +15404,7 @@ unsafe impl ::windows::core::Abi for CLUS_DNN_LEADER_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_DNN_LEADER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_DNN_LEADER_STATUS>()) == 0 }
+        self.IsOnline == other.IsOnline && self.IsFileServerPresent == other.IsFileServerPresent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15726,7 +15437,7 @@ unsafe impl ::windows::core::Abi for CLUS_DNN_SODAFS_CLONE_STATUS {
 }
 impl ::core::cmp::PartialEq for CLUS_DNN_SODAFS_CLONE_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_DNN_SODAFS_CLONE_STATUS>()) == 0 }
+        self.NodeId == other.NodeId && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for CLUS_DNN_SODAFS_CLONE_STATUS {}
@@ -15759,7 +15470,7 @@ unsafe impl ::windows::core::Abi for CLUS_FORCE_QUORUM_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_FORCE_QUORUM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_FORCE_QUORUM_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwNodeBitMask == other.dwNodeBitMask && self.dwMaxNumberofNodes == other.dwMaxNumberofNodes && self.multiszNodeList == other.multiszNodeList
     }
 }
 impl ::core::cmp::Eq for CLUS_FORCE_QUORUM_INFO {}
@@ -15790,7 +15501,7 @@ unsafe impl ::windows::core::Abi for CLUS_FTSET_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_FTSET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_FTSET_INFO>()) == 0 }
+        self.dwRootSignature == other.dwRootSignature && self.dwFtType == other.dwFtType
     }
 }
 impl ::core::cmp::Eq for CLUS_FTSET_INFO {}
@@ -15826,7 +15537,7 @@ unsafe impl ::windows::core::Abi for CLUS_MAINTENANCE_MODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_MAINTENANCE_MODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_MAINTENANCE_MODE_INFO>()) == 0 }
+        self.InMaintenance == other.InMaintenance
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15867,7 +15578,7 @@ unsafe impl ::windows::core::Abi for CLUS_MAINTENANCE_MODE_INFOEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_MAINTENANCE_MODE_INFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_MAINTENANCE_MODE_INFOEX>()) == 0 }
+        self.InMaintenance == other.InMaintenance && self.MaintainenceModeType == other.MaintainenceModeType && self.InternalState == other.InternalState && self.Signature == other.Signature
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15901,7 +15612,7 @@ unsafe impl ::windows::core::Abi for CLUS_NETNAME_IP_INFO_ENTRY {
 }
 impl ::core::cmp::PartialEq for CLUS_NETNAME_IP_INFO_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_NETNAME_IP_INFO_ENTRY>()) == 0 }
+        self.NodeId == other.NodeId && self.AddressSize == other.AddressSize && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for CLUS_NETNAME_IP_INFO_ENTRY {}
@@ -15933,7 +15644,7 @@ unsafe impl ::windows::core::Abi for CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {
 }
 impl ::core::cmp::PartialEq for CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL>()) == 0 }
+        self.szName == other.szName && self.NumEntries == other.NumEntries && self.IpInfo == other.IpInfo
     }
 }
 impl ::core::cmp::Eq for CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {}
@@ -15966,7 +15677,7 @@ unsafe impl ::windows::core::Abi for CLUS_NETNAME_PWD_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_NETNAME_PWD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_NETNAME_PWD_INFO>()) == 0 }
+        self.Flags == other.Flags && self.Password == other.Password && self.CreatingDC == other.CreatingDC && self.ObjectGuid == other.ObjectGuid
     }
 }
 impl ::core::cmp::Eq for CLUS_NETNAME_PWD_INFO {}
@@ -15999,7 +15710,7 @@ unsafe impl ::windows::core::Abi for CLUS_NETNAME_PWD_INFOEX {
 }
 impl ::core::cmp::PartialEq for CLUS_NETNAME_PWD_INFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_NETNAME_PWD_INFOEX>()) == 0 }
+        self.Flags == other.Flags && self.Password == other.Password && self.CreatingDC == other.CreatingDC && self.ObjectGuid == other.ObjectGuid
     }
 }
 impl ::core::cmp::Eq for CLUS_NETNAME_PWD_INFOEX {}
@@ -16037,7 +15748,7 @@ unsafe impl ::windows::core::Abi for CLUS_NETNAME_VS_TOKEN_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_NETNAME_VS_TOKEN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_NETNAME_VS_TOKEN_INFO>()) == 0 }
+        self.ProcessID == other.ProcessID && self.DesiredAccess == other.DesiredAccess && self.InheritHandle == other.InheritHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16075,7 +15786,7 @@ unsafe impl ::windows::core::Abi for CLUS_PARTITION_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_PARTITION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_PARTITION_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.szDeviceName == other.szDeviceName && self.szVolumeLabel == other.szVolumeLabel && self.dwSerialNumber == other.dwSerialNumber && self.rgdwMaximumComponentLength == other.rgdwMaximumComponentLength && self.dwFileSystemFlags == other.dwFileSystemFlags && self.szFileSystem == other.szFileSystem
     }
 }
 impl ::core::cmp::Eq for CLUS_PARTITION_INFO {}
@@ -16129,7 +15840,7 @@ unsafe impl ::windows::core::Abi for CLUS_PARTITION_INFO_EX {
 }
 impl ::core::cmp::PartialEq for CLUS_PARTITION_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_PARTITION_INFO_EX>()) == 0 }
+        self.dwFlags == other.dwFlags && self.szDeviceName == other.szDeviceName && self.szVolumeLabel == other.szVolumeLabel && self.dwSerialNumber == other.dwSerialNumber && self.rgdwMaximumComponentLength == other.rgdwMaximumComponentLength && self.dwFileSystemFlags == other.dwFileSystemFlags && self.szFileSystem == other.szFileSystem && self.TotalSizeInBytes == other.TotalSizeInBytes && self.FreeSizeInBytes == other.FreeSizeInBytes && self.DeviceNumber == other.DeviceNumber && self.PartitionNumber == other.PartitionNumber && self.VolumeGuid == other.VolumeGuid
     }
 }
 impl ::core::cmp::Eq for CLUS_PARTITION_INFO_EX {}
@@ -16161,7 +15872,7 @@ unsafe impl ::windows::core::Abi for CLUS_PARTITION_INFO_EX2 {
 }
 impl ::core::cmp::PartialEq for CLUS_PARTITION_INFO_EX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_PARTITION_INFO_EX2>()) == 0 }
+        self.GptPartitionId == other.GptPartitionId && self.szPartitionName == other.szPartitionName && self.EncryptionFlags == other.EncryptionFlags
     }
 }
 impl ::core::cmp::Eq for CLUS_PARTITION_INFO_EX2 {}
@@ -16193,7 +15904,7 @@ unsafe impl ::windows::core::Abi for CLUS_PROVIDER_STATE_CHANGE_INFO {
 }
 impl ::core::cmp::PartialEq for CLUS_PROVIDER_STATE_CHANGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_PROVIDER_STATE_CHANGE_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.resourceState == other.resourceState && self.szProviderId == other.szProviderId
     }
 }
 impl ::core::cmp::Eq for CLUS_PROVIDER_STATE_CHANGE_INFO {}
@@ -16216,12 +15927,6 @@ impl ::core::clone::Clone for CLUS_RESOURCE_CLASS_INFO {
 unsafe impl ::windows::core::Abi for CLUS_RESOURCE_CLASS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_RESOURCE_CLASS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_RESOURCE_CLASS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_RESOURCE_CLASS_INFO {}
 impl ::core::default::Default for CLUS_RESOURCE_CLASS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16242,12 +15947,6 @@ impl ::core::clone::Clone for CLUS_RESOURCE_CLASS_INFO_0 {
 unsafe impl ::windows::core::Abi for CLUS_RESOURCE_CLASS_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_RESOURCE_CLASS_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_RESOURCE_CLASS_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_RESOURCE_CLASS_INFO_0 {}
 impl ::core::default::Default for CLUS_RESOURCE_CLASS_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16268,12 +15967,6 @@ impl ::core::clone::Clone for CLUS_RESOURCE_CLASS_INFO_0_0 {
 unsafe impl ::windows::core::Abi for CLUS_RESOURCE_CLASS_INFO_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_RESOURCE_CLASS_INFO_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_RESOURCE_CLASS_INFO_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_RESOURCE_CLASS_INFO_0_0 {}
 impl ::core::default::Default for CLUS_RESOURCE_CLASS_INFO_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16294,12 +15987,6 @@ impl ::core::clone::Clone for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
 unsafe impl ::windows::core::Abi for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_RESOURCE_CLASS_INFO_0_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_RESOURCE_CLASS_INFO_0_0_0 {}
 impl ::core::default::Default for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16319,12 +16006,6 @@ impl ::core::clone::Clone for CLUS_SCSI_ADDRESS {
 unsafe impl ::windows::core::Abi for CLUS_SCSI_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_SCSI_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_SCSI_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_SCSI_ADDRESS {}
 impl ::core::default::Default for CLUS_SCSI_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16345,12 +16026,6 @@ impl ::core::clone::Clone for CLUS_SCSI_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for CLUS_SCSI_ADDRESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLUS_SCSI_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_SCSI_ADDRESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLUS_SCSI_ADDRESS_0 {}
 impl ::core::default::Default for CLUS_SCSI_ADDRESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16380,7 +16055,7 @@ unsafe impl ::windows::core::Abi for CLUS_SCSI_ADDRESS_0_0 {
 }
 impl ::core::cmp::PartialEq for CLUS_SCSI_ADDRESS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_SCSI_ADDRESS_0_0>()) == 0 }
+        self.PortNumber == other.PortNumber && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun
     }
 }
 impl ::core::cmp::Eq for CLUS_SCSI_ADDRESS_0_0 {}
@@ -16418,7 +16093,7 @@ unsafe impl ::windows::core::Abi for CLUS_SET_MAINTENANCE_MODE_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_SET_MAINTENANCE_MODE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_SET_MAINTENANCE_MODE_INPUT>()) == 0 }
+        self.InMaintenance == other.InMaintenance && self.ExtraParameterSize == other.ExtraParameterSize && self.ExtraParameter == other.ExtraParameter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16452,7 +16127,7 @@ unsafe impl ::windows::core::Abi for CLUS_SHARED_VOLUME_BACKUP_MODE {
 }
 impl ::core::cmp::PartialEq for CLUS_SHARED_VOLUME_BACKUP_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_SHARED_VOLUME_BACKUP_MODE>()) == 0 }
+        self.BackupState == other.BackupState && self.DelayTimerInSecs == other.DelayTimerInSecs && self.VolumeName == other.VolumeName
     }
 }
 impl ::core::cmp::Eq for CLUS_SHARED_VOLUME_BACKUP_MODE {}
@@ -16490,7 +16165,7 @@ unsafe impl ::windows::core::Abi for CLUS_STARTING_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_STARTING_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_STARTING_PARAMS>()) == 0 }
+        self.dwSize == other.dwSize && self.bForm == other.bForm && self.bFirst == other.bFirst
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16522,7 +16197,7 @@ unsafe impl ::windows::core::Abi for CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {
 }
 impl ::core::cmp::PartialEq for CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS>()) == 0 }
+        self.AvailDrivelettersMask == other.AvailDrivelettersMask
     }
 }
 impl ::core::cmp::Eq for CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {}
@@ -16553,7 +16228,7 @@ unsafe impl ::windows::core::Abi for CLUS_STORAGE_REMAP_DRIVELETTER {
 }
 impl ::core::cmp::PartialEq for CLUS_STORAGE_REMAP_DRIVELETTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_STORAGE_REMAP_DRIVELETTER>()) == 0 }
+        self.CurrentDriveLetterMask == other.CurrentDriveLetterMask && self.TargetDriveLetterMask == other.TargetDriveLetterMask
     }
 }
 impl ::core::cmp::Eq for CLUS_STORAGE_REMAP_DRIVELETTER {}
@@ -16584,7 +16259,7 @@ unsafe impl ::windows::core::Abi for CLUS_STORAGE_SET_DRIVELETTER {
 }
 impl ::core::cmp::PartialEq for CLUS_STORAGE_SET_DRIVELETTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_STORAGE_SET_DRIVELETTER>()) == 0 }
+        self.PartitionNumber == other.PartitionNumber && self.DriveLetterMask == other.DriveLetterMask
     }
 }
 impl ::core::cmp::Eq for CLUS_STORAGE_SET_DRIVELETTER {}
@@ -16621,7 +16296,7 @@ unsafe impl ::windows::core::Abi for CLUS_WORKER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLUS_WORKER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUS_WORKER>()) == 0 }
+        self.hThread == other.hThread && self.Terminate == other.Terminate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16667,7 +16342,7 @@ unsafe impl ::windows::core::Abi for CREATE_CLUSTER_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREATE_CLUSTER_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_CLUSTER_CONFIG>()) == 0 }
+        self.dwVersion == other.dwVersion && self.lpszClusterName == other.lpszClusterName && self.cNodes == other.cNodes && self.ppszNodeNames == other.ppszNodeNames && self.cIpEntries == other.cIpEntries && self.pIpEntries == other.pIpEntries && self.fEmptyCluster == other.fEmptyCluster && self.managementPointType == other.managementPointType && self.managementPointResType == other.managementPointResType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16713,7 +16388,7 @@ unsafe impl ::windows::core::Abi for CREATE_CLUSTER_NAME_ACCOUNT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREATE_CLUSTER_NAME_ACCOUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_CLUSTER_NAME_ACCOUNT>()) == 0 }
+        self.dwVersion == other.dwVersion && self.lpszClusterName == other.lpszClusterName && self.dwFlags == other.dwFlags && self.pszUserName == other.pszUserName && self.pszPassword == other.pszPassword && self.pszDomain == other.pszDomain && self.managementPointType == other.managementPointType && self.managementPointResType == other.managementPointResType && self.bUpgradeVCOs == other.bUpgradeVCOs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16746,7 +16421,7 @@ unsafe impl ::windows::core::Abi for FILESHARE_CHANGE {
 }
 impl ::core::cmp::PartialEq for FILESHARE_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILESHARE_CHANGE>()) == 0 }
+        self.Change == other.Change && self.ShareName == other.ShareName
     }
 }
 impl ::core::cmp::Eq for FILESHARE_CHANGE {}
@@ -16777,7 +16452,7 @@ unsafe impl ::windows::core::Abi for FILESHARE_CHANGE_LIST {
 }
 impl ::core::cmp::PartialEq for FILESHARE_CHANGE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILESHARE_CHANGE_LIST>()) == 0 }
+        self.NumEntries == other.NumEntries && self.ChangeEntry == other.ChangeEntry
     }
 }
 impl ::core::cmp::Eq for FILESHARE_CHANGE_LIST {}
@@ -16810,7 +16485,7 @@ unsafe impl ::windows::core::Abi for GET_OPERATION_CONTEXT_PARAMS {
 }
 impl ::core::cmp::PartialEq for GET_OPERATION_CONTEXT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_OPERATION_CONTEXT_PARAMS>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.Type == other.Type && self.Priority == other.Priority
     }
 }
 impl ::core::cmp::Eq for GET_OPERATION_CONTEXT_PARAMS {}
@@ -16841,7 +16516,7 @@ unsafe impl ::windows::core::Abi for GROUP_FAILURE_INFO {
 }
 impl ::core::cmp::PartialEq for GROUP_FAILURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_FAILURE_INFO>()) == 0 }
+        self.dwFailoverAttemptsRemaining == other.dwFailoverAttemptsRemaining && self.dwFailoverPeriodRemaining == other.dwFailoverPeriodRemaining
     }
 }
 impl ::core::cmp::Eq for GROUP_FAILURE_INFO {}
@@ -16872,7 +16547,7 @@ unsafe impl ::windows::core::Abi for GROUP_FAILURE_INFO_BUFFER {
 }
 impl ::core::cmp::PartialEq for GROUP_FAILURE_INFO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_FAILURE_INFO_BUFFER>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Info == other.Info
     }
 }
 impl ::core::cmp::Eq for GROUP_FAILURE_INFO_BUFFER {}
@@ -16911,7 +16586,7 @@ unsafe impl ::windows::core::Abi for MONITOR_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONITOR_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONITOR_STATE>()) == 0 }
+        self.LastUpdate == other.LastUpdate && self.State == other.State && self.ActiveResource == other.ActiveResource && self.ResmonStop == other.ResmonStop
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16944,7 +16619,7 @@ unsafe impl ::windows::core::Abi for NOTIFY_FILTER_AND_TYPE {
 }
 impl ::core::cmp::PartialEq for NOTIFY_FILTER_AND_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFY_FILTER_AND_TYPE>()) == 0 }
+        self.dwObjectType == other.dwObjectType && self.FilterFlags == other.FilterFlags
     }
 }
 impl ::core::cmp::Eq for NOTIFY_FILTER_AND_TYPE {}
@@ -16976,7 +16651,7 @@ unsafe impl ::windows::core::Abi for NodeUtilizationInfoElement {
 }
 impl ::core::cmp::PartialEq for NodeUtilizationInfoElement {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NodeUtilizationInfoElement>()) == 0 }
+        self.Id == other.Id && self.AvailableMemory == other.AvailableMemory && self.AvailableMemoryAfterReclamation == other.AvailableMemoryAfterReclamation
     }
 }
 impl ::core::cmp::Eq for NodeUtilizationInfoElement {}
@@ -17010,7 +16685,7 @@ unsafe impl ::windows::core::Abi for POST_UPGRADE_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for POST_UPGRADE_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POST_UPGRADE_VERSION_INFO>()) == 0 }
+        self.newMajorVersion == other.newMajorVersion && self.newUpgradeVersion == other.newUpgradeVersion && self.oldMajorVersion == other.oldMajorVersion && self.oldUpgradeVersion == other.oldUpgradeVersion && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for POST_UPGRADE_VERSION_INFO {}
@@ -17066,7 +16741,19 @@ unsafe impl ::windows::core::Abi for PaxosTagCStruct {
 }
 impl ::core::cmp::PartialEq for PaxosTagCStruct {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PaxosTagCStruct>()) == 0 }
+        self.__padding__PaxosTagVtable == other.__padding__PaxosTagVtable
+            && self.__padding__NextEpochVtable == other.__padding__NextEpochVtable
+            && self.__padding__NextEpoch_DateTimeVtable == other.__padding__NextEpoch_DateTimeVtable
+            && self.NextEpoch_DateTime_ticks == other.NextEpoch_DateTime_ticks
+            && self.NextEpoch_Value == other.NextEpoch_Value
+            && self.__padding__BoundryNextEpoch == other.__padding__BoundryNextEpoch
+            && self.__padding__EpochVtable == other.__padding__EpochVtable
+            && self.__padding__Epoch_DateTimeVtable == other.__padding__Epoch_DateTimeVtable
+            && self.Epoch_DateTime_ticks == other.Epoch_DateTime_ticks
+            && self.Epoch_Value == other.Epoch_Value
+            && self.__padding__BoundryEpoch == other.__padding__BoundryEpoch
+            && self.Sequence == other.Sequence
+            && self.__padding__BoundrySequence == other.__padding__BoundrySequence
     }
 }
 impl ::core::cmp::Eq for PaxosTagCStruct {}
@@ -17097,7 +16784,7 @@ unsafe impl ::windows::core::Abi for RESOURCE_FAILURE_INFO {
 }
 impl ::core::cmp::PartialEq for RESOURCE_FAILURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCE_FAILURE_INFO>()) == 0 }
+        self.dwRestartAttemptsRemaining == other.dwRestartAttemptsRemaining && self.dwRestartPeriodRemaining == other.dwRestartPeriodRemaining
     }
 }
 impl ::core::cmp::Eq for RESOURCE_FAILURE_INFO {}
@@ -17128,7 +16815,7 @@ unsafe impl ::windows::core::Abi for RESOURCE_FAILURE_INFO_BUFFER {
 }
 impl ::core::cmp::PartialEq for RESOURCE_FAILURE_INFO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCE_FAILURE_INFO_BUFFER>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Info == other.Info
     }
 }
 impl ::core::cmp::Eq for RESOURCE_FAILURE_INFO_BUFFER {}
@@ -17167,7 +16854,7 @@ unsafe impl ::windows::core::Abi for RESOURCE_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESOURCE_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCE_STATUS>()) == 0 }
+        self.ResourceState == other.ResourceState && self.CheckPoint == other.CheckPoint && self.WaitHint == other.WaitHint && self.EventHandle == other.EventHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17210,7 +16897,7 @@ unsafe impl ::windows::core::Abi for RESOURCE_STATUS_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESOURCE_STATUS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCE_STATUS_EX>()) == 0 }
+        self.ResourceState == other.ResourceState && self.CheckPoint == other.CheckPoint && self.EventHandle == other.EventHandle && self.ApplicationSpecificErrorCode == other.ApplicationSpecificErrorCode && self.Flags == other.Flags && self.WaitHint == other.WaitHint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17249,7 +16936,7 @@ unsafe impl ::windows::core::Abi for RESOURCE_TERMINAL_FAILURE_INFO_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESOURCE_TERMINAL_FAILURE_INFO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCE_TERMINAL_FAILURE_INFO_BUFFER>()) == 0 }
+        self.isTerminalFailure == other.isTerminalFailure && self.restartPeriodRemaining == other.restartPeriodRemaining
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17289,7 +16976,7 @@ unsafe impl ::windows::core::Abi for RESUTIL_FILETIME_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESUTIL_FILETIME_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUTIL_FILETIME_DATA>()) == 0 }
+        self.Default == other.Default && self.Minimum == other.Minimum && self.Maximum == other.Maximum
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17323,7 +17010,7 @@ unsafe impl ::windows::core::Abi for RESUTIL_LARGEINT_DATA {
 }
 impl ::core::cmp::PartialEq for RESUTIL_LARGEINT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUTIL_LARGEINT_DATA>()) == 0 }
+        self.Default == other.Default && self.Minimum == other.Minimum && self.Maximum == other.Maximum
     }
 }
 impl ::core::cmp::Eq for RESUTIL_LARGEINT_DATA {}
@@ -17358,14 +17045,6 @@ unsafe impl ::windows::core::Abi for RESUTIL_PROPERTY_ITEM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RESUTIL_PROPERTY_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUTIL_PROPERTY_ITEM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RESUTIL_PROPERTY_ITEM {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RESUTIL_PROPERTY_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17395,14 +17074,6 @@ unsafe impl ::windows::core::Abi for RESUTIL_PROPERTY_ITEM_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RESUTIL_PROPERTY_ITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUTIL_PROPERTY_ITEM_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RESUTIL_PROPERTY_ITEM_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RESUTIL_PROPERTY_ITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17431,7 +17102,7 @@ unsafe impl ::windows::core::Abi for RESUTIL_ULARGEINT_DATA {
 }
 impl ::core::cmp::PartialEq for RESUTIL_ULARGEINT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUTIL_ULARGEINT_DATA>()) == 0 }
+        self.Default == other.Default && self.Minimum == other.Minimum && self.Maximum == other.Maximum
     }
 }
 impl ::core::cmp::Eq for RESUTIL_ULARGEINT_DATA {}
@@ -17462,7 +17133,7 @@ unsafe impl ::windows::core::Abi for ResourceUtilizationInfoElement {
 }
 impl ::core::cmp::PartialEq for ResourceUtilizationInfoElement {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ResourceUtilizationInfoElement>()) == 0 }
+        self.PhysicalNumaId == other.PhysicalNumaId && self.CurrentMemory == other.CurrentMemory
     }
 }
 impl ::core::cmp::Eq for ResourceUtilizationInfoElement {}
@@ -17522,7 +17193,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP>()) == 0 }
+        self.ReplicationGroupName == other.ReplicationGroupName && self.Description == other.Description && self.LogPath == other.LogPath && self.MaxLogSizeInBytes == other.MaxLogSizeInBytes && self.LogType == other.LogType && self.ReplicationMode == other.ReplicationMode && self.MinimumPartnersInSync == other.MinimumPartnersInSync && self.EnableWriteConsistency == other.EnableWriteConsistency && self.EnableEncryption == other.EnableEncryption && self.CertificateThumbprint == other.CertificateThumbprint && self.VolumeNameCount == other.VolumeNameCount && self.VolumeNames == other.VolumeNames
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17555,7 +17226,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESU
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT>()) == 0 }
+        self.Result == other.Result && self.ErrorString == other.ErrorString
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT {}
@@ -17586,7 +17257,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_DISK_INFO {
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_DISK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_DISK_INFO>()) == 0 }
+        self.Reason == other.Reason && self.DiskGuid == other.DiskGuid
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_DISK_INFO {}
@@ -17617,7 +17288,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT>()) == 0 }
+        self.Count == other.Count && self.DiskInfo == other.DiskInfo
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {}
@@ -17654,7 +17325,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_LOGDISKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_LOGDISKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_QUERY_ELIGIBLE_LOGDISKS>()) == 0 }
+        self.DataDiskGuid == other.DataDiskGuid && self.IncludeOfflineDisks == other.IncludeOfflineDisks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17693,7 +17364,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATA
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATADISKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATADISKS>()) == 0 }
+        self.DataDiskGuid == other.DataDiskGuid && self.IncludeAvailableStoargeDisks == other.IncludeAvailableStoargeDisks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17734,7 +17405,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_TARGET_DATA
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_TARGET_DATADISKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_QUERY_ELIGIBLE_TARGET_DATADISKS>()) == 0 }
+        self.SourceDataDiskGuid == other.SourceDataDiskGuid && self.TargetReplicationGroupGuid == other.TargetReplicationGroupGuid && self.SkipConnectivityCheck == other.SkipConnectivityCheck && self.IncludeOfflineDisks == other.IncludeOfflineDisks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17769,7 +17440,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_REPLICATED_DISK {
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_REPLICATED_DISK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_REPLICATED_DISK>()) == 0 }
+        self.Type == other.Type && self.ClusterDiskResourceGuid == other.ClusterDiskResourceGuid && self.ReplicationGroupId == other.ReplicationGroupId && self.ReplicationGroupName == other.ReplicationGroupName
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_REPLICATED_DISK {}
@@ -17800,7 +17471,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT>()) == 0 }
+        self.Count == other.Count && self.ReplicatedDisks == other.ReplicatedDisks
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {}
@@ -17831,7 +17502,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY>()) == 0 }
+        self.Count == other.Count && self.PartitionArray == other.PartitionArray
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY {}
@@ -17862,7 +17533,7 @@ unsafe impl ::windows::core::Abi for SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO 
 }
 impl ::core::cmp::PartialEq for SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO>()) == 0 }
+        self.PartitionOffset == other.PartitionOffset && self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO {}
@@ -17893,7 +17564,7 @@ unsafe impl ::windows::core::Abi for WitnessTagHelper {
 }
 impl ::core::cmp::PartialEq for WitnessTagHelper {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WitnessTagHelper>()) == 0 }
+        self.Version == other.Version && self.paxosToValidate == other.paxosToValidate
     }
 }
 impl ::core::cmp::Eq for WitnessTagHelper {}
@@ -17925,7 +17596,7 @@ unsafe impl ::windows::core::Abi for WitnessTagUpdateHelper {
 }
 impl ::core::cmp::PartialEq for WitnessTagUpdateHelper {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WitnessTagUpdateHelper>()) == 0 }
+        self.Version == other.Version && self.paxosToSet == other.paxosToSet && self.paxosToValidate == other.paxosToValidate
     }
 }
 impl ::core::cmp::Eq for WitnessTagUpdateHelper {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -1913,7 +1913,7 @@ unsafe impl ::windows::core::Abi for HTTP2_SETTINGS_LIMITS_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP2_SETTINGS_LIMITS_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP2_SETTINGS_LIMITS_PARAM>()) == 0 }
+        self.Http2MaxSettingsPerFrame == other.Http2MaxSettingsPerFrame && self.Http2MaxSettingsPerMinute == other.Http2MaxSettingsPerMinute
     }
 }
 impl ::core::cmp::Eq for HTTP2_SETTINGS_LIMITS_PARAM {}
@@ -1943,7 +1943,7 @@ unsafe impl ::windows::core::Abi for HTTP2_WINDOW_SIZE_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP2_WINDOW_SIZE_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP2_WINDOW_SIZE_PARAM>()) == 0 }
+        self.Http2ReceiveWindowSize == other.Http2ReceiveWindowSize
     }
 }
 impl ::core::cmp::Eq for HTTP2_WINDOW_SIZE_PARAM {}
@@ -1974,7 +1974,7 @@ unsafe impl ::windows::core::Abi for HTTPAPI_VERSION {
 }
 impl ::core::cmp::PartialEq for HTTPAPI_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTPAPI_VERSION>()) == 0 }
+        self.HttpApiMajorVersion == other.HttpApiMajorVersion && self.HttpApiMinorVersion == other.HttpApiMinorVersion
     }
 }
 impl ::core::cmp::Eq for HTTPAPI_VERSION {}
@@ -2005,7 +2005,7 @@ unsafe impl ::windows::core::Abi for HTTP_BANDWIDTH_LIMIT_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_BANDWIDTH_LIMIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_BANDWIDTH_LIMIT_INFO>()) == 0 }
+        self.Flags == other.Flags && self.MaxBandwidth == other.MaxBandwidth
     }
 }
 impl ::core::cmp::Eq for HTTP_BANDWIDTH_LIMIT_INFO {}
@@ -2042,7 +2042,7 @@ unsafe impl ::windows::core::Abi for HTTP_BINDING_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_BINDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_BINDING_INFO>()) == 0 }
+        self.Flags == other.Flags && self.RequestQueueHandle == other.RequestQueueHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2075,7 +2075,7 @@ unsafe impl ::windows::core::Abi for HTTP_BYTE_RANGE {
 }
 impl ::core::cmp::PartialEq for HTTP_BYTE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_BYTE_RANGE>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for HTTP_BYTE_RANGE {}
@@ -2106,7 +2106,7 @@ unsafe impl ::windows::core::Abi for HTTP_CACHE_POLICY {
 }
 impl ::core::cmp::PartialEq for HTTP_CACHE_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_CACHE_POLICY>()) == 0 }
+        self.Policy == other.Policy && self.SecondsToLive == other.SecondsToLive
     }
 }
 impl ::core::cmp::Eq for HTTP_CACHE_POLICY {}
@@ -2139,7 +2139,7 @@ unsafe impl ::windows::core::Abi for HTTP_CHANNEL_BIND_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_CHANNEL_BIND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_CHANNEL_BIND_INFO>()) == 0 }
+        self.Hardening == other.Hardening && self.Flags == other.Flags && self.ServiceNames == other.ServiceNames && self.NumberOfServiceNames == other.NumberOfServiceNames
     }
 }
 impl ::core::cmp::Eq for HTTP_CHANNEL_BIND_INFO {}
@@ -2170,7 +2170,7 @@ unsafe impl ::windows::core::Abi for HTTP_CONNECTION_LIMIT_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_CONNECTION_LIMIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_CONNECTION_LIMIT_INFO>()) == 0 }
+        self.Flags == other.Flags && self.MaxConnections == other.MaxConnections
     }
 }
 impl ::core::cmp::Eq for HTTP_CONNECTION_LIMIT_INFO {}
@@ -2207,7 +2207,7 @@ unsafe impl ::windows::core::Abi for HTTP_COOKED_URL {
 }
 impl ::core::cmp::PartialEq for HTTP_COOKED_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_COOKED_URL>()) == 0 }
+        self.FullUrlLength == other.FullUrlLength && self.HostLength == other.HostLength && self.AbsPathLength == other.AbsPathLength && self.QueryStringLength == other.QueryStringLength && self.pFullUrl == other.pFullUrl && self.pHost == other.pHost && self.pAbsPath == other.pAbsPath && self.pQueryString == other.pQueryString
     }
 }
 impl ::core::cmp::Eq for HTTP_COOKED_URL {}
@@ -2239,7 +2239,7 @@ unsafe impl ::windows::core::Abi for HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO>()) == 0 }
+        self.PropertyId == other.PropertyId && self.PropertyInfoLength == other.PropertyInfoLength && self.PropertyInfo == other.PropertyInfo
     }
 }
 impl ::core::cmp::Eq for HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO {}
@@ -2268,14 +2268,6 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HTTP_DATA_CHUNK {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HTTP_DATA_CHUNK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2303,14 +2295,6 @@ impl ::core::clone::Clone for HTTP_DATA_CHUNK_0 {
 unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HTTP_DATA_CHUNK_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HTTP_DATA_CHUNK_0 {
     fn default() -> Self {
@@ -2345,7 +2329,7 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0_0>()) == 0 }
+        self.ByteRange == other.ByteRange && self.FileHandle == other.FileHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2384,7 +2368,7 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0_1>()) == 0 }
+        self.ByteRange == other.ByteRange && self.pFragmentName == other.pFragmentName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2423,7 +2407,7 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0_2>()) == 0 }
+        self.FragmentNameLength == other.FragmentNameLength && self.pFragmentName == other.pFragmentName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2462,7 +2446,7 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0_3>()) == 0 }
+        self.pBuffer == other.pBuffer && self.BufferLength == other.BufferLength
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2501,7 +2485,7 @@ unsafe impl ::windows::core::Abi for HTTP_DATA_CHUNK_0_4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_DATA_CHUNK_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DATA_CHUNK_0_4>()) == 0 }
+        self.TrailerCount == other.TrailerCount && self.pTrailers == other.pTrailers
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2535,7 +2519,7 @@ unsafe impl ::windows::core::Abi for HTTP_DELEGATE_REQUEST_PROPERTY_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_DELEGATE_REQUEST_PROPERTY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_DELEGATE_REQUEST_PROPERTY_INFO>()) == 0 }
+        self.PropertyId == other.PropertyId && self.PropertyInfoLength == other.PropertyInfoLength && self.PropertyInfo == other.PropertyInfo
     }
 }
 impl ::core::cmp::Eq for HTTP_DELEGATE_REQUEST_PROPERTY_INFO {}
@@ -2567,7 +2551,7 @@ unsafe impl ::windows::core::Abi for HTTP_ERROR_HEADERS_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_ERROR_HEADERS_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_ERROR_HEADERS_PARAM>()) == 0 }
+        self.StatusCode == other.StatusCode && self.HeaderCount == other.HeaderCount && self.Headers == other.Headers
     }
 }
 impl ::core::cmp::Eq for HTTP_ERROR_HEADERS_PARAM {}
@@ -2600,7 +2584,7 @@ unsafe impl ::windows::core::Abi for HTTP_FLOWRATE_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_FLOWRATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FLOWRATE_INFO>()) == 0 }
+        self.Flags == other.Flags && self.MaxBandwidth == other.MaxBandwidth && self.MaxPeakBandwidth == other.MaxPeakBandwidth && self.BurstSize == other.BurstSize
     }
 }
 impl ::core::cmp::Eq for HTTP_FLOWRATE_INFO {}
@@ -2631,7 +2615,7 @@ unsafe impl ::windows::core::Abi for HTTP_KNOWN_HEADER {
 }
 impl ::core::cmp::PartialEq for HTTP_KNOWN_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_KNOWN_HEADER>()) == 0 }
+        self.RawValueLength == other.RawValueLength && self.pRawValue == other.pRawValue
     }
 }
 impl ::core::cmp::Eq for HTTP_KNOWN_HEADER {}
@@ -2668,7 +2652,7 @@ unsafe impl ::windows::core::Abi for HTTP_LISTEN_ENDPOINT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_LISTEN_ENDPOINT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_LISTEN_ENDPOINT_INFO>()) == 0 }
+        self.Flags == other.Flags && self.EnableSharing == other.EnableSharing
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2734,7 +2718,7 @@ unsafe impl ::windows::core::Abi for HTTP_LOGGING_INFO {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for HTTP_LOGGING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_LOGGING_INFO>()) == 0 }
+        self.Flags == other.Flags && self.LoggingFlags == other.LoggingFlags && self.SoftwareName == other.SoftwareName && self.SoftwareNameLength == other.SoftwareNameLength && self.DirectoryNameLength == other.DirectoryNameLength && self.DirectoryName == other.DirectoryName && self.Format == other.Format && self.Fields == other.Fields && self.pExtFields == other.pExtFields && self.NumOfExtFields == other.NumOfExtFields && self.MaxRecordSize == other.MaxRecordSize && self.RolloverType == other.RolloverType && self.RolloverSize == other.RolloverSize && self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -2766,7 +2750,7 @@ unsafe impl ::windows::core::Abi for HTTP_LOG_DATA {
 }
 impl ::core::cmp::PartialEq for HTTP_LOG_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_LOG_DATA>()) == 0 }
+        self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for HTTP_LOG_DATA {}
@@ -2856,7 +2840,36 @@ unsafe impl ::windows::core::Abi for HTTP_LOG_FIELDS_DATA {
 }
 impl ::core::cmp::PartialEq for HTTP_LOG_FIELDS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_LOG_FIELDS_DATA>()) == 0 }
+        self.Base == other.Base
+            && self.UserNameLength == other.UserNameLength
+            && self.UriStemLength == other.UriStemLength
+            && self.ClientIpLength == other.ClientIpLength
+            && self.ServerNameLength == other.ServerNameLength
+            && self.ServiceNameLength == other.ServiceNameLength
+            && self.ServerIpLength == other.ServerIpLength
+            && self.MethodLength == other.MethodLength
+            && self.UriQueryLength == other.UriQueryLength
+            && self.HostLength == other.HostLength
+            && self.UserAgentLength == other.UserAgentLength
+            && self.CookieLength == other.CookieLength
+            && self.ReferrerLength == other.ReferrerLength
+            && self.UserName == other.UserName
+            && self.UriStem == other.UriStem
+            && self.ClientIp == other.ClientIp
+            && self.ServerName == other.ServerName
+            && self.ServiceName == other.ServiceName
+            && self.ServerIp == other.ServerIp
+            && self.Method == other.Method
+            && self.UriQuery == other.UriQuery
+            && self.Host == other.Host
+            && self.UserAgent == other.UserAgent
+            && self.Cookie == other.Cookie
+            && self.Referrer == other.Referrer
+            && self.ServerPort == other.ServerPort
+            && self.ProtocolStatus == other.ProtocolStatus
+            && self.Win32Status == other.Win32Status
+            && self.MethodNum == other.MethodNum
+            && self.SubStatus == other.SubStatus
     }
 }
 impl ::core::cmp::Eq for HTTP_LOG_FIELDS_DATA {}
@@ -2889,7 +2902,7 @@ unsafe impl ::windows::core::Abi for HTTP_MULTIPLE_KNOWN_HEADERS {
 }
 impl ::core::cmp::PartialEq for HTTP_MULTIPLE_KNOWN_HEADERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_MULTIPLE_KNOWN_HEADERS>()) == 0 }
+        self.HeaderId == other.HeaderId && self.Flags == other.Flags && self.KnownHeaderCount == other.KnownHeaderCount && self.KnownHeaders == other.KnownHeaders
     }
 }
 impl ::core::cmp::Eq for HTTP_MULTIPLE_KNOWN_HEADERS {}
@@ -2921,7 +2934,7 @@ unsafe impl ::windows::core::Abi for HTTP_PERFORMANCE_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_PERFORMANCE_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_PERFORMANCE_PARAM>()) == 0 }
+        self.Type == other.Type && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for HTTP_PERFORMANCE_PARAM {}
@@ -2951,7 +2964,7 @@ unsafe impl ::windows::core::Abi for HTTP_PROPERTY_FLAGS {
 }
 impl ::core::cmp::PartialEq for HTTP_PROPERTY_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_PROPERTY_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for HTTP_PROPERTY_FLAGS {}
@@ -2982,7 +2995,7 @@ unsafe impl ::windows::core::Abi for HTTP_PROTECTION_LEVEL_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_PROTECTION_LEVEL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_PROTECTION_LEVEL_INFO>()) == 0 }
+        self.Flags == other.Flags && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for HTTP_PROTECTION_LEVEL_INFO {}
@@ -3013,7 +3026,7 @@ unsafe impl ::windows::core::Abi for HTTP_QOS_SETTING_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_QOS_SETTING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QOS_SETTING_INFO>()) == 0 }
+        self.QosType == other.QosType && self.QosSetting == other.QosSetting
     }
 }
 impl ::core::cmp::Eq for HTTP_QOS_SETTING_INFO {}
@@ -3043,7 +3056,7 @@ unsafe impl ::windows::core::Abi for HTTP_QUERY_REQUEST_QUALIFIER_QUIC {
 }
 impl ::core::cmp::PartialEq for HTTP_QUERY_REQUEST_QUALIFIER_QUIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QUERY_REQUEST_QUALIFIER_QUIC>()) == 0 }
+        self.Freshness == other.Freshness
     }
 }
 impl ::core::cmp::Eq for HTTP_QUERY_REQUEST_QUALIFIER_QUIC {}
@@ -3073,7 +3086,7 @@ unsafe impl ::windows::core::Abi for HTTP_QUERY_REQUEST_QUALIFIER_TCP {
 }
 impl ::core::cmp::PartialEq for HTTP_QUERY_REQUEST_QUALIFIER_TCP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QUERY_REQUEST_QUALIFIER_TCP>()) == 0 }
+        self.Freshness == other.Freshness
     }
 }
 impl ::core::cmp::Eq for HTTP_QUERY_REQUEST_QUALIFIER_TCP {}
@@ -3104,7 +3117,7 @@ unsafe impl ::windows::core::Abi for HTTP_QUIC_API_TIMINGS {
 }
 impl ::core::cmp::PartialEq for HTTP_QUIC_API_TIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QUIC_API_TIMINGS>()) == 0 }
+        self.ConnectionTimings == other.ConnectionTimings && self.StreamTimings == other.StreamTimings
     }
 }
 impl ::core::cmp::Eq for HTTP_QUIC_API_TIMINGS {}
@@ -3160,7 +3173,7 @@ unsafe impl ::windows::core::Abi for HTTP_QUIC_CONNECTION_API_TIMINGS {
 }
 impl ::core::cmp::PartialEq for HTTP_QUIC_CONNECTION_API_TIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QUIC_CONNECTION_API_TIMINGS>()) == 0 }
+        self.OpenTime == other.OpenTime && self.CloseTime == other.CloseTime && self.StartTime == other.StartTime && self.ShutdownTime == other.ShutdownTime && self.SecConfigCreateTime == other.SecConfigCreateTime && self.SecConfigDeleteTime == other.SecConfigDeleteTime && self.GetParamCount == other.GetParamCount && self.GetParamSum == other.GetParamSum && self.SetParamCount == other.SetParamCount && self.SetParamSum == other.SetParamSum && self.SetCallbackHandlerCount == other.SetCallbackHandlerCount && self.SetCallbackHandlerSum == other.SetCallbackHandlerSum && self.ControlStreamTimings == other.ControlStreamTimings
     }
 }
 impl ::core::cmp::Eq for HTTP_QUIC_CONNECTION_API_TIMINGS {}
@@ -3226,7 +3239,7 @@ unsafe impl ::windows::core::Abi for HTTP_QUIC_STREAM_API_TIMINGS {
 }
 impl ::core::cmp::PartialEq for HTTP_QUIC_STREAM_API_TIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_QUIC_STREAM_API_TIMINGS>()) == 0 }
+        self.OpenCount == other.OpenCount && self.OpenSum == other.OpenSum && self.CloseCount == other.CloseCount && self.CloseSum == other.CloseSum && self.StartCount == other.StartCount && self.StartSum == other.StartSum && self.ShutdownCount == other.ShutdownCount && self.ShutdownSum == other.ShutdownSum && self.SendCount == other.SendCount && self.SendSum == other.SendSum && self.ReceiveSetEnabledCount == other.ReceiveSetEnabledCount && self.ReceiveSetEnabledSum == other.ReceiveSetEnabledSum && self.GetParamCount == other.GetParamCount && self.GetParamSum == other.GetParamSum && self.SetParamCount == other.SetParamCount && self.SetParamSum == other.SetParamSum && self.SetCallbackHandlerCount == other.SetCallbackHandlerCount && self.SetCallbackHandlerSum == other.SetCallbackHandlerSum
     }
 }
 impl ::core::cmp::Eq for HTTP_QUIC_STREAM_API_TIMINGS {}
@@ -3288,7 +3301,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_AUTH_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_REQUEST_AUTH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_AUTH_INFO>()) == 0 }
+        self.AuthStatus == other.AuthStatus && self.SecStatus == other.SecStatus && self.Flags == other.Flags && self.AuthType == other.AuthType && self.AccessToken == other.AccessToken && self.ContextAttributes == other.ContextAttributes && self.PackedContextLength == other.PackedContextLength && self.PackedContextType == other.PackedContextType && self.PackedContext == other.PackedContext && self.MutualAuthDataLength == other.MutualAuthDataLength && self.pMutualAuthData == other.pMutualAuthData && self.PackageNameLength == other.PackageNameLength && self.pPackageName == other.pPackageName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3323,7 +3336,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_CHANNEL_BIND_STATUS {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_CHANNEL_BIND_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_CHANNEL_BIND_STATUS>()) == 0 }
+        self.ServiceName == other.ServiceName && self.ChannelToken == other.ChannelToken && self.ChannelTokenSize == other.ChannelTokenSize && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_CHANNEL_BIND_STATUS {}
@@ -3357,7 +3370,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_HEADERS {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_HEADERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_HEADERS>()) == 0 }
+        self.UnknownHeaderCount == other.UnknownHeaderCount && self.pUnknownHeaders == other.pUnknownHeaders && self.TrailerCount == other.TrailerCount && self.pTrailers == other.pTrailers && self.KnownHeaders == other.KnownHeaders
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_HEADERS {}
@@ -3389,7 +3402,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_INFO>()) == 0 }
+        self.InfoType == other.InfoType && self.InfoLength == other.InfoLength && self.pInfo == other.pInfo
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_INFO {}
@@ -3420,7 +3433,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_PROPERTY_SNI {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_PROPERTY_SNI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_PROPERTY_SNI>()) == 0 }
+        self.Hostname == other.Hostname && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_PROPERTY_SNI {}
@@ -3450,7 +3463,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_PROPERTY_STREAM_ERROR {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_PROPERTY_STREAM_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_PROPERTY_STREAM_ERROR>()) == 0 }
+        self.ErrorCode == other.ErrorCode
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_PROPERTY_STREAM_ERROR {}
@@ -3483,7 +3496,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_SIZING_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_SIZING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_SIZING_INFO>()) == 0 }
+        self.Flags == other.Flags && self.RequestIndex == other.RequestIndex && self.RequestSizingCount == other.RequestSizingCount && self.RequestSizing == other.RequestSizing
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_SIZING_INFO {}
@@ -3514,7 +3527,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_TIMING_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_TIMING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_TIMING_INFO>()) == 0 }
+        self.RequestTimingCount == other.RequestTimingCount && self.RequestTiming == other.RequestTiming
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_TIMING_INFO {}
@@ -3548,7 +3561,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_TOKEN_BINDING_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_TOKEN_BINDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_TOKEN_BINDING_INFO>()) == 0 }
+        self.TokenBinding == other.TokenBinding && self.TokenBindingSize == other.TokenBindingSize && self.EKM == other.EKM && self.EKMSize == other.EKMSize && self.KeyType == other.KeyType
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_TOKEN_BINDING_INFO {}
@@ -3620,7 +3633,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_V1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_REQUEST_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_V1>()) == 0 }
+        self.Flags == other.Flags && self.ConnectionId == other.ConnectionId && self.RequestId == other.RequestId && self.UrlContext == other.UrlContext && self.Version == other.Version && self.Verb == other.Verb && self.UnknownVerbLength == other.UnknownVerbLength && self.RawUrlLength == other.RawUrlLength && self.pUnknownVerb == other.pUnknownVerb && self.pRawUrl == other.pRawUrl && self.CookedUrl == other.CookedUrl && self.Address == other.Address && self.Headers == other.Headers && self.BytesReceived == other.BytesReceived && self.EntityChunkCount == other.EntityChunkCount && self.pEntityChunks == other.pEntityChunks && self.RawConnectionId == other.RawConnectionId && self.pSslInfo == other.pSslInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3660,7 +3673,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_V2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_REQUEST_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_V2>()) == 0 }
+        self.Base == other.Base && self.RequestInfoCount == other.RequestInfoCount && self.pRequestInfo == other.pRequestInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -3696,7 +3709,7 @@ unsafe impl ::windows::core::Abi for HTTP_RESPONSE_HEADERS {
 }
 impl ::core::cmp::PartialEq for HTTP_RESPONSE_HEADERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_RESPONSE_HEADERS>()) == 0 }
+        self.UnknownHeaderCount == other.UnknownHeaderCount && self.pUnknownHeaders == other.pUnknownHeaders && self.TrailerCount == other.TrailerCount && self.pTrailers == other.pTrailers && self.KnownHeaders == other.KnownHeaders
     }
 }
 impl ::core::cmp::Eq for HTTP_RESPONSE_HEADERS {}
@@ -3728,7 +3741,7 @@ unsafe impl ::windows::core::Abi for HTTP_RESPONSE_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_RESPONSE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_RESPONSE_INFO>()) == 0 }
+        self.Type == other.Type && self.Length == other.Length && self.pInfo == other.pInfo
     }
 }
 impl ::core::cmp::Eq for HTTP_RESPONSE_INFO {}
@@ -3771,7 +3784,7 @@ unsafe impl ::windows::core::Abi for HTTP_RESPONSE_V1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_RESPONSE_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_RESPONSE_V1>()) == 0 }
+        self.Flags == other.Flags && self.Version == other.Version && self.StatusCode == other.StatusCode && self.ReasonLength == other.ReasonLength && self.pReason == other.pReason && self.Headers == other.Headers && self.EntityChunkCount == other.EntityChunkCount && self.pEntityChunks == other.pEntityChunks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3811,7 +3824,7 @@ unsafe impl ::windows::core::Abi for HTTP_RESPONSE_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_RESPONSE_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_RESPONSE_V2>()) == 0 }
+        self.Base == other.Base && self.ResponseInfoCount == other.ResponseInfoCount && self.pResponseInfo == other.pResponseInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3844,7 +3857,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS>()) == 0 }
+        self.RealmLength == other.RealmLength && self.Realm == other.Realm
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {}
@@ -3877,7 +3890,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS>()) == 0 }
+        self.DomainNameLength == other.DomainNameLength && self.DomainName == other.DomainName && self.RealmLength == other.RealmLength && self.Realm == other.Realm
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {}
@@ -3920,7 +3933,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVER_AUTHENTICATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_SERVER_AUTHENTICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVER_AUTHENTICATION_INFO>()) == 0 }
+        self.Flags == other.Flags && self.AuthSchemes == other.AuthSchemes && self.ReceiveMutualAuth == other.ReceiveMutualAuth && self.ReceiveContextHandle == other.ReceiveContextHandle && self.DisableNTLMCredentialCaching == other.DisableNTLMCredentialCaching && self.ExFlags == other.ExFlags && self.DigestParams == other.DigestParams && self.BasicParams == other.BasicParams
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3954,7 +3967,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_BINDING_A {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_BINDING_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_BINDING_A>()) == 0 }
+        self.Base == other.Base && self.Buffer == other.Buffer && self.BufferSize == other.BufferSize
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_BINDING_A {}
@@ -3984,7 +3997,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_BINDING_BASE {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_BINDING_BASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_BINDING_BASE>()) == 0 }
+        self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_BINDING_BASE {}
@@ -4016,7 +4029,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_BINDING_W {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_BINDING_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_BINDING_W>()) == 0 }
+        self.Base == other.Base && self.Buffer == other.Buffer && self.BufferSize == other.BufferSize
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_BINDING_W {}
@@ -4047,7 +4060,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_CACHE_SET {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_CACHE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_CACHE_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_CACHE_SET {}
@@ -4084,7 +4097,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM>()) == 0 }
+        self.AddrLength == other.AddrLength && self.pAddress == other.pAddress
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4123,7 +4136,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY>()) == 0 }
+        self.AddrCount == other.AddrCount && self.AddrList == other.AddrList
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4156,7 +4169,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SETTING_SET {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SETTING_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SETTING_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SETTING_SET {}
@@ -4192,7 +4205,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_CCS_KEY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_CCS_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_CCS_KEY>()) == 0 }
+        self.LocalAddress == other.LocalAddress
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4232,7 +4245,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_CCS_QUERY>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4273,7 +4286,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY_EX {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_CCS_QUERY_EX>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken && self.ParamType == other.ParamType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4312,7 +4325,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_CCS_SET {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_CCS_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_CCS_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4342,14 +4355,6 @@ impl ::core::clone::Clone for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
 unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
     fn default() -> Self {
@@ -4383,7 +4388,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_KEY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_KEY>()) == 0 }
+        self.pIpPort == other.pIpPort
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4421,7 +4426,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_KEY_EX {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_KEY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_KEY_EX>()) == 0 }
+        self.IpPort == other.IpPort
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4473,7 +4478,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_PARAM>()) == 0 }
+        self.SslHashLength == other.SslHashLength && self.pSslHash == other.pSslHash && self.AppId == other.AppId && self.pSslCertStoreName == other.pSslCertStoreName && self.DefaultCertCheckMode == other.DefaultCertCheckMode && self.DefaultRevocationFreshnessTime == other.DefaultRevocationFreshnessTime && self.DefaultRevocationUrlRetrievalTimeout == other.DefaultRevocationUrlRetrievalTimeout && self.pDefaultSslCtlIdentifier == other.pDefaultSslCtlIdentifier && self.pDefaultSslCtlStoreName == other.pDefaultSslCtlStoreName && self.DefaultFlags == other.DefaultFlags
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_PARAM {}
@@ -4498,12 +4503,6 @@ impl ::core::clone::Clone for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
 unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_PARAM_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {}
 impl ::core::default::Default for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4528,12 +4527,6 @@ impl ::core::clone::Clone for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
 unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {}
 impl ::core::default::Default for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4568,7 +4561,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_QUERY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_QUERY>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4609,7 +4602,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_QUERY_EX {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_QUERY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_QUERY_EX>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken && self.ParamType == other.ParamType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4648,7 +4641,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SET {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4678,14 +4671,6 @@ impl ::core::clone::Clone for HTTP_SERVICE_CONFIG_SSL_SET_EX {
 unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SET_EX {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SET_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SET_EX>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_SET_EX {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for HTTP_SERVICE_CONFIG_SSL_SET_EX {
     fn default() -> Self {
@@ -4720,7 +4705,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SNI_KEY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SNI_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SNI_KEY>()) == 0 }
+        self.IpPort == other.IpPort && self.Host == other.Host
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4760,7 +4745,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SNI_QUERY>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4801,7 +4786,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY_EX {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SNI_QUERY_EX>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken && self.ParamType == other.ParamType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4840,7 +4825,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SNI_SET {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SNI_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SNI_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -4871,14 +4856,6 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4906,7 +4883,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_TIMEOUT_SET {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_TIMEOUT_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_TIMEOUT_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_TIMEOUT_SET {}
@@ -4936,7 +4913,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_URLACL_KEY {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_URLACL_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_URLACL_KEY>()) == 0 }
+        self.pUrlPrefix == other.pUrlPrefix
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_URLACL_KEY {}
@@ -4966,7 +4943,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_URLACL_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_URLACL_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_URLACL_PARAM>()) == 0 }
+        self.pStringSecurityDescriptor == other.pStringSecurityDescriptor
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_URLACL_PARAM {}
@@ -4998,7 +4975,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_URLACL_QUERY {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_URLACL_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_URLACL_QUERY>()) == 0 }
+        self.QueryDesc == other.QueryDesc && self.KeyDesc == other.KeyDesc && self.dwToken == other.dwToken
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_URLACL_QUERY {}
@@ -5029,7 +5006,7 @@ unsafe impl ::windows::core::Abi for HTTP_SERVICE_CONFIG_URLACL_SET {
 }
 impl ::core::cmp::PartialEq for HTTP_SERVICE_CONFIG_URLACL_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SERVICE_CONFIG_URLACL_SET>()) == 0 }
+        self.KeyDesc == other.KeyDesc && self.ParamDesc == other.ParamDesc
     }
 }
 impl ::core::cmp::Eq for HTTP_SERVICE_CONFIG_URLACL_SET {}
@@ -5069,7 +5046,7 @@ unsafe impl ::windows::core::Abi for HTTP_SSL_CLIENT_CERT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_SSL_CLIENT_CERT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SSL_CLIENT_CERT_INFO>()) == 0 }
+        self.CertFlags == other.CertFlags && self.CertEncodedSize == other.CertEncodedSize && self.pCertEncoded == other.pCertEncoded && self.Token == other.Token && self.CertDeniedByMapper == other.CertDeniedByMapper
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5114,7 +5091,7 @@ unsafe impl ::windows::core::Abi for HTTP_SSL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_SSL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SSL_INFO>()) == 0 }
+        self.ServerCertKeySize == other.ServerCertKeySize && self.ConnectionKeySize == other.ConnectionKeySize && self.ServerCertIssuerSize == other.ServerCertIssuerSize && self.ServerCertSubjectSize == other.ServerCertSubjectSize && self.pServerCertIssuer == other.pServerCertIssuer && self.pServerCertSubject == other.pServerCertSubject && self.pClientCertInfo == other.pClientCertInfo && self.SslClientCertNegotiated == other.SslClientCertNegotiated
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5152,7 +5129,7 @@ unsafe impl ::windows::core::Abi for HTTP_SSL_PROTOCOL_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_SSL_PROTOCOL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_SSL_PROTOCOL_INFO>()) == 0 }
+        self.Protocol == other.Protocol && self.CipherType == other.CipherType && self.CipherStrength == other.CipherStrength && self.HashType == other.HashType && self.HashStrength == other.HashStrength && self.KeyExchangeType == other.KeyExchangeType && self.KeyExchangeStrength == other.KeyExchangeStrength
     }
 }
 impl ::core::cmp::Eq for HTTP_SSL_PROTOCOL_INFO {}
@@ -5183,7 +5160,7 @@ unsafe impl ::windows::core::Abi for HTTP_STATE_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_STATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_STATE_INFO>()) == 0 }
+        self.Flags == other.Flags && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for HTTP_STATE_INFO {}
@@ -5219,7 +5196,7 @@ unsafe impl ::windows::core::Abi for HTTP_TIMEOUT_LIMIT_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_TIMEOUT_LIMIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TIMEOUT_LIMIT_INFO>()) == 0 }
+        self.Flags == other.Flags && self.EntityBody == other.EntityBody && self.DrainEntityBody == other.DrainEntityBody && self.RequestQueue == other.RequestQueue && self.IdleConnection == other.IdleConnection && self.HeaderWait == other.HeaderWait && self.MinSendRate == other.MinSendRate
     }
 }
 impl ::core::cmp::Eq for HTTP_TIMEOUT_LIMIT_INFO {}
@@ -5250,7 +5227,7 @@ unsafe impl ::windows::core::Abi for HTTP_TLS_RESTRICTIONS_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_TLS_RESTRICTIONS_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TLS_RESTRICTIONS_PARAM>()) == 0 }
+        self.RestrictionCount == other.RestrictionCount && self.TlsRestrictions == other.TlsRestrictions
     }
 }
 impl ::core::cmp::Eq for HTTP_TLS_RESTRICTIONS_PARAM {}
@@ -5281,7 +5258,7 @@ unsafe impl ::windows::core::Abi for HTTP_TLS_SESSION_TICKET_KEYS_PARAM {
 }
 impl ::core::cmp::PartialEq for HTTP_TLS_SESSION_TICKET_KEYS_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TLS_SESSION_TICKET_KEYS_PARAM>()) == 0 }
+        self.SessionTicketKeyCount == other.SessionTicketKeyCount && self.SessionTicketKeys == other.SessionTicketKeys
     }
 }
 impl ::core::cmp::Eq for HTTP_TLS_SESSION_TICKET_KEYS_PARAM {}
@@ -5318,7 +5295,7 @@ unsafe impl ::windows::core::Abi for HTTP_TRANSPORT_ADDRESS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for HTTP_TRANSPORT_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TRANSPORT_ADDRESS>()) == 0 }
+        self.pRemoteAddress == other.pRemoteAddress && self.pLocalAddress == other.pLocalAddress
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -5353,7 +5330,7 @@ unsafe impl ::windows::core::Abi for HTTP_UNKNOWN_HEADER {
 }
 impl ::core::cmp::PartialEq for HTTP_UNKNOWN_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_UNKNOWN_HEADER>()) == 0 }
+        self.NameLength == other.NameLength && self.RawValueLength == other.RawValueLength && self.pName == other.pName && self.pRawValue == other.pRawValue
     }
 }
 impl ::core::cmp::Eq for HTTP_UNKNOWN_HEADER {}
@@ -5384,7 +5361,7 @@ unsafe impl ::windows::core::Abi for HTTP_VERSION {
 }
 impl ::core::cmp::PartialEq for HTTP_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for HTTP_VERSION {}
@@ -5438,7 +5415,7 @@ unsafe impl ::windows::core::Abi for HTTP_WSK_API_TIMINGS {
 }
 impl ::core::cmp::PartialEq for HTTP_WSK_API_TIMINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_WSK_API_TIMINGS>()) == 0 }
+        self.ConnectCount == other.ConnectCount && self.ConnectSum == other.ConnectSum && self.DisconnectCount == other.DisconnectCount && self.DisconnectSum == other.DisconnectSum && self.SendCount == other.SendCount && self.SendSum == other.SendSum && self.ReceiveCount == other.ReceiveCount && self.ReceiveSum == other.ReceiveSum && self.ReleaseCount == other.ReleaseCount && self.ReleaseSum == other.ReleaseSum && self.ControlSocketCount == other.ControlSocketCount && self.ControlSocketSum == other.ControlSocketSum
     }
 }
 impl ::core::cmp::Eq for HTTP_WSK_API_TIMINGS {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
@@ -2922,7 +2922,7 @@ unsafe impl ::windows::core::Abi for BerElement {
 }
 impl ::core::cmp::PartialEq for BerElement {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BerElement>()) == 0 }
+        self.opaque == other.opaque
     }
 }
 impl ::core::cmp::Eq for BerElement {}
@@ -2984,7 +2984,7 @@ unsafe impl ::windows::core::Abi for LDAP {
 }
 impl ::core::cmp::PartialEq for LDAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP>()) == 0 }
+        self.ld_sb == other.ld_sb && self.ld_host == other.ld_host && self.ld_version == other.ld_version && self.ld_lberoptions == other.ld_lberoptions && self.ld_deref == other.ld_deref && self.ld_timelimit == other.ld_timelimit && self.ld_sizelimit == other.ld_sizelimit && self.ld_errno == other.ld_errno && self.ld_matched == other.ld_matched && self.ld_error == other.ld_error && self.ld_msgid == other.ld_msgid && self.Reserved3 == other.Reserved3 && self.ld_cldaptries == other.ld_cldaptries && self.ld_cldaptimeout == other.ld_cldaptimeout && self.ld_refhoplimit == other.ld_refhoplimit && self.ld_options == other.ld_options
     }
 }
 impl ::core::cmp::Eq for LDAP {}
@@ -3017,7 +3017,7 @@ unsafe impl ::windows::core::Abi for LDAP_0 {
 }
 impl ::core::cmp::PartialEq for LDAP_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP_0>()) == 0 }
+        self.sb_sd == other.sb_sd && self.Reserved1 == other.Reserved1 && self.sb_naddr == other.sb_naddr && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for LDAP_0 {}
@@ -3049,7 +3049,7 @@ unsafe impl ::windows::core::Abi for LDAPAPIFeatureInfoA {
 }
 impl ::core::cmp::PartialEq for LDAPAPIFeatureInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPAPIFeatureInfoA>()) == 0 }
+        self.ldapaif_info_version == other.ldapaif_info_version && self.ldapaif_name == other.ldapaif_name && self.ldapaif_version == other.ldapaif_version
     }
 }
 impl ::core::cmp::Eq for LDAPAPIFeatureInfoA {}
@@ -3081,7 +3081,7 @@ unsafe impl ::windows::core::Abi for LDAPAPIFeatureInfoW {
 }
 impl ::core::cmp::PartialEq for LDAPAPIFeatureInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPAPIFeatureInfoW>()) == 0 }
+        self.ldapaif_info_version == other.ldapaif_info_version && self.ldapaif_name == other.ldapaif_name && self.ldapaif_version == other.ldapaif_version
     }
 }
 impl ::core::cmp::Eq for LDAPAPIFeatureInfoW {}
@@ -3116,7 +3116,7 @@ unsafe impl ::windows::core::Abi for LDAPAPIInfoA {
 }
 impl ::core::cmp::PartialEq for LDAPAPIInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPAPIInfoA>()) == 0 }
+        self.ldapai_info_version == other.ldapai_info_version && self.ldapai_api_version == other.ldapai_api_version && self.ldapai_protocol_version == other.ldapai_protocol_version && self.ldapai_extensions == other.ldapai_extensions && self.ldapai_vendor_name == other.ldapai_vendor_name && self.ldapai_vendor_version == other.ldapai_vendor_version
     }
 }
 impl ::core::cmp::Eq for LDAPAPIInfoA {}
@@ -3151,7 +3151,7 @@ unsafe impl ::windows::core::Abi for LDAPAPIInfoW {
 }
 impl ::core::cmp::PartialEq for LDAPAPIInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPAPIInfoW>()) == 0 }
+        self.ldapai_info_version == other.ldapai_info_version && self.ldapai_api_version == other.ldapai_api_version && self.ldapai_protocol_version == other.ldapai_protocol_version && self.ldapai_extensions == other.ldapai_extensions && self.ldapai_vendor_name == other.ldapai_vendor_name && self.ldapai_vendor_version == other.ldapai_vendor_version
     }
 }
 impl ::core::cmp::Eq for LDAPAPIInfoW {}
@@ -3189,7 +3189,7 @@ unsafe impl ::windows::core::Abi for LDAPControlA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LDAPControlA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPControlA>()) == 0 }
+        self.ldctl_oid == other.ldctl_oid && self.ldctl_value == other.ldctl_value && self.ldctl_iscritical == other.ldctl_iscritical
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3229,7 +3229,7 @@ unsafe impl ::windows::core::Abi for LDAPControlW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LDAPControlW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPControlW>()) == 0 }
+        self.ldctl_oid == other.ldctl_oid && self.ldctl_value == other.ldctl_value && self.ldctl_iscritical == other.ldctl_iscritical
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3293,7 +3293,7 @@ unsafe impl ::windows::core::Abi for LDAPMessage {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LDAPMessage {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPMessage>()) == 0 }
+        self.lm_msgid == other.lm_msgid && self.lm_msgtype == other.lm_msgtype && self.lm_ber == other.lm_ber && self.lm_chain == other.lm_chain && self.lm_next == other.lm_next && self.lm_time == other.lm_time && self.Connection == other.Connection && self.Request == other.Request && self.lm_returncode == other.lm_returncode && self.lm_referral == other.lm_referral && self.lm_chased == other.lm_chased && self.lm_eom == other.lm_eom && self.ConnectionReferenced == other.ConnectionReferenced
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3320,12 +3320,6 @@ impl ::core::clone::Clone for LDAPModA {
 unsafe impl ::windows::core::Abi for LDAPModA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDAPModA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPModA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDAPModA {}
 impl ::core::default::Default for LDAPModA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3346,12 +3340,6 @@ impl ::core::clone::Clone for LDAPModA_0 {
 unsafe impl ::windows::core::Abi for LDAPModA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDAPModA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPModA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDAPModA_0 {}
 impl ::core::default::Default for LDAPModA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3373,12 +3361,6 @@ impl ::core::clone::Clone for LDAPModW {
 unsafe impl ::windows::core::Abi for LDAPModW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDAPModW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPModW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDAPModW {}
 impl ::core::default::Default for LDAPModW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3399,12 +3381,6 @@ impl ::core::clone::Clone for LDAPModW_0 {
 unsafe impl ::windows::core::Abi for LDAPModW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDAPModW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPModW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDAPModW_0 {}
 impl ::core::default::Default for LDAPModW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3441,7 +3417,7 @@ unsafe impl ::windows::core::Abi for LDAPSortKeyA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LDAPSortKeyA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPSortKeyA>()) == 0 }
+        self.sk_attrtype == other.sk_attrtype && self.sk_matchruleoid == other.sk_matchruleoid && self.sk_reverseorder == other.sk_reverseorder
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3481,7 +3457,7 @@ unsafe impl ::windows::core::Abi for LDAPSortKeyW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LDAPSortKeyW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPSortKeyW>()) == 0 }
+        self.sk_attrtype == other.sk_attrtype && self.sk_matchruleoid == other.sk_matchruleoid && self.sk_reverseorder == other.sk_reverseorder
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3520,7 +3496,7 @@ unsafe impl ::windows::core::Abi for LDAPVLVInfo {
 }
 impl ::core::cmp::PartialEq for LDAPVLVInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAPVLVInfo>()) == 0 }
+        self.ldvlv_version == other.ldvlv_version && self.ldvlv_before_count == other.ldvlv_before_count && self.ldvlv_after_count == other.ldvlv_after_count && self.ldvlv_offset == other.ldvlv_offset && self.ldvlv_count == other.ldvlv_count && self.ldvlv_attrvalue == other.ldvlv_attrvalue && self.ldvlv_context == other.ldvlv_context && self.ldvlv_extradata == other.ldvlv_extradata
     }
 }
 impl ::core::cmp::Eq for LDAPVLVInfo {}
@@ -3551,7 +3527,7 @@ unsafe impl ::windows::core::Abi for LDAP_BERVAL {
 }
 impl ::core::cmp::PartialEq for LDAP_BERVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP_BERVAL>()) == 0 }
+        self.bv_len == other.bv_len && self.bv_val == other.bv_val
     }
 }
 impl ::core::cmp::Eq for LDAP_BERVAL {}
@@ -3580,21 +3556,13 @@ impl ::core::clone::Clone for LDAP_REFERRAL_CALLBACK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for LDAP_REFERRAL_CALLBACK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LDAP_REFERRAL_CALLBACK").field("SizeOfCallbacks", &self.SizeOfCallbacks).field("QueryForConnection", &self.QueryForConnection.map(|f| f as usize)).field("NotifyRoutine", &self.NotifyRoutine.map(|f| f as usize)).field("DereferenceRoutine", &self.DereferenceRoutine.map(|f| f as usize)).finish()
+        f.debug_struct("LDAP_REFERRAL_CALLBACK").field("SizeOfCallbacks", &self.SizeOfCallbacks).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for LDAP_REFERRAL_CALLBACK {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LDAP_REFERRAL_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP_REFERRAL_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LDAP_REFERRAL_CALLBACK {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LDAP_REFERRAL_CALLBACK {
     fn default() -> Self {
@@ -3623,7 +3591,7 @@ unsafe impl ::windows::core::Abi for LDAP_TIMEVAL {
 }
 impl ::core::cmp::PartialEq for LDAP_TIMEVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP_TIMEVAL>()) == 0 }
+        self.tv_sec == other.tv_sec && self.tv_usec == other.tv_usec
     }
 }
 impl ::core::cmp::Eq for LDAP_TIMEVAL {}
@@ -3655,7 +3623,7 @@ unsafe impl ::windows::core::Abi for LDAP_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for LDAP_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDAP_VERSION_INFO>()) == 0 }
+        self.lv_size == other.lv_size && self.lv_major == other.lv_major && self.lv_minor == other.lv_minor
     }
 }
 impl ::core::cmp::Eq for LDAP_VERSION_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
@@ -1146,7 +1146,7 @@ unsafe impl ::windows::core::Abi for NLM_DATAPLAN_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLM_DATAPLAN_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLM_DATAPLAN_STATUS>()) == 0 }
+        self.InterfaceGuid == other.InterfaceGuid && self.UsageData == other.UsageData && self.DataLimitInMegabytes == other.DataLimitInMegabytes && self.InboundBandwidthInKbps == other.InboundBandwidthInKbps && self.OutboundBandwidthInKbps == other.OutboundBandwidthInKbps && self.NextBillingCycle == other.NextBillingCycle && self.MaxTransferSizeInMegabytes == other.MaxTransferSizeInMegabytes && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1181,7 +1181,7 @@ unsafe impl ::windows::core::Abi for NLM_SIMULATED_PROFILE_INFO {
 }
 impl ::core::cmp::PartialEq for NLM_SIMULATED_PROFILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLM_SIMULATED_PROFILE_INFO>()) == 0 }
+        self.ProfileName == other.ProfileName && self.cost == other.cost && self.UsageInMegabytes == other.UsageInMegabytes && self.DataLimitInMegabytes == other.DataLimitInMegabytes
     }
 }
 impl ::core::cmp::Eq for NLM_SIMULATED_PROFILE_INFO {}
@@ -1211,7 +1211,7 @@ unsafe impl ::windows::core::Abi for NLM_SOCKADDR {
 }
 impl ::core::cmp::PartialEq for NLM_SOCKADDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLM_SOCKADDR>()) == 0 }
+        self.data == other.data
     }
 }
 impl ::core::cmp::Eq for NLM_SOCKADDR {}
@@ -1248,7 +1248,7 @@ unsafe impl ::windows::core::Abi for NLM_USAGE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLM_USAGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLM_USAGE_DATA>()) == 0 }
+        self.UsageInMegabytes == other.UsageInMegabytes && self.LastSyncTime == other.LastSyncTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
@@ -1238,7 +1238,7 @@ unsafe impl ::windows::core::Abi for FindSimilarFileIndexResults {
 }
 impl ::core::cmp::PartialEq for FindSimilarFileIndexResults {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FindSimilarFileIndexResults>()) == 0 }
+        self.m_FileIndex == other.m_FileIndex && self.m_MatchCount == other.m_MatchCount
     }
 }
 impl ::core::cmp::Eq for FindSimilarFileIndexResults {}
@@ -1270,7 +1270,7 @@ unsafe impl ::windows::core::Abi for RdcBufferPointer {
 }
 impl ::core::cmp::PartialEq for RdcBufferPointer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RdcBufferPointer>()) == 0 }
+        self.m_Size == other.m_Size && self.m_Used == other.m_Used && self.m_Data == other.m_Data
     }
 }
 impl ::core::cmp::Eq for RdcBufferPointer {}
@@ -1302,7 +1302,7 @@ unsafe impl ::windows::core::Abi for RdcNeed {
 }
 impl ::core::cmp::PartialEq for RdcNeed {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RdcNeed>()) == 0 }
+        self.m_BlockType == other.m_BlockType && self.m_FileOffset == other.m_FileOffset && self.m_BlockLength == other.m_BlockLength
     }
 }
 impl ::core::cmp::Eq for RdcNeed {}
@@ -1334,7 +1334,7 @@ unsafe impl ::windows::core::Abi for RdcNeedPointer {
 }
 impl ::core::cmp::PartialEq for RdcNeedPointer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RdcNeedPointer>()) == 0 }
+        self.m_Size == other.m_Size && self.m_Used == other.m_Used && self.m_Data == other.m_Data
     }
 }
 impl ::core::cmp::Eq for RdcNeedPointer {}
@@ -1365,7 +1365,7 @@ unsafe impl ::windows::core::Abi for RdcSignature {
 }
 impl ::core::cmp::PartialEq for RdcSignature {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RdcSignature>()) == 0 }
+        self.m_Signature == other.m_Signature && self.m_BlockLength == other.m_BlockLength
     }
 }
 impl ::core::cmp::Eq for RdcSignature {}
@@ -1397,7 +1397,7 @@ unsafe impl ::windows::core::Abi for RdcSignaturePointer {
 }
 impl ::core::cmp::PartialEq for RdcSignaturePointer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RdcSignaturePointer>()) == 0 }
+        self.m_Size == other.m_Size && self.m_Used == other.m_Used && self.m_Data == other.m_Data
     }
 }
 impl ::core::cmp::Eq for RdcSignaturePointer {}
@@ -1427,7 +1427,7 @@ unsafe impl ::windows::core::Abi for SimilarityData {
 }
 impl ::core::cmp::PartialEq for SimilarityData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SimilarityData>()) == 0 }
+        self.m_Data == other.m_Data
     }
 }
 impl ::core::cmp::Eq for SimilarityData {}
@@ -1458,7 +1458,7 @@ unsafe impl ::windows::core::Abi for SimilarityDumpData {
 }
 impl ::core::cmp::PartialEq for SimilarityDumpData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SimilarityDumpData>()) == 0 }
+        self.m_FileIndex == other.m_FileIndex && self.m_Data == other.m_Data
     }
 }
 impl ::core::cmp::Eq for SimilarityDumpData {}
@@ -1488,7 +1488,7 @@ unsafe impl ::windows::core::Abi for SimilarityFileId {
 }
 impl ::core::cmp::PartialEq for SimilarityFileId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SimilarityFileId>()) == 0 }
+        self.m_FileId == other.m_FileId
     }
 }
 impl ::core::cmp::Eq for SimilarityFileId {}
@@ -1519,7 +1519,7 @@ unsafe impl ::windows::core::Abi for SimilarityMappedViewInfo {
 }
 impl ::core::cmp::PartialEq for SimilarityMappedViewInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SimilarityMappedViewInfo>()) == 0 }
+        self.m_Data == other.m_Data && self.m_Length == other.m_Length
     }
 }
 impl ::core::cmp::Eq for SimilarityMappedViewInfo {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
@@ -320,12 +320,6 @@ impl ::core::clone::Clone for WEB_SOCKET_BUFFER {
 unsafe impl ::windows::core::Abi for WEB_SOCKET_BUFFER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WEB_SOCKET_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEB_SOCKET_BUFFER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WEB_SOCKET_BUFFER {}
 impl ::core::default::Default for WEB_SOCKET_BUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -354,7 +348,7 @@ unsafe impl ::windows::core::Abi for WEB_SOCKET_BUFFER_0 {
 }
 impl ::core::cmp::PartialEq for WEB_SOCKET_BUFFER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEB_SOCKET_BUFFER_0>()) == 0 }
+        self.pbReason == other.pbReason && self.ulReasonLength == other.ulReasonLength && self.usStatus == other.usStatus
     }
 }
 impl ::core::cmp::Eq for WEB_SOCKET_BUFFER_0 {}
@@ -385,7 +379,7 @@ unsafe impl ::windows::core::Abi for WEB_SOCKET_BUFFER_1 {
 }
 impl ::core::cmp::PartialEq for WEB_SOCKET_BUFFER_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEB_SOCKET_BUFFER_1>()) == 0 }
+        self.pbBuffer == other.pbBuffer && self.ulBufferLength == other.ulBufferLength
     }
 }
 impl ::core::cmp::Eq for WEB_SOCKET_BUFFER_1 {}
@@ -450,7 +444,7 @@ unsafe impl ::windows::core::Abi for WEB_SOCKET_HTTP_HEADER {
 }
 impl ::core::cmp::PartialEq for WEB_SOCKET_HTTP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEB_SOCKET_HTTP_HEADER>()) == 0 }
+        self.pcName == other.pcName && self.ulNameLength == other.ulNameLength && self.pcValue == other.pcValue && self.ulValueLength == other.ulValueLength
     }
 }
 impl ::core::cmp::Eq for WEB_SOCKET_HTTP_HEADER {}
@@ -482,7 +476,7 @@ unsafe impl ::windows::core::Abi for WEB_SOCKET_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WEB_SOCKET_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEB_SOCKET_PROPERTY>()) == 0 }
+        self.Type == other.Type && self.pvValue == other.pvValue && self.ulValueSize == other.ulValueSize
     }
 }
 impl ::core::cmp::Eq for WEB_SOCKET_PROPERTY {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -1855,7 +1855,7 @@ unsafe impl ::windows::core::Abi for HTTP_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for HTTP_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_VERSION_INFO>()) == 0 }
+        self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion
     }
 }
 impl ::core::cmp::Eq for HTTP_VERSION_INFO {}
@@ -1915,7 +1915,7 @@ unsafe impl ::windows::core::Abi for URL_COMPONENTS {
 }
 impl ::core::cmp::PartialEq for URL_COMPONENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URL_COMPONENTS>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.lpszScheme == other.lpszScheme && self.dwSchemeLength == other.dwSchemeLength && self.nScheme == other.nScheme && self.lpszHostName == other.lpszHostName && self.dwHostNameLength == other.dwHostNameLength && self.nPort == other.nPort && self.lpszUserName == other.lpszUserName && self.dwUserNameLength == other.dwUserNameLength && self.lpszPassword == other.lpszPassword && self.dwPasswordLength == other.dwPasswordLength && self.lpszUrlPath == other.lpszUrlPath && self.dwUrlPathLength == other.dwUrlPathLength && self.lpszExtraInfo == other.lpszExtraInfo && self.dwExtraInfoLength == other.dwExtraInfoLength
     }
 }
 impl ::core::cmp::Eq for URL_COMPONENTS {}
@@ -1946,7 +1946,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_ASYNC_RESULT {
 }
 impl ::core::cmp::PartialEq for WINHTTP_ASYNC_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_ASYNC_RESULT>()) == 0 }
+        self.dwResult == other.dwResult && self.dwError == other.dwError
     }
 }
 impl ::core::cmp::Eq for WINHTTP_ASYNC_RESULT {}
@@ -1987,7 +1987,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_AUTOPROXY_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_AUTOPROXY_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_AUTOPROXY_OPTIONS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwAutoDetectFlags == other.dwAutoDetectFlags && self.lpszAutoConfigUrl == other.lpszAutoConfigUrl && self.lpvReserved == other.lpvReserved && self.dwReserved == other.dwReserved && self.fAutoLogonIfChallenged == other.fAutoLogonIfChallenged
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2032,7 +2032,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_CERTIFICATE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_CERTIFICATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CERTIFICATE_INFO>()) == 0 }
+        self.ftExpiry == other.ftExpiry && self.ftStart == other.ftStart && self.lpszSubjectInfo == other.lpszSubjectInfo && self.lpszIssuerInfo == other.lpszIssuerInfo && self.lpszProtocolName == other.lpszProtocolName && self.lpszSignatureAlgName == other.lpszSignatureAlgName && self.lpszEncryptionAlgName == other.lpszEncryptionAlgName && self.dwKeySize == other.dwKeySize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2065,7 +2065,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_CONNECTION_GROUP {
 }
 impl ::core::cmp::PartialEq for WINHTTP_CONNECTION_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CONNECTION_GROUP>()) == 0 }
+        self.cConnections == other.cConnections && self.guidGroup == other.guidGroup
     }
 }
 impl ::core::cmp::Eq for WINHTTP_CONNECTION_GROUP {}
@@ -2100,16 +2100,6 @@ unsafe impl ::windows::core::Abi for WINHTTP_CONNECTION_INFO {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for WINHTTP_CONNECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CONNECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for WINHTTP_CONNECTION_INFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for WINHTTP_CONNECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2139,16 +2129,6 @@ impl ::core::clone::Clone for WINHTTP_CONNECTION_INFO {
 unsafe impl ::windows::core::Abi for WINHTTP_CONNECTION_INFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::PartialEq for WINHTTP_CONNECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CONNECTION_INFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
-impl ::core::cmp::Eq for WINHTTP_CONNECTION_INFO {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::default::Default for WINHTTP_CONNECTION_INFO {
@@ -2182,7 +2162,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_CREDS {
 }
 impl ::core::cmp::PartialEq for WINHTTP_CREDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CREDS>()) == 0 }
+        self.lpszUserName == other.lpszUserName && self.lpszPassword == other.lpszPassword && self.lpszRealm == other.lpszRealm && self.dwAuthScheme == other.dwAuthScheme && self.lpszHostName == other.lpszHostName && self.dwPort == other.dwPort
     }
 }
 impl ::core::cmp::Eq for WINHTTP_CREDS {}
@@ -2218,7 +2198,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_CREDS_EX {
 }
 impl ::core::cmp::PartialEq for WINHTTP_CREDS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CREDS_EX>()) == 0 }
+        self.lpszUserName == other.lpszUserName && self.lpszPassword == other.lpszPassword && self.lpszRealm == other.lpszRealm && self.dwAuthScheme == other.dwAuthScheme && self.lpszHostName == other.lpszHostName && self.dwPort == other.dwPort && self.lpszUrl == other.lpszUrl
     }
 }
 impl ::core::cmp::Eq for WINHTTP_CREDS_EX {}
@@ -2257,7 +2237,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_CURRENT_USER_IE_PROXY_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_CURRENT_USER_IE_PROXY_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_CURRENT_USER_IE_PROXY_CONFIG>()) == 0 }
+        self.fAutoDetect == other.fAutoDetect && self.lpszAutoConfigUrl == other.lpszAutoConfigUrl && self.lpszProxy == other.lpszProxy && self.lpszProxyBypass == other.lpszProxyBypass
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2283,12 +2263,6 @@ impl ::core::clone::Clone for WINHTTP_EXTENDED_HEADER {
 unsafe impl ::windows::core::Abi for WINHTTP_EXTENDED_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINHTTP_EXTENDED_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_EXTENDED_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINHTTP_EXTENDED_HEADER {}
 impl ::core::default::Default for WINHTTP_EXTENDED_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2309,12 +2283,6 @@ impl ::core::clone::Clone for WINHTTP_EXTENDED_HEADER_0 {
 unsafe impl ::windows::core::Abi for WINHTTP_EXTENDED_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINHTTP_EXTENDED_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_EXTENDED_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINHTTP_EXTENDED_HEADER_0 {}
 impl ::core::default::Default for WINHTTP_EXTENDED_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2335,12 +2303,6 @@ impl ::core::clone::Clone for WINHTTP_EXTENDED_HEADER_1 {
 unsafe impl ::windows::core::Abi for WINHTTP_EXTENDED_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINHTTP_EXTENDED_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_EXTENDED_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINHTTP_EXTENDED_HEADER_1 {}
 impl ::core::default::Default for WINHTTP_EXTENDED_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2368,7 +2330,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_FAILED_CONNECTION_RETRIES {
 }
 impl ::core::cmp::PartialEq for WINHTTP_FAILED_CONNECTION_RETRIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_FAILED_CONNECTION_RETRIES>()) == 0 }
+        self.dwMaxRetries == other.dwMaxRetries && self.dwAllowedRetryConditions == other.dwAllowedRetryConditions
     }
 }
 impl ::core::cmp::Eq for WINHTTP_FAILED_CONNECTION_RETRIES {}
@@ -2392,12 +2354,6 @@ impl ::core::clone::Clone for WINHTTP_HEADER_NAME {
 unsafe impl ::windows::core::Abi for WINHTTP_HEADER_NAME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINHTTP_HEADER_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_HEADER_NAME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINHTTP_HEADER_NAME {}
 impl ::core::default::Default for WINHTTP_HEADER_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2426,7 +2382,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_HOST_CONNECTION_GROUP {
 }
 impl ::core::cmp::PartialEq for WINHTTP_HOST_CONNECTION_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_HOST_CONNECTION_GROUP>()) == 0 }
+        self.pwszHost == other.pwszHost && self.cConnectionGroups == other.cConnectionGroups && self.pConnectionGroups == other.pConnectionGroups
     }
 }
 impl ::core::cmp::Eq for WINHTTP_HOST_CONNECTION_GROUP {}
@@ -2457,7 +2413,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_HTTP2_RECEIVE_WINDOW {
 }
 impl ::core::cmp::PartialEq for WINHTTP_HTTP2_RECEIVE_WINDOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_HTTP2_RECEIVE_WINDOW>()) == 0 }
+        self.ulStreamWindow == other.ulStreamWindow && self.ulStreamWindowUpdateDelta == other.ulStreamWindowUpdateDelta
     }
 }
 impl ::core::cmp::Eq for WINHTTP_HTTP2_RECEIVE_WINDOW {}
@@ -2486,14 +2442,6 @@ unsafe impl ::windows::core::Abi for WINHTTP_MATCH_CONNECTION_GUID {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for WINHTTP_MATCH_CONNECTION_GUID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_MATCH_CONNECTION_GUID>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for WINHTTP_MATCH_CONNECTION_GUID {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for WINHTTP_MATCH_CONNECTION_GUID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2518,14 +2466,6 @@ impl ::core::clone::Clone for WINHTTP_MATCH_CONNECTION_GUID {
 unsafe impl ::windows::core::Abi for WINHTTP_MATCH_CONNECTION_GUID {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for WINHTTP_MATCH_CONNECTION_GUID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_MATCH_CONNECTION_GUID>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for WINHTTP_MATCH_CONNECTION_GUID {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for WINHTTP_MATCH_CONNECTION_GUID {
     fn default() -> Self {
@@ -2555,7 +2495,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_INFO {
 }
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_INFO>()) == 0 }
+        self.dwAccessType == other.dwAccessType && self.lpszProxy == other.lpszProxy && self.lpszProxyBypass == other.lpszProxyBypass
     }
 }
 impl ::core::cmp::Eq for WINHTTP_PROXY_INFO {}
@@ -2585,7 +2525,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_NETWORKING_KEY {
 }
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_NETWORKING_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_NETWORKING_KEY>()) == 0 }
+        self.pbBuffer == other.pbBuffer
     }
 }
 impl ::core::cmp::Eq for WINHTTP_PROXY_NETWORKING_KEY {}
@@ -2622,7 +2562,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_RESULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_RESULT>()) == 0 }
+        self.cEntries == other.cEntries && self.pEntries == other.pEntries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2664,7 +2604,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_RESULT_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_RESULT_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_RESULT_ENTRY>()) == 0 }
+        self.fProxy == other.fProxy && self.fBypass == other.fBypass && self.ProxyScheme == other.ProxyScheme && self.pwszProxy == other.pwszProxy && self.ProxyPort == other.ProxyPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2705,7 +2645,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_RESULT_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_RESULT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_RESULT_EX>()) == 0 }
+        self.cEntries == other.cEntries && self.pEntries == other.pEntries && self.hProxyDetectionHandle == other.hProxyDetectionHandle && self.dwProxyInterfaceAffinity == other.dwProxyInterfaceAffinity
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2775,7 +2715,22 @@ unsafe impl ::windows::core::Abi for WINHTTP_PROXY_SETTINGS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINHTTP_PROXY_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_PROXY_SETTINGS>()) == 0 }
+        self.dwStructSize == other.dwStructSize
+            && self.dwFlags == other.dwFlags
+            && self.dwCurrentSettingsVersion == other.dwCurrentSettingsVersion
+            && self.pwszConnectionName == other.pwszConnectionName
+            && self.pwszProxy == other.pwszProxy
+            && self.pwszProxyBypass == other.pwszProxyBypass
+            && self.pwszAutoconfigUrl == other.pwszAutoconfigUrl
+            && self.pwszAutoconfigSecondaryUrl == other.pwszAutoconfigSecondaryUrl
+            && self.dwAutoDiscoveryFlags == other.dwAutoDiscoveryFlags
+            && self.pwszLastKnownGoodAutoConfigUrl == other.pwszLastKnownGoodAutoConfigUrl
+            && self.dwAutoconfigReloadDelayMins == other.dwAutoconfigReloadDelayMins
+            && self.ftLastKnownDetectTime == other.ftLastKnownDetectTime
+            && self.dwDetectedInterfaceIpCount == other.dwDetectedInterfaceIpCount
+            && self.pdwDetectedInterfaceIp == other.pdwDetectedInterfaceIp
+            && self.cNetworkKeys == other.cNetworkKeys
+            && self.pNetworkKeys == other.pNetworkKeys
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2808,7 +2763,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_QUERY_CONNECTION_GROUP_RESULT {
 }
 impl ::core::cmp::PartialEq for WINHTTP_QUERY_CONNECTION_GROUP_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_QUERY_CONNECTION_GROUP_RESULT>()) == 0 }
+        self.cHosts == other.cHosts && self.pHostConnectionGroups == other.pHostConnectionGroups
     }
 }
 impl ::core::cmp::Eq for WINHTTP_QUERY_CONNECTION_GROUP_RESULT {}
@@ -2839,14 +2794,6 @@ unsafe impl ::windows::core::Abi for WINHTTP_REQUEST_STATS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for WINHTTP_REQUEST_STATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_REQUEST_STATS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for WINHTTP_REQUEST_STATS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for WINHTTP_REQUEST_STATS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2874,14 +2821,6 @@ unsafe impl ::windows::core::Abi for WINHTTP_REQUEST_STATS {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for WINHTTP_REQUEST_STATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_REQUEST_STATS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for WINHTTP_REQUEST_STATS {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for WINHTTP_REQUEST_STATS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2907,14 +2846,6 @@ unsafe impl ::windows::core::Abi for WINHTTP_REQUEST_TIMES {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for WINHTTP_REQUEST_TIMES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_REQUEST_TIMES>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for WINHTTP_REQUEST_TIMES {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for WINHTTP_REQUEST_TIMES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2939,14 +2870,6 @@ impl ::core::clone::Clone for WINHTTP_REQUEST_TIMES {
 unsafe impl ::windows::core::Abi for WINHTTP_REQUEST_TIMES {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for WINHTTP_REQUEST_TIMES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_REQUEST_TIMES>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for WINHTTP_REQUEST_TIMES {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for WINHTTP_REQUEST_TIMES {
     fn default() -> Self {
@@ -2976,14 +2899,6 @@ impl ::core::clone::Clone for WINHTTP_RESOLVER_CACHE_CONFIG {
 unsafe impl ::windows::core::Abi for WINHTTP_RESOLVER_CACHE_CONFIG {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for WINHTTP_RESOLVER_CACHE_CONFIG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_RESOLVER_CACHE_CONFIG>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for WINHTTP_RESOLVER_CACHE_CONFIG {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for WINHTTP_RESOLVER_CACHE_CONFIG {
     fn default() -> Self {
@@ -3013,14 +2928,6 @@ impl ::core::clone::Clone for WINHTTP_RESOLVER_CACHE_CONFIG {
 unsafe impl ::windows::core::Abi for WINHTTP_RESOLVER_CACHE_CONFIG {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for WINHTTP_RESOLVER_CACHE_CONFIG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_RESOLVER_CACHE_CONFIG>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for WINHTTP_RESOLVER_CACHE_CONFIG {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for WINHTTP_RESOLVER_CACHE_CONFIG {
     fn default() -> Self {
@@ -3049,7 +2956,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_WEB_SOCKET_ASYNC_RESULT {
 }
 impl ::core::cmp::PartialEq for WINHTTP_WEB_SOCKET_ASYNC_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_WEB_SOCKET_ASYNC_RESULT>()) == 0 }
+        self.AsyncResult == other.AsyncResult && self.Operation == other.Operation
     }
 }
 impl ::core::cmp::Eq for WINHTTP_WEB_SOCKET_ASYNC_RESULT {}
@@ -3080,7 +2987,7 @@ unsafe impl ::windows::core::Abi for WINHTTP_WEB_SOCKET_STATUS {
 }
 impl ::core::cmp::PartialEq for WINHTTP_WEB_SOCKET_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINHTTP_WEB_SOCKET_STATUS>()) == 0 }
+        self.dwBytesTransferred == other.dwBytesTransferred && self.eBufferType == other.eBufferType
     }
 }
 impl ::core::cmp::Eq for WINHTTP_WEB_SOCKET_STATUS {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -5791,7 +5791,7 @@ unsafe impl ::windows::core::Abi for APP_CACHE_DOWNLOAD_ENTRY {
 }
 impl ::core::cmp::PartialEq for APP_CACHE_DOWNLOAD_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_CACHE_DOWNLOAD_ENTRY>()) == 0 }
+        self.pwszUrl == other.pwszUrl && self.dwEntryType == other.dwEntryType
     }
 }
 impl ::core::cmp::Eq for APP_CACHE_DOWNLOAD_ENTRY {}
@@ -5822,7 +5822,7 @@ unsafe impl ::windows::core::Abi for APP_CACHE_DOWNLOAD_LIST {
 }
 impl ::core::cmp::PartialEq for APP_CACHE_DOWNLOAD_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_CACHE_DOWNLOAD_LIST>()) == 0 }
+        self.dwEntryCount == other.dwEntryCount && self.pEntries == other.pEntries
     }
 }
 impl ::core::cmp::Eq for APP_CACHE_DOWNLOAD_LIST {}
@@ -5860,7 +5860,7 @@ unsafe impl ::windows::core::Abi for APP_CACHE_GROUP_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for APP_CACHE_GROUP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_CACHE_GROUP_INFO>()) == 0 }
+        self.pwszManifestUrl == other.pwszManifestUrl && self.ftLastAccessTime == other.ftLastAccessTime && self.ullSize == other.ullSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5899,7 +5899,7 @@ unsafe impl ::windows::core::Abi for APP_CACHE_GROUP_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for APP_CACHE_GROUP_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_CACHE_GROUP_LIST>()) == 0 }
+        self.dwAppCacheGroupCount == other.dwAppCacheGroupCount && self.pAppCacheGroups == other.pAppCacheGroups
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5933,7 +5933,7 @@ unsafe impl ::windows::core::Abi for AUTO_PROXY_SCRIPT_BUFFER {
 }
 impl ::core::cmp::PartialEq for AUTO_PROXY_SCRIPT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTO_PROXY_SCRIPT_BUFFER>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.lpszScriptBuffer == other.lpszScriptBuffer && self.dwScriptBufferSize == other.dwScriptBufferSize
     }
 }
 impl ::core::cmp::Eq for AUTO_PROXY_SCRIPT_BUFFER {}
@@ -5963,7 +5963,7 @@ unsafe impl ::windows::core::Abi for AutoProxyHelperFunctions {
 }
 impl ::core::cmp::PartialEq for AutoProxyHelperFunctions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AutoProxyHelperFunctions>()) == 0 }
+        self.lpVtbl == other.lpVtbl
     }
 }
 impl ::core::cmp::Eq for AutoProxyHelperFunctions {}
@@ -6001,7 +6001,7 @@ unsafe impl ::windows::core::Abi for AutoProxyHelperVtbl {
 }
 impl ::core::cmp::PartialEq for AutoProxyHelperVtbl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AutoProxyHelperVtbl>()) == 0 }
+        self.IsResolvable == other.IsResolvable && self.GetIPAddress == other.GetIPAddress && self.ResolveHostName == other.ResolveHostName && self.IsInNet == other.IsInNet && self.IsResolvableEx == other.IsResolvableEx && self.GetIPAddressEx == other.GetIPAddressEx && self.ResolveHostNameEx == other.ResolveHostNameEx && self.IsInNetEx == other.IsInNetEx && self.SortIpList == other.SortIpList
     }
 }
 impl ::core::cmp::Eq for AutoProxyHelperVtbl {}
@@ -6043,7 +6043,7 @@ unsafe impl ::windows::core::Abi for COOKIE_DLG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COOKIE_DLG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COOKIE_DLG_INFO>()) == 0 }
+        self.pszServer == other.pszServer && self.pic == other.pic && self.dwStopWarning == other.dwStopWarning && self.cx == other.cx && self.cy == other.cy && self.pszHeader == other.pszHeader && self.dwOperation == other.dwOperation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6082,7 +6082,7 @@ unsafe impl ::windows::core::Abi for CookieDecision {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CookieDecision {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CookieDecision>()) == 0 }
+        self.dwCookieState == other.dwCookieState && self.fAllowSession == other.fAllowSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6115,7 +6115,7 @@ unsafe impl ::windows::core::Abi for GOPHER_ABSTRACT_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_ABSTRACT_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ABSTRACT_ATTRIBUTE_TYPE>()) == 0 }
+        self.ShortAbstract == other.ShortAbstract && self.AbstractFile == other.AbstractFile
     }
 }
 impl ::core::cmp::Eq for GOPHER_ABSTRACT_ATTRIBUTE_TYPE {}
@@ -6146,7 +6146,7 @@ unsafe impl ::windows::core::Abi for GOPHER_ADMIN_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_ADMIN_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ADMIN_ATTRIBUTE_TYPE>()) == 0 }
+        self.Comment == other.Comment && self.EmailAddress == other.EmailAddress
     }
 }
 impl ::core::cmp::Eq for GOPHER_ADMIN_ATTRIBUTE_TYPE {}
@@ -6177,7 +6177,7 @@ unsafe impl ::windows::core::Abi for GOPHER_ASK_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_ASK_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ASK_ATTRIBUTE_TYPE>()) == 0 }
+        self.QuestionType == other.QuestionType && self.QuestionText == other.QuestionText
     }
 }
 impl ::core::cmp::Eq for GOPHER_ASK_ATTRIBUTE_TYPE {}
@@ -6206,14 +6206,6 @@ impl ::core::clone::Clone for GOPHER_ATTRIBUTE_TYPE {
 unsafe impl ::windows::core::Abi for GOPHER_ATTRIBUTE_TYPE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GOPHER_ATTRIBUTE_TYPE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ATTRIBUTE_TYPE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GOPHER_ATTRIBUTE_TYPE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GOPHER_ATTRIBUTE_TYPE {
     fn default() -> Self {
@@ -6255,14 +6247,6 @@ unsafe impl ::windows::core::Abi for GOPHER_ATTRIBUTE_TYPE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GOPHER_ATTRIBUTE_TYPE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ATTRIBUTE_TYPE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GOPHER_ATTRIBUTE_TYPE_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GOPHER_ATTRIBUTE_TYPE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6300,7 +6284,7 @@ unsafe impl ::windows::core::Abi for GOPHER_FIND_DATAA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GOPHER_FIND_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_FIND_DATAA>()) == 0 }
+        self.DisplayString == other.DisplayString && self.GopherType == other.GopherType && self.SizeLow == other.SizeLow && self.SizeHigh == other.SizeHigh && self.LastModificationTime == other.LastModificationTime && self.Locator == other.Locator
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6343,7 +6327,7 @@ unsafe impl ::windows::core::Abi for GOPHER_FIND_DATAW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GOPHER_FIND_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_FIND_DATAW>()) == 0 }
+        self.DisplayString == other.DisplayString && self.GopherType == other.GopherType && self.SizeLow == other.SizeLow && self.SizeHigh == other.SizeHigh && self.LastModificationTime == other.LastModificationTime && self.Locator == other.Locator
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6380,7 +6364,7 @@ unsafe impl ::windows::core::Abi for GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE
 }
 impl ::core::cmp::PartialEq for GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE>()) == 0 }
+        self.DegreesNorth == other.DegreesNorth && self.MinutesNorth == other.MinutesNorth && self.SecondsNorth == other.SecondsNorth && self.DegreesEast == other.DegreesEast && self.MinutesEast == other.MinutesEast && self.SecondsEast == other.SecondsEast
     }
 }
 impl ::core::cmp::Eq for GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE {}
@@ -6410,7 +6394,7 @@ unsafe impl ::windows::core::Abi for GOPHER_LOCATION_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_LOCATION_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_LOCATION_ATTRIBUTE_TYPE>()) == 0 }
+        self.Location == other.Location
     }
 }
 impl ::core::cmp::Eq for GOPHER_LOCATION_ATTRIBUTE_TYPE {}
@@ -6446,7 +6430,7 @@ unsafe impl ::windows::core::Abi for GOPHER_MOD_DATE_ATTRIBUTE_TYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GOPHER_MOD_DATE_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_MOD_DATE_ATTRIBUTE_TYPE>()) == 0 }
+        self.DateAndTime == other.DateAndTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6478,7 +6462,7 @@ unsafe impl ::windows::core::Abi for GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_ORGANIZATION_ATTRIBUTE_TYPE>()) == 0 }
+        self.Organization == other.Organization
     }
 }
 impl ::core::cmp::Eq for GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {}
@@ -6508,7 +6492,7 @@ unsafe impl ::windows::core::Abi for GOPHER_PROVIDER_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_PROVIDER_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_PROVIDER_ATTRIBUTE_TYPE>()) == 0 }
+        self.Provider == other.Provider
     }
 }
 impl ::core::cmp::Eq for GOPHER_PROVIDER_ATTRIBUTE_TYPE {}
@@ -6538,7 +6522,7 @@ unsafe impl ::windows::core::Abi for GOPHER_SCORE_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_SCORE_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_SCORE_ATTRIBUTE_TYPE>()) == 0 }
+        self.Score == other.Score
     }
 }
 impl ::core::cmp::Eq for GOPHER_SCORE_ATTRIBUTE_TYPE {}
@@ -6569,7 +6553,7 @@ unsafe impl ::windows::core::Abi for GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE>()) == 0 }
+        self.LowerBound == other.LowerBound && self.UpperBound == other.UpperBound
     }
 }
 impl ::core::cmp::Eq for GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {}
@@ -6599,7 +6583,7 @@ unsafe impl ::windows::core::Abi for GOPHER_SITE_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_SITE_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_SITE_ATTRIBUTE_TYPE>()) == 0 }
+        self.Site == other.Site
     }
 }
 impl ::core::cmp::Eq for GOPHER_SITE_ATTRIBUTE_TYPE {}
@@ -6629,7 +6613,7 @@ unsafe impl ::windows::core::Abi for GOPHER_TIMEZONE_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_TIMEZONE_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_TIMEZONE_ATTRIBUTE_TYPE>()) == 0 }
+        self.Zone == other.Zone
     }
 }
 impl ::core::cmp::Eq for GOPHER_TIMEZONE_ATTRIBUTE_TYPE {}
@@ -6659,7 +6643,7 @@ unsafe impl ::windows::core::Abi for GOPHER_TTL_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_TTL_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_TTL_ATTRIBUTE_TYPE>()) == 0 }
+        self.Ttl == other.Ttl
     }
 }
 impl ::core::cmp::Eq for GOPHER_TTL_ATTRIBUTE_TYPE {}
@@ -6689,7 +6673,7 @@ unsafe impl ::windows::core::Abi for GOPHER_UNKNOWN_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_UNKNOWN_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_UNKNOWN_ATTRIBUTE_TYPE>()) == 0 }
+        self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for GOPHER_UNKNOWN_ATTRIBUTE_TYPE {}
@@ -6725,7 +6709,7 @@ unsafe impl ::windows::core::Abi for GOPHER_VERONICA_ATTRIBUTE_TYPE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GOPHER_VERONICA_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_VERONICA_ATTRIBUTE_TYPE>()) == 0 }
+        self.TreeWalk == other.TreeWalk
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6757,7 +6741,7 @@ unsafe impl ::windows::core::Abi for GOPHER_VERSION_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_VERSION_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_VERSION_ATTRIBUTE_TYPE>()) == 0 }
+        self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for GOPHER_VERSION_ATTRIBUTE_TYPE {}
@@ -6789,7 +6773,7 @@ unsafe impl ::windows::core::Abi for GOPHER_VIEW_ATTRIBUTE_TYPE {
 }
 impl ::core::cmp::PartialEq for GOPHER_VIEW_ATTRIBUTE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GOPHER_VIEW_ATTRIBUTE_TYPE>()) == 0 }
+        self.ContentType == other.ContentType && self.Language == other.Language && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for GOPHER_VIEW_ATTRIBUTE_TYPE {}
@@ -6826,7 +6810,7 @@ unsafe impl ::windows::core::Abi for HTTP_PUSH_NOTIFICATION_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_PUSH_NOTIFICATION_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_PUSH_NOTIFICATION_STATUS>()) == 0 }
+        self.ChannelStatusValid == other.ChannelStatusValid && self.ChannelStatus == other.ChannelStatus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6859,7 +6843,7 @@ unsafe impl ::windows::core::Abi for HTTP_PUSH_TRANSPORT_SETTING {
 }
 impl ::core::cmp::PartialEq for HTTP_PUSH_TRANSPORT_SETTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_PUSH_TRANSPORT_SETTING>()) == 0 }
+        self.TransportSettingId == other.TransportSettingId && self.BrokerEventId == other.BrokerEventId
     }
 }
 impl ::core::cmp::Eq for HTTP_PUSH_TRANSPORT_SETTING {}
@@ -6922,7 +6906,7 @@ unsafe impl ::windows::core::Abi for HTTP_REQUEST_TIMES {
 }
 impl ::core::cmp::PartialEq for HTTP_REQUEST_TIMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_REQUEST_TIMES>()) == 0 }
+        self.cTimes == other.cTimes && self.rgTimes == other.rgTimes
     }
 }
 impl ::core::cmp::Eq for HTTP_REQUEST_TIMES {}
@@ -6955,7 +6939,7 @@ unsafe impl ::windows::core::Abi for HTTP_WEB_SOCKET_ASYNC_RESULT {
 }
 impl ::core::cmp::PartialEq for HTTP_WEB_SOCKET_ASYNC_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_WEB_SOCKET_ASYNC_RESULT>()) == 0 }
+        self.AsyncResult == other.AsyncResult && self.Operation == other.Operation && self.BufferType == other.BufferType && self.dwBytesTransferred == other.dwBytesTransferred
     }
 }
 impl ::core::cmp::Eq for HTTP_WEB_SOCKET_ASYNC_RESULT {}
@@ -6986,7 +6970,7 @@ unsafe impl ::windows::core::Abi for INTERNET_ASYNC_RESULT {
 }
 impl ::core::cmp::PartialEq for INTERNET_ASYNC_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_ASYNC_RESULT>()) == 0 }
+        self.dwResult == other.dwResult && self.dwError == other.dwError
     }
 }
 impl ::core::cmp::Eq for INTERNET_ASYNC_RESULT {}
@@ -7011,18 +6995,12 @@ impl ::core::clone::Clone for INTERNET_AUTH_NOTIFY_DATA {
 }
 impl ::core::fmt::Debug for INTERNET_AUTH_NOTIFY_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("INTERNET_AUTH_NOTIFY_DATA").field("cbStruct", &self.cbStruct).field("dwOptions", &self.dwOptions).field("pfnNotify", &self.pfnNotify.map(|f| f as usize)).field("dwContext", &self.dwContext).finish()
+        f.debug_struct("INTERNET_AUTH_NOTIFY_DATA").field("cbStruct", &self.cbStruct).field("dwOptions", &self.dwOptions).field("dwContext", &self.dwContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for INTERNET_AUTH_NOTIFY_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INTERNET_AUTH_NOTIFY_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_AUTH_NOTIFY_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INTERNET_AUTH_NOTIFY_DATA {}
 impl ::core::default::Default for INTERNET_AUTH_NOTIFY_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7058,7 +7036,7 @@ unsafe impl ::windows::core::Abi for INTERNET_BUFFERSA {
 }
 impl ::core::cmp::PartialEq for INTERNET_BUFFERSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_BUFFERSA>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.Next == other.Next && self.lpcszHeader == other.lpcszHeader && self.dwHeadersLength == other.dwHeadersLength && self.dwHeadersTotal == other.dwHeadersTotal && self.lpvBuffer == other.lpvBuffer && self.dwBufferLength == other.dwBufferLength && self.dwBufferTotal == other.dwBufferTotal && self.dwOffsetLow == other.dwOffsetLow && self.dwOffsetHigh == other.dwOffsetHigh
     }
 }
 impl ::core::cmp::Eq for INTERNET_BUFFERSA {}
@@ -7097,7 +7075,7 @@ unsafe impl ::windows::core::Abi for INTERNET_BUFFERSW {
 }
 impl ::core::cmp::PartialEq for INTERNET_BUFFERSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_BUFFERSW>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.Next == other.Next && self.lpcszHeader == other.lpcszHeader && self.dwHeadersLength == other.dwHeadersLength && self.dwHeadersTotal == other.dwHeadersTotal && self.lpvBuffer == other.lpvBuffer && self.dwBufferLength == other.dwBufferLength && self.dwBufferTotal == other.dwBufferTotal && self.dwOffsetLow == other.dwOffsetLow && self.dwOffsetHigh == other.dwOffsetHigh
     }
 }
 impl ::core::cmp::Eq for INTERNET_BUFFERSW {}
@@ -7134,14 +7112,6 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_CONFIG_INFOA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_CONFIG_INFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7166,14 +7136,6 @@ impl ::core::clone::Clone for INTERNET_CACHE_CONFIG_INFOA_0 {
 unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_CONFIG_INFOA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_CONFIG_INFOA_0 {
     fn default() -> Self {
@@ -7208,7 +7170,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOA_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOA_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOA_0_0>()) == 0 }
+        self.CachePath == other.CachePath && self.dwCacheSize == other.dwCacheSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7247,14 +7209,6 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_CONFIG_INFOW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_CONFIG_INFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7279,14 +7233,6 @@ impl ::core::clone::Clone for INTERNET_CACHE_CONFIG_INFOW_0 {
 unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_CONFIG_INFOW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_CONFIG_INFOW_0 {
     fn default() -> Self {
@@ -7321,7 +7267,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_INFOW_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_INFOW_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_INFOW_0_0>()) == 0 }
+        self.CachePath == other.CachePath && self.dwCacheSize == other.dwCacheSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7360,7 +7306,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_PATH_ENTRYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_PATH_ENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_PATH_ENTRYA>()) == 0 }
+        self.CachePath == other.CachePath && self.dwCacheSize == other.dwCacheSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7393,7 +7339,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONFIG_PATH_ENTRYW {
 }
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONFIG_PATH_ENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONFIG_PATH_ENTRYW>()) == 0 }
+        self.CachePath == other.CachePath && self.dwCacheSize == other.dwCacheSize
     }
 }
 impl ::core::cmp::Eq for INTERNET_CACHE_CONFIG_PATH_ENTRYW {}
@@ -7427,7 +7373,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONTAINER_INFOA {
 }
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONTAINER_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONTAINER_INFOA>()) == 0 }
+        self.dwCacheVersion == other.dwCacheVersion && self.lpszName == other.lpszName && self.lpszCachePrefix == other.lpszCachePrefix && self.lpszVolumeLabel == other.lpszVolumeLabel && self.lpszVolumeTitle == other.lpszVolumeTitle
     }
 }
 impl ::core::cmp::Eq for INTERNET_CACHE_CONTAINER_INFOA {}
@@ -7461,7 +7407,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_CONTAINER_INFOW {
 }
 impl ::core::cmp::PartialEq for INTERNET_CACHE_CONTAINER_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_CONTAINER_INFOW>()) == 0 }
+        self.dwCacheVersion == other.dwCacheVersion && self.lpszName == other.lpszName && self.lpszCachePrefix == other.lpszCachePrefix && self.lpszVolumeLabel == other.lpszVolumeLabel && self.lpszVolumeTitle == other.lpszVolumeTitle
     }
 }
 impl ::core::cmp::Eq for INTERNET_CACHE_CONTAINER_INFOW {}
@@ -7504,14 +7450,6 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_ENTRY_INFOA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_ENTRY_INFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_ENTRY_INFOA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_ENTRY_INFOA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_ENTRY_INFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7536,14 +7474,6 @@ impl ::core::clone::Clone for INTERNET_CACHE_ENTRY_INFOA_0 {
 unsafe impl ::windows::core::Abi for INTERNET_CACHE_ENTRY_INFOA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_ENTRY_INFOA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_ENTRY_INFOA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_ENTRY_INFOA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_ENTRY_INFOA_0 {
     fn default() -> Self {
@@ -7584,14 +7514,6 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_ENTRY_INFOW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_ENTRY_INFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_ENTRY_INFOW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_ENTRY_INFOW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_ENTRY_INFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7616,14 +7538,6 @@ impl ::core::clone::Clone for INTERNET_CACHE_ENTRY_INFOW_0 {
 unsafe impl ::windows::core::Abi for INTERNET_CACHE_ENTRY_INFOW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CACHE_ENTRY_INFOW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_ENTRY_INFOW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CACHE_ENTRY_INFOW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CACHE_ENTRY_INFOW_0 {
     fn default() -> Self {
@@ -7663,7 +7577,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_GROUP_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CACHE_GROUP_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_GROUP_INFOA>()) == 0 }
+        self.dwGroupSize == other.dwGroupSize && self.dwGroupFlags == other.dwGroupFlags && self.dwGroupType == other.dwGroupType && self.dwDiskUsage == other.dwDiskUsage && self.dwDiskQuota == other.dwDiskQuota && self.dwOwnerStorage == other.dwOwnerStorage && self.szGroupName == other.szGroupName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7701,7 +7615,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_GROUP_INFOW {
 }
 impl ::core::cmp::PartialEq for INTERNET_CACHE_GROUP_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_GROUP_INFOW>()) == 0 }
+        self.dwGroupSize == other.dwGroupSize && self.dwGroupFlags == other.dwGroupFlags && self.dwGroupType == other.dwGroupType && self.dwDiskUsage == other.dwDiskUsage && self.dwDiskQuota == other.dwDiskQuota && self.dwOwnerStorage == other.dwOwnerStorage && self.szGroupName == other.szGroupName
     }
 }
 impl ::core::cmp::Eq for INTERNET_CACHE_GROUP_INFOW {}
@@ -7738,7 +7652,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CACHE_TIMESTAMPS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CACHE_TIMESTAMPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CACHE_TIMESTAMPS>()) == 0 }
+        self.ftExpires == other.ftExpires && self.ftLastModified == other.ftLastModified
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7781,7 +7695,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CALLBACK_COOKIE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CALLBACK_COOKIE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CALLBACK_COOKIE>()) == 0 }
+        self.pcwszName == other.pcwszName && self.pcwszValue == other.pcwszValue && self.pcwszDomain == other.pcwszDomain && self.pcwszPath == other.pcwszPath && self.ftExpires == other.ftExpires && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7826,7 +7740,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CERTIFICATE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CERTIFICATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CERTIFICATE_INFO>()) == 0 }
+        self.ftExpiry == other.ftExpiry && self.ftStart == other.ftStart && self.lpszSubjectInfo == other.lpszSubjectInfo && self.lpszIssuerInfo == other.lpszIssuerInfo && self.lpszProtocolName == other.lpszProtocolName && self.lpszSignatureAlgName == other.lpszSignatureAlgName && self.lpszEncryptionAlgName == other.lpszEncryptionAlgName && self.dwKeySize == other.dwKeySize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7859,7 +7773,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CONNECTED_INFO {
 }
 impl ::core::cmp::PartialEq for INTERNET_CONNECTED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CONNECTED_INFO>()) == 0 }
+        self.dwConnectedState == other.dwConnectedState && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for INTERNET_CONNECTED_INFO {}
@@ -7903,7 +7817,7 @@ unsafe impl ::windows::core::Abi for INTERNET_COOKIE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_COOKIE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_COOKIE>()) == 0 }
+        self.cbSize == other.cbSize && self.pszName == other.pszName && self.pszData == other.pszData && self.pszDomain == other.pszDomain && self.pszPath == other.pszPath && self.pftExpires == other.pftExpires && self.dwFlags == other.dwFlags && self.pszUrl == other.pszUrl && self.pszP3PPolicy == other.pszP3PPolicy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7947,7 +7861,7 @@ unsafe impl ::windows::core::Abi for INTERNET_COOKIE2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_COOKIE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_COOKIE2>()) == 0 }
+        self.pwszName == other.pwszName && self.pwszValue == other.pwszValue && self.pwszDomain == other.pwszDomain && self.pwszPath == other.pwszPath && self.dwFlags == other.dwFlags && self.ftExpires == other.ftExpires && self.fExpiresSet == other.fExpiresSet
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7983,14 +7897,6 @@ unsafe impl ::windows::core::Abi for INTERNET_CREDENTIALS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CREDENTIALS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CREDENTIALS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CREDENTIALS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CREDENTIALS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8015,14 +7921,6 @@ impl ::core::clone::Clone for INTERNET_CREDENTIALS_0 {
 unsafe impl ::windows::core::Abi for INTERNET_CREDENTIALS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_CREDENTIALS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CREDENTIALS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_CREDENTIALS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_CREDENTIALS_0 {
     fn default() -> Self {
@@ -8057,7 +7955,7 @@ unsafe impl ::windows::core::Abi for INTERNET_CREDENTIALS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_CREDENTIALS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_CREDENTIALS_0_0>()) == 0 }
+        self.lpcwszUserName == other.lpcwszUserName && self.lpcwszPassword == other.lpcwszPassword
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8092,7 +7990,7 @@ unsafe impl ::windows::core::Abi for INTERNET_DIAGNOSTIC_SOCKET_INFO {
 }
 impl ::core::cmp::PartialEq for INTERNET_DIAGNOSTIC_SOCKET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_DIAGNOSTIC_SOCKET_INFO>()) == 0 }
+        self.Socket == other.Socket && self.SourcePort == other.SourcePort && self.DestPort == other.DestPort && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for INTERNET_DIAGNOSTIC_SOCKET_INFO {}
@@ -8129,7 +8027,7 @@ unsafe impl ::windows::core::Abi for INTERNET_DOWNLOAD_MODE_HANDLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_DOWNLOAD_MODE_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_DOWNLOAD_MODE_HANDLE>()) == 0 }
+        self.pcwszFileName == other.pcwszFileName && self.phFile == other.phFile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8162,7 +8060,7 @@ unsafe impl ::windows::core::Abi for INTERNET_END_BROWSER_SESSION_DATA {
 }
 impl ::core::cmp::PartialEq for INTERNET_END_BROWSER_SESSION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_END_BROWSER_SESSION_DATA>()) == 0 }
+        self.lpBuffer == other.lpBuffer && self.dwBufferLength == other.dwBufferLength
     }
 }
 impl ::core::cmp::Eq for INTERNET_END_BROWSER_SESSION_DATA {}
@@ -8191,14 +8089,6 @@ unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTIONA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTIONA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTIONA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_PER_CONN_OPTIONA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_PER_CONN_OPTIONA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8225,14 +8115,6 @@ unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTIONA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTIONA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTIONA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_PER_CONN_OPTIONA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_PER_CONN_OPTIONA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8257,14 +8139,6 @@ impl ::core::clone::Clone for INTERNET_PER_CONN_OPTIONW {
 unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTIONW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTIONW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTIONW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_PER_CONN_OPTIONW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_PER_CONN_OPTIONW {
     fn default() -> Self {
@@ -8291,14 +8165,6 @@ impl ::core::clone::Clone for INTERNET_PER_CONN_OPTIONW_0 {
 unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTIONW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTIONW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTIONW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERNET_PER_CONN_OPTIONW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERNET_PER_CONN_OPTIONW_0 {
     fn default() -> Self {
@@ -8336,7 +8202,7 @@ unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTION_LISTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTION_LISTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTION_LISTA>()) == 0 }
+        self.dwSize == other.dwSize && self.pszConnection == other.pszConnection && self.dwOptionCount == other.dwOptionCount && self.dwOptionError == other.dwOptionError && self.pOptions == other.pOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8378,7 +8244,7 @@ unsafe impl ::windows::core::Abi for INTERNET_PER_CONN_OPTION_LISTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_PER_CONN_OPTION_LISTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PER_CONN_OPTION_LISTW>()) == 0 }
+        self.dwSize == other.dwSize && self.pszConnection == other.pszConnection && self.dwOptionCount == other.dwOptionCount && self.dwOptionError == other.dwOptionError && self.pOptions == other.pOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8411,7 +8277,7 @@ unsafe impl ::windows::core::Abi for INTERNET_PREFETCH_STATUS {
 }
 impl ::core::cmp::PartialEq for INTERNET_PREFETCH_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PREFETCH_STATUS>()) == 0 }
+        self.dwStatus == other.dwStatus && self.dwSize == other.dwSize
     }
 }
 impl ::core::cmp::Eq for INTERNET_PREFETCH_STATUS {}
@@ -8443,7 +8309,7 @@ unsafe impl ::windows::core::Abi for INTERNET_PROXY_INFO {
 }
 impl ::core::cmp::PartialEq for INTERNET_PROXY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_PROXY_INFO>()) == 0 }
+        self.dwAccessType == other.dwAccessType && self.lpszProxy == other.lpszProxy && self.lpszProxyBypass == other.lpszProxyBypass
     }
 }
 impl ::core::cmp::Eq for INTERNET_PROXY_INFO {}
@@ -8482,7 +8348,7 @@ unsafe impl ::windows::core::Abi for INTERNET_SECURITY_CONNECTION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity"))]
 impl ::core::cmp::PartialEq for INTERNET_SECURITY_CONNECTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_SECURITY_CONNECTION_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.fSecure == other.fSecure && self.connectionInfo == other.connectionInfo && self.cipherInfo == other.cipherInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity"))]
@@ -8526,7 +8392,7 @@ unsafe impl ::windows::core::Abi for INTERNET_SECURITY_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for INTERNET_SECURITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_SECURITY_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pCertificate == other.pCertificate && self.pcCertChain == other.pcCertChain && self.connectionInfo == other.connectionInfo && self.cipherInfo == other.cipherInfo && self.pcUnverifiedCertChain == other.pcUnverifiedCertChain && self.channelBindingToken == other.channelBindingToken
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
@@ -8571,7 +8437,7 @@ unsafe impl ::windows::core::Abi for INTERNET_SERVER_CONNECTION_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERNET_SERVER_CONNECTION_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_SERVER_CONNECTION_STATE>()) == 0 }
+        self.lpcwszHostName == other.lpcwszHostName && self.fProxy == other.fProxy && self.dwCounter == other.dwCounter && self.dwConnectionLimit == other.dwConnectionLimit && self.dwAvailableCreates == other.dwAvailableCreates && self.dwAvailableKeepAlives == other.dwAvailableKeepAlives && self.dwActiveConnections == other.dwActiveConnections && self.dwWaiters == other.dwWaiters
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8604,7 +8470,7 @@ unsafe impl ::windows::core::Abi for INTERNET_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for INTERNET_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERNET_VERSION_INFO>()) == 0 }
+        self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion
     }
 }
 impl ::core::cmp::Eq for INTERNET_VERSION_INFO {}
@@ -8640,7 +8506,7 @@ unsafe impl ::windows::core::Abi for IncomingCookieState {
 }
 impl ::core::cmp::PartialEq for IncomingCookieState {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IncomingCookieState>()) == 0 }
+        self.cSession == other.cSession && self.cPersistent == other.cPersistent && self.cAccepted == other.cAccepted && self.cLeashed == other.cLeashed && self.cDowngraded == other.cDowngraded && self.cBlocked == other.cBlocked && self.pszLocation == other.pszLocation
     }
 }
 impl ::core::cmp::Eq for IncomingCookieState {}
@@ -8679,7 +8545,7 @@ unsafe impl ::windows::core::Abi for InternetCookieHistory {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for InternetCookieHistory {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InternetCookieHistory>()) == 0 }
+        self.fAccepted == other.fAccepted && self.fLeashed == other.fLeashed && self.fDowngraded == other.fDowngraded && self.fRejected == other.fRejected
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8713,7 +8579,7 @@ unsafe impl ::windows::core::Abi for OutgoingCookieState {
 }
 impl ::core::cmp::PartialEq for OutgoingCookieState {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OutgoingCookieState>()) == 0 }
+        self.cSent == other.cSent && self.cSuppressed == other.cSuppressed && self.pszLocation == other.pszLocation
     }
 }
 impl ::core::cmp::Eq for OutgoingCookieState {}
@@ -8746,7 +8612,7 @@ unsafe impl ::windows::core::Abi for ProofOfPossessionCookieInfo {
 }
 impl ::core::cmp::PartialEq for ProofOfPossessionCookieInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ProofOfPossessionCookieInfo>()) == 0 }
+        self.name == other.name && self.data == other.data && self.flags == other.flags && self.p3pHeader == other.p3pHeader
     }
 }
 impl ::core::cmp::Eq for ProofOfPossessionCookieInfo {}
@@ -8812,7 +8678,7 @@ unsafe impl ::windows::core::Abi for URLCACHE_ENTRY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for URLCACHE_ENTRY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URLCACHE_ENTRY_INFO>()) == 0 }
+        self.pwszSourceUrlName == other.pwszSourceUrlName && self.pwszLocalFileName == other.pwszLocalFileName && self.dwCacheEntryType == other.dwCacheEntryType && self.dwUseCount == other.dwUseCount && self.dwHitRate == other.dwHitRate && self.dwSizeLow == other.dwSizeLow && self.dwSizeHigh == other.dwSizeHigh && self.ftLastModifiedTime == other.ftLastModifiedTime && self.ftExpireTime == other.ftExpireTime && self.ftLastAccessTime == other.ftLastAccessTime && self.ftLastSyncTime == other.ftLastSyncTime && self.pbHeaderInfo == other.pbHeaderInfo && self.cbHeaderInfoSize == other.cbHeaderInfoSize && self.pbExtraData == other.pbExtraData && self.cbExtraDataSize == other.cbExtraDataSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8874,7 +8740,7 @@ unsafe impl ::windows::core::Abi for URL_COMPONENTSA {
 }
 impl ::core::cmp::PartialEq for URL_COMPONENTSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URL_COMPONENTSA>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.lpszScheme == other.lpszScheme && self.dwSchemeLength == other.dwSchemeLength && self.nScheme == other.nScheme && self.lpszHostName == other.lpszHostName && self.dwHostNameLength == other.dwHostNameLength && self.nPort == other.nPort && self.lpszUserName == other.lpszUserName && self.dwUserNameLength == other.dwUserNameLength && self.lpszPassword == other.lpszPassword && self.dwPasswordLength == other.dwPasswordLength && self.lpszUrlPath == other.lpszUrlPath && self.dwUrlPathLength == other.dwUrlPathLength && self.lpszExtraInfo == other.lpszExtraInfo && self.dwExtraInfoLength == other.dwExtraInfoLength
     }
 }
 impl ::core::cmp::Eq for URL_COMPONENTSA {}
@@ -8934,7 +8800,7 @@ unsafe impl ::windows::core::Abi for URL_COMPONENTSW {
 }
 impl ::core::cmp::PartialEq for URL_COMPONENTSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URL_COMPONENTSW>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.lpszScheme == other.lpszScheme && self.dwSchemeLength == other.dwSchemeLength && self.nScheme == other.nScheme && self.lpszHostName == other.lpszHostName && self.dwHostNameLength == other.dwHostNameLength && self.nPort == other.nPort && self.lpszUserName == other.lpszUserName && self.dwUserNameLength == other.dwUserNameLength && self.lpszPassword == other.lpszPassword && self.dwPasswordLength == other.dwPasswordLength && self.lpszUrlPath == other.lpszUrlPath && self.dwUrlPathLength == other.dwUrlPathLength && self.lpszExtraInfo == other.lpszExtraInfo && self.dwExtraInfoLength == other.dwExtraInfoLength
     }
 }
 impl ::core::cmp::Eq for URL_COMPONENTSW {}
@@ -8974,7 +8840,7 @@ unsafe impl ::windows::core::Abi for WININET_PROXY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WININET_PROXY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WININET_PROXY_INFO>()) == 0 }
+        self.fProxy == other.fProxy && self.fBypass == other.fBypass && self.ProxyScheme == other.ProxyScheme && self.pwszProxy == other.pwszProxy && self.ProxyPort == other.ProxyPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9013,7 +8879,7 @@ unsafe impl ::windows::core::Abi for WININET_PROXY_INFO_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WININET_PROXY_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WININET_PROXY_INFO_LIST>()) == 0 }
+        self.dwProxyInfoCount == other.dwProxyInfoCount && self.pProxyInfo == other.pProxyInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -6266,7 +6266,7 @@ unsafe impl ::windows::core::Abi for AAL5_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for AAL5_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AAL5_PARAMETERS>()) == 0 }
+        self.ForwardMaxCPCSSDUSize == other.ForwardMaxCPCSSDUSize && self.BackwardMaxCPCSSDUSize == other.BackwardMaxCPCSSDUSize && self.Mode == other.Mode && self.SSCSType == other.SSCSType
     }
 }
 impl ::core::cmp::Eq for AAL5_PARAMETERS {}
@@ -6296,7 +6296,7 @@ unsafe impl ::windows::core::Abi for AALUSER_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for AALUSER_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AALUSER_PARAMETERS>()) == 0 }
+        self.UserDefined == other.UserDefined
     }
 }
 impl ::core::cmp::Eq for AALUSER_PARAMETERS {}
@@ -6320,12 +6320,6 @@ impl ::core::clone::Clone for AAL_PARAMETERS_IE {
 unsafe impl ::windows::core::Abi for AAL_PARAMETERS_IE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AAL_PARAMETERS_IE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AAL_PARAMETERS_IE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AAL_PARAMETERS_IE {}
 impl ::core::default::Default for AAL_PARAMETERS_IE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6346,12 +6340,6 @@ impl ::core::clone::Clone for AAL_PARAMETERS_IE_0 {
 unsafe impl ::windows::core::Abi for AAL_PARAMETERS_IE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AAL_PARAMETERS_IE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AAL_PARAMETERS_IE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AAL_PARAMETERS_IE_0 {}
 impl ::core::default::Default for AAL_PARAMETERS_IE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6391,7 +6379,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOA>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_next == other.ai_next
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6455,7 +6443,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX2A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX2A>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6519,7 +6507,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX2W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX2W>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6585,7 +6573,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX3>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn && self.ai_interfaceindex == other.ai_interfaceindex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6653,7 +6641,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX4>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn && self.ai_interfaceindex == other.ai_interfaceindex && self.ai_resolutionhandle == other.ai_resolutionhandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6723,7 +6711,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX5 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX5>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn && self.ai_interfaceindex == other.ai_interfaceindex && self.ai_resolutionhandle == other.ai_resolutionhandle && self.ai_ttl == other.ai_ttl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6799,7 +6787,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEX6 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEX6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEX6>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next && self.ai_version == other.ai_version && self.ai_fqdn == other.ai_fqdn && self.ai_interfaceindex == other.ai_interfaceindex && self.ai_resolutionhandle == other.ai_resolutionhandle && self.ai_ttl == other.ai_ttl && self.ai_numservers == other.ai_numservers && self.ai_servers == other.ai_servers && self.ai_responseflags == other.ai_responseflags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6847,7 +6835,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEXA>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6895,7 +6883,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOEXW>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_blob == other.ai_blob && self.ai_bloblen == other.ai_bloblen && self.ai_provider == other.ai_provider && self.ai_next == other.ai_next
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6940,7 +6928,7 @@ unsafe impl ::windows::core::Abi for ADDRINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ADDRINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFOW>()) == 0 }
+        self.ai_flags == other.ai_flags && self.ai_family == other.ai_family && self.ai_socktype == other.ai_socktype && self.ai_protocol == other.ai_protocol && self.ai_addrlen == other.ai_addrlen && self.ai_canonname == other.ai_canonname && self.ai_addr == other.ai_addr && self.ai_next == other.ai_next
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6974,14 +6962,6 @@ unsafe impl ::windows::core::Abi for ADDRINFO_DNS_SERVER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ADDRINFO_DNS_SERVER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFO_DNS_SERVER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ADDRINFO_DNS_SERVER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ADDRINFO_DNS_SERVER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7005,14 +6985,6 @@ impl ::core::clone::Clone for ADDRINFO_DNS_SERVER_0 {
 unsafe impl ::windows::core::Abi for ADDRINFO_DNS_SERVER_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ADDRINFO_DNS_SERVER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRINFO_DNS_SERVER_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ADDRINFO_DNS_SERVER_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ADDRINFO_DNS_SERVER_0 {
     fn default() -> Self {
@@ -7041,7 +7013,7 @@ unsafe impl ::windows::core::Abi for AFPROTOCOLS {
 }
 impl ::core::cmp::PartialEq for AFPROTOCOLS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AFPROTOCOLS>()) == 0 }
+        self.iAddressFamily == other.iAddressFamily && self.iProtocol == other.iProtocol
     }
 }
 impl ::core::cmp::Eq for AFPROTOCOLS {}
@@ -7076,7 +7048,7 @@ unsafe impl ::windows::core::Abi for ARP_HEADER {
 }
 impl ::core::cmp::PartialEq for ARP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARP_HEADER>()) == 0 }
+        self.HardwareAddressSpace == other.HardwareAddressSpace && self.ProtocolAddressSpace == other.ProtocolAddressSpace && self.HardwareAddressLength == other.HardwareAddressLength && self.ProtocolAddressLength == other.ProtocolAddressLength && self.Opcode == other.Opcode && self.SenderHardwareAddress == other.SenderHardwareAddress
     }
 }
 impl ::core::cmp::Eq for ARP_HEADER {}
@@ -7107,7 +7079,7 @@ unsafe impl ::windows::core::Abi for ASSOCIATE_NAMERES_CONTEXT_INPUT {
 }
 impl ::core::cmp::PartialEq for ASSOCIATE_NAMERES_CONTEXT_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASSOCIATE_NAMERES_CONTEXT_INPUT>()) == 0 }
+        self.TransportSettingId == other.TransportSettingId && self.Handle == other.Handle
     }
 }
 impl ::core::cmp::Eq for ASSOCIATE_NAMERES_CONTEXT_INPUT {}
@@ -7139,7 +7111,7 @@ unsafe impl ::windows::core::Abi for ATM_ADDRESS {
 }
 impl ::core::cmp::PartialEq for ATM_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_ADDRESS>()) == 0 }
+        self.AddressType == other.AddressType && self.NumofDigits == other.NumofDigits && self.Addr == other.Addr
     }
 }
 impl ::core::cmp::Eq for ATM_ADDRESS {}
@@ -7171,7 +7143,7 @@ unsafe impl ::windows::core::Abi for ATM_BHLI {
 }
 impl ::core::cmp::PartialEq for ATM_BHLI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_BHLI>()) == 0 }
+        self.HighLayerInfoType == other.HighLayerInfoType && self.HighLayerInfoLength == other.HighLayerInfoLength && self.HighLayerInfo == other.HighLayerInfo
     }
 }
 impl ::core::cmp::Eq for ATM_BHLI {}
@@ -7206,7 +7178,7 @@ unsafe impl ::windows::core::Abi for ATM_BLLI {
 }
 impl ::core::cmp::PartialEq for ATM_BLLI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_BLLI>()) == 0 }
+        self.Layer2Protocol == other.Layer2Protocol && self.Layer2UserSpecifiedProtocol == other.Layer2UserSpecifiedProtocol && self.Layer3Protocol == other.Layer3Protocol && self.Layer3UserSpecifiedProtocol == other.Layer3UserSpecifiedProtocol && self.Layer3IPI == other.Layer3IPI && self.SnapID == other.SnapID
     }
 }
 impl ::core::cmp::Eq for ATM_BLLI {}
@@ -7258,7 +7230,7 @@ unsafe impl ::windows::core::Abi for ATM_BLLI_IE {
 }
 impl ::core::cmp::PartialEq for ATM_BLLI_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_BLLI_IE>()) == 0 }
+        self.Layer2Protocol == other.Layer2Protocol && self.Layer2Mode == other.Layer2Mode && self.Layer2WindowSize == other.Layer2WindowSize && self.Layer2UserSpecifiedProtocol == other.Layer2UserSpecifiedProtocol && self.Layer3Protocol == other.Layer3Protocol && self.Layer3Mode == other.Layer3Mode && self.Layer3DefaultPacketSize == other.Layer3DefaultPacketSize && self.Layer3PacketWindowSize == other.Layer3PacketWindowSize && self.Layer3UserSpecifiedProtocol == other.Layer3UserSpecifiedProtocol && self.Layer3IPI == other.Layer3IPI && self.SnapID == other.SnapID
     }
 }
 impl ::core::cmp::Eq for ATM_BLLI_IE {}
@@ -7292,7 +7264,7 @@ unsafe impl ::windows::core::Abi for ATM_BROADBAND_BEARER_CAPABILITY_IE {
 }
 impl ::core::cmp::PartialEq for ATM_BROADBAND_BEARER_CAPABILITY_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_BROADBAND_BEARER_CAPABILITY_IE>()) == 0 }
+        self.BearerClass == other.BearerClass && self.TrafficType == other.TrafficType && self.TimingRequirements == other.TimingRequirements && self.ClippingSusceptability == other.ClippingSusceptability && self.UserPlaneConnectionConfig == other.UserPlaneConnectionConfig
     }
 }
 impl ::core::cmp::Eq for ATM_BROADBAND_BEARER_CAPABILITY_IE {}
@@ -7324,7 +7296,7 @@ unsafe impl ::windows::core::Abi for ATM_CALLING_PARTY_NUMBER_IE {
 }
 impl ::core::cmp::PartialEq for ATM_CALLING_PARTY_NUMBER_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_CALLING_PARTY_NUMBER_IE>()) == 0 }
+        self.ATM_Number == other.ATM_Number && self.Presentation_Indication == other.Presentation_Indication && self.Screening_Indicator == other.Screening_Indicator
     }
 }
 impl ::core::cmp::Eq for ATM_CALLING_PARTY_NUMBER_IE {}
@@ -7357,7 +7329,7 @@ unsafe impl ::windows::core::Abi for ATM_CAUSE_IE {
 }
 impl ::core::cmp::PartialEq for ATM_CAUSE_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_CAUSE_IE>()) == 0 }
+        self.Location == other.Location && self.Cause == other.Cause && self.DiagnosticsLength == other.DiagnosticsLength && self.Diagnostics == other.Diagnostics
     }
 }
 impl ::core::cmp::Eq for ATM_CAUSE_IE {}
@@ -7389,7 +7361,7 @@ unsafe impl ::windows::core::Abi for ATM_CONNECTION_ID {
 }
 impl ::core::cmp::PartialEq for ATM_CONNECTION_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_CONNECTION_ID>()) == 0 }
+        self.DeviceNumber == other.DeviceNumber && self.VPI == other.VPI && self.VCI == other.VCI
     }
 }
 impl ::core::cmp::Eq for ATM_CONNECTION_ID {}
@@ -7413,12 +7385,6 @@ impl ::core::clone::Clone for ATM_PVC_PARAMS {
 unsafe impl ::windows::core::Abi for ATM_PVC_PARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ATM_PVC_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_PVC_PARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ATM_PVC_PARAMS {}
 impl ::core::default::Default for ATM_PVC_PARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7446,7 +7412,7 @@ unsafe impl ::windows::core::Abi for ATM_QOS_CLASS_IE {
 }
 impl ::core::cmp::PartialEq for ATM_QOS_CLASS_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_QOS_CLASS_IE>()) == 0 }
+        self.QOSClassForward == other.QOSClassForward && self.QOSClassBackward == other.QOSClassBackward
     }
 }
 impl ::core::cmp::Eq for ATM_QOS_CLASS_IE {}
@@ -7488,7 +7454,7 @@ unsafe impl ::windows::core::Abi for ATM_TD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ATM_TD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_TD>()) == 0 }
+        self.PeakCellRate_CLP0 == other.PeakCellRate_CLP0 && self.PeakCellRate_CLP01 == other.PeakCellRate_CLP01 && self.SustainableCellRate_CLP0 == other.SustainableCellRate_CLP0 && self.SustainableCellRate_CLP01 == other.SustainableCellRate_CLP01 && self.MaxBurstSize_CLP0 == other.MaxBurstSize_CLP0 && self.MaxBurstSize_CLP01 == other.MaxBurstSize_CLP01 && self.Tagging == other.Tagging
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7528,7 +7494,7 @@ unsafe impl ::windows::core::Abi for ATM_TRAFFIC_DESCRIPTOR_IE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ATM_TRAFFIC_DESCRIPTOR_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_TRAFFIC_DESCRIPTOR_IE>()) == 0 }
+        self.Forward == other.Forward && self.Backward == other.Backward && self.BestEffort == other.BestEffort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7563,7 +7529,7 @@ unsafe impl ::windows::core::Abi for ATM_TRANSIT_NETWORK_SELECTION_IE {
 }
 impl ::core::cmp::PartialEq for ATM_TRANSIT_NETWORK_SELECTION_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATM_TRANSIT_NETWORK_SELECTION_IE>()) == 0 }
+        self.TypeOfNetworkId == other.TypeOfNetworkId && self.NetworkIdPlan == other.NetworkIdPlan && self.NetworkIdLength == other.NetworkIdLength && self.NetworkId == other.NetworkId
     }
 }
 impl ::core::cmp::Eq for ATM_TRANSIT_NETWORK_SELECTION_IE {}
@@ -7595,7 +7561,7 @@ unsafe impl ::windows::core::Abi for CMSGHDR {
 }
 impl ::core::cmp::PartialEq for CMSGHDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSGHDR>()) == 0 }
+        self.cmsg_len == other.cmsg_len && self.cmsg_level == other.cmsg_level && self.cmsg_type == other.cmsg_type
     }
 }
 impl ::core::cmp::Eq for CMSGHDR {}
@@ -7634,7 +7600,7 @@ unsafe impl ::windows::core::Abi for CSADDR_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CSADDR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSADDR_INFO>()) == 0 }
+        self.LocalAddr == other.LocalAddr && self.RemoteAddr == other.RemoteAddr && self.iSocketType == other.iSocketType && self.iProtocol == other.iProtocol
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7659,12 +7625,6 @@ impl ::core::clone::Clone for DL_EI48 {
 unsafe impl ::windows::core::Abi for DL_EI48 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EI48 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EI48>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EI48 {}
 impl ::core::default::Default for DL_EI48 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7684,12 +7644,6 @@ impl ::core::clone::Clone for DL_EI64 {
 unsafe impl ::windows::core::Abi for DL_EI64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EI64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EI64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EI64 {}
 impl ::core::default::Default for DL_EI64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7710,12 +7664,6 @@ impl ::core::clone::Clone for DL_EUI48 {
 unsafe impl ::windows::core::Abi for DL_EUI48 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI48 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI48>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI48 {}
 impl ::core::default::Default for DL_EUI48 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7736,12 +7684,6 @@ impl ::core::clone::Clone for DL_EUI48_0 {
 unsafe impl ::windows::core::Abi for DL_EUI48_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI48_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI48_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI48_0 {}
 impl ::core::default::Default for DL_EUI48_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7763,12 +7705,6 @@ impl ::core::clone::Clone for DL_EUI64 {
 unsafe impl ::windows::core::Abi for DL_EUI64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI64 {}
 impl ::core::default::Default for DL_EUI64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7789,12 +7725,6 @@ impl ::core::clone::Clone for DL_EUI64_0 {
 unsafe impl ::windows::core::Abi for DL_EUI64_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI64_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI64_0 {}
 impl ::core::default::Default for DL_EUI64_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7815,12 +7745,6 @@ impl ::core::clone::Clone for DL_EUI64_0_0 {
 unsafe impl ::windows::core::Abi for DL_EUI64_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI64_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI64_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI64_0_0 {}
 impl ::core::default::Default for DL_EUI64_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7842,12 +7766,6 @@ impl ::core::clone::Clone for DL_EUI64_0_0_0 {
 unsafe impl ::windows::core::Abi for DL_EUI64_0_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_EUI64_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_EUI64_0_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_EUI64_0_0_0 {}
 impl ::core::default::Default for DL_EUI64_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7868,12 +7786,6 @@ impl ::core::clone::Clone for DL_OUI {
 unsafe impl ::windows::core::Abi for DL_OUI {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_OUI {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_OUI>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_OUI {}
 impl ::core::default::Default for DL_OUI {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7900,7 +7812,7 @@ unsafe impl ::windows::core::Abi for DL_OUI_0 {
 }
 impl ::core::cmp::PartialEq for DL_OUI_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_OUI_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DL_OUI_0 {}
@@ -7924,12 +7836,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7950,12 +7856,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS_0 {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7977,12 +7877,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS_0_0 {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS_0_0 {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8003,12 +7897,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS_PRV {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS_PRV {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS_PRV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS_PRV>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS_PRV {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS_PRV {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8029,12 +7917,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS_PRV_0 {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS_PRV_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS_PRV_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS_PRV_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS_PRV_0 {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS_PRV_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8060,12 +7942,6 @@ impl ::core::clone::Clone for DL_TEREDO_ADDRESS_PRV_0_0 {
 unsafe impl ::windows::core::Abi for DL_TEREDO_ADDRESS_PRV_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DL_TEREDO_ADDRESS_PRV_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TEREDO_ADDRESS_PRV_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DL_TEREDO_ADDRESS_PRV_0_0 {}
 impl ::core::default::Default for DL_TEREDO_ADDRESS_PRV_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8092,14 +7968,6 @@ unsafe impl ::windows::core::Abi for DL_TUNNEL_ADDRESS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for DL_TUNNEL_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DL_TUNNEL_ADDRESS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for DL_TUNNEL_ADDRESS {}
-#[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for DL_TUNNEL_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8121,12 +7989,6 @@ impl ::core::clone::Clone for ETHERNET_HEADER {
 unsafe impl ::windows::core::Abi for ETHERNET_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ETHERNET_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETHERNET_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ETHERNET_HEADER {}
 impl ::core::default::Default for ETHERNET_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8147,12 +8009,6 @@ impl ::core::clone::Clone for ETHERNET_HEADER_0 {
 unsafe impl ::windows::core::Abi for ETHERNET_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ETHERNET_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETHERNET_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ETHERNET_HEADER_0 {}
 impl ::core::default::Default for ETHERNET_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8180,7 +8036,7 @@ unsafe impl ::windows::core::Abi for FD_SET {
 }
 impl ::core::cmp::PartialEq for FD_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FD_SET>()) == 0 }
+        self.fd_count == other.fd_count && self.fd_array == other.fd_array
     }
 }
 impl ::core::cmp::Eq for FD_SET {}
@@ -8217,7 +8073,7 @@ unsafe impl ::windows::core::Abi for FLOWSPEC {
 }
 impl ::core::cmp::PartialEq for FLOWSPEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOWSPEC>()) == 0 }
+        self.TokenRate == other.TokenRate && self.TokenBucketSize == other.TokenBucketSize && self.PeakBandwidth == other.PeakBandwidth && self.Latency == other.Latency && self.DelayVariation == other.DelayVariation && self.ServiceType == other.ServiceType && self.MaxSduSize == other.MaxSduSize && self.MinimumPolicedSize == other.MinimumPolicedSize
     }
 }
 impl ::core::cmp::Eq for FLOWSPEC {}
@@ -8257,7 +8113,7 @@ unsafe impl ::windows::core::Abi for GROUP_FILTER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_FILTER>()) == 0 }
+        self.gf_interface == other.gf_interface && self.gf_group == other.gf_group && self.gf_fmode == other.gf_fmode && self.gf_numsrc == other.gf_numsrc && self.gf_slist == other.gf_slist
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8296,7 +8152,7 @@ unsafe impl ::windows::core::Abi for GROUP_REQ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_REQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_REQ>()) == 0 }
+        self.gr_interface == other.gr_interface && self.gr_group == other.gr_group
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8336,7 +8192,7 @@ unsafe impl ::windows::core::Abi for GROUP_SOURCE_REQ {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_SOURCE_REQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_SOURCE_REQ>()) == 0 }
+        self.gsr_interface == other.gsr_interface && self.gsr_group == other.gsr_group && self.gsr_source == other.gsr_source
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8372,7 +8228,7 @@ unsafe impl ::windows::core::Abi for HOSTENT {
 }
 impl ::core::cmp::PartialEq for HOSTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HOSTENT>()) == 0 }
+        self.h_name == other.h_name && self.h_aliases == other.h_aliases && self.h_addrtype == other.h_addrtype && self.h_length == other.h_length && self.h_addr_list == other.h_addr_list
     }
 }
 impl ::core::cmp::Eq for HOSTENT {}
@@ -8428,12 +8284,6 @@ impl ::core::clone::Clone for ICMPV4_ADDRESS_MASK_MESSAGE {
 unsafe impl ::windows::core::Abi for ICMPV4_ADDRESS_MASK_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV4_ADDRESS_MASK_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV4_ADDRESS_MASK_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV4_ADDRESS_MASK_MESSAGE {}
 impl ::core::default::Default for ICMPV4_ADDRESS_MASK_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8454,12 +8304,6 @@ impl ::core::clone::Clone for ICMPV4_ROUTER_ADVERT_ENTRY {
 unsafe impl ::windows::core::Abi for ICMPV4_ROUTER_ADVERT_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV4_ROUTER_ADVERT_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV4_ROUTER_ADVERT_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV4_ROUTER_ADVERT_ENTRY {}
 impl ::core::default::Default for ICMPV4_ROUTER_ADVERT_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8479,12 +8323,6 @@ impl ::core::clone::Clone for ICMPV4_ROUTER_ADVERT_HEADER {
 unsafe impl ::windows::core::Abi for ICMPV4_ROUTER_ADVERT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV4_ROUTER_ADVERT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV4_ROUTER_ADVERT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV4_ROUTER_ADVERT_HEADER {}
 impl ::core::default::Default for ICMPV4_ROUTER_ADVERT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8504,12 +8342,6 @@ impl ::core::clone::Clone for ICMPV4_ROUTER_SOLICIT {
 unsafe impl ::windows::core::Abi for ICMPV4_ROUTER_SOLICIT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV4_ROUTER_SOLICIT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV4_ROUTER_SOLICIT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV4_ROUTER_SOLICIT {}
 impl ::core::default::Default for ICMPV4_ROUTER_SOLICIT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8532,12 +8364,6 @@ impl ::core::clone::Clone for ICMPV4_TIMESTAMP_MESSAGE {
 unsafe impl ::windows::core::Abi for ICMPV4_TIMESTAMP_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMPV4_TIMESTAMP_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMPV4_TIMESTAMP_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMPV4_TIMESTAMP_MESSAGE {}
 impl ::core::default::Default for ICMPV4_TIMESTAMP_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8564,14 +8390,6 @@ impl ::core::clone::Clone for ICMP_ERROR_INFO {
 unsafe impl ::windows::core::Abi for ICMP_ERROR_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ICMP_ERROR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_ERROR_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ICMP_ERROR_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ICMP_ERROR_INFO {
     fn default() -> Self {
@@ -8601,7 +8419,7 @@ unsafe impl ::windows::core::Abi for ICMP_HEADER {
 }
 impl ::core::cmp::PartialEq for ICMP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_HEADER>()) == 0 }
+        self.Type == other.Type && self.Code == other.Code && self.Checksum == other.Checksum
     }
 }
 impl ::core::cmp::Eq for ICMP_HEADER {}
@@ -8625,12 +8443,6 @@ impl ::core::clone::Clone for ICMP_MESSAGE {
 unsafe impl ::windows::core::Abi for ICMP_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMP_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMP_MESSAGE {}
 impl ::core::default::Default for ICMP_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8652,12 +8464,6 @@ impl ::core::clone::Clone for ICMP_MESSAGE_0 {
 unsafe impl ::windows::core::Abi for ICMP_MESSAGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ICMP_MESSAGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICMP_MESSAGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ICMP_MESSAGE_0 {}
 impl ::core::default::Default for ICMP_MESSAGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8683,12 +8489,6 @@ impl ::core::clone::Clone for IGMPV3_QUERY_HEADER {
 unsafe impl ::windows::core::Abi for IGMPV3_QUERY_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMPV3_QUERY_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_QUERY_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMPV3_QUERY_HEADER {}
 impl ::core::default::Default for IGMPV3_QUERY_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8709,12 +8509,6 @@ impl ::core::clone::Clone for IGMPV3_QUERY_HEADER_0 {
 unsafe impl ::windows::core::Abi for IGMPV3_QUERY_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMPV3_QUERY_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_QUERY_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMPV3_QUERY_HEADER_0 {}
 impl ::core::default::Default for IGMPV3_QUERY_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8741,7 +8535,7 @@ unsafe impl ::windows::core::Abi for IGMPV3_QUERY_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IGMPV3_QUERY_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_QUERY_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IGMPV3_QUERY_HEADER_0_0 {}
@@ -8765,12 +8559,6 @@ impl ::core::clone::Clone for IGMPV3_QUERY_HEADER_1 {
 unsafe impl ::windows::core::Abi for IGMPV3_QUERY_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMPV3_QUERY_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_QUERY_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMPV3_QUERY_HEADER_1 {}
 impl ::core::default::Default for IGMPV3_QUERY_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8797,7 +8585,7 @@ unsafe impl ::windows::core::Abi for IGMPV3_QUERY_HEADER_1_0 {
 }
 impl ::core::cmp::PartialEq for IGMPV3_QUERY_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_QUERY_HEADER_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IGMPV3_QUERY_HEADER_1_0 {}
@@ -8831,7 +8619,7 @@ unsafe impl ::windows::core::Abi for IGMPV3_REPORT_HEADER {
 }
 impl ::core::cmp::PartialEq for IGMPV3_REPORT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_REPORT_HEADER>()) == 0 }
+        self.Type == other.Type && self.Reserved == other.Reserved && self.Checksum == other.Checksum && self.Reserved2 == other.Reserved2 && self.RecordCount == other.RecordCount
     }
 }
 impl ::core::cmp::Eq for IGMPV3_REPORT_HEADER {}
@@ -8857,12 +8645,6 @@ impl ::core::clone::Clone for IGMPV3_REPORT_RECORD_HEADER {
 unsafe impl ::windows::core::Abi for IGMPV3_REPORT_RECORD_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMPV3_REPORT_RECORD_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMPV3_REPORT_RECORD_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMPV3_REPORT_RECORD_HEADER {}
 impl ::core::default::Default for IGMPV3_REPORT_RECORD_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8885,12 +8667,6 @@ impl ::core::clone::Clone for IGMP_HEADER {
 unsafe impl ::windows::core::Abi for IGMP_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMP_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMP_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMP_HEADER {}
 impl ::core::default::Default for IGMP_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8911,12 +8687,6 @@ impl ::core::clone::Clone for IGMP_HEADER_0 {
 unsafe impl ::windows::core::Abi for IGMP_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMP_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMP_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMP_HEADER_0 {}
 impl ::core::default::Default for IGMP_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8943,7 +8713,7 @@ unsafe impl ::windows::core::Abi for IGMP_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IGMP_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMP_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IGMP_HEADER_0_0 {}
@@ -8968,12 +8738,6 @@ impl ::core::clone::Clone for IGMP_HEADER_1 {
 unsafe impl ::windows::core::Abi for IGMP_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IGMP_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IGMP_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IGMP_HEADER_1 {}
 impl ::core::default::Default for IGMP_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8993,12 +8757,6 @@ impl ::core::clone::Clone for IN6_ADDR {
 unsafe impl ::windows::core::Abi for IN6_ADDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN6_ADDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN6_ADDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN6_ADDR {}
 impl ::core::default::Default for IN6_ADDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9029,12 +8787,6 @@ impl ::core::clone::Clone for IN6_ADDR_0 {
 unsafe impl ::windows::core::Abi for IN6_ADDR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN6_ADDR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN6_ADDR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN6_ADDR_0 {}
 impl ::core::default::Default for IN6_ADDR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9055,12 +8807,6 @@ impl ::core::clone::Clone for IN6_PKTINFO {
 unsafe impl ::windows::core::Abi for IN6_PKTINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN6_PKTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN6_PKTINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN6_PKTINFO {}
 impl ::core::default::Default for IN6_PKTINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9081,12 +8827,6 @@ impl ::core::clone::Clone for IN6_PKTINFO_EX {
 unsafe impl ::windows::core::Abi for IN6_PKTINFO_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN6_PKTINFO_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN6_PKTINFO_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN6_PKTINFO_EX {}
 impl ::core::default::Default for IN6_PKTINFO_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9114,7 +8854,7 @@ unsafe impl ::windows::core::Abi for INET_PORT_RANGE {
 }
 impl ::core::cmp::PartialEq for INET_PORT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_PORT_RANGE>()) == 0 }
+        self.StartPort == other.StartPort && self.NumberOfPorts == other.NumberOfPorts
     }
 }
 impl ::core::cmp::Eq for INET_PORT_RANGE {}
@@ -9144,7 +8884,7 @@ unsafe impl ::windows::core::Abi for INET_PORT_RESERVATION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for INET_PORT_RESERVATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_PORT_RESERVATION_INFORMATION>()) == 0 }
+        self.OwningPid == other.OwningPid
     }
 }
 impl ::core::cmp::Eq for INET_PORT_RESERVATION_INFORMATION {}
@@ -9175,7 +8915,7 @@ unsafe impl ::windows::core::Abi for INET_PORT_RESERVATION_INSTANCE {
 }
 impl ::core::cmp::PartialEq for INET_PORT_RESERVATION_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_PORT_RESERVATION_INSTANCE>()) == 0 }
+        self.Reservation == other.Reservation && self.Token == other.Token
     }
 }
 impl ::core::cmp::Eq for INET_PORT_RESERVATION_INSTANCE {}
@@ -9205,7 +8945,7 @@ unsafe impl ::windows::core::Abi for INET_PORT_RESERVATION_TOKEN {
 }
 impl ::core::cmp::PartialEq for INET_PORT_RESERVATION_TOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INET_PORT_RESERVATION_TOKEN>()) == 0 }
+        self.Token == other.Token
     }
 }
 impl ::core::cmp::Eq for INET_PORT_RESERVATION_TOKEN {}
@@ -9235,14 +8975,6 @@ impl ::core::clone::Clone for INTERFACE_INFO {
 unsafe impl ::windows::core::Abi for INTERFACE_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INTERFACE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INTERFACE_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INTERFACE_INFO {
     fn default() -> Self {
@@ -9279,7 +9011,7 @@ unsafe impl ::windows::core::Abi for INTERFACE_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTERFACE_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACE_INFO_EX>()) == 0 }
+        self.iiFlags == other.iiFlags && self.iiAddress == other.iiAddress && self.iiBroadcastAddress == other.iiBroadcastAddress && self.iiNetmask == other.iiNetmask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9304,12 +9036,6 @@ impl ::core::clone::Clone for IN_ADDR {
 unsafe impl ::windows::core::Abi for IN_ADDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN_ADDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN_ADDR {}
 impl ::core::default::Default for IN_ADDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9341,12 +9067,6 @@ impl ::core::clone::Clone for IN_ADDR_0 {
 unsafe impl ::windows::core::Abi for IN_ADDR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN_ADDR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN_ADDR_0 {}
 impl ::core::default::Default for IN_ADDR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9376,7 +9096,7 @@ unsafe impl ::windows::core::Abi for IN_ADDR_0_0 {
 }
 impl ::core::cmp::PartialEq for IN_ADDR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR_0_0>()) == 0 }
+        self.s_b1 == other.s_b1 && self.s_b2 == other.s_b2 && self.s_b3 == other.s_b3 && self.s_b4 == other.s_b4
     }
 }
 impl ::core::cmp::Eq for IN_ADDR_0_0 {}
@@ -9407,7 +9127,7 @@ unsafe impl ::windows::core::Abi for IN_ADDR_0_1 {
 }
 impl ::core::cmp::PartialEq for IN_ADDR_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_ADDR_0_1>()) == 0 }
+        self.s_w1 == other.s_w1 && self.s_w2 == other.s_w2
     }
 }
 impl ::core::cmp::Eq for IN_ADDR_0_1 {}
@@ -9431,12 +9151,6 @@ impl ::core::clone::Clone for IN_PKTINFO {
 unsafe impl ::windows::core::Abi for IN_PKTINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN_PKTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_PKTINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN_PKTINFO {}
 impl ::core::default::Default for IN_PKTINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9457,12 +9171,6 @@ impl ::core::clone::Clone for IN_PKTINFO_EX {
 unsafe impl ::windows::core::Abi for IN_PKTINFO_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IN_PKTINFO_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_PKTINFO_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IN_PKTINFO_EX {}
 impl ::core::default::Default for IN_PKTINFO_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9492,7 +9200,7 @@ unsafe impl ::windows::core::Abi for IN_RECVERR {
 }
 impl ::core::cmp::PartialEq for IN_RECVERR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IN_RECVERR>()) == 0 }
+        self.protocol == other.protocol && self.info == other.info && self.r#type == other.r#type && self.code == other.code
     }
 }
 impl ::core::cmp::Eq for IN_RECVERR {}
@@ -9515,12 +9223,6 @@ impl ::core::clone::Clone for IPTLS_METADATA {
 unsafe impl ::windows::core::Abi for IPTLS_METADATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPTLS_METADATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPTLS_METADATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPTLS_METADATA {}
 impl ::core::default::Default for IPTLS_METADATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9549,12 +9251,6 @@ impl ::core::clone::Clone for IPV4_HEADER {
 unsafe impl ::windows::core::Abi for IPV4_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_HEADER {}
 impl ::core::default::Default for IPV4_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9575,12 +9271,6 @@ impl ::core::clone::Clone for IPV4_HEADER_0 {
 unsafe impl ::windows::core::Abi for IPV4_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_HEADER_0 {}
 impl ::core::default::Default for IPV4_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9607,7 +9297,7 @@ unsafe impl ::windows::core::Abi for IPV4_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IPV4_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV4_HEADER_0_0 {}
@@ -9631,12 +9321,6 @@ impl ::core::clone::Clone for IPV4_HEADER_1 {
 unsafe impl ::windows::core::Abi for IPV4_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_HEADER_1 {}
 impl ::core::default::Default for IPV4_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9663,7 +9347,7 @@ unsafe impl ::windows::core::Abi for IPV4_HEADER_1_0 {
 }
 impl ::core::cmp::PartialEq for IPV4_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV4_HEADER_1_0 {}
@@ -9687,12 +9371,6 @@ impl ::core::clone::Clone for IPV4_HEADER_2 {
 unsafe impl ::windows::core::Abi for IPV4_HEADER_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_HEADER_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_HEADER_2 {}
 impl ::core::default::Default for IPV4_HEADER_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9719,7 +9397,7 @@ unsafe impl ::windows::core::Abi for IPV4_HEADER_2_0 {
 }
 impl ::core::cmp::PartialEq for IPV4_HEADER_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_HEADER_2_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV4_HEADER_2_0 {}
@@ -9743,12 +9421,6 @@ impl ::core::clone::Clone for IPV4_OPTION_HEADER {
 unsafe impl ::windows::core::Abi for IPV4_OPTION_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_OPTION_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_OPTION_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_OPTION_HEADER {}
 impl ::core::default::Default for IPV4_OPTION_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9769,12 +9441,6 @@ impl ::core::clone::Clone for IPV4_OPTION_HEADER_0 {
 unsafe impl ::windows::core::Abi for IPV4_OPTION_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_OPTION_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_OPTION_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_OPTION_HEADER_0 {}
 impl ::core::default::Default for IPV4_OPTION_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9801,7 +9467,7 @@ unsafe impl ::windows::core::Abi for IPV4_OPTION_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IPV4_OPTION_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_OPTION_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV4_OPTION_HEADER_0_0 {}
@@ -9825,12 +9491,6 @@ impl ::core::clone::Clone for IPV4_ROUTING_HEADER {
 unsafe impl ::windows::core::Abi for IPV4_ROUTING_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_ROUTING_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_ROUTING_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_ROUTING_HEADER {}
 impl ::core::default::Default for IPV4_ROUTING_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9852,12 +9512,6 @@ impl ::core::clone::Clone for IPV4_TIMESTAMP_OPTION {
 unsafe impl ::windows::core::Abi for IPV4_TIMESTAMP_OPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_TIMESTAMP_OPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_TIMESTAMP_OPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_TIMESTAMP_OPTION {}
 impl ::core::default::Default for IPV4_TIMESTAMP_OPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9878,12 +9532,6 @@ impl ::core::clone::Clone for IPV4_TIMESTAMP_OPTION_0 {
 unsafe impl ::windows::core::Abi for IPV4_TIMESTAMP_OPTION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV4_TIMESTAMP_OPTION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_TIMESTAMP_OPTION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV4_TIMESTAMP_OPTION_0 {}
 impl ::core::default::Default for IPV4_TIMESTAMP_OPTION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9910,7 +9558,7 @@ unsafe impl ::windows::core::Abi for IPV4_TIMESTAMP_OPTION_0_0 {
 }
 impl ::core::cmp::PartialEq for IPV4_TIMESTAMP_OPTION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV4_TIMESTAMP_OPTION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV4_TIMESTAMP_OPTION_0_0 {}
@@ -9941,7 +9589,7 @@ unsafe impl ::windows::core::Abi for IPV6_EXTENSION_HEADER {
 }
 impl ::core::cmp::PartialEq for IPV6_EXTENSION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_EXTENSION_HEADER>()) == 0 }
+        self.NextHeader == other.NextHeader && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for IPV6_EXTENSION_HEADER {}
@@ -9967,12 +9615,6 @@ impl ::core::clone::Clone for IPV6_FRAGMENT_HEADER {
 unsafe impl ::windows::core::Abi for IPV6_FRAGMENT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_FRAGMENT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_FRAGMENT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_FRAGMENT_HEADER {}
 impl ::core::default::Default for IPV6_FRAGMENT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9993,12 +9635,6 @@ impl ::core::clone::Clone for IPV6_FRAGMENT_HEADER_0 {
 unsafe impl ::windows::core::Abi for IPV6_FRAGMENT_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_FRAGMENT_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_FRAGMENT_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_FRAGMENT_HEADER_0 {}
 impl ::core::default::Default for IPV6_FRAGMENT_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10025,7 +9661,7 @@ unsafe impl ::windows::core::Abi for IPV6_FRAGMENT_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IPV6_FRAGMENT_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_FRAGMENT_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV6_FRAGMENT_HEADER_0_0 {}
@@ -10053,12 +9689,6 @@ impl ::core::clone::Clone for IPV6_HEADER {
 unsafe impl ::windows::core::Abi for IPV6_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_HEADER {}
 impl ::core::default::Default for IPV6_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10079,12 +9709,6 @@ impl ::core::clone::Clone for IPV6_HEADER_0 {
 unsafe impl ::windows::core::Abi for IPV6_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_HEADER_0 {}
 impl ::core::default::Default for IPV6_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10111,7 +9735,7 @@ unsafe impl ::windows::core::Abi for IPV6_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for IPV6_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV6_HEADER_0_0 {}
@@ -10135,12 +9759,6 @@ impl ::core::clone::Clone for IPV6_MREQ {
 unsafe impl ::windows::core::Abi for IPV6_MREQ {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_MREQ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_MREQ>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_MREQ {}
 impl ::core::default::Default for IPV6_MREQ {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10161,12 +9779,6 @@ impl ::core::clone::Clone for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
 unsafe impl ::windows::core::Abi for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {}
 impl ::core::default::Default for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10194,7 +9806,7 @@ unsafe impl ::windows::core::Abi for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {
 }
 impl ::core::cmp::PartialEq for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0>()) == 0 }
+        self._bitfield == other._bitfield && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {}
@@ -10225,7 +9837,7 @@ unsafe impl ::windows::core::Abi for IPV6_OPTION_HEADER {
 }
 impl ::core::cmp::PartialEq for IPV6_OPTION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_OPTION_HEADER>()) == 0 }
+        self.Type == other.Type && self.DataLength == other.DataLength
     }
 }
 impl ::core::cmp::Eq for IPV6_OPTION_HEADER {}
@@ -10256,7 +9868,7 @@ unsafe impl ::windows::core::Abi for IPV6_OPTION_JUMBOGRAM {
 }
 impl ::core::cmp::PartialEq for IPV6_OPTION_JUMBOGRAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_OPTION_JUMBOGRAM>()) == 0 }
+        self.Header == other.Header && self.JumbogramLength == other.JumbogramLength
     }
 }
 impl ::core::cmp::Eq for IPV6_OPTION_JUMBOGRAM {}
@@ -10287,7 +9899,7 @@ unsafe impl ::windows::core::Abi for IPV6_OPTION_ROUTER_ALERT {
 }
 impl ::core::cmp::PartialEq for IPV6_OPTION_ROUTER_ALERT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_OPTION_ROUTER_ALERT>()) == 0 }
+        self.Header == other.Header && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for IPV6_OPTION_ROUTER_ALERT {}
@@ -10311,12 +9923,6 @@ impl ::core::clone::Clone for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
 unsafe impl ::windows::core::Abi for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_ROUTER_ADVERTISEMENT_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPV6_ROUTER_ADVERTISEMENT_FLAGS {}
 impl ::core::default::Default for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10343,7 +9949,7 @@ unsafe impl ::windows::core::Abi for IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {
 }
 impl ::core::cmp::PartialEq for IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_ROUTER_ADVERTISEMENT_FLAGS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {}
@@ -10377,7 +9983,7 @@ unsafe impl ::windows::core::Abi for IPV6_ROUTING_HEADER {
 }
 impl ::core::cmp::PartialEq for IPV6_ROUTING_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPV6_ROUTING_HEADER>()) == 0 }
+        self.NextHeader == other.NextHeader && self.Length == other.Length && self.RoutingType == other.RoutingType && self.SegmentsLeft == other.SegmentsLeft && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for IPV6_ROUTING_HEADER {}
@@ -10419,7 +10025,7 @@ unsafe impl ::windows::core::Abi for IPX_ADDRESS_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IPX_ADDRESS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPX_ADDRESS_DATA>()) == 0 }
+        self.adapternum == other.adapternum && self.netnum == other.netnum && self.nodenum == other.nodenum && self.wan == other.wan && self.status == other.status && self.maxpkt == other.maxpkt && self.linkspeed == other.linkspeed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10455,7 +10061,7 @@ unsafe impl ::windows::core::Abi for IPX_NETNUM_DATA {
 }
 impl ::core::cmp::PartialEq for IPX_NETNUM_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPX_NETNUM_DATA>()) == 0 }
+        self.netnum == other.netnum && self.hopcount == other.hopcount && self.netdelay == other.netdelay && self.cardnum == other.cardnum && self.router == other.router
     }
 }
 impl ::core::cmp::Eq for IPX_NETNUM_DATA {}
@@ -10521,7 +10127,24 @@ unsafe impl ::windows::core::Abi for IPX_SPXCONNSTATUS_DATA {
 }
 impl ::core::cmp::PartialEq for IPX_SPXCONNSTATUS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPX_SPXCONNSTATUS_DATA>()) == 0 }
+        self.ConnectionState == other.ConnectionState
+            && self.WatchDogActive == other.WatchDogActive
+            && self.LocalConnectionId == other.LocalConnectionId
+            && self.RemoteConnectionId == other.RemoteConnectionId
+            && self.LocalSequenceNumber == other.LocalSequenceNumber
+            && self.LocalAckNumber == other.LocalAckNumber
+            && self.LocalAllocNumber == other.LocalAllocNumber
+            && self.RemoteAckNumber == other.RemoteAckNumber
+            && self.RemoteAllocNumber == other.RemoteAllocNumber
+            && self.LocalSocket == other.LocalSocket
+            && self.ImmediateAddress == other.ImmediateAddress
+            && self.RemoteNetwork == other.RemoteNetwork
+            && self.RemoteNode == other.RemoteNode
+            && self.RemoteSocket == other.RemoteSocket
+            && self.RetransmissionCount == other.RetransmissionCount
+            && self.EstimatedRoundTripDelay == other.EstimatedRoundTripDelay
+            && self.RetransmittedPackets == other.RetransmittedPackets
+            && self.SuppressedPacket == other.SuppressedPacket
     }
 }
 impl ::core::cmp::Eq for IPX_SPXCONNSTATUS_DATA {}
@@ -10545,12 +10168,6 @@ impl ::core::clone::Clone for IP_MREQ {
 unsafe impl ::windows::core::Abi for IP_MREQ {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IP_MREQ {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_MREQ>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IP_MREQ {}
 impl ::core::default::Default for IP_MREQ {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10572,12 +10189,6 @@ impl ::core::clone::Clone for IP_MREQ_SOURCE {
 unsafe impl ::windows::core::Abi for IP_MREQ_SOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IP_MREQ_SOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_MREQ_SOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IP_MREQ_SOURCE {}
 impl ::core::default::Default for IP_MREQ_SOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10601,12 +10212,6 @@ impl ::core::clone::Clone for IP_MSFILTER {
 unsafe impl ::windows::core::Abi for IP_MSFILTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IP_MSFILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IP_MSFILTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IP_MSFILTER {}
 impl ::core::default::Default for IP_MSFILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10634,7 +10239,7 @@ unsafe impl ::windows::core::Abi for LINGER {
 }
 impl ::core::cmp::PartialEq for LINGER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINGER>()) == 0 }
+        self.l_onoff == other.l_onoff && self.l_linger == other.l_linger
     }
 }
 impl ::core::cmp::Eq for LINGER {}
@@ -10671,7 +10276,7 @@ unsafe impl ::windows::core::Abi for LM_IRPARMS {
 }
 impl ::core::cmp::PartialEq for LM_IRPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LM_IRPARMS>()) == 0 }
+        self.nTXDataBytes == other.nTXDataBytes && self.nRXDataBytes == other.nRXDataBytes && self.nBaudRate == other.nBaudRate && self.thresholdTime == other.thresholdTime && self.discTime == other.discTime && self.nMSLinkTurn == other.nMSLinkTurn && self.nTXPackets == other.nTXPackets && self.nRXPackets == other.nRXPackets
     }
 }
 impl ::core::cmp::Eq for LM_IRPARMS {}
@@ -10700,12 +10305,6 @@ impl ::core::clone::Clone for MLDV2_QUERY_HEADER {
 unsafe impl ::windows::core::Abi for MLDV2_QUERY_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLDV2_QUERY_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_QUERY_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLDV2_QUERY_HEADER {}
 impl ::core::default::Default for MLDV2_QUERY_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10726,12 +10325,6 @@ impl ::core::clone::Clone for MLDV2_QUERY_HEADER_0 {
 unsafe impl ::windows::core::Abi for MLDV2_QUERY_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLDV2_QUERY_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_QUERY_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLDV2_QUERY_HEADER_0 {}
 impl ::core::default::Default for MLDV2_QUERY_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10758,7 +10351,7 @@ unsafe impl ::windows::core::Abi for MLDV2_QUERY_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for MLDV2_QUERY_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_QUERY_HEADER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MLDV2_QUERY_HEADER_0_0 {}
@@ -10782,12 +10375,6 @@ impl ::core::clone::Clone for MLDV2_QUERY_HEADER_1 {
 unsafe impl ::windows::core::Abi for MLDV2_QUERY_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLDV2_QUERY_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_QUERY_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLDV2_QUERY_HEADER_1 {}
 impl ::core::default::Default for MLDV2_QUERY_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10814,7 +10401,7 @@ unsafe impl ::windows::core::Abi for MLDV2_QUERY_HEADER_1_0 {
 }
 impl ::core::cmp::PartialEq for MLDV2_QUERY_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_QUERY_HEADER_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for MLDV2_QUERY_HEADER_1_0 {}
@@ -10846,7 +10433,7 @@ unsafe impl ::windows::core::Abi for MLDV2_REPORT_HEADER {
 }
 impl ::core::cmp::PartialEq for MLDV2_REPORT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_REPORT_HEADER>()) == 0 }
+        self.IcmpHeader == other.IcmpHeader && self.Reserved == other.Reserved && self.RecordCount == other.RecordCount
     }
 }
 impl ::core::cmp::Eq for MLDV2_REPORT_HEADER {}
@@ -10872,12 +10459,6 @@ impl ::core::clone::Clone for MLDV2_REPORT_RECORD_HEADER {
 unsafe impl ::windows::core::Abi for MLDV2_REPORT_RECORD_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLDV2_REPORT_RECORD_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLDV2_REPORT_RECORD_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLDV2_REPORT_RECORD_HEADER {}
 impl ::core::default::Default for MLDV2_REPORT_RECORD_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10900,12 +10481,6 @@ impl ::core::clone::Clone for MLD_HEADER {
 unsafe impl ::windows::core::Abi for MLD_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLD_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MLD_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MLD_HEADER {}
 impl ::core::default::Default for MLD_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10935,7 +10510,7 @@ unsafe impl ::windows::core::Abi for NAPI_DOMAIN_DESCRIPTION_BLOB {
 }
 impl ::core::cmp::PartialEq for NAPI_DOMAIN_DESCRIPTION_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAPI_DOMAIN_DESCRIPTION_BLOB>()) == 0 }
+        self.AuthLevel == other.AuthLevel && self.cchDomainName == other.cchDomainName && self.OffsetNextDomainDescription == other.OffsetNextDomainDescription && self.OffsetThisDomainName == other.OffsetThisDomainName
     }
 }
 impl ::core::cmp::Eq for NAPI_DOMAIN_DESCRIPTION_BLOB {}
@@ -10969,7 +10544,7 @@ unsafe impl ::windows::core::Abi for NAPI_PROVIDER_INSTALLATION_BLOB {
 }
 impl ::core::cmp::PartialEq for NAPI_PROVIDER_INSTALLATION_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAPI_PROVIDER_INSTALLATION_BLOB>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwProviderType == other.dwProviderType && self.fSupportsWildCard == other.fSupportsWildCard && self.cDomains == other.cDomains && self.OffsetFirstDomain == other.OffsetFirstDomain
     }
 }
 impl ::core::cmp::Eq for NAPI_PROVIDER_INSTALLATION_BLOB {}
@@ -10993,12 +10568,6 @@ impl ::core::clone::Clone for ND_NEIGHBOR_ADVERT_HEADER {
 unsafe impl ::windows::core::Abi for ND_NEIGHBOR_ADVERT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_NEIGHBOR_ADVERT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_NEIGHBOR_ADVERT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_NEIGHBOR_ADVERT_HEADER {}
 impl ::core::default::Default for ND_NEIGHBOR_ADVERT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11019,12 +10588,6 @@ impl ::core::clone::Clone for ND_NEIGHBOR_SOLICIT_HEADER {
 unsafe impl ::windows::core::Abi for ND_NEIGHBOR_SOLICIT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_NEIGHBOR_SOLICIT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_NEIGHBOR_SOLICIT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_NEIGHBOR_SOLICIT_HEADER {}
 impl ::core::default::Default for ND_NEIGHBOR_SOLICIT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11054,7 +10617,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_DNSSL {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_DNSSL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_DNSSL>()) == 0 }
+        self.nd_opt_dnssl_type == other.nd_opt_dnssl_type && self.nd_opt_dnssl_len == other.nd_opt_dnssl_len && self.nd_opt_dnssl_reserved == other.nd_opt_dnssl_reserved && self.nd_opt_dnssl_lifetime == other.nd_opt_dnssl_lifetime
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_DNSSL {}
@@ -11085,7 +10648,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_HDR {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_HDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_HDR>()) == 0 }
+        self.nd_opt_type == other.nd_opt_type && self.nd_opt_len == other.nd_opt_len
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_HDR {}
@@ -11118,7 +10681,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_MTU {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_MTU {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_MTU>()) == 0 }
+        self.nd_opt_mtu_type == other.nd_opt_mtu_type && self.nd_opt_mtu_len == other.nd_opt_mtu_len && self.nd_opt_mtu_reserved == other.nd_opt_mtu_reserved && self.nd_opt_mtu_mtu == other.nd_opt_mtu_mtu
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_MTU {}
@@ -11148,12 +10711,6 @@ impl ::core::clone::Clone for ND_OPTION_PREFIX_INFO {
 unsafe impl ::windows::core::Abi for ND_OPTION_PREFIX_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_OPTION_PREFIX_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_PREFIX_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_OPTION_PREFIX_INFO {}
 impl ::core::default::Default for ND_OPTION_PREFIX_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11174,12 +10731,6 @@ impl ::core::clone::Clone for ND_OPTION_PREFIX_INFO_0 {
 unsafe impl ::windows::core::Abi for ND_OPTION_PREFIX_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_OPTION_PREFIX_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_PREFIX_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_OPTION_PREFIX_INFO_0 {}
 impl ::core::default::Default for ND_OPTION_PREFIX_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11206,7 +10757,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_PREFIX_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_PREFIX_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_PREFIX_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_PREFIX_INFO_0_0 {}
@@ -11230,12 +10781,6 @@ impl ::core::clone::Clone for ND_OPTION_PREFIX_INFO_1 {
 unsafe impl ::windows::core::Abi for ND_OPTION_PREFIX_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_OPTION_PREFIX_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_PREFIX_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_OPTION_PREFIX_INFO_1 {}
 impl ::core::default::Default for ND_OPTION_PREFIX_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11263,7 +10808,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_PREFIX_INFO_1_0 {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_PREFIX_INFO_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_PREFIX_INFO_1_0>()) == 0 }
+        self.nd_opt_pi_reserved3 == other.nd_opt_pi_reserved3 && self.nd_opt_pi_site_prefix_len == other.nd_opt_pi_site_prefix_len
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_PREFIX_INFO_1_0 {}
@@ -11296,7 +10841,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_RDNSS {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_RDNSS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_RDNSS>()) == 0 }
+        self.nd_opt_rdnss_type == other.nd_opt_rdnss_type && self.nd_opt_rdnss_len == other.nd_opt_rdnss_len && self.nd_opt_rdnss_reserved == other.nd_opt_rdnss_reserved && self.nd_opt_rdnss_lifetime == other.nd_opt_rdnss_lifetime
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_RDNSS {}
@@ -11329,7 +10874,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_RD_HDR {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_RD_HDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_RD_HDR>()) == 0 }
+        self.nd_opt_rh_type == other.nd_opt_rh_type && self.nd_opt_rh_len == other.nd_opt_rh_len && self.nd_opt_rh_reserved1 == other.nd_opt_rh_reserved1 && self.nd_opt_rh_reserved2 == other.nd_opt_rh_reserved2
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_RD_HDR {}
@@ -11357,12 +10902,6 @@ impl ::core::clone::Clone for ND_OPTION_ROUTE_INFO {
 unsafe impl ::windows::core::Abi for ND_OPTION_ROUTE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_OPTION_ROUTE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_ROUTE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_OPTION_ROUTE_INFO {}
 impl ::core::default::Default for ND_OPTION_ROUTE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11383,12 +10922,6 @@ impl ::core::clone::Clone for ND_OPTION_ROUTE_INFO_0 {
 unsafe impl ::windows::core::Abi for ND_OPTION_ROUTE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_OPTION_ROUTE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_ROUTE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_OPTION_ROUTE_INFO_0 {}
 impl ::core::default::Default for ND_OPTION_ROUTE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11415,7 +10948,7 @@ unsafe impl ::windows::core::Abi for ND_OPTION_ROUTE_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for ND_OPTION_ROUTE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_OPTION_ROUTE_INFO_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for ND_OPTION_ROUTE_INFO_0_0 {}
@@ -11440,12 +10973,6 @@ impl ::core::clone::Clone for ND_REDIRECT_HEADER {
 unsafe impl ::windows::core::Abi for ND_REDIRECT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_REDIRECT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_REDIRECT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_REDIRECT_HEADER {}
 impl ::core::default::Default for ND_REDIRECT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11467,12 +10994,6 @@ impl ::core::clone::Clone for ND_ROUTER_ADVERT_HEADER {
 unsafe impl ::windows::core::Abi for ND_ROUTER_ADVERT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_ROUTER_ADVERT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_ROUTER_ADVERT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_ROUTER_ADVERT_HEADER {}
 impl ::core::default::Default for ND_ROUTER_ADVERT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11492,12 +11013,6 @@ impl ::core::clone::Clone for ND_ROUTER_SOLICIT_HEADER {
 unsafe impl ::windows::core::Abi for ND_ROUTER_SOLICIT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ND_ROUTER_SOLICIT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ND_ROUTER_SOLICIT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ND_ROUTER_SOLICIT_HEADER {}
 impl ::core::default::Default for ND_ROUTER_SOLICIT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11534,7 +11049,7 @@ unsafe impl ::windows::core::Abi for NETRESOURCE2A {
 }
 impl ::core::cmp::PartialEq for NETRESOURCE2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETRESOURCE2A>()) == 0 }
+        self.dwScope == other.dwScope && self.dwType == other.dwType && self.dwUsage == other.dwUsage && self.dwDisplayType == other.dwDisplayType && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.lpComment == other.lpComment && self.ns_info == other.ns_info && self.ServiceType == other.ServiceType && self.dwProtocols == other.dwProtocols && self.lpiProtocols == other.lpiProtocols
     }
 }
 impl ::core::cmp::Eq for NETRESOURCE2A {}
@@ -11574,7 +11089,7 @@ unsafe impl ::windows::core::Abi for NETRESOURCE2W {
 }
 impl ::core::cmp::PartialEq for NETRESOURCE2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETRESOURCE2W>()) == 0 }
+        self.dwScope == other.dwScope && self.dwType == other.dwType && self.dwUsage == other.dwUsage && self.dwDisplayType == other.dwDisplayType && self.lpLocalName == other.lpLocalName && self.lpRemoteName == other.lpRemoteName && self.lpComment == other.lpComment && self.ns_info == other.ns_info && self.ServiceType == other.ServiceType && self.dwProtocols == other.dwProtocols && self.lpiProtocols == other.lpiProtocols
     }
 }
 impl ::core::cmp::Eq for NETRESOURCE2W {}
@@ -11603,14 +11118,6 @@ unsafe impl ::windows::core::Abi for NLA_BLOB {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NLA_BLOB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NLA_BLOB {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NLA_BLOB {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11638,14 +11145,6 @@ impl ::core::clone::Clone for NLA_BLOB_0 {
 unsafe impl ::windows::core::Abi for NLA_BLOB_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NLA_BLOB_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NLA_BLOB_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NLA_BLOB_0 {
     fn default() -> Self {
@@ -11679,7 +11178,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0_0>()) == 0 }
+        self.remote == other.remote
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11721,7 +11220,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_0_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0_0_0>()) == 0 }
+        self.speed == other.speed && self.r#type == other.r#type && self.state == other.state && self.machineName == other.machineName && self.sharedAdapterName == other.sharedAdapterName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11760,7 +11259,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0_1>()) == 0 }
+        self.r#type == other.r#type && self.internet == other.internet
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11800,7 +11299,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0_2>()) == 0 }
+        self.dwType == other.dwType && self.dwSpeed == other.dwSpeed && self.adapterName == other.adapterName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11838,7 +11337,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_0_3>()) == 0 }
+        self.information == other.information
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11878,7 +11377,7 @@ unsafe impl ::windows::core::Abi for NLA_BLOB_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NLA_BLOB_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NLA_BLOB_1>()) == 0 }
+        self.r#type == other.r#type && self.dwSize == other.dwSize && self.nextOffset == other.nextOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11918,7 +11417,7 @@ unsafe impl ::windows::core::Abi for NL_BANDWIDTH_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NL_BANDWIDTH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NL_BANDWIDTH_INFORMATION>()) == 0 }
+        self.Bandwidth == other.Bandwidth && self.Instability == other.Instability && self.BandwidthPeaked == other.BandwidthPeaked
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11950,7 +11449,7 @@ unsafe impl ::windows::core::Abi for NL_INTERFACE_OFFLOAD_ROD {
 }
 impl ::core::cmp::PartialEq for NL_INTERFACE_OFFLOAD_ROD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NL_INTERFACE_OFFLOAD_ROD>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NL_INTERFACE_OFFLOAD_ROD {}
@@ -11990,7 +11489,7 @@ unsafe impl ::windows::core::Abi for NL_NETWORK_CONNECTIVITY_HINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NL_NETWORK_CONNECTIVITY_HINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NL_NETWORK_CONNECTIVITY_HINT>()) == 0 }
+        self.ConnectivityLevel == other.ConnectivityLevel && self.ConnectivityCost == other.ConnectivityCost && self.ApproachingDataLimit == other.ApproachingDataLimit && self.OverDataLimit == other.OverDataLimit && self.Roaming == other.Roaming
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12030,7 +11529,7 @@ unsafe impl ::windows::core::Abi for NL_PATH_BANDWIDTH_ROD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NL_PATH_BANDWIDTH_ROD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NL_PATH_BANDWIDTH_ROD>()) == 0 }
+        self.Bandwidth == other.Bandwidth && self.Instability == other.Instability && self.BandwidthPeaked == other.BandwidthPeaked
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12062,14 +11561,6 @@ unsafe impl ::windows::core::Abi for NPI_MODULEID {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NPI_MODULEID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NPI_MODULEID>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NPI_MODULEID {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NPI_MODULEID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12094,14 +11585,6 @@ impl ::core::clone::Clone for NPI_MODULEID_0 {
 unsafe impl ::windows::core::Abi for NPI_MODULEID_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NPI_MODULEID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NPI_MODULEID_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NPI_MODULEID_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NPI_MODULEID_0 {
     fn default() -> Self {
@@ -12134,32 +11617,13 @@ impl ::core::clone::Clone for NSPV2_ROUTINE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::fmt::Debug for NSPV2_ROUTINE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NSPV2_ROUTINE")
-            .field("cbSize", &self.cbSize)
-            .field("dwMajorVersion", &self.dwMajorVersion)
-            .field("dwMinorVersion", &self.dwMinorVersion)
-            .field("NSPv2Startup", &self.NSPv2Startup.map(|f| f as usize))
-            .field("NSPv2Cleanup", &self.NSPv2Cleanup.map(|f| f as usize))
-            .field("NSPv2LookupServiceBegin", &self.NSPv2LookupServiceBegin.map(|f| f as usize))
-            .field("NSPv2LookupServiceNextEx", &self.NSPv2LookupServiceNextEx.map(|f| f as usize))
-            .field("NSPv2LookupServiceEnd", &self.NSPv2LookupServiceEnd.map(|f| f as usize))
-            .field("NSPv2SetServiceEx", &self.NSPv2SetServiceEx.map(|f| f as usize))
-            .field("NSPv2ClientSessionRundown", &self.NSPv2ClientSessionRundown.map(|f| f as usize))
-            .finish()
+        f.debug_struct("NSPV2_ROUTINE").field("cbSize", &self.cbSize).field("dwMajorVersion", &self.dwMajorVersion).field("dwMinorVersion", &self.dwMinorVersion).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 unsafe impl ::windows::core::Abi for NSPV2_ROUTINE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for NSPV2_ROUTINE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NSPV2_ROUTINE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for NSPV2_ROUTINE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for NSPV2_ROUTINE {
     fn default() -> Self {
@@ -12194,34 +11658,13 @@ impl ::core::clone::Clone for NSP_ROUTINE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for NSP_ROUTINE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NSP_ROUTINE")
-            .field("cbSize", &self.cbSize)
-            .field("dwMajorVersion", &self.dwMajorVersion)
-            .field("dwMinorVersion", &self.dwMinorVersion)
-            .field("NSPCleanup", &self.NSPCleanup.map(|f| f as usize))
-            .field("NSPLookupServiceBegin", &self.NSPLookupServiceBegin.map(|f| f as usize))
-            .field("NSPLookupServiceNext", &self.NSPLookupServiceNext.map(|f| f as usize))
-            .field("NSPLookupServiceEnd", &self.NSPLookupServiceEnd.map(|f| f as usize))
-            .field("NSPSetService", &self.NSPSetService.map(|f| f as usize))
-            .field("NSPInstallServiceClass", &self.NSPInstallServiceClass.map(|f| f as usize))
-            .field("NSPRemoveServiceClass", &self.NSPRemoveServiceClass.map(|f| f as usize))
-            .field("NSPGetServiceClassInfo", &self.NSPGetServiceClassInfo.map(|f| f as usize))
-            .field("NSPIoctl", &self.NSPIoctl.map(|f| f as usize))
-            .finish()
+        f.debug_struct("NSP_ROUTINE").field("cbSize", &self.cbSize).field("dwMajorVersion", &self.dwMajorVersion).field("dwMinorVersion", &self.dwMinorVersion).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for NSP_ROUTINE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for NSP_ROUTINE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NSP_ROUTINE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for NSP_ROUTINE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
 impl ::core::default::Default for NSP_ROUTINE {
     fn default() -> Self {
@@ -12251,7 +11694,7 @@ unsafe impl ::windows::core::Abi for NS_INFOA {
 }
 impl ::core::cmp::PartialEq for NS_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_INFOA>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.dwNameSpaceFlags == other.dwNameSpaceFlags && self.lpNameSpace == other.lpNameSpace
     }
 }
 impl ::core::cmp::Eq for NS_INFOA {}
@@ -12283,7 +11726,7 @@ unsafe impl ::windows::core::Abi for NS_INFOW {
 }
 impl ::core::cmp::PartialEq for NS_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_INFOW>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.dwNameSpaceFlags == other.dwNameSpaceFlags && self.lpNameSpace == other.lpNameSpace
     }
 }
 impl ::core::cmp::Eq for NS_INFOW {}
@@ -12320,7 +11763,7 @@ unsafe impl ::windows::core::Abi for NS_SERVICE_INFOA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for NS_SERVICE_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_SERVICE_INFOA>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.ServiceInfo == other.ServiceInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -12359,7 +11802,7 @@ unsafe impl ::windows::core::Abi for NS_SERVICE_INFOW {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for NS_SERVICE_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NS_SERVICE_INFOW>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.ServiceInfo == other.ServiceInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -12392,7 +11835,7 @@ unsafe impl ::windows::core::Abi for PRIORITY_STATUS {
 }
 impl ::core::cmp::PartialEq for PRIORITY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRIORITY_STATUS>()) == 0 }
+        self.Sender == other.Sender && self.Receiver == other.Receiver
     }
 }
 impl ::core::cmp::Eq for PRIORITY_STATUS {}
@@ -12429,7 +11872,7 @@ unsafe impl ::windows::core::Abi for PROTOCOL_INFOA {
 }
 impl ::core::cmp::PartialEq for PROTOCOL_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTOCOL_INFOA>()) == 0 }
+        self.dwServiceFlags == other.dwServiceFlags && self.iAddressFamily == other.iAddressFamily && self.iMaxSockAddr == other.iMaxSockAddr && self.iMinSockAddr == other.iMinSockAddr && self.iSocketType == other.iSocketType && self.iProtocol == other.iProtocol && self.dwMessageSize == other.dwMessageSize && self.lpProtocol == other.lpProtocol
     }
 }
 impl ::core::cmp::Eq for PROTOCOL_INFOA {}
@@ -12466,7 +11909,7 @@ unsafe impl ::windows::core::Abi for PROTOCOL_INFOW {
 }
 impl ::core::cmp::PartialEq for PROTOCOL_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTOCOL_INFOW>()) == 0 }
+        self.dwServiceFlags == other.dwServiceFlags && self.iAddressFamily == other.iAddressFamily && self.iMaxSockAddr == other.iMaxSockAddr && self.iMinSockAddr == other.iMinSockAddr && self.iSocketType == other.iSocketType && self.iProtocol == other.iProtocol && self.dwMessageSize == other.dwMessageSize && self.lpProtocol == other.lpProtocol
     }
 }
 impl ::core::cmp::Eq for PROTOCOL_INFOW {}
@@ -12498,7 +11941,7 @@ unsafe impl ::windows::core::Abi for PROTOENT {
 }
 impl ::core::cmp::PartialEq for PROTOENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTOENT>()) == 0 }
+        self.p_name == other.p_name && self.p_aliases == other.p_aliases && self.p_proto == other.p_proto
     }
 }
 impl ::core::cmp::Eq for PROTOENT {}
@@ -12530,7 +11973,7 @@ unsafe impl ::windows::core::Abi for Q2931_IE {
 }
 impl ::core::cmp::PartialEq for Q2931_IE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Q2931_IE>()) == 0 }
+        self.IEType == other.IEType && self.IELength == other.IELength && self.IE == other.IE
     }
 }
 impl ::core::cmp::Eq for Q2931_IE {}
@@ -12562,7 +12005,7 @@ unsafe impl ::windows::core::Abi for QOS {
 }
 impl ::core::cmp::PartialEq for QOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOS>()) == 0 }
+        self.SendingFlowspec == other.SendingFlowspec && self.ReceivingFlowspec == other.ReceivingFlowspec && self.ProviderSpecific == other.ProviderSpecific
     }
 }
 impl ::core::cmp::Eq for QOS {}
@@ -12593,7 +12036,7 @@ unsafe impl ::windows::core::Abi for RCVALL_IF {
 }
 impl ::core::cmp::PartialEq for RCVALL_IF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RCVALL_IF>()) == 0 }
+        self.Mode == other.Mode && self.Interface == other.Interface
     }
 }
 impl ::core::cmp::Eq for RCVALL_IF {}
@@ -12624,7 +12067,7 @@ unsafe impl ::windows::core::Abi for REAL_TIME_NOTIFICATION_SETTING_INPUT {
 }
 impl ::core::cmp::PartialEq for REAL_TIME_NOTIFICATION_SETTING_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REAL_TIME_NOTIFICATION_SETTING_INPUT>()) == 0 }
+        self.TransportSettingId == other.TransportSettingId && self.BrokerEventGuid == other.BrokerEventGuid
     }
 }
 impl ::core::cmp::Eq for REAL_TIME_NOTIFICATION_SETTING_INPUT {}
@@ -12662,7 +12105,7 @@ unsafe impl ::windows::core::Abi for REAL_TIME_NOTIFICATION_SETTING_INPUT_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REAL_TIME_NOTIFICATION_SETTING_INPUT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REAL_TIME_NOTIFICATION_SETTING_INPUT_EX>()) == 0 }
+        self.TransportSettingId == other.TransportSettingId && self.BrokerEventGuid == other.BrokerEventGuid && self.Unmark == other.Unmark
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12694,7 +12137,7 @@ unsafe impl ::windows::core::Abi for REAL_TIME_NOTIFICATION_SETTING_OUTPUT {
 }
 impl ::core::cmp::PartialEq for REAL_TIME_NOTIFICATION_SETTING_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REAL_TIME_NOTIFICATION_SETTING_OUTPUT>()) == 0 }
+        self.ChannelStatus == other.ChannelStatus
     }
 }
 impl ::core::cmp::Eq for REAL_TIME_NOTIFICATION_SETTING_OUTPUT {}
@@ -12727,7 +12170,7 @@ unsafe impl ::windows::core::Abi for RIORESULT {
 }
 impl ::core::cmp::PartialEq for RIORESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIORESULT>()) == 0 }
+        self.Status == other.Status && self.BytesTransferred == other.BytesTransferred && self.SocketContext == other.SocketContext && self.RequestContext == other.RequestContext
     }
 }
 impl ::core::cmp::Eq for RIORESULT {}
@@ -12759,7 +12202,7 @@ unsafe impl ::windows::core::Abi for RIO_BUF {
 }
 impl ::core::cmp::PartialEq for RIO_BUF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_BUF>()) == 0 }
+        self.BufferId == other.BufferId && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for RIO_BUF {}
@@ -12791,7 +12234,7 @@ unsafe impl ::windows::core::Abi for RIO_CMSG_BUFFER {
 }
 impl ::core::cmp::PartialEq for RIO_CMSG_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_CMSG_BUFFER>()) == 0 }
+        self.TotalLength == other.TotalLength
     }
 }
 impl ::core::cmp::Eq for RIO_CMSG_BUFFER {}
@@ -12832,36 +12275,13 @@ impl ::core::clone::Clone for RIO_EXTENSION_FUNCTION_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for RIO_EXTENSION_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("RIO_EXTENSION_FUNCTION_TABLE")
-            .field("cbSize", &self.cbSize)
-            .field("RIOReceive", &self.RIOReceive.map(|f| f as usize))
-            .field("RIOReceiveEx", &self.RIOReceiveEx.map(|f| f as usize))
-            .field("RIOSend", &self.RIOSend.map(|f| f as usize))
-            .field("RIOSendEx", &self.RIOSendEx.map(|f| f as usize))
-            .field("RIOCloseCompletionQueue", &self.RIOCloseCompletionQueue.map(|f| f as usize))
-            .field("RIOCreateCompletionQueue", &self.RIOCreateCompletionQueue.map(|f| f as usize))
-            .field("RIOCreateRequestQueue", &self.RIOCreateRequestQueue.map(|f| f as usize))
-            .field("RIODequeueCompletion", &self.RIODequeueCompletion.map(|f| f as usize))
-            .field("RIODeregisterBuffer", &self.RIODeregisterBuffer.map(|f| f as usize))
-            .field("RIONotify", &self.RIONotify.map(|f| f as usize))
-            .field("RIORegisterBuffer", &self.RIORegisterBuffer.map(|f| f as usize))
-            .field("RIOResizeCompletionQueue", &self.RIOResizeCompletionQueue.map(|f| f as usize))
-            .field("RIOResizeRequestQueue", &self.RIOResizeRequestQueue.map(|f| f as usize))
-            .finish()
+        f.debug_struct("RIO_EXTENSION_FUNCTION_TABLE").field("cbSize", &self.cbSize).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for RIO_EXTENSION_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RIO_EXTENSION_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_EXTENSION_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RIO_EXTENSION_FUNCTION_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RIO_EXTENSION_FUNCTION_TABLE {
     fn default() -> Self {
@@ -12888,14 +12308,6 @@ unsafe impl ::windows::core::Abi for RIO_NOTIFICATION_COMPLETION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RIO_NOTIFICATION_COMPLETION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_NOTIFICATION_COMPLETION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RIO_NOTIFICATION_COMPLETION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RIO_NOTIFICATION_COMPLETION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12920,14 +12332,6 @@ impl ::core::clone::Clone for RIO_NOTIFICATION_COMPLETION_0 {
 unsafe impl ::windows::core::Abi for RIO_NOTIFICATION_COMPLETION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RIO_NOTIFICATION_COMPLETION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_NOTIFICATION_COMPLETION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RIO_NOTIFICATION_COMPLETION_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RIO_NOTIFICATION_COMPLETION_0 {
     fn default() -> Self {
@@ -12962,7 +12366,7 @@ unsafe impl ::windows::core::Abi for RIO_NOTIFICATION_COMPLETION_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RIO_NOTIFICATION_COMPLETION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_NOTIFICATION_COMPLETION_0_0>()) == 0 }
+        self.EventHandle == other.EventHandle && self.NotifyReset == other.NotifyReset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13002,7 +12406,7 @@ unsafe impl ::windows::core::Abi for RIO_NOTIFICATION_COMPLETION_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RIO_NOTIFICATION_COMPLETION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIO_NOTIFICATION_COMPLETION_0_1>()) == 0 }
+        self.IocpHandle == other.IocpHandle && self.CompletionKey == other.CompletionKey && self.Overlapped == other.Overlapped
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13045,7 +12449,7 @@ unsafe impl ::windows::core::Abi for RM_FEC_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RM_FEC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_FEC_INFO>()) == 0 }
+        self.FECBlockSize == other.FECBlockSize && self.FECProActivePackets == other.FECProActivePackets && self.FECGroupSize == other.FECGroupSize && self.fFECOnDemandParityEnabled == other.fFECOnDemandParityEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13113,7 +12517,24 @@ unsafe impl ::windows::core::Abi for RM_RECEIVER_STATS {
 }
 impl ::core::cmp::PartialEq for RM_RECEIVER_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_RECEIVER_STATS>()) == 0 }
+        self.NumODataPacketsReceived == other.NumODataPacketsReceived
+            && self.NumRDataPacketsReceived == other.NumRDataPacketsReceived
+            && self.NumDuplicateDataPackets == other.NumDuplicateDataPackets
+            && self.DataBytesReceived == other.DataBytesReceived
+            && self.TotalBytesReceived == other.TotalBytesReceived
+            && self.RateKBitsPerSecOverall == other.RateKBitsPerSecOverall
+            && self.RateKBitsPerSecLast == other.RateKBitsPerSecLast
+            && self.TrailingEdgeSeqId == other.TrailingEdgeSeqId
+            && self.LeadingEdgeSeqId == other.LeadingEdgeSeqId
+            && self.AverageSequencesInWindow == other.AverageSequencesInWindow
+            && self.MinSequencesInWindow == other.MinSequencesInWindow
+            && self.MaxSequencesInWindow == other.MaxSequencesInWindow
+            && self.FirstNakSequenceNumber == other.FirstNakSequenceNumber
+            && self.NumPendingNaks == other.NumPendingNaks
+            && self.NumOutstandingNaks == other.NumOutstandingNaks
+            && self.NumDataPacketsBuffered == other.NumDataPacketsBuffered
+            && self.TotalSelectiveNaksSent == other.TotalSelectiveNaksSent
+            && self.TotalParityNaksSent == other.TotalParityNaksSent
     }
 }
 impl ::core::cmp::Eq for RM_RECEIVER_STATS {}
@@ -13169,7 +12590,7 @@ unsafe impl ::windows::core::Abi for RM_SENDER_STATS {
 }
 impl ::core::cmp::PartialEq for RM_SENDER_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_SENDER_STATS>()) == 0 }
+        self.DataBytesSent == other.DataBytesSent && self.TotalBytesSent == other.TotalBytesSent && self.NaksReceived == other.NaksReceived && self.NaksReceivedTooLate == other.NaksReceivedTooLate && self.NumOutstandingNaks == other.NumOutstandingNaks && self.NumNaksAfterRData == other.NumNaksAfterRData && self.RepairPacketsSent == other.RepairPacketsSent && self.BufferSpaceAvailable == other.BufferSpaceAvailable && self.TrailingEdgeSeqId == other.TrailingEdgeSeqId && self.LeadingEdgeSeqId == other.LeadingEdgeSeqId && self.RateKBitsPerSecOverall == other.RateKBitsPerSecOverall && self.RateKBitsPerSecLast == other.RateKBitsPerSecLast && self.TotalODataPacketsSent == other.TotalODataPacketsSent
     }
 }
 impl ::core::cmp::Eq for RM_SENDER_STATS {}
@@ -13201,7 +12622,7 @@ unsafe impl ::windows::core::Abi for RM_SEND_WINDOW {
 }
 impl ::core::cmp::PartialEq for RM_SEND_WINDOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_SEND_WINDOW>()) == 0 }
+        self.RateKbitsPerSec == other.RateKbitsPerSec && self.WindowSizeInMSecs == other.WindowSizeInMSecs && self.WindowSizeInBytes == other.WindowSizeInBytes
     }
 }
 impl ::core::cmp::Eq for RM_SEND_WINDOW {}
@@ -13237,7 +12658,7 @@ unsafe impl ::windows::core::Abi for RSS_SCALABILITY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RSS_SCALABILITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSS_SCALABILITY_INFO>()) == 0 }
+        self.RssEnabled == other.RssEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13262,12 +12683,6 @@ impl ::core::clone::Clone for SCOPE_ID {
 unsafe impl ::windows::core::Abi for SCOPE_ID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SCOPE_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_ID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SCOPE_ID {}
 impl ::core::default::Default for SCOPE_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13288,12 +12703,6 @@ impl ::core::clone::Clone for SCOPE_ID_0 {
 unsafe impl ::windows::core::Abi for SCOPE_ID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SCOPE_ID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_ID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SCOPE_ID_0 {}
 impl ::core::default::Default for SCOPE_ID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13320,7 +12729,7 @@ unsafe impl ::windows::core::Abi for SCOPE_ID_0_0 {
 }
 impl ::core::cmp::PartialEq for SCOPE_ID_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_ID_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCOPE_ID_0_0 {}
@@ -13359,7 +12768,7 @@ unsafe impl ::windows::core::Abi for SERVENT {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SERVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVENT>()) == 0 }
+        self.s_name == other.s_name && self.s_aliases == other.s_aliases && self.s_proto == other.s_proto && self.s_port == other.s_port
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -13400,7 +12809,7 @@ unsafe impl ::windows::core::Abi for SERVENT {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for SERVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVENT>()) == 0 }
+        self.s_name == other.s_name && self.s_aliases == other.s_aliases && self.s_port == other.s_port && self.s_proto == other.s_proto
     }
 }
 #[cfg(target_arch = "x86")]
@@ -13437,7 +12846,7 @@ unsafe impl ::windows::core::Abi for SERVICE_ADDRESS {
 }
 impl ::core::cmp::PartialEq for SERVICE_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_ADDRESS>()) == 0 }
+        self.dwAddressType == other.dwAddressType && self.dwAddressFlags == other.dwAddressFlags && self.dwAddressLength == other.dwAddressLength && self.dwPrincipalLength == other.dwPrincipalLength && self.lpAddress == other.lpAddress && self.lpPrincipal == other.lpPrincipal
     }
 }
 impl ::core::cmp::Eq for SERVICE_ADDRESS {}
@@ -13468,7 +12877,7 @@ unsafe impl ::windows::core::Abi for SERVICE_ADDRESSES {
 }
 impl ::core::cmp::PartialEq for SERVICE_ADDRESSES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_ADDRESSES>()) == 0 }
+        self.dwAddressCount == other.dwAddressCount && self.Addresses == other.Addresses
     }
 }
 impl ::core::cmp::Eq for SERVICE_ADDRESSES {}
@@ -13496,21 +12905,13 @@ impl ::core::clone::Clone for SERVICE_ASYNC_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for SERVICE_ASYNC_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_ASYNC_INFO").field("lpServiceCallbackProc", &self.lpServiceCallbackProc.map(|f| f as usize)).field("lParam", &self.lParam).field("hAsyncTaskHandle", &self.hAsyncTaskHandle).finish()
+        f.debug_struct("SERVICE_ASYNC_INFO").field("lParam", &self.lParam).field("hAsyncTaskHandle", &self.hAsyncTaskHandle).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for SERVICE_ASYNC_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SERVICE_ASYNC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_ASYNC_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SERVICE_ASYNC_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SERVICE_ASYNC_INFO {
     fn default() -> Self {
@@ -13553,7 +12954,7 @@ unsafe impl ::windows::core::Abi for SERVICE_INFOA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SERVICE_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_INFOA>()) == 0 }
+        self.lpServiceType == other.lpServiceType && self.lpServiceName == other.lpServiceName && self.lpComment == other.lpComment && self.lpLocale == other.lpLocale && self.dwDisplayHint == other.dwDisplayHint && self.dwVersion == other.dwVersion && self.dwTime == other.dwTime && self.lpMachineName == other.lpMachineName && self.lpServiceAddress == other.lpServiceAddress && self.ServiceSpecificInfo == other.ServiceSpecificInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -13600,7 +13001,7 @@ unsafe impl ::windows::core::Abi for SERVICE_INFOW {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SERVICE_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_INFOW>()) == 0 }
+        self.lpServiceType == other.lpServiceType && self.lpServiceName == other.lpServiceName && self.lpComment == other.lpComment && self.lpLocale == other.lpLocale && self.dwDisplayHint == other.dwDisplayHint && self.dwVersion == other.dwVersion && self.dwTime == other.dwTime && self.lpMachineName == other.lpMachineName && self.lpServiceAddress == other.lpServiceAddress && self.ServiceSpecificInfo == other.ServiceSpecificInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -13634,7 +13035,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_INFO>()) == 0 }
+        self.dwTypeNameOffset == other.dwTypeNameOffset && self.dwValueCount == other.dwValueCount && self.Values == other.Values
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_INFO {}
@@ -13666,7 +13067,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_INFO_ABSA {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_INFO_ABSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_INFO_ABSA>()) == 0 }
+        self.lpTypeName == other.lpTypeName && self.dwValueCount == other.dwValueCount && self.Values == other.Values
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_INFO_ABSA {}
@@ -13698,7 +13099,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_INFO_ABSW {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_INFO_ABSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_INFO_ABSW>()) == 0 }
+        self.lpTypeName == other.lpTypeName && self.dwValueCount == other.dwValueCount && self.Values == other.Values
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_INFO_ABSW {}
@@ -13732,7 +13133,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_VALUE {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_VALUE>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.dwValueType == other.dwValueType && self.dwValueSize == other.dwValueSize && self.dwValueNameOffset == other.dwValueNameOffset && self.dwValueOffset == other.dwValueOffset
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_VALUE {}
@@ -13766,7 +13167,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_VALUE_ABSA {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_VALUE_ABSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_VALUE_ABSA>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.dwValueType == other.dwValueType && self.dwValueSize == other.dwValueSize && self.lpValueName == other.lpValueName && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_VALUE_ABSA {}
@@ -13800,7 +13201,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TYPE_VALUE_ABSW {
 }
 impl ::core::cmp::PartialEq for SERVICE_TYPE_VALUE_ABSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TYPE_VALUE_ABSW>()) == 0 }
+        self.dwNameSpace == other.dwNameSpace && self.dwValueType == other.dwValueType && self.dwValueSize == other.dwValueSize && self.lpValueName == other.lpValueName && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for SERVICE_TYPE_VALUE_ABSW {}
@@ -13834,7 +13235,7 @@ unsafe impl ::windows::core::Abi for SNAP_HEADER {
 }
 impl ::core::cmp::PartialEq for SNAP_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SNAP_HEADER>()) == 0 }
+        self.Dsap == other.Dsap && self.Ssap == other.Ssap && self.Control == other.Control && self.Oui == other.Oui && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for SNAP_HEADER {}
@@ -13871,7 +13272,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR>()) == 0 }
+        self.sa_family == other.sa_family && self.sa_data == other.sa_data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13906,7 +13307,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_ATM {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_ATM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_ATM>()) == 0 }
+        self.satm_family == other.satm_family && self.satm_number == other.satm_number && self.satm_blli == other.satm_blli && self.satm_bhli == other.satm_bhli
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_ATM {}
@@ -13938,7 +13339,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_DL {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_DL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_DL>()) == 0 }
+        self.sdl_family == other.sdl_family && self.sdl_data == other.sdl_data && self.sdl_zero == other.sdl_zero
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_DL {}
@@ -13969,14 +13370,6 @@ unsafe impl ::windows::core::Abi for SOCKADDR_IN {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SOCKADDR_IN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SOCKADDR_IN {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SOCKADDR_IN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14005,12 +13398,6 @@ impl ::core::clone::Clone for SOCKADDR_IN6 {
 unsafe impl ::windows::core::Abi for SOCKADDR_IN6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SOCKADDR_IN6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IN6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SOCKADDR_IN6 {}
 impl ::core::default::Default for SOCKADDR_IN6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14043,12 +13430,6 @@ impl ::core::clone::Clone for SOCKADDR_IN6_0 {
 unsafe impl ::windows::core::Abi for SOCKADDR_IN6_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SOCKADDR_IN6_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IN6_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SOCKADDR_IN6_0 {}
 impl ::core::default::Default for SOCKADDR_IN6_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14076,7 +13457,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_IN6_PAIR {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_IN6_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IN6_PAIR>()) == 0 }
+        self.SourceAddress == other.SourceAddress && self.DestinationAddress == other.DestinationAddress
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_IN6_PAIR {}
@@ -14103,12 +13484,6 @@ impl ::core::clone::Clone for SOCKADDR_IN6_W2KSP1 {
 unsafe impl ::windows::core::Abi for SOCKADDR_IN6_W2KSP1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SOCKADDR_IN6_W2KSP1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IN6_W2KSP1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SOCKADDR_IN6_W2KSP1 {}
 impl ::core::default::Default for SOCKADDR_IN6_W2KSP1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14134,14 +13509,6 @@ impl ::core::clone::Clone for SOCKADDR_INET {
 unsafe impl ::windows::core::Abi for SOCKADDR_INET {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SOCKADDR_INET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_INET>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SOCKADDR_INET {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SOCKADDR_INET {
     fn default() -> Self {
@@ -14196,7 +13563,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_IPX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_IPX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IPX>()) == 0 }
+        self.sa_family == other.sa_family && self.sa_netnum == other.sa_netnum && self.sa_nodenum == other.sa_nodenum && self.sa_socket == other.sa_socket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14236,7 +13603,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_IRDA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_IRDA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_IRDA>()) == 0 }
+        self.irdaAddressFamily == other.irdaAddressFamily && self.irdaDeviceID == other.irdaDeviceID && self.irdaServiceName == other.irdaServiceName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14276,7 +13643,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_NB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_NB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_NB>()) == 0 }
+        self.snb_family == other.snb_family && self.snb_type == other.snb_type && self.snb_name == other.snb_name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14317,7 +13684,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_STORAGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_STORAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_STORAGE>()) == 0 }
+        self.ss_family == other.ss_family && self.__ss_pad1 == other.__ss_pad1 && self.__ss_align == other.__ss_align && self.__ss_pad2 == other.__ss_pad2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14358,7 +13725,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_STORAGE_XP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_STORAGE_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_STORAGE_XP>()) == 0 }
+        self.ss_family == other.ss_family && self.__ss_pad1 == other.__ss_pad1 && self.__ss_align == other.__ss_align && self.__ss_pad2 == other.__ss_pad2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14394,7 +13761,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_TP {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_TP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_TP>()) == 0 }
+        self.tp_family == other.tp_family && self.tp_addr_type == other.tp_addr_type && self.tp_taddr_len == other.tp_taddr_len && self.tp_tsel_len == other.tp_tsel_len && self.tp_addr == other.tp_addr
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_TP {}
@@ -14431,7 +13798,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_UN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKADDR_UN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_UN>()) == 0 }
+        self.sun_family == other.sun_family && self.sun_path == other.sun_path
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14468,7 +13835,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_VNS {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_VNS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_VNS>()) == 0 }
+        self.sin_family == other.sin_family && self.net_address == other.net_address && self.subnet_addr == other.subnet_addr && self.port == other.port && self.hops == other.hops && self.filler == other.filler
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_VNS {}
@@ -14532,7 +13899,7 @@ unsafe impl ::windows::core::Abi for SOCKET_ADDRESS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKET_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_ADDRESS>()) == 0 }
+        self.lpSockaddr == other.lpSockaddr && self.iSockaddrLength == other.iSockaddrLength
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14571,7 +13938,7 @@ unsafe impl ::windows::core::Abi for SOCKET_ADDRESS_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKET_ADDRESS_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_ADDRESS_LIST>()) == 0 }
+        self.iAddressCount == other.iAddressCount && self.Address == other.Address
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14612,7 +13979,7 @@ unsafe impl ::windows::core::Abi for SOCKET_PEER_TARGET_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKET_PEER_TARGET_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_PEER_TARGET_NAME>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.PeerAddress == other.PeerAddress && self.PeerTargetNameStringLen == other.PeerTargetNameStringLen && self.AllStrings == other.AllStrings
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14652,7 +14019,7 @@ unsafe impl ::windows::core::Abi for SOCKET_PROCESSOR_AFFINITY {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for SOCKET_PROCESSOR_AFFINITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_PROCESSOR_AFFINITY>()) == 0 }
+        self.Processor == other.Processor && self.NumaNodeId == other.NumaNodeId && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -14687,7 +14054,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_QUERY_INFO {
 }
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_QUERY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_QUERY_INFO>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.Flags == other.Flags && self.PeerApplicationAccessTokenHandle == other.PeerApplicationAccessTokenHandle && self.PeerMachineAccessTokenHandle == other.PeerMachineAccessTokenHandle
     }
 }
 impl ::core::cmp::Eq for SOCKET_SECURITY_QUERY_INFO {}
@@ -14724,7 +14091,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_QUERY_INFO_IPSEC2 {
 }
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_QUERY_INFO_IPSEC2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_QUERY_INFO_IPSEC2>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.Flags == other.Flags && self.PeerApplicationAccessTokenHandle == other.PeerApplicationAccessTokenHandle && self.PeerMachineAccessTokenHandle == other.PeerMachineAccessTokenHandle && self.MmSaId == other.MmSaId && self.QmSaId == other.QmSaId && self.NegotiationWinerr == other.NegotiationWinerr && self.SaLookupContext == other.SaLookupContext
     }
 }
 impl ::core::cmp::Eq for SOCKET_SECURITY_QUERY_INFO_IPSEC2 {}
@@ -14762,7 +14129,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_QUERY_TEMPLATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_QUERY_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_QUERY_TEMPLATE>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.PeerAddress == other.PeerAddress && self.PeerTokenAccessMask == other.PeerTokenAccessMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14804,7 +14171,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_QUERY_TEMPLATE_IPSEC2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_QUERY_TEMPLATE_IPSEC2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_QUERY_TEMPLATE_IPSEC2>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.PeerAddress == other.PeerAddress && self.PeerTokenAccessMask == other.PeerTokenAccessMask && self.Flags == other.Flags && self.FieldMask == other.FieldMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14837,7 +14204,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_SETTINGS {
 }
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_SETTINGS>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.SecurityFlags == other.SecurityFlags
     }
 }
 impl ::core::cmp::Eq for SOCKET_SECURITY_SETTINGS {}
@@ -14889,7 +14256,7 @@ unsafe impl ::windows::core::Abi for SOCKET_SECURITY_SETTINGS_IPSEC {
 }
 impl ::core::cmp::PartialEq for SOCKET_SECURITY_SETTINGS_IPSEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKET_SECURITY_SETTINGS_IPSEC>()) == 0 }
+        self.SecurityProtocol == other.SecurityProtocol && self.SecurityFlags == other.SecurityFlags && self.IpsecFlags == other.IpsecFlags && self.AuthipMMPolicyKey == other.AuthipMMPolicyKey && self.AuthipQMPolicyKey == other.AuthipQMPolicyKey && self.Reserved == other.Reserved && self.Reserved2 == other.Reserved2 && self.UserNameStringLen == other.UserNameStringLen && self.DomainNameStringLen == other.DomainNameStringLen && self.PasswordStringLen == other.PasswordStringLen && self.AllStrings == other.AllStrings
     }
 }
 impl ::core::cmp::Eq for SOCKET_SECURITY_SETTINGS_IPSEC {}
@@ -14924,7 +14291,7 @@ unsafe impl ::windows::core::Abi for SOCK_NOTIFY_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for SOCK_NOTIFY_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCK_NOTIFY_REGISTRATION>()) == 0 }
+        self.socket == other.socket && self.completionKey == other.completionKey && self.eventFilter == other.eventFilter && self.operation == other.operation && self.triggerFlags == other.triggerFlags && self.registrationResult == other.registrationResult
     }
 }
 impl ::core::cmp::Eq for SOCK_NOTIFY_REGISTRATION {}
@@ -14954,7 +14321,7 @@ unsafe impl ::windows::core::Abi for TCP_ACK_FREQUENCY_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for TCP_ACK_FREQUENCY_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ACK_FREQUENCY_PARAMETERS>()) == 0 }
+        self.TcpDelayedAckFrequency == other.TcpDelayedAckFrequency
     }
 }
 impl ::core::cmp::Eq for TCP_ACK_FREQUENCY_PARAMETERS {}
@@ -14985,12 +14352,6 @@ impl ::core::clone::Clone for TCP_HDR {
 unsafe impl ::windows::core::Abi for TCP_HDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_HDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_HDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_HDR {}
 impl ::core::default::Default for TCP_HDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15017,7 +14378,7 @@ unsafe impl ::windows::core::Abi for TCP_ICW_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for TCP_ICW_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_ICW_PARAMETERS>()) == 0 }
+        self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for TCP_ICW_PARAMETERS {}
@@ -15091,7 +14452,7 @@ unsafe impl ::windows::core::Abi for TCP_INFO_v0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_INFO_v0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_INFO_v0>()) == 0 }
+        self.State == other.State && self.Mss == other.Mss && self.ConnectionTimeMs == other.ConnectionTimeMs && self.TimestampsEnabled == other.TimestampsEnabled && self.RttUs == other.RttUs && self.MinRttUs == other.MinRttUs && self.BytesInFlight == other.BytesInFlight && self.Cwnd == other.Cwnd && self.SndWnd == other.SndWnd && self.RcvWnd == other.RcvWnd && self.RcvBuf == other.RcvBuf && self.BytesOut == other.BytesOut && self.BytesIn == other.BytesIn && self.BytesReordered == other.BytesReordered && self.BytesRetrans == other.BytesRetrans && self.FastRetrans == other.FastRetrans && self.DupAcksIn == other.DupAcksIn && self.TimeoutEpisodes == other.TimeoutEpisodes && self.SynRetrans == other.SynRetrans
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15185,7 +14546,34 @@ unsafe impl ::windows::core::Abi for TCP_INFO_v1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCP_INFO_v1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_INFO_v1>()) == 0 }
+        self.State == other.State
+            && self.Mss == other.Mss
+            && self.ConnectionTimeMs == other.ConnectionTimeMs
+            && self.TimestampsEnabled == other.TimestampsEnabled
+            && self.RttUs == other.RttUs
+            && self.MinRttUs == other.MinRttUs
+            && self.BytesInFlight == other.BytesInFlight
+            && self.Cwnd == other.Cwnd
+            && self.SndWnd == other.SndWnd
+            && self.RcvWnd == other.RcvWnd
+            && self.RcvBuf == other.RcvBuf
+            && self.BytesOut == other.BytesOut
+            && self.BytesIn == other.BytesIn
+            && self.BytesReordered == other.BytesReordered
+            && self.BytesRetrans == other.BytesRetrans
+            && self.FastRetrans == other.FastRetrans
+            && self.DupAcksIn == other.DupAcksIn
+            && self.TimeoutEpisodes == other.TimeoutEpisodes
+            && self.SynRetrans == other.SynRetrans
+            && self.SndLimTransRwin == other.SndLimTransRwin
+            && self.SndLimTimeRwin == other.SndLimTimeRwin
+            && self.SndLimBytesRwin == other.SndLimBytesRwin
+            && self.SndLimTransCwnd == other.SndLimTransCwnd
+            && self.SndLimTimeCwnd == other.SndLimTimeCwnd
+            && self.SndLimBytesCwnd == other.SndLimBytesCwnd
+            && self.SndLimTransSnd == other.SndLimTransSnd
+            && self.SndLimTimeSnd == other.SndLimTimeSnd
+            && self.SndLimBytesSnd == other.SndLimBytesSnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15218,7 +14606,7 @@ unsafe impl ::windows::core::Abi for TCP_INITIAL_RTO_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for TCP_INITIAL_RTO_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_INITIAL_RTO_PARAMETERS>()) == 0 }
+        self.Rtt == other.Rtt && self.MaxSynRetransmissions == other.MaxSynRetransmissions
     }
 }
 impl ::core::cmp::Eq for TCP_INITIAL_RTO_PARAMETERS {}
@@ -15243,12 +14631,6 @@ impl ::core::clone::Clone for TCP_OPT_FASTOPEN {
 unsafe impl ::windows::core::Abi for TCP_OPT_FASTOPEN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_FASTOPEN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_FASTOPEN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_FASTOPEN {}
 impl ::core::default::Default for TCP_OPT_FASTOPEN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15270,12 +14652,6 @@ impl ::core::clone::Clone for TCP_OPT_MSS {
 unsafe impl ::windows::core::Abi for TCP_OPT_MSS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_MSS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_MSS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_MSS {}
 impl ::core::default::Default for TCP_OPT_MSS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15297,12 +14673,6 @@ impl ::core::clone::Clone for TCP_OPT_SACK {
 unsafe impl ::windows::core::Abi for TCP_OPT_SACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_SACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_SACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_SACK {}
 impl ::core::default::Default for TCP_OPT_SACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15323,12 +14693,6 @@ impl ::core::clone::Clone for TCP_OPT_SACK_0 {
 unsafe impl ::windows::core::Abi for TCP_OPT_SACK_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_SACK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_SACK_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_SACK_0 {}
 impl ::core::default::Default for TCP_OPT_SACK_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15349,12 +14713,6 @@ impl ::core::clone::Clone for TCP_OPT_SACK_PERMITTED {
 unsafe impl ::windows::core::Abi for TCP_OPT_SACK_PERMITTED {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_SACK_PERMITTED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_SACK_PERMITTED>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_SACK_PERMITTED {}
 impl ::core::default::Default for TCP_OPT_SACK_PERMITTED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15377,12 +14735,6 @@ impl ::core::clone::Clone for TCP_OPT_TS {
 unsafe impl ::windows::core::Abi for TCP_OPT_TS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_TS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_TS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_TS {}
 impl ::core::default::Default for TCP_OPT_TS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15403,12 +14755,6 @@ impl ::core::clone::Clone for TCP_OPT_UNKNOWN {
 unsafe impl ::windows::core::Abi for TCP_OPT_UNKNOWN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_UNKNOWN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_UNKNOWN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_UNKNOWN {}
 impl ::core::default::Default for TCP_OPT_UNKNOWN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15430,12 +14776,6 @@ impl ::core::clone::Clone for TCP_OPT_WS {
 unsafe impl ::windows::core::Abi for TCP_OPT_WS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TCP_OPT_WS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_OPT_WS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TCP_OPT_WS {}
 impl ::core::default::Default for TCP_OPT_WS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15463,7 +14803,7 @@ unsafe impl ::windows::core::Abi for TIMESTAMPING_CONFIG {
 }
 impl ::core::cmp::PartialEq for TIMESTAMPING_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMESTAMPING_CONFIG>()) == 0 }
+        self.Flags == other.Flags && self.TxTimestampsBuffered == other.TxTimestampsBuffered
     }
 }
 impl ::core::cmp::Eq for TIMESTAMPING_CONFIG {}
@@ -15494,7 +14834,7 @@ unsafe impl ::windows::core::Abi for TIMEVAL {
 }
 impl ::core::cmp::PartialEq for TIMEVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMEVAL>()) == 0 }
+        self.tv_sec == other.tv_sec && self.tv_usec == other.tv_usec
     }
 }
 impl ::core::cmp::Eq for TIMEVAL {}
@@ -15527,7 +14867,7 @@ unsafe impl ::windows::core::Abi for TRANSMIT_FILE_BUFFERS {
 }
 impl ::core::cmp::PartialEq for TRANSMIT_FILE_BUFFERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMIT_FILE_BUFFERS>()) == 0 }
+        self.Head == other.Head && self.HeadLength == other.HeadLength && self.Tail == other.Tail && self.TailLength == other.TailLength
     }
 }
 impl ::core::cmp::Eq for TRANSMIT_FILE_BUFFERS {}
@@ -15557,14 +14897,6 @@ unsafe impl ::windows::core::Abi for TRANSMIT_PACKETS_ELEMENT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TRANSMIT_PACKETS_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMIT_PACKETS_ELEMENT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TRANSMIT_PACKETS_ELEMENT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TRANSMIT_PACKETS_ELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15589,14 +14921,6 @@ impl ::core::clone::Clone for TRANSMIT_PACKETS_ELEMENT_0 {
 unsafe impl ::windows::core::Abi for TRANSMIT_PACKETS_ELEMENT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TRANSMIT_PACKETS_ELEMENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMIT_PACKETS_ELEMENT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TRANSMIT_PACKETS_ELEMENT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TRANSMIT_PACKETS_ELEMENT_0 {
     fn default() -> Self {
@@ -15631,7 +14955,7 @@ unsafe impl ::windows::core::Abi for TRANSMIT_PACKETS_ELEMENT_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRANSMIT_PACKETS_ELEMENT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMIT_PACKETS_ELEMENT_0_0>()) == 0 }
+        self.nFileOffset == other.nFileOffset && self.hFile == other.hFile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15663,7 +14987,7 @@ unsafe impl ::windows::core::Abi for TRANSPORT_SETTING_ID {
 }
 impl ::core::cmp::PartialEq for TRANSPORT_SETTING_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORT_SETTING_ID>()) == 0 }
+        self.Guid == other.Guid
     }
 }
 impl ::core::cmp::Eq for TRANSPORT_SETTING_ID {}
@@ -15687,12 +15011,6 @@ impl ::core::clone::Clone for VLAN_TAG {
 unsafe impl ::windows::core::Abi for VLAN_TAG {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VLAN_TAG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VLAN_TAG>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VLAN_TAG {}
 impl ::core::default::Default for VLAN_TAG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15713,12 +15031,6 @@ impl ::core::clone::Clone for VLAN_TAG_0 {
 unsafe impl ::windows::core::Abi for VLAN_TAG_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VLAN_TAG_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VLAN_TAG_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VLAN_TAG_0 {}
 impl ::core::default::Default for VLAN_TAG_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15745,7 +15057,7 @@ unsafe impl ::windows::core::Abi for VLAN_TAG_0_0 {
 }
 impl ::core::cmp::PartialEq for VLAN_TAG_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VLAN_TAG_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for VLAN_TAG_0_0 {}
@@ -15782,7 +15094,7 @@ unsafe impl ::windows::core::Abi for WCE_DEVICELIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCE_DEVICELIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCE_DEVICELIST>()) == 0 }
+        self.numDevice == other.numDevice && self.Device == other.Device
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15822,7 +15134,7 @@ unsafe impl ::windows::core::Abi for WCE_IRDA_DEVICE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCE_IRDA_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCE_IRDA_DEVICE_INFO>()) == 0 }
+        self.irdaDeviceID == other.irdaDeviceID && self.irdaDeviceName == other.irdaDeviceName && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15861,7 +15173,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_DEVICELIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_DEVICELIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_DEVICELIST>()) == 0 }
+        self.numDevice == other.numDevice && self.Device == other.Device
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15895,14 +15207,6 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_QUERY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINDOWS_IAS_QUERY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_QUERY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINDOWS_IAS_QUERY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINDOWS_IAS_QUERY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15928,14 +15232,6 @@ impl ::core::clone::Clone for WINDOWS_IAS_QUERY_0 {
 unsafe impl ::windows::core::Abi for WINDOWS_IAS_QUERY_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINDOWS_IAS_QUERY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_QUERY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINDOWS_IAS_QUERY_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINDOWS_IAS_QUERY_0 {
     fn default() -> Self {
@@ -15970,7 +15266,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_QUERY_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_IAS_QUERY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_QUERY_0_0>()) == 0 }
+        self.Len == other.Len && self.OctetSeq == other.OctetSeq
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16010,7 +15306,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_QUERY_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_IAS_QUERY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_QUERY_0_1>()) == 0 }
+        self.Len == other.Len && self.CharSet == other.CharSet && self.UsrStr == other.UsrStr
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16043,14 +15339,6 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_SET {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINDOWS_IAS_SET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_SET>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINDOWS_IAS_SET {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINDOWS_IAS_SET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16076,14 +15364,6 @@ impl ::core::clone::Clone for WINDOWS_IAS_SET_0 {
 unsafe impl ::windows::core::Abi for WINDOWS_IAS_SET_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WINDOWS_IAS_SET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_SET_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WINDOWS_IAS_SET_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WINDOWS_IAS_SET_0 {
     fn default() -> Self {
@@ -16118,7 +15398,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_SET_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_IAS_SET_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_SET_0_0>()) == 0 }
+        self.Len == other.Len && self.OctetSeq == other.OctetSeq
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16158,7 +15438,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_IAS_SET_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_IAS_SET_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IAS_SET_0_1>()) == 0 }
+        self.Len == other.Len && self.CharSet == other.CharSet && self.UsrStr == other.UsrStr
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16200,7 +15480,7 @@ unsafe impl ::windows::core::Abi for WINDOWS_IRDA_DEVICE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWS_IRDA_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWS_IRDA_DEVICE_INFO>()) == 0 }
+        self.irdaDeviceID == other.irdaDeviceID && self.irdaDeviceName == other.irdaDeviceName && self.irdaDeviceHints1 == other.irdaDeviceHints1 && self.irdaDeviceHints2 == other.irdaDeviceHints2 && self.irdaCharSet == other.irdaCharSet
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16233,7 +15513,7 @@ unsafe impl ::windows::core::Abi for WSABUF {
 }
 impl ::core::cmp::PartialEq for WSABUF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSABUF>()) == 0 }
+        self.len == other.len && self.buf == other.buf
     }
 }
 impl ::core::cmp::Eq for WSABUF {}
@@ -16262,14 +15542,6 @@ unsafe impl ::windows::core::Abi for WSACOMPLETION {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WSACOMPLETION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WSACOMPLETION {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WSACOMPLETION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16297,14 +15569,6 @@ unsafe impl ::windows::core::Abi for WSACOMPLETION_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WSACOMPLETION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WSACOMPLETION_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WSACOMPLETION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16328,21 +15592,13 @@ impl ::core::clone::Clone for WSACOMPLETION_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WSACOMPLETION_0_0 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSACOMPLETION_0_0").field("lpOverlapped", &self.lpOverlapped).field("lpfnCompletionProc", &self.lpfnCompletionProc.map(|f| f as usize)).finish()
+        f.debug_struct("WSACOMPLETION_0_0").field("lpOverlapped", &self.lpOverlapped).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WSACOMPLETION_0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WSACOMPLETION_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION_0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WSACOMPLETION_0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WSACOMPLETION_0_0 {
     fn default() -> Self {
@@ -16376,7 +15632,7 @@ unsafe impl ::windows::core::Abi for WSACOMPLETION_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for WSACOMPLETION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION_0_1>()) == 0 }
+        self.lpOverlapped == other.lpOverlapped
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -16416,7 +15672,7 @@ unsafe impl ::windows::core::Abi for WSACOMPLETION_0_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for WSACOMPLETION_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION_0_2>()) == 0 }
+        self.lpOverlapped == other.lpOverlapped && self.hPort == other.hPort && self.Key == other.Key
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -16456,7 +15712,7 @@ unsafe impl ::windows::core::Abi for WSACOMPLETION_0_3 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for WSACOMPLETION_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSACOMPLETION_0_3>()) == 0 }
+        self.hWnd == other.hWnd && self.uMsg == other.uMsg && self.context == other.context
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -16506,7 +15762,7 @@ unsafe impl ::windows::core::Abi for WSADATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSADATA>()) == 0 }
+        self.wVersion == other.wVersion && self.wHighVersion == other.wHighVersion && self.iMaxSockets == other.iMaxSockets && self.iMaxUdpDg == other.iMaxUdpDg && self.lpVendorInfo == other.lpVendorInfo && self.szDescription == other.szDescription && self.szSystemStatus == other.szSystemStatus
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -16558,7 +15814,7 @@ unsafe impl ::windows::core::Abi for WSADATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSADATA>()) == 0 }
+        self.wVersion == other.wVersion && self.wHighVersion == other.wHighVersion && self.szDescription == other.szDescription && self.szSystemStatus == other.szSystemStatus && self.iMaxSockets == other.iMaxSockets && self.iMaxUdpDg == other.iMaxUdpDg && self.lpVendorInfo == other.lpVendorInfo
     }
 }
 #[cfg(target_arch = "x86")]
@@ -16603,7 +15859,7 @@ unsafe impl ::windows::core::Abi for WSAMSG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSAMSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAMSG>()) == 0 }
+        self.name == other.name && self.namelen == other.namelen && self.lpBuffers == other.lpBuffers && self.dwBufferCount == other.dwBufferCount && self.Control == other.Control && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16645,7 +15901,7 @@ unsafe impl ::windows::core::Abi for WSANAMESPACE_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSANAMESPACE_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANAMESPACE_INFOA>()) == 0 }
+        self.NSProviderId == other.NSProviderId && self.dwNameSpace == other.dwNameSpace && self.fActive == other.fActive && self.dwVersion == other.dwVersion && self.lpszIdentifier == other.lpszIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16688,7 +15944,7 @@ unsafe impl ::windows::core::Abi for WSANAMESPACE_INFOEXA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSANAMESPACE_INFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANAMESPACE_INFOEXA>()) == 0 }
+        self.NSProviderId == other.NSProviderId && self.dwNameSpace == other.dwNameSpace && self.fActive == other.fActive && self.dwVersion == other.dwVersion && self.lpszIdentifier == other.lpszIdentifier && self.ProviderSpecific == other.ProviderSpecific
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -16731,7 +15987,7 @@ unsafe impl ::windows::core::Abi for WSANAMESPACE_INFOEXW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSANAMESPACE_INFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANAMESPACE_INFOEXW>()) == 0 }
+        self.NSProviderId == other.NSProviderId && self.dwNameSpace == other.dwNameSpace && self.fActive == other.fActive && self.dwVersion == other.dwVersion && self.lpszIdentifier == other.lpszIdentifier && self.ProviderSpecific == other.ProviderSpecific
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -16773,7 +16029,7 @@ unsafe impl ::windows::core::Abi for WSANAMESPACE_INFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSANAMESPACE_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANAMESPACE_INFOW>()) == 0 }
+        self.NSProviderId == other.NSProviderId && self.dwNameSpace == other.dwNameSpace && self.fActive == other.fActive && self.dwVersion == other.dwVersion && self.lpszIdentifier == other.lpszIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16806,7 +16062,7 @@ unsafe impl ::windows::core::Abi for WSANETWORKEVENTS {
 }
 impl ::core::cmp::PartialEq for WSANETWORKEVENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANETWORKEVENTS>()) == 0 }
+        self.lNetworkEvents == other.lNetworkEvents && self.iErrorCode == other.iErrorCode
     }
 }
 impl ::core::cmp::Eq for WSANETWORKEVENTS {}
@@ -16840,7 +16096,7 @@ unsafe impl ::windows::core::Abi for WSANSCLASSINFOA {
 }
 impl ::core::cmp::PartialEq for WSANSCLASSINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANSCLASSINFOA>()) == 0 }
+        self.lpszName == other.lpszName && self.dwNameSpace == other.dwNameSpace && self.dwValueType == other.dwValueType && self.dwValueSize == other.dwValueSize && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for WSANSCLASSINFOA {}
@@ -16874,7 +16130,7 @@ unsafe impl ::windows::core::Abi for WSANSCLASSINFOW {
 }
 impl ::core::cmp::PartialEq for WSANSCLASSINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSANSCLASSINFOW>()) == 0 }
+        self.lpszName == other.lpszName && self.dwNameSpace == other.dwNameSpace && self.dwValueType == other.dwValueType && self.dwValueSize == other.dwValueSize && self.lpValue == other.lpValue
     }
 }
 impl ::core::cmp::Eq for WSANSCLASSINFOW {}
@@ -16907,7 +16163,7 @@ unsafe impl ::windows::core::Abi for WSAPOLLDATA {
 }
 impl ::core::cmp::PartialEq for WSAPOLLDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAPOLLDATA>()) == 0 }
+        self.result == other.result && self.fds == other.fds && self.timeout == other.timeout && self.fdArray == other.fdArray
     }
 }
 impl ::core::cmp::Eq for WSAPOLLDATA {}
@@ -16939,7 +16195,7 @@ unsafe impl ::windows::core::Abi for WSAPOLLFD {
 }
 impl ::core::cmp::PartialEq for WSAPOLLFD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAPOLLFD>()) == 0 }
+        self.fd == other.fd && self.events == other.events && self.revents == other.revents
     }
 }
 impl ::core::cmp::Eq for WSAPOLLFD {}
@@ -16970,7 +16226,7 @@ unsafe impl ::windows::core::Abi for WSAPROTOCOLCHAIN {
 }
 impl ::core::cmp::PartialEq for WSAPROTOCOLCHAIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAPROTOCOLCHAIN>()) == 0 }
+        self.ChainLen == other.ChainLen && self.ChainEntries == other.ChainEntries
     }
 }
 impl ::core::cmp::Eq for WSAPROTOCOLCHAIN {}
@@ -17046,7 +16302,26 @@ unsafe impl ::windows::core::Abi for WSAPROTOCOL_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSAPROTOCOL_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAPROTOCOL_INFOA>()) == 0 }
+        self.dwServiceFlags1 == other.dwServiceFlags1
+            && self.dwServiceFlags2 == other.dwServiceFlags2
+            && self.dwServiceFlags3 == other.dwServiceFlags3
+            && self.dwServiceFlags4 == other.dwServiceFlags4
+            && self.dwProviderFlags == other.dwProviderFlags
+            && self.ProviderId == other.ProviderId
+            && self.dwCatalogEntryId == other.dwCatalogEntryId
+            && self.ProtocolChain == other.ProtocolChain
+            && self.iVersion == other.iVersion
+            && self.iAddressFamily == other.iAddressFamily
+            && self.iMaxSockAddr == other.iMaxSockAddr
+            && self.iMinSockAddr == other.iMinSockAddr
+            && self.iSocketType == other.iSocketType
+            && self.iProtocol == other.iProtocol
+            && self.iProtocolMaxOffset == other.iProtocolMaxOffset
+            && self.iNetworkByteOrder == other.iNetworkByteOrder
+            && self.iSecurityScheme == other.iSecurityScheme
+            && self.dwMessageSize == other.dwMessageSize
+            && self.dwProviderReserved == other.dwProviderReserved
+            && self.szProtocol == other.szProtocol
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17118,7 +16393,26 @@ unsafe impl ::windows::core::Abi for WSAPROTOCOL_INFOW {
 }
 impl ::core::cmp::PartialEq for WSAPROTOCOL_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAPROTOCOL_INFOW>()) == 0 }
+        self.dwServiceFlags1 == other.dwServiceFlags1
+            && self.dwServiceFlags2 == other.dwServiceFlags2
+            && self.dwServiceFlags3 == other.dwServiceFlags3
+            && self.dwServiceFlags4 == other.dwServiceFlags4
+            && self.dwProviderFlags == other.dwProviderFlags
+            && self.ProviderId == other.ProviderId
+            && self.dwCatalogEntryId == other.dwCatalogEntryId
+            && self.ProtocolChain == other.ProtocolChain
+            && self.iVersion == other.iVersion
+            && self.iAddressFamily == other.iAddressFamily
+            && self.iMaxSockAddr == other.iMaxSockAddr
+            && self.iMinSockAddr == other.iMinSockAddr
+            && self.iSocketType == other.iSocketType
+            && self.iProtocol == other.iProtocol
+            && self.iProtocolMaxOffset == other.iProtocolMaxOffset
+            && self.iNetworkByteOrder == other.iNetworkByteOrder
+            && self.iSecurityScheme == other.iSecurityScheme
+            && self.dwMessageSize == other.dwMessageSize
+            && self.dwProviderReserved == other.dwProviderReserved
+            && self.szProtocol == other.szProtocol
     }
 }
 impl ::core::cmp::Eq for WSAPROTOCOL_INFOW {}
@@ -17182,7 +16476,7 @@ unsafe impl ::windows::core::Abi for WSAQUERYSET2A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSAQUERYSET2A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAQUERYSET2A>()) == 0 }
+        self.dwSize == other.dwSize && self.lpszServiceInstanceName == other.lpszServiceInstanceName && self.lpVersion == other.lpVersion && self.lpszComment == other.lpszComment && self.dwNameSpace == other.dwNameSpace && self.lpNSProviderId == other.lpNSProviderId && self.lpszContext == other.lpszContext && self.dwNumberOfProtocols == other.dwNumberOfProtocols && self.lpafpProtocols == other.lpafpProtocols && self.lpszQueryString == other.lpszQueryString && self.dwNumberOfCsAddrs == other.dwNumberOfCsAddrs && self.lpcsaBuffer == other.lpcsaBuffer && self.dwOutputFlags == other.dwOutputFlags && self.lpBlob == other.lpBlob
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -17248,7 +16542,7 @@ unsafe impl ::windows::core::Abi for WSAQUERYSET2W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSAQUERYSET2W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAQUERYSET2W>()) == 0 }
+        self.dwSize == other.dwSize && self.lpszServiceInstanceName == other.lpszServiceInstanceName && self.lpVersion == other.lpVersion && self.lpszComment == other.lpszComment && self.dwNameSpace == other.dwNameSpace && self.lpNSProviderId == other.lpNSProviderId && self.lpszContext == other.lpszContext && self.dwNumberOfProtocols == other.dwNumberOfProtocols && self.lpafpProtocols == other.lpafpProtocols && self.lpszQueryString == other.lpszQueryString && self.dwNumberOfCsAddrs == other.dwNumberOfCsAddrs && self.lpcsaBuffer == other.lpcsaBuffer && self.dwOutputFlags == other.dwOutputFlags && self.lpBlob == other.lpBlob
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -17316,7 +16610,7 @@ unsafe impl ::windows::core::Abi for WSAQUERYSETA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSAQUERYSETA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAQUERYSETA>()) == 0 }
+        self.dwSize == other.dwSize && self.lpszServiceInstanceName == other.lpszServiceInstanceName && self.lpServiceClassId == other.lpServiceClassId && self.lpVersion == other.lpVersion && self.lpszComment == other.lpszComment && self.dwNameSpace == other.dwNameSpace && self.lpNSProviderId == other.lpNSProviderId && self.lpszContext == other.lpszContext && self.dwNumberOfProtocols == other.dwNumberOfProtocols && self.lpafpProtocols == other.lpafpProtocols && self.lpszQueryString == other.lpszQueryString && self.dwNumberOfCsAddrs == other.dwNumberOfCsAddrs && self.lpcsaBuffer == other.lpcsaBuffer && self.dwOutputFlags == other.dwOutputFlags && self.lpBlob == other.lpBlob
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -17384,7 +16678,7 @@ unsafe impl ::windows::core::Abi for WSAQUERYSETW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for WSAQUERYSETW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAQUERYSETW>()) == 0 }
+        self.dwSize == other.dwSize && self.lpszServiceInstanceName == other.lpszServiceInstanceName && self.lpServiceClassId == other.lpServiceClassId && self.lpVersion == other.lpVersion && self.lpszComment == other.lpszComment && self.dwNameSpace == other.dwNameSpace && self.lpNSProviderId == other.lpNSProviderId && self.lpszContext == other.lpszContext && self.dwNumberOfProtocols == other.dwNumberOfProtocols && self.lpafpProtocols == other.lpafpProtocols && self.lpszQueryString == other.lpszQueryString && self.dwNumberOfCsAddrs == other.dwNumberOfCsAddrs && self.lpcsaBuffer == other.lpcsaBuffer && self.dwOutputFlags == other.dwOutputFlags && self.lpBlob == other.lpBlob
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -17416,21 +16710,13 @@ impl ::core::clone::Clone for WSASENDMSG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WSASENDMSG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSASENDMSG").field("lpMsg", &self.lpMsg).field("dwFlags", &self.dwFlags).field("lpNumberOfBytesSent", &self.lpNumberOfBytesSent).field("lpOverlapped", &self.lpOverlapped).field("lpCompletionRoutine", &self.lpCompletionRoutine.map(|f| f as usize)).finish()
+        f.debug_struct("WSASENDMSG").field("lpMsg", &self.lpMsg).field("dwFlags", &self.dwFlags).field("lpNumberOfBytesSent", &self.lpNumberOfBytesSent).field("lpOverlapped", &self.lpOverlapped).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WSASENDMSG {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WSASENDMSG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSASENDMSG>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WSASENDMSG {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WSASENDMSG {
     fn default() -> Self {
@@ -17461,7 +16747,7 @@ unsafe impl ::windows::core::Abi for WSASERVICECLASSINFOA {
 }
 impl ::core::cmp::PartialEq for WSASERVICECLASSINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSASERVICECLASSINFOA>()) == 0 }
+        self.lpServiceClassId == other.lpServiceClassId && self.lpszServiceClassName == other.lpszServiceClassName && self.dwCount == other.dwCount && self.lpClassInfos == other.lpClassInfos
     }
 }
 impl ::core::cmp::Eq for WSASERVICECLASSINFOA {}
@@ -17494,7 +16780,7 @@ unsafe impl ::windows::core::Abi for WSASERVICECLASSINFOW {
 }
 impl ::core::cmp::PartialEq for WSASERVICECLASSINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSASERVICECLASSINFOW>()) == 0 }
+        self.lpServiceClassId == other.lpServiceClassId && self.lpszServiceClassName == other.lpszServiceClassName && self.dwCount == other.dwCount && self.lpClassInfos == other.lpClassInfos
     }
 }
 impl ::core::cmp::Eq for WSASERVICECLASSINFOW {}
@@ -17531,7 +16817,7 @@ unsafe impl ::windows::core::Abi for WSATHREADID {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSATHREADID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSATHREADID>()) == 0 }
+        self.ThreadHandle == other.ThreadHandle && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17564,7 +16850,7 @@ unsafe impl ::windows::core::Abi for WSAVERSION {
 }
 impl ::core::cmp::PartialEq for WSAVERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSAVERSION>()) == 0 }
+        self.dwVersion == other.dwVersion && self.ecHow == other.ecHow
     }
 }
 impl ::core::cmp::Eq for WSAVERSION {}
@@ -17595,7 +16881,7 @@ unsafe impl ::windows::core::Abi for WSA_COMPATIBILITY_MODE {
 }
 impl ::core::cmp::PartialEq for WSA_COMPATIBILITY_MODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSA_COMPATIBILITY_MODE>()) == 0 }
+        self.BehaviorId == other.BehaviorId && self.TargetOsVersion == other.TargetOsVersion
     }
 }
 impl ::core::cmp::Eq for WSA_COMPATIBILITY_MODE {}
@@ -17626,7 +16912,7 @@ unsafe impl ::windows::core::Abi for WSC_PROVIDER_AUDIT_INFO {
 }
 impl ::core::cmp::PartialEq for WSC_PROVIDER_AUDIT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSC_PROVIDER_AUDIT_INFO>()) == 0 }
+        self.RecordSize == other.RecordSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WSC_PROVIDER_AUDIT_INFO {}
@@ -17658,7 +16944,7 @@ unsafe impl ::windows::core::Abi for WSPDATA {
 }
 impl ::core::cmp::PartialEq for WSPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSPDATA>()) == 0 }
+        self.wVersion == other.wVersion && self.wHighVersion == other.wHighVersion && self.szDescription == other.szDescription
     }
 }
 impl ::core::cmp::Eq for WSPDATA {}
@@ -17713,52 +16999,13 @@ impl ::core::clone::Clone for WSPPROC_TABLE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for WSPPROC_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSPPROC_TABLE")
-            .field("lpWSPAccept", &self.lpWSPAccept.map(|f| f as usize))
-            .field("lpWSPAddressToString", &self.lpWSPAddressToString.map(|f| f as usize))
-            .field("lpWSPAsyncSelect", &self.lpWSPAsyncSelect.map(|f| f as usize))
-            .field("lpWSPBind", &self.lpWSPBind.map(|f| f as usize))
-            .field("lpWSPCancelBlockingCall", &self.lpWSPCancelBlockingCall.map(|f| f as usize))
-            .field("lpWSPCleanup", &self.lpWSPCleanup.map(|f| f as usize))
-            .field("lpWSPCloseSocket", &self.lpWSPCloseSocket.map(|f| f as usize))
-            .field("lpWSPConnect", &self.lpWSPConnect.map(|f| f as usize))
-            .field("lpWSPDuplicateSocket", &self.lpWSPDuplicateSocket.map(|f| f as usize))
-            .field("lpWSPEnumNetworkEvents", &self.lpWSPEnumNetworkEvents.map(|f| f as usize))
-            .field("lpWSPEventSelect", &self.lpWSPEventSelect.map(|f| f as usize))
-            .field("lpWSPGetOverlappedResult", &self.lpWSPGetOverlappedResult.map(|f| f as usize))
-            .field("lpWSPGetPeerName", &self.lpWSPGetPeerName.map(|f| f as usize))
-            .field("lpWSPGetSockName", &self.lpWSPGetSockName.map(|f| f as usize))
-            .field("lpWSPGetSockOpt", &self.lpWSPGetSockOpt.map(|f| f as usize))
-            .field("lpWSPGetQOSByName", &self.lpWSPGetQOSByName.map(|f| f as usize))
-            .field("lpWSPIoctl", &self.lpWSPIoctl.map(|f| f as usize))
-            .field("lpWSPJoinLeaf", &self.lpWSPJoinLeaf.map(|f| f as usize))
-            .field("lpWSPListen", &self.lpWSPListen.map(|f| f as usize))
-            .field("lpWSPRecv", &self.lpWSPRecv.map(|f| f as usize))
-            .field("lpWSPRecvDisconnect", &self.lpWSPRecvDisconnect.map(|f| f as usize))
-            .field("lpWSPRecvFrom", &self.lpWSPRecvFrom.map(|f| f as usize))
-            .field("lpWSPSelect", &self.lpWSPSelect.map(|f| f as usize))
-            .field("lpWSPSend", &self.lpWSPSend.map(|f| f as usize))
-            .field("lpWSPSendDisconnect", &self.lpWSPSendDisconnect.map(|f| f as usize))
-            .field("lpWSPSendTo", &self.lpWSPSendTo.map(|f| f as usize))
-            .field("lpWSPSetSockOpt", &self.lpWSPSetSockOpt.map(|f| f as usize))
-            .field("lpWSPShutdown", &self.lpWSPShutdown.map(|f| f as usize))
-            .field("lpWSPSocket", &self.lpWSPSocket.map(|f| f as usize))
-            .field("lpWSPStringToAddress", &self.lpWSPStringToAddress.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WSPPROC_TABLE").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for WSPPROC_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for WSPPROC_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSPPROC_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for WSPPROC_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for WSPPROC_TABLE {
     fn default() -> Self {
@@ -17796,37 +17043,13 @@ impl ::core::clone::Clone for WSPUPCALLTABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WSPUPCALLTABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSPUPCALLTABLE")
-            .field("lpWPUCloseEvent", &self.lpWPUCloseEvent.map(|f| f as usize))
-            .field("lpWPUCloseSocketHandle", &self.lpWPUCloseSocketHandle.map(|f| f as usize))
-            .field("lpWPUCreateEvent", &self.lpWPUCreateEvent.map(|f| f as usize))
-            .field("lpWPUCreateSocketHandle", &self.lpWPUCreateSocketHandle.map(|f| f as usize))
-            .field("lpWPUFDIsSet", &self.lpWPUFDIsSet.map(|f| f as usize))
-            .field("lpWPUGetProviderPath", &self.lpWPUGetProviderPath.map(|f| f as usize))
-            .field("lpWPUModifyIFSHandle", &self.lpWPUModifyIFSHandle.map(|f| f as usize))
-            .field("lpWPUPostMessage", &self.lpWPUPostMessage.map(|f| f as usize))
-            .field("lpWPUQueryBlockingCallback", &self.lpWPUQueryBlockingCallback.map(|f| f as usize))
-            .field("lpWPUQuerySocketHandleContext", &self.lpWPUQuerySocketHandleContext.map(|f| f as usize))
-            .field("lpWPUQueueApc", &self.lpWPUQueueApc.map(|f| f as usize))
-            .field("lpWPUResetEvent", &self.lpWPUResetEvent.map(|f| f as usize))
-            .field("lpWPUSetEvent", &self.lpWPUSetEvent.map(|f| f as usize))
-            .field("lpWPUOpenCurrentThread", &self.lpWPUOpenCurrentThread.map(|f| f as usize))
-            .field("lpWPUCloseThread", &self.lpWPUCloseThread.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WSPUPCALLTABLE").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WSPUPCALLTABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WSPUPCALLTABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSPUPCALLTABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WSPUPCALLTABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WSPUPCALLTABLE {
     fn default() -> Self {
@@ -17857,7 +17080,7 @@ unsafe impl ::windows::core::Abi for netent {
 }
 impl ::core::cmp::PartialEq for netent {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<netent>()) == 0 }
+        self.n_name == other.n_name && self.n_aliases == other.n_aliases && self.n_addrtype == other.n_addrtype && self.n_net == other.n_net
     }
 }
 impl ::core::cmp::Eq for netent {}
@@ -17887,14 +17110,6 @@ unsafe impl ::windows::core::Abi for sockaddr_gen {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for sockaddr_gen {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<sockaddr_gen>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for sockaddr_gen {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for sockaddr_gen {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17917,12 +17132,6 @@ impl ::core::clone::Clone for sockaddr_in6_old {
 unsafe impl ::windows::core::Abi for sockaddr_in6_old {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for sockaddr_in6_old {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<sockaddr_in6_old>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for sockaddr_in6_old {}
 impl ::core::default::Default for sockaddr_in6_old {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17950,7 +17159,7 @@ unsafe impl ::windows::core::Abi for sockproto {
 }
 impl ::core::cmp::PartialEq for sockproto {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<sockproto>()) == 0 }
+        self.sp_family == other.sp_family && self.sp_protocol == other.sp_protocol
     }
 }
 impl ::core::cmp::Eq for sockproto {}
@@ -17982,7 +17191,7 @@ unsafe impl ::windows::core::Abi for tcp_keepalive {
 }
 impl ::core::cmp::PartialEq for tcp_keepalive {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<tcp_keepalive>()) == 0 }
+        self.onoff == other.onoff && self.keepalivetime == other.keepalivetime && self.keepaliveinterval == other.keepaliveinterval
     }
 }
 impl ::core::cmp::Eq for tcp_keepalive {}

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -5639,7 +5639,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_ASSERTION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_ASSERTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_ASSERTION>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbAuthenticatorData == other.cbAuthenticatorData && self.pbAuthenticatorData == other.pbAuthenticatorData && self.cbSignature == other.cbSignature && self.pbSignature == other.pbSignature && self.Credential == other.Credential && self.cbUserId == other.cbUserId && self.pbUserId == other.pbUserId && self.Extensions == other.Extensions && self.cbCredLargeBlob == other.cbCredLargeBlob && self.pbCredLargeBlob == other.pbCredLargeBlob && self.dwCredLargeBlobStatus == other.dwCredLargeBlobStatus
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_ASSERTION {}
@@ -5703,7 +5703,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTION
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwTimeoutMilliseconds == other.dwTimeoutMilliseconds && self.CredentialList == other.CredentialList && self.Extensions == other.Extensions && self.dwAuthenticatorAttachment == other.dwAuthenticatorAttachment && self.dwUserVerificationRequirement == other.dwUserVerificationRequirement && self.dwFlags == other.dwFlags && self.pwszU2fAppId == other.pwszU2fAppId && self.pbU2fAppId == other.pbU2fAppId && self.pCancellationId == other.pCancellationId && self.pAllowCredentialList == other.pAllowCredentialList && self.dwCredLargeBlobOperation == other.dwCredLargeBlobOperation && self.cbCredLargeBlob == other.cbCredLargeBlob && self.pbCredLargeBlob == other.pbCredLargeBlob
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5769,7 +5769,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTI
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwTimeoutMilliseconds == other.dwTimeoutMilliseconds && self.CredentialList == other.CredentialList && self.Extensions == other.Extensions && self.dwAuthenticatorAttachment == other.dwAuthenticatorAttachment && self.bRequireResidentKey == other.bRequireResidentKey && self.dwUserVerificationRequirement == other.dwUserVerificationRequirement && self.dwAttestationConveyancePreference == other.dwAttestationConveyancePreference && self.dwFlags == other.dwFlags && self.pCancellationId == other.pCancellationId && self.pExcludeCredentialList == other.pExcludeCredentialList && self.dwEnterpriseAttestation == other.dwEnterpriseAttestation && self.dwLargeBlobSupport == other.dwLargeBlobSupport && self.bPreferResidentKey == other.bPreferResidentKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5804,7 +5804,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CLIENT_DATA {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CLIENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CLIENT_DATA>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbClientDataJSON == other.cbClientDataJSON && self.pbClientDataJSON == other.pbClientDataJSON && self.pwszHashAlgId == other.pwszHashAlgId
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CLIENT_DATA {}
@@ -5845,7 +5845,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_COMMON_ATTESTATION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_COMMON_ATTESTATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_COMMON_ATTESTATION>()) == 0 }
+        self.dwVersion == other.dwVersion && self.pwszAlg == other.pwszAlg && self.lAlg == other.lAlg && self.cbSignature == other.cbSignature && self.pbSignature == other.pbSignature && self.cX5c == other.cX5c && self.pX5c == other.pX5c && self.pwszVer == other.pwszVer && self.cbCertInfo == other.cbCertInfo && self.pbCertInfo == other.pbCertInfo && self.cbPubArea == other.cbPubArea && self.pbPubArea == other.pbPubArea
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_COMMON_ATTESTATION {}
@@ -5877,7 +5877,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_COSE_CREDENTIAL_PARAMETER>()) == 0 }
+        self.dwVersion == other.dwVersion && self.pwszCredentialType == other.pwszCredentialType && self.lAlg == other.lAlg
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_COSE_CREDENTIAL_PARAMETER {}
@@ -5908,7 +5908,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_COSE_CREDENTIAL_PARAMETERS>()) == 0 }
+        self.cCredentialParameters == other.cCredentialParameters && self.pCredentialParameters == other.pCredentialParameters
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {}
@@ -5941,7 +5941,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CREDENTIAL>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbId == other.cbId && self.pbId == other.pbId && self.pwszCredentialType == other.pwszCredentialType
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CREDENTIAL {}
@@ -5972,7 +5972,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CREDENTIALS {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CREDENTIALS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CREDENTIALS>()) == 0 }
+        self.cCredentials == other.cCredentials && self.pCredentials == other.pCredentials
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CREDENTIALS {}
@@ -6042,7 +6042,23 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CREDENTIAL_ATTESTATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WEBAUTHN_CREDENTIAL_ATTESTATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CREDENTIAL_ATTESTATION>()) == 0 }
+        self.dwVersion == other.dwVersion
+            && self.pwszFormatType == other.pwszFormatType
+            && self.cbAuthenticatorData == other.cbAuthenticatorData
+            && self.pbAuthenticatorData == other.pbAuthenticatorData
+            && self.cbAttestation == other.cbAttestation
+            && self.pbAttestation == other.pbAttestation
+            && self.dwAttestationDecodeType == other.dwAttestationDecodeType
+            && self.pvAttestationDecode == other.pvAttestationDecode
+            && self.cbAttestationObject == other.cbAttestationObject
+            && self.pbAttestationObject == other.pbAttestationObject
+            && self.cbCredentialId == other.cbCredentialId
+            && self.pbCredentialId == other.pbCredentialId
+            && self.Extensions == other.Extensions
+            && self.dwUsedTransport == other.dwUsedTransport
+            && self.bEpAtt == other.bEpAtt
+            && self.bLargeBlobSupported == other.bLargeBlobSupported
+            && self.bResidentKey == other.bResidentKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6078,7 +6094,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CREDENTIAL_EX {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CREDENTIAL_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CREDENTIAL_EX>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbId == other.cbId && self.pbId == other.pbId && self.pwszCredentialType == other.pwszCredentialType && self.dwTransports == other.dwTransports
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CREDENTIAL_EX {}
@@ -6109,7 +6125,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CREDENTIAL_LIST {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CREDENTIAL_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CREDENTIAL_LIST>()) == 0 }
+        self.cCredentials == other.cCredentials && self.ppCredentials == other.ppCredentials
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CREDENTIAL_LIST {}
@@ -6140,7 +6156,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CRED_BLOB_EXTENSION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_CRED_BLOB_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CRED_BLOB_EXTENSION>()) == 0 }
+        self.cbCredBlob == other.cbCredBlob && self.pbCredBlob == other.pbCredBlob
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_CRED_BLOB_EXTENSION {}
@@ -6177,7 +6193,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_CRED_PROTECT_EXTENSION_IN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WEBAUTHN_CRED_PROTECT_EXTENSION_IN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_CRED_PROTECT_EXTENSION_IN>()) == 0 }
+        self.dwCredProtect == other.dwCredProtect && self.bRequireCredProtect == other.bRequireCredProtect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6211,7 +6227,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_EXTENSION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_EXTENSION>()) == 0 }
+        self.pwszExtensionIdentifier == other.pwszExtensionIdentifier && self.cbExtension == other.cbExtension && self.pvExtension == other.pvExtension
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_EXTENSION {}
@@ -6242,7 +6258,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_EXTENSIONS {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_EXTENSIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_EXTENSIONS>()) == 0 }
+        self.cExtensions == other.cExtensions && self.pExtensions == other.pExtensions
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_EXTENSIONS {}
@@ -6275,7 +6291,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_RP_ENTITY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_RP_ENTITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_RP_ENTITY_INFORMATION>()) == 0 }
+        self.dwVersion == other.dwVersion && self.pwszId == other.pwszId && self.pwszName == other.pwszName && self.pwszIcon == other.pwszIcon
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_RP_ENTITY_INFORMATION {}
@@ -6310,7 +6326,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_USER_ENTITY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_USER_ENTITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_USER_ENTITY_INFORMATION>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbId == other.cbId && self.pbId == other.pbId && self.pwszName == other.pwszName && self.pwszIcon == other.pwszIcon && self.pwszDisplayName == other.pwszDisplayName
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_USER_ENTITY_INFORMATION {}
@@ -6341,7 +6357,7 @@ unsafe impl ::windows::core::Abi for WEBAUTHN_X5C {
 }
 impl ::core::cmp::PartialEq for WEBAUTHN_X5C {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEBAUTHN_X5C>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for WEBAUTHN_X5C {}
@@ -6379,7 +6395,7 @@ unsafe impl ::windows::core::Abi for WS_ANY_ATTRIBUTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ANY_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ANY_ATTRIBUTE>()) == 0 }
+        self.localName == other.localName && self.ns == other.ns && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6418,7 +6434,7 @@ unsafe impl ::windows::core::Abi for WS_ANY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ANY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ANY_ATTRIBUTES>()) == 0 }
+        self.attributes == other.attributes && self.attributeCount == other.attributeCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6443,18 +6459,12 @@ impl ::core::clone::Clone for WS_ASYNC_CONTEXT {
 }
 impl ::core::fmt::Debug for WS_ASYNC_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_ASYNC_CONTEXT").field("callback", &self.callback.map(|f| f as usize)).field("callbackState", &self.callbackState).finish()
+        f.debug_struct("WS_ASYNC_CONTEXT").field("callbackState", &self.callbackState).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_ASYNC_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_ASYNC_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ASYNC_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_ASYNC_CONTEXT {}
 impl ::core::default::Default for WS_ASYNC_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6473,18 +6483,12 @@ impl ::core::clone::Clone for WS_ASYNC_OPERATION {
 }
 impl ::core::fmt::Debug for WS_ASYNC_OPERATION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_ASYNC_OPERATION").field("function", &self.function.map(|f| f as usize)).finish()
+        f.debug_struct("WS_ASYNC_OPERATION").finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_ASYNC_OPERATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_ASYNC_OPERATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ASYNC_OPERATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_ASYNC_OPERATION {}
 impl ::core::default::Default for WS_ASYNC_OPERATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6515,7 +6519,7 @@ unsafe impl ::windows::core::Abi for WS_ASYNC_STATE {
 }
 impl ::core::cmp::PartialEq for WS_ASYNC_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ASYNC_STATE>()) == 0 }
+        self.internal0 == other.internal0 && self.internal1 == other.internal1 && self.internal2 == other.internal2 && self.internal3 == other.internal3 && self.internal4 == other.internal4
     }
 }
 impl ::core::cmp::Eq for WS_ASYNC_STATE {}
@@ -6554,7 +6558,7 @@ unsafe impl ::windows::core::Abi for WS_ATTRIBUTE_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ATTRIBUTE_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ATTRIBUTE_DESCRIPTION>()) == 0 }
+        self.attributeLocalName == other.attributeLocalName && self.attributeNs == other.attributeNs && self.r#type == other.r#type && self.typeDescription == other.typeDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6592,7 +6596,7 @@ unsafe impl ::windows::core::Abi for WS_BOOL_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_BOOL_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_BOOL_DESCRIPTION>()) == 0 }
+        self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6625,7 +6629,7 @@ unsafe impl ::windows::core::Abi for WS_BUFFERS {
 }
 impl ::core::cmp::PartialEq for WS_BUFFERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_BUFFERS>()) == 0 }
+        self.bufferCount == other.bufferCount && self.buffers == other.buffers
     }
 }
 impl ::core::cmp::Eq for WS_BUFFERS {}
@@ -6656,7 +6660,7 @@ unsafe impl ::windows::core::Abi for WS_BYTES {
 }
 impl ::core::cmp::PartialEq for WS_BYTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_BYTES>()) == 0 }
+        self.length == other.length && self.bytes == other.bytes
     }
 }
 impl ::core::cmp::Eq for WS_BYTES {}
@@ -6687,7 +6691,7 @@ unsafe impl ::windows::core::Abi for WS_BYTES_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_BYTES_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_BYTES_DESCRIPTION>()) == 0 }
+        self.minByteCount == other.minByteCount && self.maxByteCount == other.maxByteCount
     }
 }
 impl ::core::cmp::Eq for WS_BYTES_DESCRIPTION {}
@@ -6718,7 +6722,7 @@ unsafe impl ::windows::core::Abi for WS_BYTE_ARRAY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_BYTE_ARRAY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_BYTE_ARRAY_DESCRIPTION>()) == 0 }
+        self.minByteCount == other.minByteCount && self.maxByteCount == other.maxByteCount
     }
 }
 impl ::core::cmp::Eq for WS_BYTE_ARRAY_DESCRIPTION {}
@@ -6750,7 +6754,7 @@ unsafe impl ::windows::core::Abi for WS_CALL_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_CALL_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CALL_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_CALL_PROPERTY {}
@@ -6782,7 +6786,7 @@ unsafe impl ::windows::core::Abi for WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE {
 }
 impl ::core::cmp::PartialEq for WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE>()) == 0 }
+        self.keyHandle == other.keyHandle && self.provider == other.provider && self.keySpec == other.keySpec
     }
 }
 impl ::core::cmp::Eq for WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE {}
@@ -6809,21 +6813,13 @@ impl ::core::clone::Clone for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::fmt::Debug for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT").field("callback", &self.callback.map(|f| f as usize)).field("state", &self.state).finish()
+        f.debug_struct("WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT").field("state", &self.state).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 unsafe impl ::windows::core::Abi for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
     fn default() -> Self {
@@ -6851,7 +6847,7 @@ unsafe impl ::windows::core::Abi for WS_CERT_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_CERT_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CERT_CREDENTIAL>()) == 0 }
+        self.credentialType == other.credentialType
     }
 }
 impl ::core::cmp::Eq for WS_CERT_CREDENTIAL {}
@@ -6882,7 +6878,7 @@ unsafe impl ::windows::core::Abi for WS_CERT_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_CERT_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CERT_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.rawCertificateData == other.rawCertificateData
     }
 }
 impl ::core::cmp::Eq for WS_CERT_ENDPOINT_IDENTITY {}
@@ -6913,7 +6909,7 @@ unsafe impl ::windows::core::Abi for WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT
 }
 impl ::core::cmp::PartialEq for WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT {}
@@ -6944,21 +6940,13 @@ impl ::core::clone::Clone for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::fmt::Debug for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CERT_SIGNED_SAML_AUTHENTICATOR").field("authenticator", &self.authenticator).field("trustedIssuerCerts", &self.trustedIssuerCerts).field("trustedIssuerCertCount", &self.trustedIssuerCertCount).field("decryptionCert", &self.decryptionCert).field("samlValidator", &self.samlValidator.map(|f| f as usize)).field("samlValidatorCallbackState", &self.samlValidatorCallbackState).finish()
+        f.debug_struct("WS_CERT_SIGNED_SAML_AUTHENTICATOR").field("authenticator", &self.authenticator).field("trustedIssuerCerts", &self.trustedIssuerCerts).field("trustedIssuerCertCount", &self.trustedIssuerCertCount).field("decryptionCert", &self.decryptionCert).field("samlValidatorCallbackState", &self.samlValidatorCallbackState).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 unsafe impl ::windows::core::Abi for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CERT_SIGNED_SAML_AUTHENTICATOR>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WS_CERT_SIGNED_SAML_AUTHENTICATOR {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
     fn default() -> Self {
@@ -6986,26 +6974,12 @@ impl ::core::clone::Clone for WS_CHANNEL_DECODER {
 }
 impl ::core::fmt::Debug for WS_CHANNEL_DECODER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CHANNEL_DECODER")
-            .field("createContext", &self.createContext)
-            .field("createDecoderCallback", &self.createDecoderCallback.map(|f| f as usize))
-            .field("decoderGetContentTypeCallback", &self.decoderGetContentTypeCallback.map(|f| f as usize))
-            .field("decoderStartCallback", &self.decoderStartCallback.map(|f| f as usize))
-            .field("decoderDecodeCallback", &self.decoderDecodeCallback.map(|f| f as usize))
-            .field("decoderEndCallback", &self.decoderEndCallback.map(|f| f as usize))
-            .field("freeDecoderCallback", &self.freeDecoderCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WS_CHANNEL_DECODER").field("createContext", &self.createContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_CHANNEL_DECODER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_CHANNEL_DECODER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_DECODER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_CHANNEL_DECODER {}
 impl ::core::default::Default for WS_CHANNEL_DECODER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7030,26 +7004,12 @@ impl ::core::clone::Clone for WS_CHANNEL_ENCODER {
 }
 impl ::core::fmt::Debug for WS_CHANNEL_ENCODER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CHANNEL_ENCODER")
-            .field("createContext", &self.createContext)
-            .field("createEncoderCallback", &self.createEncoderCallback.map(|f| f as usize))
-            .field("encoderGetContentTypeCallback", &self.encoderGetContentTypeCallback.map(|f| f as usize))
-            .field("encoderStartCallback", &self.encoderStartCallback.map(|f| f as usize))
-            .field("encoderEncodeCallback", &self.encoderEncodeCallback.map(|f| f as usize))
-            .field("encoderEndCallback", &self.encoderEndCallback.map(|f| f as usize))
-            .field("freeEncoderCallback", &self.freeEncoderCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WS_CHANNEL_ENCODER").field("createContext", &self.createContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_CHANNEL_ENCODER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_CHANNEL_ENCODER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_ENCODER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_CHANNEL_ENCODER {}
 impl ::core::default::Default for WS_CHANNEL_ENCODER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7077,7 +7037,7 @@ unsafe impl ::windows::core::Abi for WS_CHANNEL_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_CHANNEL_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_CHANNEL_PROPERTIES {}
@@ -7109,7 +7069,7 @@ unsafe impl ::windows::core::Abi for WS_CHANNEL_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_CHANNEL_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_CHANNEL_PROPERTY {}
@@ -7142,7 +7102,7 @@ unsafe impl ::windows::core::Abi for WS_CHANNEL_PROPERTY_CONSTRAINT {
 }
 impl ::core::cmp::PartialEq for WS_CHANNEL_PROPERTY_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_PROPERTY_CONSTRAINT>()) == 0 }
+        self.id == other.id && self.allowedValues == other.allowedValues && self.allowedValuesSize == other.allowedValuesSize && self.out == other.out
     }
 }
 impl ::core::cmp::Eq for WS_CHANNEL_PROPERTY_CONSTRAINT {}
@@ -7172,7 +7132,7 @@ unsafe impl ::windows::core::Abi for WS_CHANNEL_PROPERTY_CONSTRAINT_0 {
 }
 impl ::core::cmp::PartialEq for WS_CHANNEL_PROPERTY_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHANNEL_PROPERTY_CONSTRAINT_0>()) == 0 }
+        self.channelProperty == other.channelProperty
     }
 }
 impl ::core::cmp::Eq for WS_CHANNEL_PROPERTY_CONSTRAINT_0 {}
@@ -7203,7 +7163,7 @@ unsafe impl ::windows::core::Abi for WS_CHAR_ARRAY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_CHAR_ARRAY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CHAR_ARRAY_DESCRIPTION>()) == 0 }
+        self.minCharCount == other.minCharCount && self.maxCharCount == other.maxCharCount
     }
 }
 impl ::core::cmp::Eq for WS_CHAR_ARRAY_DESCRIPTION {}
@@ -7240,7 +7200,7 @@ unsafe impl ::windows::core::Abi for WS_CONTRACT_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_CONTRACT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CONTRACT_DESCRIPTION>()) == 0 }
+        self.operationCount == other.operationCount && self.operations == other.operations
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7272,21 +7232,13 @@ impl ::core::clone::Clone for WS_CUSTOM_CERT_CREDENTIAL {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
 impl ::core::fmt::Debug for WS_CUSTOM_CERT_CREDENTIAL {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CUSTOM_CERT_CREDENTIAL").field("credential", &self.credential).field("getCertCallback", &self.getCertCallback.map(|f| f as usize)).field("getCertCallbackState", &self.getCertCallbackState).field("certIssuerListNotificationCallback", &self.certIssuerListNotificationCallback.map(|f| f as usize)).field("certIssuerListNotificationCallbackState", &self.certIssuerListNotificationCallbackState).finish()
+        f.debug_struct("WS_CUSTOM_CERT_CREDENTIAL").field("credential", &self.credential).field("getCertCallbackState", &self.getCertCallbackState).field("certIssuerListNotificationCallbackState", &self.certIssuerListNotificationCallbackState).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
 unsafe impl ::windows::core::Abi for WS_CUSTOM_CERT_CREDENTIAL {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WS_CUSTOM_CERT_CREDENTIAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CUSTOM_CERT_CREDENTIAL>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WS_CUSTOM_CERT_CREDENTIAL {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WS_CUSTOM_CERT_CREDENTIAL {
     fn default() -> Self {
@@ -7319,33 +7271,12 @@ impl ::core::clone::Clone for WS_CUSTOM_CHANNEL_CALLBACKS {
 }
 impl ::core::fmt::Debug for WS_CUSTOM_CHANNEL_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CUSTOM_CHANNEL_CALLBACKS")
-            .field("createChannelCallback", &self.createChannelCallback.map(|f| f as usize))
-            .field("freeChannelCallback", &self.freeChannelCallback.map(|f| f as usize))
-            .field("resetChannelCallback", &self.resetChannelCallback.map(|f| f as usize))
-            .field("openChannelCallback", &self.openChannelCallback.map(|f| f as usize))
-            .field("closeChannelCallback", &self.closeChannelCallback.map(|f| f as usize))
-            .field("abortChannelCallback", &self.abortChannelCallback.map(|f| f as usize))
-            .field("getChannelPropertyCallback", &self.getChannelPropertyCallback.map(|f| f as usize))
-            .field("setChannelPropertyCallback", &self.setChannelPropertyCallback.map(|f| f as usize))
-            .field("writeMessageStartCallback", &self.writeMessageStartCallback.map(|f| f as usize))
-            .field("writeMessageEndCallback", &self.writeMessageEndCallback.map(|f| f as usize))
-            .field("readMessageStartCallback", &self.readMessageStartCallback.map(|f| f as usize))
-            .field("readMessageEndCallback", &self.readMessageEndCallback.map(|f| f as usize))
-            .field("abandonMessageCallback", &self.abandonMessageCallback.map(|f| f as usize))
-            .field("shutdownSessionChannelCallback", &self.shutdownSessionChannelCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WS_CUSTOM_CHANNEL_CALLBACKS").finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_CUSTOM_CHANNEL_CALLBACKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_CUSTOM_CHANNEL_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CUSTOM_CHANNEL_CALLBACKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_CUSTOM_CHANNEL_CALLBACKS {}
 impl ::core::default::Default for WS_CUSTOM_CHANNEL_CALLBACKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7373,7 +7304,7 @@ unsafe impl ::windows::core::Abi for WS_CUSTOM_HTTP_PROXY {
 }
 impl ::core::cmp::PartialEq for WS_CUSTOM_HTTP_PROXY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CUSTOM_HTTP_PROXY>()) == 0 }
+        self.servers == other.servers && self.bypass == other.bypass
     }
 }
 impl ::core::cmp::Eq for WS_CUSTOM_HTTP_PROXY {}
@@ -7404,29 +7335,12 @@ impl ::core::clone::Clone for WS_CUSTOM_LISTENER_CALLBACKS {
 }
 impl ::core::fmt::Debug for WS_CUSTOM_LISTENER_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CUSTOM_LISTENER_CALLBACKS")
-            .field("createListenerCallback", &self.createListenerCallback.map(|f| f as usize))
-            .field("freeListenerCallback", &self.freeListenerCallback.map(|f| f as usize))
-            .field("resetListenerCallback", &self.resetListenerCallback.map(|f| f as usize))
-            .field("openListenerCallback", &self.openListenerCallback.map(|f| f as usize))
-            .field("closeListenerCallback", &self.closeListenerCallback.map(|f| f as usize))
-            .field("abortListenerCallback", &self.abortListenerCallback.map(|f| f as usize))
-            .field("getListenerPropertyCallback", &self.getListenerPropertyCallback.map(|f| f as usize))
-            .field("setListenerPropertyCallback", &self.setListenerPropertyCallback.map(|f| f as usize))
-            .field("createChannelForListenerCallback", &self.createChannelForListenerCallback.map(|f| f as usize))
-            .field("acceptChannelCallback", &self.acceptChannelCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WS_CUSTOM_LISTENER_CALLBACKS").finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_CUSTOM_LISTENER_CALLBACKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_CUSTOM_LISTENER_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CUSTOM_LISTENER_CALLBACKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_CUSTOM_LISTENER_CALLBACKS {}
 impl ::core::default::Default for WS_CUSTOM_LISTENER_CALLBACKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7454,21 +7368,13 @@ impl ::core::clone::Clone for WS_CUSTOM_TYPE_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_CUSTOM_TYPE_DESCRIPTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_CUSTOM_TYPE_DESCRIPTION").field("size", &self.size).field("alignment", &self.alignment).field("readCallback", &self.readCallback.map(|f| f as usize)).field("writeCallback", &self.writeCallback.map(|f| f as usize)).field("descriptionData", &self.descriptionData).field("isDefaultValueCallback", &self.isDefaultValueCallback.map(|f| f as usize)).finish()
+        f.debug_struct("WS_CUSTOM_TYPE_DESCRIPTION").field("size", &self.size).field("alignment", &self.alignment).field("descriptionData", &self.descriptionData).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_CUSTOM_TYPE_DESCRIPTION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_CUSTOM_TYPE_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_CUSTOM_TYPE_DESCRIPTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_CUSTOM_TYPE_DESCRIPTION {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_CUSTOM_TYPE_DESCRIPTION {
     fn default() -> Self {
@@ -7497,7 +7403,7 @@ unsafe impl ::windows::core::Abi for WS_DATETIME {
 }
 impl ::core::cmp::PartialEq for WS_DATETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DATETIME>()) == 0 }
+        self.ticks == other.ticks && self.format == other.format
     }
 }
 impl ::core::cmp::Eq for WS_DATETIME {}
@@ -7528,7 +7434,7 @@ unsafe impl ::windows::core::Abi for WS_DATETIME_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_DATETIME_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DATETIME_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_DATETIME_DESCRIPTION {}
@@ -7557,14 +7463,6 @@ unsafe impl ::windows::core::Abi for WS_DECIMAL_DESCRIPTION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_DECIMAL_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DECIMAL_DESCRIPTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_DECIMAL_DESCRIPTION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_DECIMAL_DESCRIPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7592,7 +7490,7 @@ unsafe impl ::windows::core::Abi for WS_DEFAULT_VALUE {
 }
 impl ::core::cmp::PartialEq for WS_DEFAULT_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DEFAULT_VALUE>()) == 0 }
+        self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_DEFAULT_VALUE {}
@@ -7622,7 +7520,7 @@ unsafe impl ::windows::core::Abi for WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTI
 }
 impl ::core::cmp::PartialEq for WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL>()) == 0 }
+        self.credential == other.credential
     }
 }
 impl ::core::cmp::Eq for WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {}
@@ -7653,7 +7551,7 @@ unsafe impl ::windows::core::Abi for WS_DISALLOWED_USER_AGENT_SUBSTRINGS {
 }
 impl ::core::cmp::PartialEq for WS_DISALLOWED_USER_AGENT_SUBSTRINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DISALLOWED_USER_AGENT_SUBSTRINGS>()) == 0 }
+        self.subStringCount == other.subStringCount && self.subStrings == other.subStrings
     }
 }
 impl ::core::cmp::Eq for WS_DISALLOWED_USER_AGENT_SUBSTRINGS {}
@@ -7684,7 +7582,7 @@ unsafe impl ::windows::core::Abi for WS_DNS_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_DNS_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DNS_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.dns == other.dns
     }
 }
 impl ::core::cmp::Eq for WS_DNS_ENDPOINT_IDENTITY {}
@@ -7715,7 +7613,7 @@ unsafe impl ::windows::core::Abi for WS_DOUBLE_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_DOUBLE_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DOUBLE_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_DOUBLE_DESCRIPTION {}
@@ -7759,7 +7657,7 @@ unsafe impl ::windows::core::Abi for WS_DURATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_DURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DURATION>()) == 0 }
+        self.negative == other.negative && self.years == other.years && self.months == other.months && self.days == other.days && self.hours == other.hours && self.minutes == other.minutes && self.seconds == other.seconds && self.milliseconds == other.milliseconds && self.ticks == other.ticks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7789,21 +7687,13 @@ impl ::core::clone::Clone for WS_DURATION_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_DURATION_DESCRIPTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_DURATION_DESCRIPTION").field("minValue", &self.minValue).field("maxValue", &self.maxValue).field("comparer", &self.comparer.map(|f| f as usize)).finish()
+        f.debug_struct("WS_DURATION_DESCRIPTION").field("minValue", &self.minValue).field("maxValue", &self.maxValue).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_DURATION_DESCRIPTION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_DURATION_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_DURATION_DESCRIPTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_DURATION_DESCRIPTION {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_DURATION_DESCRIPTION {
     fn default() -> Self {
@@ -7840,7 +7730,7 @@ unsafe impl ::windows::core::Abi for WS_ELEMENT_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ELEMENT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ELEMENT_DESCRIPTION>()) == 0 }
+        self.elementLocalName == other.elementLocalName && self.elementNs == other.elementNs && self.r#type == other.r#type && self.typeDescription == other.typeDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7875,7 +7765,7 @@ unsafe impl ::windows::core::Abi for WS_ENDPOINT_ADDRESS {
 }
 impl ::core::cmp::PartialEq for WS_ENDPOINT_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENDPOINT_ADDRESS>()) == 0 }
+        self.url == other.url && self.headers == other.headers && self.extensions == other.extensions && self.identity == other.identity
     }
 }
 impl ::core::cmp::Eq for WS_ENDPOINT_ADDRESS {}
@@ -7905,7 +7795,7 @@ unsafe impl ::windows::core::Abi for WS_ENDPOINT_ADDRESS_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_ENDPOINT_ADDRESS_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENDPOINT_ADDRESS_DESCRIPTION>()) == 0 }
+        self.addressingVersion == other.addressingVersion
     }
 }
 impl ::core::cmp::Eq for WS_ENDPOINT_ADDRESS_DESCRIPTION {}
@@ -7935,7 +7825,7 @@ unsafe impl ::windows::core::Abi for WS_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENDPOINT_IDENTITY>()) == 0 }
+        self.identityType == other.identityType
     }
 }
 impl ::core::cmp::Eq for WS_ENDPOINT_IDENTITY {}
@@ -7974,7 +7864,7 @@ unsafe impl ::windows::core::Abi for WS_ENDPOINT_POLICY_EXTENSION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ENDPOINT_POLICY_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENDPOINT_POLICY_EXTENSION>()) == 0 }
+        self.policyExtension == other.policyExtension && self.assertionName == other.assertionName && self.assertionNs == other.assertionNs && self.out == other.out
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8012,7 +7902,7 @@ unsafe impl ::windows::core::Abi for WS_ENDPOINT_POLICY_EXTENSION_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ENDPOINT_POLICY_EXTENSION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENDPOINT_POLICY_EXTENSION_0>()) == 0 }
+        self.assertionValue == other.assertionValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8053,7 +7943,7 @@ unsafe impl ::windows::core::Abi for WS_ENUM_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ENUM_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENUM_DESCRIPTION>()) == 0 }
+        self.values == other.values && self.valueCount == other.valueCount && self.maxByteCount == other.maxByteCount && self.nameIndices == other.nameIndices
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8092,7 +7982,7 @@ unsafe impl ::windows::core::Abi for WS_ENUM_VALUE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ENUM_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ENUM_VALUE>()) == 0 }
+        self.value == other.value && self.name == other.name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8128,7 +8018,7 @@ unsafe impl ::windows::core::Abi for WS_ERROR_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_ERROR_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ERROR_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_ERROR_PROPERTY {}
@@ -8169,7 +8059,7 @@ unsafe impl ::windows::core::Abi for WS_FAULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_FAULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FAULT>()) == 0 }
+        self.code == other.code && self.reasons == other.reasons && self.reasonCount == other.reasonCount && self.actor == other.actor && self.node == other.node && self.detail == other.detail
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8208,7 +8098,7 @@ unsafe impl ::windows::core::Abi for WS_FAULT_CODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_FAULT_CODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FAULT_CODE>()) == 0 }
+        self.value == other.value && self.subCode == other.subCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8240,7 +8130,7 @@ unsafe impl ::windows::core::Abi for WS_FAULT_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_FAULT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FAULT_DESCRIPTION>()) == 0 }
+        self.envelopeVersion == other.envelopeVersion
     }
 }
 impl ::core::cmp::Eq for WS_FAULT_DESCRIPTION {}
@@ -8277,7 +8167,7 @@ unsafe impl ::windows::core::Abi for WS_FAULT_DETAIL_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_FAULT_DETAIL_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FAULT_DETAIL_DESCRIPTION>()) == 0 }
+        self.action == other.action && self.detailElementDescription == other.detailElementDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8310,7 +8200,7 @@ unsafe impl ::windows::core::Abi for WS_FAULT_REASON {
 }
 impl ::core::cmp::PartialEq for WS_FAULT_REASON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FAULT_REASON>()) == 0 }
+        self.text == other.text && self.lang == other.lang
     }
 }
 impl ::core::cmp::Eq for WS_FAULT_REASON {}
@@ -8357,7 +8247,7 @@ unsafe impl ::windows::core::Abi for WS_FIELD_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_FIELD_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FIELD_DESCRIPTION>()) == 0 }
+        self.mapping == other.mapping && self.localName == other.localName && self.ns == other.ns && self.r#type == other.r#type && self.typeDescription == other.typeDescription && self.offset == other.offset && self.options == other.options && self.defaultValue == other.defaultValue && self.countOffset == other.countOffset && self.itemLocalName == other.itemLocalName && self.itemNs == other.itemNs && self.itemRange == other.itemRange
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8390,7 +8280,7 @@ unsafe impl ::windows::core::Abi for WS_FLOAT_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_FLOAT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_FLOAT_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_FLOAT_DESCRIPTION {}
@@ -8420,7 +8310,7 @@ unsafe impl ::windows::core::Abi for WS_GUID_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_GUID_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_GUID_DESCRIPTION>()) == 0 }
+        self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_GUID_DESCRIPTION {}
@@ -8453,7 +8343,7 @@ unsafe impl ::windows::core::Abi for WS_HEAP_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_HEAP_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HEAP_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_HEAP_PROPERTIES {}
@@ -8485,7 +8375,7 @@ unsafe impl ::windows::core::Abi for WS_HEAP_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_HEAP_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HEAP_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_HEAP_PROPERTY {}
@@ -8516,7 +8406,7 @@ unsafe impl ::windows::core::Abi for WS_HOST_NAMES {
 }
 impl ::core::cmp::PartialEq for WS_HOST_NAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HOST_NAMES>()) == 0 }
+        self.hostNames == other.hostNames && self.hostNameCount == other.hostNameCount
     }
 }
 impl ::core::cmp::Eq for WS_HOST_NAMES {}
@@ -8552,7 +8442,7 @@ unsafe impl ::windows::core::Abi for WS_HTTPS_URL {
 }
 impl ::core::cmp::PartialEq for WS_HTTPS_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTPS_URL>()) == 0 }
+        self.url == other.url && self.host == other.host && self.port == other.port && self.portAsString == other.portAsString && self.path == other.path && self.query == other.query && self.fragment == other.fragment
     }
 }
 impl ::core::cmp::Eq for WS_HTTPS_URL {}
@@ -8582,7 +8472,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_BINDING_TEMPLATE {}
@@ -8614,7 +8504,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.httpHeaderAuthSecurityBinding == other.httpHeaderAuthSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE {}
@@ -8646,7 +8536,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.httpHeaderAuthSecurityBinding == other.httpHeaderAuthSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION {}
@@ -8677,7 +8567,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING {}
@@ -8707,7 +8597,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTR
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT {}
@@ -8737,7 +8627,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -8768,7 +8658,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLA
 }
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE {}
@@ -8805,7 +8695,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_HEADER_MAPPING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_HTTP_HEADER_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_HEADER_MAPPING>()) == 0 }
+        self.headerName == other.headerName && self.headerMappingOptions == other.headerMappingOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8848,7 +8738,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_MESSAGE_MAPPING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_HTTP_MESSAGE_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_MESSAGE_MAPPING>()) == 0 }
+        self.requestMappingOptions == other.requestMappingOptions && self.responseMappingOptions == other.responseMappingOptions && self.requestHeaderMappings == other.requestHeaderMappings && self.requestHeaderMappingCount == other.requestHeaderMappingCount && self.responseHeaderMappings == other.responseHeaderMappings && self.responseHeaderMappingCount == other.responseHeaderMappingCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8880,7 +8770,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_POLICY_DESCRIPTION {}
@@ -8903,18 +8793,12 @@ impl ::core::clone::Clone for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
 }
 impl ::core::fmt::Debug for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_HTTP_REDIRECT_CALLBACK_CONTEXT").field("callback", &self.callback.map(|f| f as usize)).field("state", &self.state).finish()
+        f.debug_struct("WS_HTTP_REDIRECT_CALLBACK_CONTEXT").field("state", &self.state).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_REDIRECT_CALLBACK_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {}
 impl ::core::default::Default for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8943,7 +8827,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_BINDING_TEMPLATE {}
@@ -8976,7 +8860,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.httpHeaderAuthSecurityBinding == other.httpHeaderAuthSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE {}
@@ -9009,7 +8893,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION 
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.httpHeaderAuthSecurityBinding == other.httpHeaderAuthSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION {}
@@ -9042,7 +8926,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE {}
@@ -9075,7 +8959,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTI
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTION {}
@@ -9109,7 +8993,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {}
@@ -9143,7 +9027,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {}
@@ -9175,7 +9059,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_POLICY_DESCRIPTION {}
@@ -9200,18 +9084,12 @@ impl ::core::clone::Clone for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
 }
 impl ::core::fmt::Debug for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sslTransportSecurityBinding", &self.sslTransportSecurityBinding).field("usernameMessageSecurityBinding", &self.usernameMessageSecurityBinding).finish()
+        f.debug_struct("WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sslTransportSecurityBinding", &self.sslTransportSecurityBinding).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {}
 impl ::core::default::Default for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9241,7 +9119,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.usernameMessageSecurityBinding == other.usernameMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION {}
@@ -9267,18 +9145,12 @@ impl ::core::clone::Clone for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMP
 }
 impl ::core::fmt::Debug for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sslTransportSecurityBinding", &self.sslTransportSecurityBinding).field("usernameMessageSecurityBinding", &self.usernameMessageSecurityBinding).field("securityContextSecurityBinding", &self.securityContextSecurityBinding).finish()
+        f.debug_struct("WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sslTransportSecurityBinding", &self.sslTransportSecurityBinding).field("securityContextSecurityBinding", &self.securityContextSecurityBinding).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {}
 impl ::core::default::Default for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9309,7 +9181,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLIC
 }
 impl ::core::cmp::PartialEq for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sslTransportSecurityBinding == other.sslTransportSecurityBinding && self.usernameMessageSecurityBinding == other.usernameMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {}
@@ -9345,7 +9217,7 @@ unsafe impl ::windows::core::Abi for WS_HTTP_URL {
 }
 impl ::core::cmp::PartialEq for WS_HTTP_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_HTTP_URL>()) == 0 }
+        self.url == other.url && self.host == other.host && self.port == other.port && self.portAsString == other.portAsString && self.path == other.path && self.query == other.query && self.fragment == other.fragment
     }
 }
 impl ::core::cmp::Eq for WS_HTTP_URL {}
@@ -9376,7 +9248,7 @@ unsafe impl ::windows::core::Abi for WS_INT16_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_INT16_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_INT16_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_INT16_DESCRIPTION {}
@@ -9407,7 +9279,7 @@ unsafe impl ::windows::core::Abi for WS_INT32_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_INT32_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_INT32_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_INT32_DESCRIPTION {}
@@ -9438,7 +9310,7 @@ unsafe impl ::windows::core::Abi for WS_INT64_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_INT64_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_INT64_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_INT64_DESCRIPTION {}
@@ -9475,7 +9347,7 @@ unsafe impl ::windows::core::Abi for WS_INT8_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_INT8_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_INT8_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9527,7 +9399,7 @@ unsafe impl ::windows::core::Abi for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.bindingUsage == other.bindingUsage && self.claimConstraints == other.claimConstraints && self.claimConstraintCount == other.claimConstraintCount && self.requestSecurityTokenPropertyConstraints == other.requestSecurityTokenPropertyConstraints && self.requestSecurityTokenPropertyConstraintCount == other.requestSecurityTokenPropertyConstraintCount && self.out == other.out
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9566,7 +9438,7 @@ unsafe impl ::windows::core::Abi for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CO
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_0>()) == 0 }
+        self.issuerAddress == other.issuerAddress && self.requestSecurityTokenTemplate == other.requestSecurityTokenTemplate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9599,7 +9471,7 @@ unsafe impl ::windows::core::Abi for WS_ITEM_RANGE {
 }
 impl ::core::cmp::PartialEq for WS_ITEM_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_ITEM_RANGE>()) == 0 }
+        self.minItemCount == other.minItemCount && self.maxItemCount == other.maxItemCount
     }
 }
 impl ::core::cmp::Eq for WS_ITEM_RANGE {}
@@ -9631,7 +9503,7 @@ unsafe impl ::windows::core::Abi for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING 
 }
 impl ::core::cmp::PartialEq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.bindingUsage == other.bindingUsage && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING {}
@@ -9662,7 +9534,7 @@ unsafe impl ::windows::core::Abi for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_
 }
 impl ::core::cmp::PartialEq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT {}
@@ -9693,7 +9565,7 @@ unsafe impl ::windows::core::Abi for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_
 }
 impl ::core::cmp::PartialEq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -9724,7 +9596,7 @@ unsafe impl ::windows::core::Abi for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_
 }
 impl ::core::cmp::PartialEq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {}
@@ -9757,7 +9629,7 @@ unsafe impl ::windows::core::Abi for WS_LISTENER_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_LISTENER_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_LISTENER_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_LISTENER_PROPERTIES {}
@@ -9789,7 +9661,7 @@ unsafe impl ::windows::core::Abi for WS_LISTENER_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_LISTENER_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_LISTENER_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_LISTENER_PROPERTY {}
@@ -9828,7 +9700,7 @@ unsafe impl ::windows::core::Abi for WS_MESSAGE_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_MESSAGE_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_MESSAGE_DESCRIPTION>()) == 0 }
+        self.action == other.action && self.bodyElementDescription == other.bodyElementDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9861,7 +9733,7 @@ unsafe impl ::windows::core::Abi for WS_MESSAGE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_MESSAGE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_MESSAGE_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_MESSAGE_PROPERTIES {}
@@ -9893,7 +9765,7 @@ unsafe impl ::windows::core::Abi for WS_MESSAGE_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_MESSAGE_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_MESSAGE_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_MESSAGE_PROPERTY {}
@@ -9939,7 +9811,7 @@ unsafe impl ::windows::core::Abi for WS_METADATA_ENDPOINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_METADATA_ENDPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_METADATA_ENDPOINT>()) == 0 }
+        self.endpointAddress == other.endpointAddress && self.endpointPolicy == other.endpointPolicy && self.portName == other.portName && self.serviceName == other.serviceName && self.serviceNs == other.serviceNs && self.bindingName == other.bindingName && self.bindingNs == other.bindingNs && self.portTypeName == other.portTypeName && self.portTypeNs == other.portTypeNs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9978,7 +9850,7 @@ unsafe impl ::windows::core::Abi for WS_METADATA_ENDPOINTS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_METADATA_ENDPOINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_METADATA_ENDPOINTS>()) == 0 }
+        self.endpoints == other.endpoints && self.endpointCount == other.endpointCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10012,7 +9884,7 @@ unsafe impl ::windows::core::Abi for WS_METADATA_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_METADATA_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_METADATA_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_METADATA_PROPERTY {}
@@ -10043,7 +9915,7 @@ unsafe impl ::windows::core::Abi for WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDIN
 }
 impl ::core::cmp::PartialEq for WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING {}
@@ -10080,7 +9952,7 @@ unsafe impl ::windows::core::Abi for WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE>()) == 0 }
+        self.keyHandle == other.keyHandle && self.asymmetricKey == other.asymmetricKey
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -10118,7 +9990,7 @@ unsafe impl ::windows::core::Abi for WS_NETPIPE_URL {
 }
 impl ::core::cmp::PartialEq for WS_NETPIPE_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_NETPIPE_URL>()) == 0 }
+        self.url == other.url && self.host == other.host && self.port == other.port && self.portAsString == other.portAsString && self.path == other.path && self.query == other.query && self.fragment == other.fragment
     }
 }
 impl ::core::cmp::Eq for WS_NETPIPE_URL {}
@@ -10154,7 +10026,7 @@ unsafe impl ::windows::core::Abi for WS_NETTCP_URL {
 }
 impl ::core::cmp::PartialEq for WS_NETTCP_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_NETTCP_URL>()) == 0 }
+        self.url == other.url && self.host == other.host && self.port == other.port && self.portAsString == other.portAsString && self.path == other.path && self.query == other.query && self.fragment == other.fragment
     }
 }
 impl ::core::cmp::Eq for WS_NETTCP_URL {}
@@ -10185,7 +10057,7 @@ unsafe impl ::windows::core::Abi for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIA
 }
 impl ::core::cmp::PartialEq for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL>()) == 0 }
+        self.credential == other.credential && self.opaqueAuthIdentity == other.opaqueAuthIdentity
     }
 }
 impl ::core::cmp::Eq for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {}
@@ -10221,31 +10093,13 @@ impl ::core::clone::Clone for WS_OPERATION_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_OPERATION_DESCRIPTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_OPERATION_DESCRIPTION")
-            .field("versionInfo", &self.versionInfo)
-            .field("inputMessageDescription", &self.inputMessageDescription)
-            .field("outputMessageDescription", &self.outputMessageDescription)
-            .field("inputMessageOptions", &self.inputMessageOptions)
-            .field("outputMessageOptions", &self.outputMessageOptions)
-            .field("parameterCount", &self.parameterCount)
-            .field("parameterDescription", &self.parameterDescription)
-            .field("stubCallback", &self.stubCallback.map(|f| f as usize))
-            .field("style", &self.style)
-            .finish()
+        f.debug_struct("WS_OPERATION_DESCRIPTION").field("versionInfo", &self.versionInfo).field("inputMessageDescription", &self.inputMessageDescription).field("outputMessageDescription", &self.outputMessageDescription).field("inputMessageOptions", &self.inputMessageOptions).field("outputMessageOptions", &self.outputMessageOptions).field("parameterCount", &self.parameterCount).field("parameterDescription", &self.parameterDescription).field("style", &self.style).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_OPERATION_DESCRIPTION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_OPERATION_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_OPERATION_DESCRIPTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_OPERATION_DESCRIPTION {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_OPERATION_DESCRIPTION {
     fn default() -> Self {
@@ -10275,7 +10129,7 @@ unsafe impl ::windows::core::Abi for WS_PARAMETER_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_PARAMETER_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_PARAMETER_DESCRIPTION>()) == 0 }
+        self.parameterType == other.parameterType && self.inputMessageIndex == other.inputMessageIndex && self.outputMessageIndex == other.outputMessageIndex
     }
 }
 impl ::core::cmp::Eq for WS_PARAMETER_DESCRIPTION {}
@@ -10312,7 +10166,7 @@ unsafe impl ::windows::core::Abi for WS_POLICY_CONSTRAINTS {
 }
 impl ::core::cmp::PartialEq for WS_POLICY_CONSTRAINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_POLICY_CONSTRAINTS>()) == 0 }
+        self.channelBinding == other.channelBinding && self.channelPropertyConstraints == other.channelPropertyConstraints && self.channelPropertyConstraintCount == other.channelPropertyConstraintCount && self.securityConstraints == other.securityConstraints && self.policyExtensions == other.policyExtensions && self.policyExtensionCount == other.policyExtensionCount
     }
 }
 impl ::core::cmp::Eq for WS_POLICY_CONSTRAINTS {}
@@ -10342,7 +10196,7 @@ unsafe impl ::windows::core::Abi for WS_POLICY_EXTENSION {
 }
 impl ::core::cmp::PartialEq for WS_POLICY_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_POLICY_EXTENSION>()) == 0 }
+        self.r#type == other.r#type
     }
 }
 impl ::core::cmp::Eq for WS_POLICY_EXTENSION {}
@@ -10373,7 +10227,7 @@ unsafe impl ::windows::core::Abi for WS_POLICY_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_POLICY_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_POLICY_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_POLICY_PROPERTIES {}
@@ -10405,7 +10259,7 @@ unsafe impl ::windows::core::Abi for WS_POLICY_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_POLICY_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_POLICY_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_POLICY_PROPERTY {}
@@ -10428,18 +10282,12 @@ impl ::core::clone::Clone for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
 }
 impl ::core::fmt::Debug for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_PROXY_MESSAGE_CALLBACK_CONTEXT").field("callback", &self.callback.map(|f| f as usize)).field("state", &self.state).finish()
+        f.debug_struct("WS_PROXY_MESSAGE_CALLBACK_CONTEXT").field("state", &self.state).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_PROXY_MESSAGE_CALLBACK_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {}
 impl ::core::default::Default for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10468,7 +10316,7 @@ unsafe impl ::windows::core::Abi for WS_PROXY_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_PROXY_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_PROXY_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_PROXY_PROPERTY {}
@@ -10499,7 +10347,7 @@ unsafe impl ::windows::core::Abi for WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE {
 }
 impl ::core::cmp::PartialEq for WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE>()) == 0 }
+        self.keyHandle == other.keyHandle && self.rawKeyBytes == other.rawKeyBytes
     }
 }
 impl ::core::cmp::Eq for WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE {}
@@ -10531,7 +10379,7 @@ unsafe impl ::windows::core::Abi for WS_REQUEST_SECURITY_TOKEN_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_REQUEST_SECURITY_TOKEN_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_REQUEST_SECURITY_TOKEN_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_REQUEST_SECURITY_TOKEN_PROPERTY {}
@@ -10564,7 +10412,7 @@ unsafe impl ::windows::core::Abi for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAI
 }
 impl ::core::cmp::PartialEq for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT>()) == 0 }
+        self.id == other.id && self.allowedValues == other.allowedValues && self.allowedValuesSize == other.allowedValuesSize && self.out == other.out
     }
 }
 impl ::core::cmp::Eq for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT {}
@@ -10594,7 +10442,7 @@ unsafe impl ::windows::core::Abi for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAI
 }
 impl ::core::cmp::PartialEq for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0>()) == 0 }
+        self.requestSecurityTokenProperty == other.requestSecurityTokenProperty
     }
 }
 impl ::core::cmp::Eq for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0 {}
@@ -10626,7 +10474,7 @@ unsafe impl ::windows::core::Abi for WS_RSA_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_RSA_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_RSA_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.modulus == other.modulus && self.exponent == other.exponent
     }
 }
 impl ::core::cmp::Eq for WS_RSA_ENDPOINT_IDENTITY {}
@@ -10656,7 +10504,7 @@ unsafe impl ::windows::core::Abi for WS_SAML_AUTHENTICATOR {
 }
 impl ::core::cmp::PartialEq for WS_SAML_AUTHENTICATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SAML_AUTHENTICATOR>()) == 0 }
+        self.authenticatorType == other.authenticatorType
     }
 }
 impl ::core::cmp::Eq for WS_SAML_AUTHENTICATOR {}
@@ -10688,7 +10536,7 @@ unsafe impl ::windows::core::Abi for WS_SAML_MESSAGE_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_SAML_MESSAGE_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SAML_MESSAGE_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.bindingUsage == other.bindingUsage && self.authenticator == other.authenticator
     }
 }
 impl ::core::cmp::Eq for WS_SAML_MESSAGE_SECURITY_BINDING {}
@@ -10720,7 +10568,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_ALGORITHM_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_ALGORITHM_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_ALGORITHM_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_ALGORITHM_PROPERTY {}
@@ -10778,7 +10626,20 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_ALGORITHM_SUITE {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_ALGORITHM_SUITE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_ALGORITHM_SUITE>()) == 0 }
+        self.canonicalizationAlgorithm == other.canonicalizationAlgorithm
+            && self.digestAlgorithm == other.digestAlgorithm
+            && self.symmetricSignatureAlgorithm == other.symmetricSignatureAlgorithm
+            && self.asymmetricSignatureAlgorithm == other.asymmetricSignatureAlgorithm
+            && self.encryptionAlgorithm == other.encryptionAlgorithm
+            && self.keyDerivationAlgorithm == other.keyDerivationAlgorithm
+            && self.symmetricKeyWrapAlgorithm == other.symmetricKeyWrapAlgorithm
+            && self.asymmetricKeyWrapAlgorithm == other.asymmetricKeyWrapAlgorithm
+            && self.minSymmetricKeyLength == other.minSymmetricKeyLength
+            && self.maxSymmetricKeyLength == other.maxSymmetricKeyLength
+            && self.minAsymmetricKeyLength == other.minAsymmetricKeyLength
+            && self.maxAsymmetricKeyLength == other.maxAsymmetricKeyLength
+            && self.properties == other.properties
+            && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_ALGORITHM_SUITE {}
@@ -10810,7 +10671,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING>()) == 0 }
+        self.bindingType == other.bindingType && self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING {}
@@ -10842,7 +10703,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING_CONSTRAINT {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.r#type == other.r#type && self.propertyConstraints == other.propertyConstraints && self.propertyConstraintCount == other.propertyConstraintCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING_CONSTRAINT {}
@@ -10873,7 +10734,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING_PROPERTIES {}
@@ -10905,7 +10766,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING_PROPERTY {}
@@ -10938,7 +10799,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING_PROPERTY_CONSTRAINT>()) == 0 }
+        self.id == other.id && self.allowedValues == other.allowedValues && self.allowedValuesSize == other.allowedValuesSize && self.out == other.out
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT {}
@@ -10968,7 +10829,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0>()) == 0 }
+        self.securityBindingProperty == other.securityBindingProperty
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {}
@@ -11001,7 +10862,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONSTRAINTS {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONSTRAINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONSTRAINTS>()) == 0 }
+        self.securityPropertyConstraints == other.securityPropertyConstraints && self.securityPropertyConstraintCount == other.securityPropertyConstraintCount && self.securityBindingConstraints == other.securityBindingConstraints && self.securityBindingConstraintCount == other.securityBindingConstraintCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONSTRAINTS {}
@@ -11035,7 +10896,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDIN
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.bindingUsage == other.bindingUsage && self.bootstrapSecurityDescription == other.bootstrapSecurityDescription
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {}
@@ -11067,7 +10928,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDIN
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.bindingUsage == other.bindingUsage && self.bootstrapSecurityConstraint == other.bootstrapSecurityConstraint
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT {}
@@ -11098,7 +10959,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDIN
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -11128,7 +10989,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDIN
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE {}
@@ -11160,7 +11021,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_PROPERTY {}
@@ -11191,7 +11052,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityContextMessageSecurityBinding == other.securityContextMessageSecurityBinding && self.securityProperties == other.securityProperties
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -11222,7 +11083,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLA
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityContextMessageSecurityBinding == other.securityContextMessageSecurityBinding && self.securityProperties == other.securityProperties
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE {}
@@ -11255,7 +11116,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_DESCRIPTION>()) == 0 }
+        self.securityBindings == other.securityBindings && self.securityBindingCount == other.securityBindingCount && self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_DESCRIPTION {}
@@ -11285,7 +11146,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_KEY_HANDLE {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_KEY_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_KEY_HANDLE>()) == 0 }
+        self.keyHandleType == other.keyHandleType
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_KEY_HANDLE {}
@@ -11316,7 +11177,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_PROPERTIES {}
@@ -11348,7 +11209,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_PROPERTY {}
@@ -11381,7 +11242,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_PROPERTY_CONSTRAINT {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_PROPERTY_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_PROPERTY_CONSTRAINT>()) == 0 }
+        self.id == other.id && self.allowedValues == other.allowedValues && self.allowedValuesSize == other.allowedValuesSize && self.out == other.out
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_PROPERTY_CONSTRAINT {}
@@ -11411,7 +11272,7 @@ unsafe impl ::windows::core::Abi for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
 }
 impl ::core::cmp::PartialEq for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SECURITY_PROPERTY_CONSTRAINT_0>()) == 0 }
+        self.securityProperty == other.securityProperty
     }
 }
 impl ::core::cmp::Eq for WS_SECURITY_PROPERTY_CONSTRAINT_0 {}
@@ -11441,21 +11302,13 @@ impl ::core::clone::Clone for WS_SERVICE_CONTRACT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_SERVICE_CONTRACT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_SERVICE_CONTRACT").field("contractDescription", &self.contractDescription).field("defaultMessageHandlerCallback", &self.defaultMessageHandlerCallback.map(|f| f as usize)).field("methodTable", &self.methodTable).finish()
+        f.debug_struct("WS_SERVICE_CONTRACT").field("contractDescription", &self.contractDescription).field("methodTable", &self.methodTable).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_SERVICE_CONTRACT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_SERVICE_CONTRACT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_CONTRACT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_SERVICE_CONTRACT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_SERVICE_CONTRACT {
     fn default() -> Self {
@@ -11487,21 +11340,13 @@ impl ::core::clone::Clone for WS_SERVICE_ENDPOINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_SERVICE_ENDPOINT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_SERVICE_ENDPOINT").field("address", &self.address).field("channelBinding", &self.channelBinding).field("channelType", &self.channelType).field("securityDescription", &self.securityDescription).field("contract", &self.contract).field("authorizationCallback", &self.authorizationCallback.map(|f| f as usize)).field("properties", &self.properties).field("propertyCount", &self.propertyCount).field("channelProperties", &self.channelProperties).finish()
+        f.debug_struct("WS_SERVICE_ENDPOINT").field("address", &self.address).field("channelBinding", &self.channelBinding).field("channelType", &self.channelType).field("securityDescription", &self.securityDescription).field("contract", &self.contract).field("properties", &self.properties).field("propertyCount", &self.propertyCount).field("channelProperties", &self.channelProperties).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_SERVICE_ENDPOINT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_SERVICE_ENDPOINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_ENDPOINT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_SERVICE_ENDPOINT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_SERVICE_ENDPOINT {
     fn default() -> Self {
@@ -11537,7 +11382,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_ENDPOINT_METADATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_SERVICE_ENDPOINT_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_ENDPOINT_METADATA>()) == 0 }
+        self.portName == other.portName && self.bindingName == other.bindingName && self.bindingNs == other.bindingNs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11571,7 +11416,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_ENDPOINT_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SERVICE_ENDPOINT_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_ENDPOINT_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SERVICE_ENDPOINT_PROPERTY {}
@@ -11612,7 +11457,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_METADATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_SERVICE_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_METADATA>()) == 0 }
+        self.documentCount == other.documentCount && self.documents == other.documents && self.serviceName == other.serviceName && self.serviceNs == other.serviceNs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11651,7 +11496,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_METADATA_DOCUMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_SERVICE_METADATA_DOCUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_METADATA_DOCUMENT>()) == 0 }
+        self.content == other.content && self.name == other.name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11685,7 +11530,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_SERVICE_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_SERVICE_PROPERTY {}
@@ -11707,18 +11552,12 @@ impl ::core::clone::Clone for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
 }
 impl ::core::fmt::Debug for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_SERVICE_PROPERTY_ACCEPT_CALLBACK").field("callback", &self.callback.map(|f| f as usize)).finish()
+        f.debug_struct("WS_SERVICE_PROPERTY_ACCEPT_CALLBACK").finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_PROPERTY_ACCEPT_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {}
 impl ::core::default::Default for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11737,18 +11576,12 @@ impl ::core::clone::Clone for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
 }
 impl ::core::fmt::Debug for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_SERVICE_PROPERTY_CLOSE_CALLBACK").field("callback", &self.callback.map(|f| f as usize)).finish()
+        f.debug_struct("WS_SERVICE_PROPERTY_CLOSE_CALLBACK").finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_PROPERTY_CLOSE_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {}
 impl ::core::default::Default for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11778,7 +11611,7 @@ unsafe impl ::windows::core::Abi for WS_SERVICE_SECURITY_IDENTITIES {
 }
 impl ::core::cmp::PartialEq for WS_SERVICE_SECURITY_IDENTITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SERVICE_SECURITY_IDENTITIES>()) == 0 }
+        self.serviceIdentities == other.serviceIdentities && self.serviceIdentityCount == other.serviceIdentityCount
     }
 }
 impl ::core::cmp::Eq for WS_SERVICE_SECURITY_IDENTITIES {}
@@ -11814,7 +11647,7 @@ unsafe impl ::windows::core::Abi for WS_SOAPUDP_URL {
 }
 impl ::core::cmp::PartialEq for WS_SOAPUDP_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SOAPUDP_URL>()) == 0 }
+        self.url == other.url && self.host == other.host && self.port == other.port && self.portAsString == other.portAsString && self.path == other.path && self.query == other.query && self.fragment == other.fragment
     }
 }
 impl ::core::cmp::Eq for WS_SOAPUDP_URL {}
@@ -11845,7 +11678,7 @@ unsafe impl ::windows::core::Abi for WS_SPN_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_SPN_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SPN_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.spn == other.spn
     }
 }
 impl ::core::cmp::Eq for WS_SPN_ENDPOINT_IDENTITY {}
@@ -11876,7 +11709,7 @@ unsafe impl ::windows::core::Abi for WS_SSL_TRANSPORT_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_SSL_TRANSPORT_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSL_TRANSPORT_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.localCertCredential == other.localCertCredential
     }
 }
 impl ::core::cmp::Eq for WS_SSL_TRANSPORT_SECURITY_BINDING {}
@@ -11913,7 +11746,7 @@ unsafe impl ::windows::core::Abi for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAIN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.out == other.out
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11951,7 +11784,7 @@ unsafe impl ::windows::core::Abi for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAIN
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_0>()) == 0 }
+        self.clientCertCredentialRequired == other.clientCertCredentialRequired
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11983,7 +11816,7 @@ unsafe impl ::windows::core::Abi for WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DE
 }
 impl ::core::cmp::PartialEq for WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties
     }
 }
 impl ::core::cmp::Eq for WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -12014,7 +11847,7 @@ unsafe impl ::windows::core::Abi for WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE 
 }
 impl ::core::cmp::PartialEq for WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.localCertCredential == other.localCertCredential
     }
 }
 impl ::core::cmp::Eq for WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE {}
@@ -12044,7 +11877,7 @@ unsafe impl ::windows::core::Abi for WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_D
 }
 impl ::core::cmp::PartialEq for WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties
     }
 }
 impl ::core::cmp::Eq for WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -12075,7 +11908,7 @@ unsafe impl ::windows::core::Abi for WS_STRING {
 }
 impl ::core::cmp::PartialEq for WS_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_STRING>()) == 0 }
+        self.length == other.length && self.chars == other.chars
     }
 }
 impl ::core::cmp::Eq for WS_STRING {}
@@ -12106,7 +11939,7 @@ unsafe impl ::windows::core::Abi for WS_STRING_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_STRING_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_STRING_DESCRIPTION>()) == 0 }
+        self.minCharCount == other.minCharCount && self.maxCharCount == other.maxCharCount
     }
 }
 impl ::core::cmp::Eq for WS_STRING_DESCRIPTION {}
@@ -12138,7 +11971,7 @@ unsafe impl ::windows::core::Abi for WS_STRING_USERNAME_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_STRING_USERNAME_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_STRING_USERNAME_CREDENTIAL>()) == 0 }
+        self.credential == other.credential && self.username == other.username && self.password == other.password
     }
 }
 impl ::core::cmp::Eq for WS_STRING_USERNAME_CREDENTIAL {}
@@ -12171,7 +12004,7 @@ unsafe impl ::windows::core::Abi for WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIA
 }
 impl ::core::cmp::PartialEq for WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL>()) == 0 }
+        self.credential == other.credential && self.username == other.username && self.password == other.password && self.domain == other.domain
     }
 }
 impl ::core::cmp::Eq for WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {}
@@ -12216,7 +12049,7 @@ unsafe impl ::windows::core::Abi for WS_STRUCT_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_STRUCT_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_STRUCT_DESCRIPTION>()) == 0 }
+        self.size == other.size && self.alignment == other.alignment && self.fields == other.fields && self.fieldCount == other.fieldCount && self.typeLocalName == other.typeLocalName && self.typeNs == other.typeNs && self.parentType == other.parentType && self.subTypes == other.subTypes && self.subTypeCount == other.subTypeCount && self.structOptions == other.structOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12251,7 +12084,7 @@ unsafe impl ::windows::core::Abi for WS_SUBJECT_NAME_CERT_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_SUBJECT_NAME_CERT_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_SUBJECT_NAME_CERT_CREDENTIAL>()) == 0 }
+        self.credential == other.credential && self.storeLocation == other.storeLocation && self.storeName == other.storeName && self.subjectName == other.subjectName
     }
 }
 impl ::core::cmp::Eq for WS_SUBJECT_NAME_CERT_CREDENTIAL {}
@@ -12281,7 +12114,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_TCP_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties
     }
 }
 impl ::core::cmp::Eq for WS_TCP_BINDING_TEMPLATE {}
@@ -12311,7 +12144,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_TCP_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties
     }
 }
 impl ::core::cmp::Eq for WS_TCP_POLICY_DESCRIPTION {}
@@ -12343,7 +12176,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_BINDING_TEMPLATE {
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_BINDING_TEMPLATE {}
@@ -12376,7 +12209,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE {}
@@ -12409,7 +12242,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTI
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTION {}
@@ -12443,7 +12276,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {}
@@ -12477,7 +12310,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.kerberosApreqMessageSecurityBinding == other.kerberosApreqMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {}
@@ -12509,7 +12342,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_POLICY_DESCRIPTION {}
@@ -12540,7 +12373,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {}
@@ -12570,7 +12403,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONS
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT {}
@@ -12601,7 +12434,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMP
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMPLATE>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.clientCredential == other.clientCredential
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMPLATE {}
@@ -12626,18 +12459,12 @@ impl ::core::clone::Clone for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
 }
 impl ::core::fmt::Debug for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sspiTransportSecurityBinding", &self.sspiTransportSecurityBinding).field("usernameMessageSecurityBinding", &self.usernameMessageSecurityBinding).finish()
+        f.debug_struct("WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sspiTransportSecurityBinding", &self.sspiTransportSecurityBinding).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {}
 impl ::core::default::Default for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12667,7 +12494,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.usernameMessageSecurityBinding == other.usernameMessageSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION {}
@@ -12693,18 +12520,12 @@ impl ::core::clone::Clone for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMP
 }
 impl ::core::fmt::Debug for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sspiTransportSecurityBinding", &self.sspiTransportSecurityBinding).field("usernameMessageSecurityBinding", &self.usernameMessageSecurityBinding).field("securityContextSecurityBinding", &self.securityContextSecurityBinding).finish()
+        f.debug_struct("WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE").field("channelProperties", &self.channelProperties).field("securityProperties", &self.securityProperties).field("sspiTransportSecurityBinding", &self.sspiTransportSecurityBinding).field("securityContextSecurityBinding", &self.securityContextSecurityBinding).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {}
 impl ::core::default::Default for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12735,7 +12556,7 @@ unsafe impl ::windows::core::Abi for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLIC
 }
 impl ::core::cmp::PartialEq for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION>()) == 0 }
+        self.channelProperties == other.channelProperties && self.securityProperties == other.securityProperties && self.sspiTransportSecurityBinding == other.sspiTransportSecurityBinding && self.usernameMessageSecurityBinding == other.usernameMessageSecurityBinding && self.securityContextSecurityBinding == other.securityContextSecurityBinding
     }
 }
 impl ::core::cmp::Eq for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {}
@@ -12768,7 +12589,7 @@ unsafe impl ::windows::core::Abi for WS_THUMBPRINT_CERT_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_THUMBPRINT_CERT_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_THUMBPRINT_CERT_CREDENTIAL>()) == 0 }
+        self.credential == other.credential && self.storeLocation == other.storeLocation && self.storeName == other.storeName && self.thumbprint == other.thumbprint
     }
 }
 impl ::core::cmp::Eq for WS_THUMBPRINT_CERT_CREDENTIAL {}
@@ -12798,7 +12619,7 @@ unsafe impl ::windows::core::Abi for WS_TIMESPAN {
 }
 impl ::core::cmp::PartialEq for WS_TIMESPAN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TIMESPAN>()) == 0 }
+        self.ticks == other.ticks
     }
 }
 impl ::core::cmp::Eq for WS_TIMESPAN {}
@@ -12829,7 +12650,7 @@ unsafe impl ::windows::core::Abi for WS_TIMESPAN_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_TIMESPAN_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_TIMESPAN_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_TIMESPAN_DESCRIPTION {}
@@ -12860,7 +12681,7 @@ unsafe impl ::windows::core::Abi for WS_UINT16_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UINT16_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UINT16_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_UINT16_DESCRIPTION {}
@@ -12891,7 +12712,7 @@ unsafe impl ::windows::core::Abi for WS_UINT32_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UINT32_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UINT32_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_UINT32_DESCRIPTION {}
@@ -12922,7 +12743,7 @@ unsafe impl ::windows::core::Abi for WS_UINT64_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UINT64_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UINT64_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_UINT64_DESCRIPTION {}
@@ -12953,7 +12774,7 @@ unsafe impl ::windows::core::Abi for WS_UINT8_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UINT8_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UINT8_DESCRIPTION>()) == 0 }
+        self.minValue == other.minValue && self.maxValue == other.maxValue
     }
 }
 impl ::core::cmp::Eq for WS_UINT8_DESCRIPTION {}
@@ -12995,7 +12816,7 @@ unsafe impl ::windows::core::Abi for WS_UNION_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_UNION_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UNION_DESCRIPTION>()) == 0 }
+        self.size == other.size && self.alignment == other.alignment && self.fields == other.fields && self.fieldCount == other.fieldCount && self.enumOffset == other.enumOffset && self.noneEnumValue == other.noneEnumValue && self.valueIndices == other.valueIndices
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13034,7 +12855,7 @@ unsafe impl ::windows::core::Abi for WS_UNION_FIELD_DESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_UNION_FIELD_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UNION_FIELD_DESCRIPTION>()) == 0 }
+        self.value == other.value && self.field == other.field
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13067,7 +12888,7 @@ unsafe impl ::windows::core::Abi for WS_UNIQUE_ID {
 }
 impl ::core::cmp::PartialEq for WS_UNIQUE_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UNIQUE_ID>()) == 0 }
+        self.uri == other.uri && self.guid == other.guid
     }
 }
 impl ::core::cmp::Eq for WS_UNIQUE_ID {}
@@ -13098,7 +12919,7 @@ unsafe impl ::windows::core::Abi for WS_UNIQUE_ID_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UNIQUE_ID_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UNIQUE_ID_DESCRIPTION>()) == 0 }
+        self.minCharCount == other.minCharCount && self.maxCharCount == other.maxCharCount
     }
 }
 impl ::core::cmp::Eq for WS_UNIQUE_ID_DESCRIPTION {}
@@ -13129,7 +12950,7 @@ unsafe impl ::windows::core::Abi for WS_UNKNOWN_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_UNKNOWN_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UNKNOWN_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.element == other.element
     }
 }
 impl ::core::cmp::Eq for WS_UNKNOWN_ENDPOINT_IDENTITY {}
@@ -13160,7 +12981,7 @@ unsafe impl ::windows::core::Abi for WS_UPN_ENDPOINT_IDENTITY {
 }
 impl ::core::cmp::PartialEq for WS_UPN_ENDPOINT_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UPN_ENDPOINT_IDENTITY>()) == 0 }
+        self.identity == other.identity && self.upn == other.upn
     }
 }
 impl ::core::cmp::Eq for WS_UPN_ENDPOINT_IDENTITY {}
@@ -13190,7 +13011,7 @@ unsafe impl ::windows::core::Abi for WS_URL {
 }
 impl ::core::cmp::PartialEq for WS_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_URL>()) == 0 }
+        self.scheme == other.scheme
     }
 }
 impl ::core::cmp::Eq for WS_URL {}
@@ -13220,7 +13041,7 @@ unsafe impl ::windows::core::Abi for WS_USERNAME_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_USERNAME_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_USERNAME_CREDENTIAL>()) == 0 }
+        self.credentialType == other.credentialType
     }
 }
 impl ::core::cmp::Eq for WS_USERNAME_CREDENTIAL {}
@@ -13246,18 +13067,12 @@ impl ::core::clone::Clone for WS_USERNAME_MESSAGE_SECURITY_BINDING {
 }
 impl ::core::fmt::Debug for WS_USERNAME_MESSAGE_SECURITY_BINDING {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_USERNAME_MESSAGE_SECURITY_BINDING").field("binding", &self.binding).field("bindingUsage", &self.bindingUsage).field("clientCredential", &self.clientCredential).field("passwordValidator", &self.passwordValidator.map(|f| f as usize)).field("passwordValidatorCallbackState", &self.passwordValidatorCallbackState).finish()
+        f.debug_struct("WS_USERNAME_MESSAGE_SECURITY_BINDING").field("binding", &self.binding).field("bindingUsage", &self.bindingUsage).field("clientCredential", &self.clientCredential).field("passwordValidatorCallbackState", &self.passwordValidatorCallbackState).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_USERNAME_MESSAGE_SECURITY_BINDING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_USERNAME_MESSAGE_SECURITY_BINDING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_USERNAME_MESSAGE_SECURITY_BINDING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_USERNAME_MESSAGE_SECURITY_BINDING {}
 impl ::core::default::Default for WS_USERNAME_MESSAGE_SECURITY_BINDING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13285,7 +13100,7 @@ unsafe impl ::windows::core::Abi for WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTR
 }
 impl ::core::cmp::PartialEq for WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT>()) == 0 }
+        self.bindingConstraint == other.bindingConstraint && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT {}
@@ -13316,7 +13131,7 @@ unsafe impl ::windows::core::Abi for WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY
 }
 impl ::core::cmp::PartialEq for WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION>()) == 0 }
+        self.securityBindingProperties == other.securityBindingProperties && self.bindingUsage == other.bindingUsage
     }
 }
 impl ::core::cmp::Eq for WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {}
@@ -13341,18 +13156,12 @@ impl ::core::clone::Clone for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
 }
 impl ::core::fmt::Debug for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE").field("securityBindingProperties", &self.securityBindingProperties).field("clientCredential", &self.clientCredential).field("passwordValidator", &self.passwordValidator.map(|f| f as usize)).field("passwordValidatorCallbackState", &self.passwordValidatorCallbackState).finish()
+        f.debug_struct("WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE").field("securityBindingProperties", &self.securityBindingProperties).field("clientCredential", &self.clientCredential).field("passwordValidatorCallbackState", &self.passwordValidatorCallbackState).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {}
 impl ::core::default::Default for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13380,7 +13189,7 @@ unsafe impl ::windows::core::Abi for WS_UTF8_ARRAY_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_UTF8_ARRAY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_UTF8_ARRAY_DESCRIPTION>()) == 0 }
+        self.minByteCount == other.minByteCount && self.maxByteCount == other.maxByteCount
     }
 }
 impl ::core::cmp::Eq for WS_UTF8_ARRAY_DESCRIPTION {}
@@ -13410,7 +13219,7 @@ unsafe impl ::windows::core::Abi for WS_VOID_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_VOID_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_VOID_DESCRIPTION>()) == 0 }
+        self.size == other.size
     }
 }
 impl ::core::cmp::Eq for WS_VOID_DESCRIPTION {}
@@ -13440,7 +13249,7 @@ unsafe impl ::windows::core::Abi for WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL>()) == 0 }
+        self.credentialType == other.credentialType
     }
 }
 impl ::core::cmp::Eq for WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {}
@@ -13471,7 +13280,7 @@ unsafe impl ::windows::core::Abi for WS_WSZ_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_WSZ_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_WSZ_DESCRIPTION>()) == 0 }
+        self.minCharCount == other.minCharCount && self.maxCharCount == other.maxCharCount
     }
 }
 impl ::core::cmp::Eq for WS_WSZ_DESCRIPTION {}
@@ -13512,7 +13321,7 @@ unsafe impl ::windows::core::Abi for WS_XML_ATTRIBUTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_ATTRIBUTE>()) == 0 }
+        self.singleQuote == other.singleQuote && self.isXmlNs == other.isXmlNs && self.prefix == other.prefix && self.localName == other.localName && self.ns == other.ns && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13546,7 +13355,7 @@ unsafe impl ::windows::core::Abi for WS_XML_BASE64_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_BASE64_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_BASE64_TEXT>()) == 0 }
+        self.text == other.text && self.bytes == other.bytes && self.length == other.length
     }
 }
 impl ::core::cmp::Eq for WS_XML_BASE64_TEXT {}
@@ -13583,7 +13392,7 @@ unsafe impl ::windows::core::Abi for WS_XML_BOOL_TEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_BOOL_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_BOOL_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13619,7 +13428,7 @@ unsafe impl ::windows::core::Abi for WS_XML_BUFFER_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_XML_BUFFER_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_BUFFER_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_BUFFER_PROPERTY {}
@@ -13656,7 +13465,7 @@ unsafe impl ::windows::core::Abi for WS_XML_CANONICALIZATION_INCLUSIVE_PREFIXES 
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_CANONICALIZATION_INCLUSIVE_PREFIXES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_CANONICALIZATION_INCLUSIVE_PREFIXES>()) == 0 }
+        self.prefixCount == other.prefixCount && self.prefixes == other.prefixes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13690,7 +13499,7 @@ unsafe impl ::windows::core::Abi for WS_XML_CANONICALIZATION_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_XML_CANONICALIZATION_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_CANONICALIZATION_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_CANONICALIZATION_PROPERTY {}
@@ -13727,7 +13536,7 @@ unsafe impl ::windows::core::Abi for WS_XML_COMMENT_NODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_COMMENT_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_COMMENT_NODE>()) == 0 }
+        self.node == other.node && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13760,7 +13569,7 @@ unsafe impl ::windows::core::Abi for WS_XML_DATETIME_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_DATETIME_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_DATETIME_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_DATETIME_TEXT {}
@@ -13788,14 +13597,6 @@ impl ::core::clone::Clone for WS_XML_DECIMAL_TEXT {
 unsafe impl ::windows::core::Abi for WS_XML_DECIMAL_TEXT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_XML_DECIMAL_TEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_DECIMAL_TEXT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_XML_DECIMAL_TEXT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_XML_DECIMAL_TEXT {
     fn default() -> Self {
@@ -13832,7 +13633,7 @@ unsafe impl ::windows::core::Abi for WS_XML_DICTIONARY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_DICTIONARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_DICTIONARY>()) == 0 }
+        self.guid == other.guid && self.strings == other.strings && self.stringCount == other.stringCount && self.isConst == other.isConst
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13865,7 +13666,7 @@ unsafe impl ::windows::core::Abi for WS_XML_DOUBLE_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_DOUBLE_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_DOUBLE_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_DOUBLE_TEXT {}
@@ -13907,7 +13708,7 @@ unsafe impl ::windows::core::Abi for WS_XML_ELEMENT_NODE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_ELEMENT_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_ELEMENT_NODE>()) == 0 }
+        self.node == other.node && self.prefix == other.prefix && self.localName == other.localName && self.ns == other.ns && self.attributeCount == other.attributeCount && self.attributes == other.attributes && self.isEmpty == other.isEmpty
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13940,7 +13741,7 @@ unsafe impl ::windows::core::Abi for WS_XML_FLOAT_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_FLOAT_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_FLOAT_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_FLOAT_TEXT {}
@@ -13971,7 +13772,7 @@ unsafe impl ::windows::core::Abi for WS_XML_GUID_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_GUID_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_GUID_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_GUID_TEXT {}
@@ -14002,7 +13803,7 @@ unsafe impl ::windows::core::Abi for WS_XML_INT32_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_INT32_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_INT32_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_INT32_TEXT {}
@@ -14033,7 +13834,7 @@ unsafe impl ::windows::core::Abi for WS_XML_INT64_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_INT64_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_INT64_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_INT64_TEXT {}
@@ -14065,7 +13866,7 @@ unsafe impl ::windows::core::Abi for WS_XML_LIST_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_LIST_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_LIST_TEXT>()) == 0 }
+        self.text == other.text && self.itemCount == other.itemCount && self.items == other.items
     }
 }
 impl ::core::cmp::Eq for WS_XML_LIST_TEXT {}
@@ -14095,7 +13896,7 @@ unsafe impl ::windows::core::Abi for WS_XML_NODE {
 }
 impl ::core::cmp::PartialEq for WS_XML_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_NODE>()) == 0 }
+        self.nodeType == other.nodeType
     }
 }
 impl ::core::cmp::Eq for WS_XML_NODE {}
@@ -14126,7 +13927,7 @@ unsafe impl ::windows::core::Abi for WS_XML_NODE_POSITION {
 }
 impl ::core::cmp::PartialEq for WS_XML_NODE_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_NODE_POSITION>()) == 0 }
+        self.buffer == other.buffer && self.node == other.node
     }
 }
 impl ::core::cmp::Eq for WS_XML_NODE_POSITION {}
@@ -14163,7 +13964,7 @@ unsafe impl ::windows::core::Abi for WS_XML_QNAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_QNAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_QNAME>()) == 0 }
+        self.localName == other.localName && self.ns == other.ns
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14198,7 +13999,7 @@ unsafe impl ::windows::core::Abi for WS_XML_QNAME_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_XML_QNAME_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_QNAME_DESCRIPTION>()) == 0 }
+        self.minLocalNameByteCount == other.minLocalNameByteCount && self.maxLocalNameByteCount == other.maxLocalNameByteCount && self.minNsByteCount == other.minNsByteCount && self.maxNsByteCount == other.maxNsByteCount
     }
 }
 impl ::core::cmp::Eq for WS_XML_QNAME_DESCRIPTION {}
@@ -14237,7 +14038,7 @@ unsafe impl ::windows::core::Abi for WS_XML_QNAME_TEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_QNAME_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_QNAME_TEXT>()) == 0 }
+        self.text == other.text && self.prefix == other.prefix && self.localName == other.localName && self.ns == other.ns
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14279,7 +14080,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_BINARY_ENCODING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_READER_BINARY_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_BINARY_ENCODING>()) == 0 }
+        self.encoding == other.encoding && self.staticDictionary == other.staticDictionary && self.dynamicDictionary == other.dynamicDictionary
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14313,7 +14114,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_BUFFER_INPUT {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_BUFFER_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_BUFFER_INPUT>()) == 0 }
+        self.input == other.input && self.encodedData == other.encodedData && self.encodedDataSize == other.encodedDataSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_BUFFER_INPUT {}
@@ -14343,7 +14144,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_ENCODING>()) == 0 }
+        self.encodingType == other.encodingType
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_ENCODING {}
@@ -14373,7 +14174,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_INPUT {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_INPUT>()) == 0 }
+        self.inputType == other.inputType
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_INPUT {}
@@ -14414,7 +14215,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_MTOM_ENCODING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_READER_MTOM_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_MTOM_ENCODING>()) == 0 }
+        self.encoding == other.encoding && self.textEncoding == other.textEncoding && self.readMimeHeader == other.readMimeHeader && self.startInfo == other.startInfo && self.boundary == other.boundary && self.startUri == other.startUri
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14447,7 +14248,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_PROPERTIES {}
@@ -14479,7 +14280,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_PROPERTY {}
@@ -14509,7 +14310,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_RAW_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_RAW_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_RAW_ENCODING>()) == 0 }
+        self.encoding == other.encoding
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_RAW_ENCODING {}
@@ -14533,18 +14334,12 @@ impl ::core::clone::Clone for WS_XML_READER_STREAM_INPUT {
 }
 impl ::core::fmt::Debug for WS_XML_READER_STREAM_INPUT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_XML_READER_STREAM_INPUT").field("input", &self.input).field("readCallback", &self.readCallback.map(|f| f as usize)).field("readCallbackState", &self.readCallbackState).finish()
+        f.debug_struct("WS_XML_READER_STREAM_INPUT").field("input", &self.input).field("readCallbackState", &self.readCallbackState).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_XML_READER_STREAM_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_XML_READER_STREAM_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_STREAM_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_XML_READER_STREAM_INPUT {}
 impl ::core::default::Default for WS_XML_READER_STREAM_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14572,7 +14367,7 @@ unsafe impl ::windows::core::Abi for WS_XML_READER_TEXT_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_READER_TEXT_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_READER_TEXT_ENCODING>()) == 0 }
+        self.encoding == other.encoding && self.charSet == other.charSet
     }
 }
 impl ::core::cmp::Eq for WS_XML_READER_TEXT_ENCODING {}
@@ -14604,7 +14399,7 @@ unsafe impl ::windows::core::Abi for WS_XML_SECURITY_TOKEN_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_XML_SECURITY_TOKEN_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_SECURITY_TOKEN_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_SECURITY_TOKEN_PROPERTY {}
@@ -14643,7 +14438,7 @@ unsafe impl ::windows::core::Abi for WS_XML_STRING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_STRING>()) == 0 }
+        self.length == other.length && self.bytes == other.bytes && self.dictionary == other.dictionary && self.id == other.id
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14676,7 +14471,7 @@ unsafe impl ::windows::core::Abi for WS_XML_STRING_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for WS_XML_STRING_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_STRING_DESCRIPTION>()) == 0 }
+        self.minByteCount == other.minByteCount && self.maxByteCount == other.maxByteCount
     }
 }
 impl ::core::cmp::Eq for WS_XML_STRING_DESCRIPTION {}
@@ -14706,7 +14501,7 @@ unsafe impl ::windows::core::Abi for WS_XML_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_TEXT>()) == 0 }
+        self.textType == other.textType
     }
 }
 impl ::core::cmp::Eq for WS_XML_TEXT {}
@@ -14737,7 +14532,7 @@ unsafe impl ::windows::core::Abi for WS_XML_TEXT_NODE {
 }
 impl ::core::cmp::PartialEq for WS_XML_TEXT_NODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_TEXT_NODE>()) == 0 }
+        self.node == other.node && self.text == other.text
     }
 }
 impl ::core::cmp::Eq for WS_XML_TEXT_NODE {}
@@ -14768,7 +14563,7 @@ unsafe impl ::windows::core::Abi for WS_XML_TIMESPAN_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_TIMESPAN_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_TIMESPAN_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_TIMESPAN_TEXT {}
@@ -14800,7 +14595,7 @@ unsafe impl ::windows::core::Abi for WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {
 }
 impl ::core::cmp::PartialEq for WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_TOKEN_MESSAGE_SECURITY_BINDING>()) == 0 }
+        self.binding == other.binding && self.bindingUsage == other.bindingUsage && self.xmlToken == other.xmlToken
     }
 }
 impl ::core::cmp::Eq for WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {}
@@ -14831,7 +14626,7 @@ unsafe impl ::windows::core::Abi for WS_XML_UINT64_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_UINT64_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_UINT64_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_UINT64_TEXT {}
@@ -14862,7 +14657,7 @@ unsafe impl ::windows::core::Abi for WS_XML_UNIQUE_ID_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_UNIQUE_ID_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_UNIQUE_ID_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WS_XML_UNIQUE_ID_TEXT {}
@@ -14894,7 +14689,7 @@ unsafe impl ::windows::core::Abi for WS_XML_UTF16_TEXT {
 }
 impl ::core::cmp::PartialEq for WS_XML_UTF16_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_UTF16_TEXT>()) == 0 }
+        self.text == other.text && self.bytes == other.bytes && self.byteCount == other.byteCount
     }
 }
 impl ::core::cmp::Eq for WS_XML_UTF16_TEXT {}
@@ -14931,7 +14726,7 @@ unsafe impl ::windows::core::Abi for WS_XML_UTF8_TEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_UTF8_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_UTF8_TEXT>()) == 0 }
+        self.text == other.text && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14964,21 +14759,13 @@ impl ::core::clone::Clone for WS_XML_WRITER_BINARY_ENCODING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WS_XML_WRITER_BINARY_ENCODING {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_XML_WRITER_BINARY_ENCODING").field("encoding", &self.encoding).field("staticDictionary", &self.staticDictionary).field("dynamicStringCallback", &self.dynamicStringCallback.map(|f| f as usize)).field("dynamicStringCallbackState", &self.dynamicStringCallbackState).finish()
+        f.debug_struct("WS_XML_WRITER_BINARY_ENCODING").field("encoding", &self.encoding).field("staticDictionary", &self.staticDictionary).field("dynamicStringCallbackState", &self.dynamicStringCallbackState).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WS_XML_WRITER_BINARY_ENCODING {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WS_XML_WRITER_BINARY_ENCODING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_BINARY_ENCODING>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WS_XML_WRITER_BINARY_ENCODING {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WS_XML_WRITER_BINARY_ENCODING {
     fn default() -> Self {
@@ -15006,7 +14793,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_BUFFER_OUTPUT {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_BUFFER_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_BUFFER_OUTPUT>()) == 0 }
+        self.output == other.output
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_BUFFER_OUTPUT {}
@@ -15036,7 +14823,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_ENCODING>()) == 0 }
+        self.encodingType == other.encodingType
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_ENCODING {}
@@ -15078,7 +14865,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_MTOM_ENCODING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WS_XML_WRITER_MTOM_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_MTOM_ENCODING>()) == 0 }
+        self.encoding == other.encoding && self.textEncoding == other.textEncoding && self.writeMimeHeader == other.writeMimeHeader && self.boundary == other.boundary && self.startInfo == other.startInfo && self.startUri == other.startUri && self.maxInlineByteCount == other.maxInlineByteCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15110,7 +14897,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_OUTPUT {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_OUTPUT>()) == 0 }
+        self.outputType == other.outputType
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_OUTPUT {}
@@ -15141,7 +14928,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_PROPERTIES>()) == 0 }
+        self.properties == other.properties && self.propertyCount == other.propertyCount
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_PROPERTIES {}
@@ -15173,7 +14960,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_PROPERTY {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_PROPERTY>()) == 0 }
+        self.id == other.id && self.value == other.value && self.valueSize == other.valueSize
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_PROPERTY {}
@@ -15203,7 +14990,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_RAW_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_RAW_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_RAW_ENCODING>()) == 0 }
+        self.encoding == other.encoding
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_RAW_ENCODING {}
@@ -15227,18 +15014,12 @@ impl ::core::clone::Clone for WS_XML_WRITER_STREAM_OUTPUT {
 }
 impl ::core::fmt::Debug for WS_XML_WRITER_STREAM_OUTPUT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WS_XML_WRITER_STREAM_OUTPUT").field("output", &self.output).field("writeCallback", &self.writeCallback.map(|f| f as usize)).field("writeCallbackState", &self.writeCallbackState).finish()
+        f.debug_struct("WS_XML_WRITER_STREAM_OUTPUT").field("output", &self.output).field("writeCallbackState", &self.writeCallbackState).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WS_XML_WRITER_STREAM_OUTPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WS_XML_WRITER_STREAM_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_STREAM_OUTPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WS_XML_WRITER_STREAM_OUTPUT {}
 impl ::core::default::Default for WS_XML_WRITER_STREAM_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15266,7 +15047,7 @@ unsafe impl ::windows::core::Abi for WS_XML_WRITER_TEXT_ENCODING {
 }
 impl ::core::cmp::PartialEq for WS_XML_WRITER_TEXT_ENCODING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WS_XML_WRITER_TEXT_ENCODING>()) == 0 }
+        self.encoding == other.encoding && self.charSet == other.charSet
     }
 }
 impl ::core::cmp::Eq for WS_XML_WRITER_TEXT_ENCODING {}

--- a/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
@@ -406,7 +406,7 @@ unsafe impl ::windows::core::Abi for SAFER_CODE_PROPERTIES_V1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_CODE_PROPERTIES_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_CODE_PROPERTIES_V1>()) == 0 }
+        self.cbSize == other.cbSize && self.dwCheckFlags == other.dwCheckFlags && self.ImagePath == other.ImagePath && self.hImageFileHandle == other.hImageFileHandle && self.UrlZoneId == other.UrlZoneId && self.ImageHash == other.ImageHash && self.dwImageHashSize == other.dwImageHashSize && self.ImageSize == other.ImageSize && self.HashAlgorithm == other.HashAlgorithm && self.pByteBlock == other.pByteBlock && self.hWndParent == other.hWndParent && self.dwWVTUIChoice == other.dwWVTUIChoice
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -478,7 +478,7 @@ unsafe impl ::windows::core::Abi for SAFER_CODE_PROPERTIES_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_CODE_PROPERTIES_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_CODE_PROPERTIES_V2>()) == 0 }
+        self.cbSize == other.cbSize && self.dwCheckFlags == other.dwCheckFlags && self.ImagePath == other.ImagePath && self.hImageFileHandle == other.hImageFileHandle && self.UrlZoneId == other.UrlZoneId && self.ImageHash == other.ImageHash && self.dwImageHashSize == other.dwImageHashSize && self.ImageSize == other.ImageSize && self.HashAlgorithm == other.HashAlgorithm && self.pByteBlock == other.pByteBlock && self.hWndParent == other.hWndParent && self.dwWVTUIChoice == other.dwWVTUIChoice && self.PackageMoniker == other.PackageMoniker && self.PackagePublisher == other.PackagePublisher && self.PackageName == other.PackageName && self.PackageVersion == other.PackageVersion && self.PackageIsFramework == other.PackageIsFramework
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -523,7 +523,7 @@ unsafe impl ::windows::core::Abi for SAFER_HASH_IDENTIFICATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_HASH_IDENTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_HASH_IDENTIFICATION>()) == 0 }
+        self.header == other.header && self.Description == other.Description && self.FriendlyName == other.FriendlyName && self.HashSize == other.HashSize && self.ImageHash == other.ImageHash && self.HashAlgorithm == other.HashAlgorithm && self.ImageSize == other.ImageSize && self.dwSaferFlags == other.dwSaferFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -564,7 +564,7 @@ unsafe impl ::windows::core::Abi for SAFER_HASH_IDENTIFICATION2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_HASH_IDENTIFICATION2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_HASH_IDENTIFICATION2>()) == 0 }
+        self.hashIdentification == other.hashIdentification && self.HashSize == other.HashSize && self.ImageHash == other.ImageHash && self.HashAlgorithm == other.HashAlgorithm
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -605,7 +605,7 @@ unsafe impl ::windows::core::Abi for SAFER_IDENTIFICATION_HEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_IDENTIFICATION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_IDENTIFICATION_HEADER>()) == 0 }
+        self.dwIdentificationType == other.dwIdentificationType && self.cbStructSize == other.cbStructSize && self.IdentificationGuid == other.IdentificationGuid && self.lastModified == other.lastModified
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -646,7 +646,7 @@ unsafe impl ::windows::core::Abi for SAFER_PATHNAME_IDENTIFICATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_PATHNAME_IDENTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_PATHNAME_IDENTIFICATION>()) == 0 }
+        self.header == other.header && self.Description == other.Description && self.ImageName == other.ImageName && self.dwSaferFlags == other.dwSaferFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -686,7 +686,7 @@ unsafe impl ::windows::core::Abi for SAFER_URLZONE_IDENTIFICATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAFER_URLZONE_IDENTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFER_URLZONE_IDENTIFICATION>()) == 0 }
+        self.header == other.header && self.UrlZoneId == other.UrlZoneId && self.dwSaferFlags == other.dwSaferFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -7633,7 +7633,7 @@ unsafe impl ::windows::core::Abi for AUDIT_POLICY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for AUDIT_POLICY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_POLICY_INFORMATION>()) == 0 }
+        self.AuditSubCategoryGuid == other.AuditSubCategoryGuid && self.AuditingInformation == other.AuditingInformation && self.AuditCategoryGuid == other.AuditCategoryGuid
     }
 }
 impl ::core::cmp::Eq for AUDIT_POLICY_INFORMATION {}
@@ -7675,7 +7675,7 @@ unsafe impl ::windows::core::Abi for CENTRAL_ACCESS_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CENTRAL_ACCESS_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CENTRAL_ACCESS_POLICY>()) == 0 }
+        self.CAPID == other.CAPID && self.Name == other.Name && self.Description == other.Description && self.ChangeId == other.ChangeId && self.Flags == other.Flags && self.CAPECount == other.CAPECount && self.CAPEs == other.CAPEs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7722,7 +7722,7 @@ unsafe impl ::windows::core::Abi for CENTRAL_ACCESS_POLICY_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CENTRAL_ACCESS_POLICY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CENTRAL_ACCESS_POLICY_ENTRY>()) == 0 }
+        self.Name == other.Name && self.Description == other.Description && self.ChangeId == other.ChangeId && self.LengthAppliesTo == other.LengthAppliesTo && self.AppliesTo == other.AppliesTo && self.LengthSD == other.LengthSD && self.SD == other.SD && self.LengthStagedSD == other.LengthStagedSD && self.StagedSD == other.StagedSD && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7760,7 +7760,7 @@ unsafe impl ::windows::core::Abi for CLEAR_BLOCK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLEAR_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLEAR_BLOCK>()) == 0 }
+        self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7796,7 +7796,7 @@ unsafe impl ::windows::core::Abi for DOMAIN_PASSWORD_INFORMATION {
 }
 impl ::core::cmp::PartialEq for DOMAIN_PASSWORD_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOMAIN_PASSWORD_INFORMATION>()) == 0 }
+        self.MinPasswordLength == other.MinPasswordLength && self.PasswordHistoryLength == other.PasswordHistoryLength && self.PasswordProperties == other.PasswordProperties && self.MaxPasswordAge == other.MaxPasswordAge && self.MinPasswordAge == other.MinPasswordAge
     }
 }
 impl ::core::cmp::Eq for DOMAIN_PASSWORD_INFORMATION {}
@@ -7833,7 +7833,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTED_CREDENTIALW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::cmp::PartialEq for ENCRYPTED_CREDENTIALW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTED_CREDENTIALW>()) == 0 }
+        self.Cred == other.Cred && self.ClearCredentialBlobSize == other.ClearCredentialBlobSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
@@ -7879,7 +7879,7 @@ unsafe impl ::windows::core::Abi for KDC_PROXY_CACHE_ENTRY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KDC_PROXY_CACHE_ENTRY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KDC_PROXY_CACHE_ENTRY_DATA>()) == 0 }
+        self.SinceLastUsed == other.SinceLastUsed && self.DomainName == other.DomainName && self.ProxyServerName == other.ProxyServerName && self.ProxyServerVdir == other.ProxyServerVdir && self.ProxyServerPort == other.ProxyServerPort && self.LogonId == other.LogonId && self.CredUserName == other.CredUserName && self.CredDomainName == other.CredDomainName && self.GlobalCache == other.GlobalCache
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7921,7 +7921,7 @@ unsafe impl ::windows::core::Abi for KERB_ADD_BINDING_CACHE_ENTRY_EX_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_ADD_BINDING_CACHE_ENTRY_EX_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_ADD_BINDING_CACHE_ENTRY_EX_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.RealmName == other.RealmName && self.KdcAddress == other.KdcAddress && self.AddressType == other.AddressType && self.DcFlags == other.DcFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7962,7 +7962,7 @@ unsafe impl ::windows::core::Abi for KERB_ADD_BINDING_CACHE_ENTRY_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_ADD_BINDING_CACHE_ENTRY_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_ADD_BINDING_CACHE_ENTRY_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.RealmName == other.RealmName && self.KdcAddress == other.KdcAddress && self.AddressType == other.AddressType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8005,7 +8005,7 @@ unsafe impl ::windows::core::Abi for KERB_ADD_CREDENTIALS_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_ADD_CREDENTIALS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_ADD_CREDENTIALS_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.UserName == other.UserName && self.DomainName == other.DomainName && self.Password == other.Password && self.LogonId == other.LogonId && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8045,7 +8045,7 @@ unsafe impl ::windows::core::Abi for KERB_ADD_CREDENTIALS_REQUEST_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_ADD_CREDENTIALS_REQUEST_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_ADD_CREDENTIALS_REQUEST_EX>()) == 0 }
+        self.Credentials == other.Credentials && self.PrincipalNameCount == other.PrincipalNameCount && self.PrincipalNames == other.PrincipalNames
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8079,7 +8079,7 @@ unsafe impl ::windows::core::Abi for KERB_AUTH_DATA {
 }
 impl ::core::cmp::PartialEq for KERB_AUTH_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_AUTH_DATA>()) == 0 }
+        self.Type == other.Type && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for KERB_AUTH_DATA {}
@@ -8122,7 +8122,7 @@ unsafe impl ::windows::core::Abi for KERB_BINDING_CACHE_ENTRY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_BINDING_CACHE_ENTRY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_BINDING_CACHE_ENTRY_DATA>()) == 0 }
+        self.DiscoveryTime == other.DiscoveryTime && self.RealmName == other.RealmName && self.KdcAddress == other.KdcAddress && self.AddressType == other.AddressType && self.Flags == other.Flags && self.DcFlags == other.DcFlags && self.CacheFlags == other.CacheFlags && self.KdcName == other.KdcName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8155,7 +8155,7 @@ unsafe impl ::windows::core::Abi for KERB_CERTIFICATE_HASHINFO {
 }
 impl ::core::cmp::PartialEq for KERB_CERTIFICATE_HASHINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CERTIFICATE_HASHINFO>()) == 0 }
+        self.StoreNameLength == other.StoreNameLength && self.HashLength == other.HashLength
     }
 }
 impl ::core::cmp::Eq for KERB_CERTIFICATE_HASHINFO {}
@@ -8186,7 +8186,7 @@ unsafe impl ::windows::core::Abi for KERB_CERTIFICATE_INFO {
 }
 impl ::core::cmp::PartialEq for KERB_CERTIFICATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CERTIFICATE_INFO>()) == 0 }
+        self.CertInfoSize == other.CertInfoSize && self.InfoType == other.InfoType
     }
 }
 impl ::core::cmp::Eq for KERB_CERTIFICATE_INFO {}
@@ -8228,7 +8228,7 @@ unsafe impl ::windows::core::Abi for KERB_CERTIFICATE_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CERTIFICATE_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CERTIFICATE_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.DomainName == other.DomainName && self.UserName == other.UserName && self.Pin == other.Pin && self.Flags == other.Flags && self.CspDataLength == other.CspDataLength && self.CspData == other.CspData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8271,7 +8271,7 @@ unsafe impl ::windows::core::Abi for KERB_CERTIFICATE_S4U_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CERTIFICATE_S4U_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CERTIFICATE_S4U_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.UserPrincipalName == other.UserPrincipalName && self.DomainName == other.DomainName && self.CertificateLength == other.CertificateLength && self.Certificate == other.Certificate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8310,7 +8310,7 @@ unsafe impl ::windows::core::Abi for KERB_CERTIFICATE_UNLOCK_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CERTIFICATE_UNLOCK_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CERTIFICATE_UNLOCK_LOGON>()) == 0 }
+        self.Logon == other.Logon && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8353,7 +8353,7 @@ unsafe impl ::windows::core::Abi for KERB_CHANGEPASSWORD_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CHANGEPASSWORD_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CHANGEPASSWORD_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.DomainName == other.DomainName && self.AccountName == other.AccountName && self.OldPassword == other.OldPassword && self.NewPassword == other.NewPassword && self.Impersonating == other.Impersonating
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8392,7 +8392,7 @@ unsafe impl ::windows::core::Abi for KERB_CLEANUP_MACHINE_PKINIT_CREDS_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CLEANUP_MACHINE_PKINIT_CREDS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CLEANUP_MACHINE_PKINIT_CREDS_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8424,7 +8424,7 @@ unsafe impl ::windows::core::Abi for KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {
 }
 impl ::core::cmp::PartialEq for KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CLOUD_KERBEROS_DEBUG_DATA_V0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {}
@@ -8461,7 +8461,7 @@ unsafe impl ::windows::core::Abi for KERB_CLOUD_KERBEROS_DEBUG_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_CLOUD_KERBEROS_DEBUG_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CLOUD_KERBEROS_DEBUG_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8496,7 +8496,7 @@ unsafe impl ::windows::core::Abi for KERB_CLOUD_KERBEROS_DEBUG_RESPONSE {
 }
 impl ::core::cmp::PartialEq for KERB_CLOUD_KERBEROS_DEBUG_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CLOUD_KERBEROS_DEBUG_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.Version == other.Version && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for KERB_CLOUD_KERBEROS_DEBUG_RESPONSE {}
@@ -8528,7 +8528,7 @@ unsafe impl ::windows::core::Abi for KERB_CRYPTO_KEY {
 }
 impl ::core::cmp::PartialEq for KERB_CRYPTO_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CRYPTO_KEY>()) == 0 }
+        self.KeyType == other.KeyType && self.Length == other.Length && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for KERB_CRYPTO_KEY {}
@@ -8560,7 +8560,7 @@ unsafe impl ::windows::core::Abi for KERB_CRYPTO_KEY32 {
 }
 impl ::core::cmp::PartialEq for KERB_CRYPTO_KEY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_CRYPTO_KEY32>()) == 0 }
+        self.KeyType == other.KeyType && self.Length == other.Length && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for KERB_CRYPTO_KEY32 {}
@@ -8605,7 +8605,7 @@ unsafe impl ::windows::core::Abi for KERB_DECRYPT_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_DECRYPT_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_DECRYPT_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.Flags == other.Flags && self.CryptoType == other.CryptoType && self.KeyUsage == other.KeyUsage && self.Key == other.Key && self.EncryptedDataSize == other.EncryptedDataSize && self.InitialVectorSize == other.InitialVectorSize && self.InitialVector == other.InitialVector && self.EncryptedData == other.EncryptedData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8637,7 +8637,7 @@ unsafe impl ::windows::core::Abi for KERB_DECRYPT_RESPONSE {
 }
 impl ::core::cmp::PartialEq for KERB_DECRYPT_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_DECRYPT_RESPONSE>()) == 0 }
+        self.DecryptedData == other.DecryptedData
     }
 }
 impl ::core::cmp::Eq for KERB_DECRYPT_RESPONSE {}
@@ -8675,7 +8675,7 @@ unsafe impl ::windows::core::Abi for KERB_EXTERNAL_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_EXTERNAL_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_EXTERNAL_NAME>()) == 0 }
+        self.NameType == other.NameType && self.NameCount == other.NameCount && self.Names == other.Names
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8745,7 +8745,7 @@ unsafe impl ::windows::core::Abi for KERB_EXTERNAL_TICKET {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_EXTERNAL_TICKET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_EXTERNAL_TICKET>()) == 0 }
+        self.ServiceName == other.ServiceName && self.TargetName == other.TargetName && self.ClientName == other.ClientName && self.DomainName == other.DomainName && self.TargetDomainName == other.TargetDomainName && self.AltTargetDomainName == other.AltTargetDomainName && self.SessionKey == other.SessionKey && self.TicketFlags == other.TicketFlags && self.Flags == other.Flags && self.KeyExpirationTime == other.KeyExpirationTime && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.RenewUntil == other.RenewUntil && self.TimeSkew == other.TimeSkew && self.EncodedTicketSize == other.EncodedTicketSize && self.EncodedTicket == other.EncodedTicket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8786,7 +8786,7 @@ unsafe impl ::windows::core::Abi for KERB_INTERACTIVE_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_INTERACTIVE_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_INTERACTIVE_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonDomainName == other.LogonDomainName && self.UserName == other.UserName && self.Password == other.Password
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8856,7 +8856,7 @@ unsafe impl ::windows::core::Abi for KERB_INTERACTIVE_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_INTERACTIVE_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_INTERACTIVE_PROFILE>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonCount == other.LogonCount && self.BadPasswordCount == other.BadPasswordCount && self.LogonTime == other.LogonTime && self.LogoffTime == other.LogoffTime && self.KickOffTime == other.KickOffTime && self.PasswordLastSet == other.PasswordLastSet && self.PasswordCanChange == other.PasswordCanChange && self.PasswordMustChange == other.PasswordMustChange && self.LogonScript == other.LogonScript && self.HomeDirectory == other.HomeDirectory && self.FullName == other.FullName && self.ProfilePath == other.ProfilePath && self.HomeDirectoryDrive == other.HomeDirectoryDrive && self.LogonServer == other.LogonServer && self.UserFlags == other.UserFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8895,7 +8895,7 @@ unsafe impl ::windows::core::Abi for KERB_INTERACTIVE_UNLOCK_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_INTERACTIVE_UNLOCK_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_INTERACTIVE_UNLOCK_LOGON>()) == 0 }
+        self.Logon == other.Logon && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8929,7 +8929,7 @@ unsafe impl ::windows::core::Abi for KERB_NET_ADDRESS {
 }
 impl ::core::cmp::PartialEq for KERB_NET_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_NET_ADDRESS>()) == 0 }
+        self.Family == other.Family && self.Length == other.Length && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for KERB_NET_ADDRESS {}
@@ -8960,7 +8960,7 @@ unsafe impl ::windows::core::Abi for KERB_NET_ADDRESSES {
 }
 impl ::core::cmp::PartialEq for KERB_NET_ADDRESSES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_NET_ADDRESSES>()) == 0 }
+        self.Number == other.Number && self.Addresses == other.Addresses
     }
 }
 impl ::core::cmp::Eq for KERB_NET_ADDRESSES {}
@@ -8990,7 +8990,7 @@ unsafe impl ::windows::core::Abi for KERB_PURGE_BINDING_CACHE_REQUEST {
 }
 impl ::core::cmp::PartialEq for KERB_PURGE_BINDING_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_PURGE_BINDING_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType
     }
 }
 impl ::core::cmp::Eq for KERB_PURGE_BINDING_CACHE_REQUEST {}
@@ -9028,7 +9028,7 @@ unsafe impl ::windows::core::Abi for KERB_PURGE_KDC_PROXY_CACHE_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_PURGE_KDC_PROXY_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_PURGE_KDC_PROXY_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9061,7 +9061,7 @@ unsafe impl ::windows::core::Abi for KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {
 }
 impl ::core::cmp::PartialEq for KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_PURGE_KDC_PROXY_CACHE_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfPurged == other.CountOfPurged
     }
 }
 impl ::core::cmp::Eq for KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {}
@@ -9100,7 +9100,7 @@ unsafe impl ::windows::core::Abi for KERB_PURGE_TKT_CACHE_EX_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_PURGE_TKT_CACHE_EX_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_PURGE_TKT_CACHE_EX_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.Flags == other.Flags && self.TicketTemplate == other.TicketTemplate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9141,7 +9141,7 @@ unsafe impl ::windows::core::Abi for KERB_PURGE_TKT_CACHE_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_PURGE_TKT_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_PURGE_TKT_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.ServerName == other.ServerName && self.RealmName == other.RealmName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9173,7 +9173,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_BINDING_CACHE_REQUEST {
 }
 impl ::core::cmp::PartialEq for KERB_QUERY_BINDING_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_BINDING_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType
     }
 }
 impl ::core::cmp::Eq for KERB_QUERY_BINDING_CACHE_REQUEST {}
@@ -9211,7 +9211,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_BINDING_CACHE_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_BINDING_CACHE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_BINDING_CACHE_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfEntries == other.CountOfEntries && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9251,7 +9251,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.DomainName == other.DomainName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9286,7 +9286,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONS
 }
 impl ::core::cmp::PartialEq for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.ExtendedPolicies == other.ExtendedPolicies && self.DsFlags == other.DsFlags
     }
 }
 impl ::core::cmp::Eq for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE {}
@@ -9324,7 +9324,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_KDC_PROXY_CACHE_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_KDC_PROXY_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_KDC_PROXY_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9364,7 +9364,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_KDC_PROXY_CACHE_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_KDC_PROXY_CACHE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_KDC_PROXY_CACHE_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfEntries == other.CountOfEntries && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9404,7 +9404,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_S4U2PROXY_CACHE_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_S4U2PROXY_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_S4U2PROXY_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9444,7 +9444,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_S4U2PROXY_CACHE_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_S4U2PROXY_CACHE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_S4U2PROXY_CACHE_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfCreds == other.CountOfCreds && self.Creds == other.Creds
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9484,7 +9484,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_TKT_CACHE_EX2_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_TKT_CACHE_EX2_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_TKT_CACHE_EX2_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfTickets == other.CountOfTickets && self.Tickets == other.Tickets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9524,7 +9524,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_TKT_CACHE_EX3_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_TKT_CACHE_EX3_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_TKT_CACHE_EX3_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfTickets == other.CountOfTickets && self.Tickets == other.Tickets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9564,7 +9564,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_TKT_CACHE_EX_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_TKT_CACHE_EX_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_TKT_CACHE_EX_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfTickets == other.CountOfTickets && self.Tickets == other.Tickets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9603,7 +9603,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_TKT_CACHE_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_TKT_CACHE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_TKT_CACHE_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9643,7 +9643,7 @@ unsafe impl ::windows::core::Abi for KERB_QUERY_TKT_CACHE_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_QUERY_TKT_CACHE_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_QUERY_TKT_CACHE_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CountOfTickets == other.CountOfTickets && self.Tickets == other.Tickets
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9676,7 +9676,7 @@ unsafe impl ::windows::core::Abi for KERB_REFRESH_POLICY_REQUEST {
 }
 impl ::core::cmp::PartialEq for KERB_REFRESH_POLICY_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_REFRESH_POLICY_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KERB_REFRESH_POLICY_REQUEST {}
@@ -9707,7 +9707,7 @@ unsafe impl ::windows::core::Abi for KERB_REFRESH_POLICY_RESPONSE {
 }
 impl ::core::cmp::PartialEq for KERB_REFRESH_POLICY_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_REFRESH_POLICY_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for KERB_REFRESH_POLICY_RESPONSE {}
@@ -9746,7 +9746,7 @@ unsafe impl ::windows::core::Abi for KERB_REFRESH_SCCRED_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_REFRESH_SCCRED_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_REFRESH_SCCRED_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.CredentialBlob == other.CredentialBlob && self.LogonId == other.LogonId && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9788,7 +9788,7 @@ unsafe impl ::windows::core::Abi for KERB_RETRIEVE_KEY_TAB_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_RETRIEVE_KEY_TAB_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_RETRIEVE_KEY_TAB_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.UserName == other.UserName && self.DomainName == other.DomainName && self.Password == other.Password
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9822,7 +9822,7 @@ unsafe impl ::windows::core::Abi for KERB_RETRIEVE_KEY_TAB_RESPONSE {
 }
 impl ::core::cmp::PartialEq for KERB_RETRIEVE_KEY_TAB_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_RETRIEVE_KEY_TAB_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.KeyTabLength == other.KeyTabLength && self.KeyTab == other.KeyTab
     }
 }
 impl ::core::cmp::Eq for KERB_RETRIEVE_KEY_TAB_RESPONSE {}
@@ -9864,7 +9864,7 @@ unsafe impl ::windows::core::Abi for KERB_RETRIEVE_TKT_REQUEST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::cmp::PartialEq for KERB_RETRIEVE_TKT_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_RETRIEVE_TKT_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.TargetName == other.TargetName && self.TicketFlags == other.TicketFlags && self.CacheOptions == other.CacheOptions && self.EncryptionType == other.EncryptionType && self.CredentialsHandle == other.CredentialsHandle
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
@@ -9902,7 +9902,7 @@ unsafe impl ::windows::core::Abi for KERB_RETRIEVE_TKT_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_RETRIEVE_TKT_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_RETRIEVE_TKT_RESPONSE>()) == 0 }
+        self.Ticket == other.Ticket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9943,7 +9943,7 @@ unsafe impl ::windows::core::Abi for KERB_S4U2PROXY_CACHE_ENTRY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_S4U2PROXY_CACHE_ENTRY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_S4U2PROXY_CACHE_ENTRY_INFO>()) == 0 }
+        self.ServerName == other.ServerName && self.Flags == other.Flags && self.LastStatus == other.LastStatus && self.Expiry == other.Expiry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9987,7 +9987,7 @@ unsafe impl ::windows::core::Abi for KERB_S4U2PROXY_CRED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_S4U2PROXY_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_S4U2PROXY_CRED>()) == 0 }
+        self.UserName == other.UserName && self.DomainName == other.DomainName && self.Flags == other.Flags && self.LastStatus == other.LastStatus && self.Expiry == other.Expiry && self.CountOfEntries == other.CountOfEntries && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10028,7 +10028,7 @@ unsafe impl ::windows::core::Abi for KERB_S4U_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_S4U_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_S4U_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.ClientUpn == other.ClientUpn && self.ClientRealm == other.ClientRealm
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10090,7 +10090,7 @@ unsafe impl ::windows::core::Abi for KERB_SETPASSWORD_EX_REQUEST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::cmp::PartialEq for KERB_SETPASSWORD_EX_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SETPASSWORD_EX_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.CredentialsHandle == other.CredentialsHandle && self.Flags == other.Flags && self.AccountRealm == other.AccountRealm && self.AccountName == other.AccountName && self.Password == other.Password && self.ClientRealm == other.ClientRealm && self.ClientName == other.ClientName && self.Impersonating == other.Impersonating && self.KdcAddress == other.KdcAddress && self.KdcAddressType == other.KdcAddressType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
@@ -10134,7 +10134,7 @@ unsafe impl ::windows::core::Abi for KERB_SETPASSWORD_REQUEST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::cmp::PartialEq for KERB_SETPASSWORD_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SETPASSWORD_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.CredentialsHandle == other.CredentialsHandle && self.Flags == other.Flags && self.DomainName == other.DomainName && self.AccountName == other.AccountName && self.Password == other.Password
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
@@ -10175,7 +10175,7 @@ unsafe impl ::windows::core::Abi for KERB_SMART_CARD_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_SMART_CARD_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SMART_CARD_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Pin == other.Pin && self.CspDataLength == other.CspDataLength && self.CspData == other.CspData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10215,7 +10215,7 @@ unsafe impl ::windows::core::Abi for KERB_SMART_CARD_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_SMART_CARD_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SMART_CARD_PROFILE>()) == 0 }
+        self.Profile == other.Profile && self.CertificateSize == other.CertificateSize && self.CertificateData == other.CertificateData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10254,7 +10254,7 @@ unsafe impl ::windows::core::Abi for KERB_SMART_CARD_UNLOCK_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_SMART_CARD_UNLOCK_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SMART_CARD_UNLOCK_LOGON>()) == 0 }
+        self.Logon == other.Logon && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10297,7 +10297,7 @@ unsafe impl ::windows::core::Abi for KERB_SUBMIT_TKT_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_SUBMIT_TKT_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_SUBMIT_TKT_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId && self.Flags == other.Flags && self.Key == other.Key && self.KerbCredSize == other.KerbCredSize && self.KerbCredOffset == other.KerbCredOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10341,7 +10341,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_CACHE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_CACHE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_CACHE_INFO>()) == 0 }
+        self.ServerName == other.ServerName && self.RealmName == other.RealmName && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.RenewTime == other.RenewTime && self.EncryptionType == other.EncryptionType && self.TicketFlags == other.TicketFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10387,7 +10387,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_CACHE_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_CACHE_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_CACHE_INFO_EX>()) == 0 }
+        self.ClientName == other.ClientName && self.ClientRealm == other.ClientRealm && self.ServerName == other.ServerName && self.ServerRealm == other.ServerRealm && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.RenewTime == other.RenewTime && self.EncryptionType == other.EncryptionType && self.TicketFlags == other.TicketFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10435,7 +10435,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_CACHE_INFO_EX2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_CACHE_INFO_EX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_CACHE_INFO_EX2>()) == 0 }
+        self.ClientName == other.ClientName && self.ClientRealm == other.ClientRealm && self.ServerName == other.ServerName && self.ServerRealm == other.ServerRealm && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.RenewTime == other.RenewTime && self.EncryptionType == other.EncryptionType && self.TicketFlags == other.TicketFlags && self.SessionKeyType == other.SessionKeyType && self.BranchId == other.BranchId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10499,7 +10499,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_CACHE_INFO_EX3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_CACHE_INFO_EX3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_CACHE_INFO_EX3>()) == 0 }
+        self.ClientName == other.ClientName && self.ClientRealm == other.ClientRealm && self.ServerName == other.ServerName && self.ServerRealm == other.ServerRealm && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.RenewTime == other.RenewTime && self.EncryptionType == other.EncryptionType && self.TicketFlags == other.TicketFlags && self.SessionKeyType == other.SessionKeyType && self.BranchId == other.BranchId && self.CacheFlags == other.CacheFlags && self.KdcCalled == other.KdcCalled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10536,7 +10536,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_LOGON {
 }
 impl ::core::cmp::PartialEq for KERB_TICKET_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.ServiceTicketLength == other.ServiceTicketLength && self.TicketGrantingTicketLength == other.TicketGrantingTicketLength && self.ServiceTicket == other.ServiceTicket && self.TicketGrantingTicket == other.TicketGrantingTicket
     }
 }
 impl ::core::cmp::Eq for KERB_TICKET_LOGON {}
@@ -10573,7 +10573,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_PROFILE>()) == 0 }
+        self.Profile == other.Profile && self.SessionKey == other.SessionKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10612,7 +10612,7 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_UNLOCK_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TICKET_UNLOCK_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TICKET_UNLOCK_LOGON>()) == 0 }
+        self.Logon == other.Logon && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10653,7 +10653,7 @@ unsafe impl ::windows::core::Abi for KERB_TRANSFER_CRED_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KERB_TRANSFER_CRED_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERB_TRANSFER_CRED_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.OriginLogonId == other.OriginLogonId && self.DestinationLogonId == other.DestinationLogonId && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10695,7 +10695,7 @@ unsafe impl ::windows::core::Abi for KSEC_LIST_ENTRY {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for KSEC_LIST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KSEC_LIST_ENTRY>()) == 0 }
+        self.List == other.List && self.RefCount == other.RefCount && self.Signature == other.Signature && self.OwningList == other.OwningList && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -10728,7 +10728,7 @@ unsafe impl ::windows::core::Abi for LOGON_HOURS {
 }
 impl ::core::cmp::PartialEq for LOGON_HOURS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGON_HOURS>()) == 0 }
+        self.UnitsPerWeek == other.UnitsPerWeek && self.LogonHours == other.LogonHours
     }
 }
 impl ::core::cmp::Eq for LOGON_HOURS {}
@@ -10761,7 +10761,7 @@ unsafe impl ::windows::core::Abi for LSA_AUTH_INFORMATION {
 }
 impl ::core::cmp::PartialEq for LSA_AUTH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_AUTH_INFORMATION>()) == 0 }
+        self.LastUpdateTime == other.LastUpdateTime && self.AuthType == other.AuthType && self.AuthInfoLength == other.AuthInfoLength && self.AuthInfo == other.AuthInfo
     }
 }
 impl ::core::cmp::Eq for LSA_AUTH_INFORMATION {}
@@ -10797,33 +10797,13 @@ impl ::core::clone::Clone for LSA_DISPATCH_TABLE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::fmt::Debug for LSA_DISPATCH_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LSA_DISPATCH_TABLE")
-            .field("CreateLogonSession", &self.CreateLogonSession.map(|f| f as usize))
-            .field("DeleteLogonSession", &self.DeleteLogonSession.map(|f| f as usize))
-            .field("AddCredential", &self.AddCredential.map(|f| f as usize))
-            .field("GetCredentials", &self.GetCredentials.map(|f| f as usize))
-            .field("DeleteCredential", &self.DeleteCredential.map(|f| f as usize))
-            .field("AllocateLsaHeap", &self.AllocateLsaHeap.map(|f| f as usize))
-            .field("FreeLsaHeap", &self.FreeLsaHeap.map(|f| f as usize))
-            .field("AllocateClientBuffer", &self.AllocateClientBuffer.map(|f| f as usize))
-            .field("FreeClientBuffer", &self.FreeClientBuffer.map(|f| f as usize))
-            .field("CopyToClientBuffer", &self.CopyToClientBuffer.map(|f| f as usize))
-            .field("CopyFromClientBuffer", &self.CopyFromClientBuffer.map(|f| f as usize))
-            .finish()
+        f.debug_struct("LSA_DISPATCH_TABLE").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 unsafe impl ::windows::core::Abi for LSA_DISPATCH_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for LSA_DISPATCH_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_DISPATCH_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for LSA_DISPATCH_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for LSA_DISPATCH_TABLE {
     fn default() -> Self {
@@ -10857,7 +10837,7 @@ unsafe impl ::windows::core::Abi for LSA_ENUMERATION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_ENUMERATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_ENUMERATION_INFORMATION>()) == 0 }
+        self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10890,7 +10870,7 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_BINARY_DATA {
 }
 impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_BINARY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_BINARY_DATA>()) == 0 }
+        self.Length == other.Length && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for LSA_FOREST_TRUST_BINARY_DATA {}
@@ -10927,7 +10907,7 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_COLLISION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_COLLISION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_COLLISION_INFORMATION>()) == 0 }
+        self.RecordCount == other.RecordCount && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10968,7 +10948,7 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_COLLISION_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_COLLISION_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_COLLISION_RECORD>()) == 0 }
+        self.Index == other.Index && self.Type == other.Type && self.Flags == other.Flags && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11008,7 +10988,7 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_DOMAIN_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_DOMAIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_DOMAIN_INFO>()) == 0 }
+        self.Sid == other.Sid && self.DnsName == other.DnsName && self.NetbiosName == other.NetbiosName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11047,7 +11027,7 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_INFORMATION>()) == 0 }
+        self.RecordCount == other.RecordCount && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11080,14 +11060,6 @@ unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_RECORD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_RECORD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LSA_FOREST_TRUST_RECORD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LSA_FOREST_TRUST_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11113,14 +11085,6 @@ impl ::core::clone::Clone for LSA_FOREST_TRUST_RECORD_0 {
 unsafe impl ::windows::core::Abi for LSA_FOREST_TRUST_RECORD_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LSA_FOREST_TRUST_RECORD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_FOREST_TRUST_RECORD_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LSA_FOREST_TRUST_RECORD_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LSA_FOREST_TRUST_RECORD_0 {
     fn default() -> Self {
@@ -11150,7 +11114,7 @@ unsafe impl ::windows::core::Abi for LSA_LAST_INTER_LOGON_INFO {
 }
 impl ::core::cmp::PartialEq for LSA_LAST_INTER_LOGON_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_LAST_INTER_LOGON_INFO>()) == 0 }
+        self.LastSuccessfulLogon == other.LastSuccessfulLogon && self.LastFailedLogon == other.LastFailedLogon && self.FailedAttemptCountSinceLastSuccessfulLogon == other.FailedAttemptCountSinceLastSuccessfulLogon
     }
 }
 impl ::core::cmp::Eq for LSA_LAST_INTER_LOGON_INFO {}
@@ -11187,7 +11151,7 @@ unsafe impl ::windows::core::Abi for LSA_REFERENCED_DOMAIN_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_REFERENCED_DOMAIN_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_REFERENCED_DOMAIN_LIST>()) == 0 }
+        self.Entries == other.Entries && self.Domains == other.Domains
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11277,85 +11241,13 @@ impl ::core::clone::Clone for LSA_SECPKG_FUNCTION_TABLE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 impl ::core::fmt::Debug for LSA_SECPKG_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LSA_SECPKG_FUNCTION_TABLE")
-            .field("CreateLogonSession", &self.CreateLogonSession.map(|f| f as usize))
-            .field("DeleteLogonSession", &self.DeleteLogonSession.map(|f| f as usize))
-            .field("AddCredential", &self.AddCredential.map(|f| f as usize))
-            .field("GetCredentials", &self.GetCredentials.map(|f| f as usize))
-            .field("DeleteCredential", &self.DeleteCredential.map(|f| f as usize))
-            .field("AllocateLsaHeap", &self.AllocateLsaHeap.map(|f| f as usize))
-            .field("FreeLsaHeap", &self.FreeLsaHeap.map(|f| f as usize))
-            .field("AllocateClientBuffer", &self.AllocateClientBuffer.map(|f| f as usize))
-            .field("FreeClientBuffer", &self.FreeClientBuffer.map(|f| f as usize))
-            .field("CopyToClientBuffer", &self.CopyToClientBuffer.map(|f| f as usize))
-            .field("CopyFromClientBuffer", &self.CopyFromClientBuffer.map(|f| f as usize))
-            .field("ImpersonateClient", &self.ImpersonateClient.map(|f| f as usize))
-            .field("UnloadPackage", &self.UnloadPackage.map(|f| f as usize))
-            .field("DuplicateHandle", &self.DuplicateHandle.map(|f| f as usize))
-            .field("SaveSupplementalCredentials", &self.SaveSupplementalCredentials.map(|f| f as usize))
-            .field("CreateThread", &self.CreateThread.map(|f| f as usize))
-            .field("GetClientInfo", &self.GetClientInfo.map(|f| f as usize))
-            .field("RegisterNotification", &self.RegisterNotification.map(|f| f as usize))
-            .field("CancelNotification", &self.CancelNotification.map(|f| f as usize))
-            .field("MapBuffer", &self.MapBuffer.map(|f| f as usize))
-            .field("CreateToken", &self.CreateToken.map(|f| f as usize))
-            .field("AuditLogon", &self.AuditLogon.map(|f| f as usize))
-            .field("CallPackage", &self.CallPackage.map(|f| f as usize))
-            .field("FreeReturnBuffer", &self.FreeReturnBuffer.map(|f| f as usize))
-            .field("GetCallInfo", &self.GetCallInfo.map(|f| f as usize))
-            .field("CallPackageEx", &self.CallPackageEx.map(|f| f as usize))
-            .field("CreateSharedMemory", &self.CreateSharedMemory.map(|f| f as usize))
-            .field("AllocateSharedMemory", &self.AllocateSharedMemory.map(|f| f as usize))
-            .field("FreeSharedMemory", &self.FreeSharedMemory.map(|f| f as usize))
-            .field("DeleteSharedMemory", &self.DeleteSharedMemory.map(|f| f as usize))
-            .field("OpenSamUser", &self.OpenSamUser.map(|f| f as usize))
-            .field("GetUserCredentials", &self.GetUserCredentials.map(|f| f as usize))
-            .field("GetUserAuthData", &self.GetUserAuthData.map(|f| f as usize))
-            .field("CloseSamUser", &self.CloseSamUser.map(|f| f as usize))
-            .field("ConvertAuthDataToToken", &self.ConvertAuthDataToToken.map(|f| f as usize))
-            .field("ClientCallback", &self.ClientCallback.map(|f| f as usize))
-            .field("UpdateCredentials", &self.UpdateCredentials.map(|f| f as usize))
-            .field("GetAuthDataForUser", &self.GetAuthDataForUser.map(|f| f as usize))
-            .field("CrackSingleName", &self.CrackSingleName.map(|f| f as usize))
-            .field("AuditAccountLogon", &self.AuditAccountLogon.map(|f| f as usize))
-            .field("CallPackagePassthrough", &self.CallPackagePassthrough.map(|f| f as usize))
-            .field("CrediRead", &self.CrediRead.map(|f| f as usize))
-            .field("CrediReadDomainCredentials", &self.CrediReadDomainCredentials.map(|f| f as usize))
-            .field("CrediFreeCredentials", &self.CrediFreeCredentials.map(|f| f as usize))
-            .field("LsaProtectMemory", &self.LsaProtectMemory.map(|f| f as usize))
-            .field("LsaUnprotectMemory", &self.LsaUnprotectMemory.map(|f| f as usize))
-            .field("OpenTokenByLogonId", &self.OpenTokenByLogonId.map(|f| f as usize))
-            .field("ExpandAuthDataForDomain", &self.ExpandAuthDataForDomain.map(|f| f as usize))
-            .field("AllocatePrivateHeap", &self.AllocatePrivateHeap.map(|f| f as usize))
-            .field("FreePrivateHeap", &self.FreePrivateHeap.map(|f| f as usize))
-            .field("CreateTokenEx", &self.CreateTokenEx.map(|f| f as usize))
-            .field("CrediWrite", &self.CrediWrite.map(|f| f as usize))
-            .field("CrediUnmarshalandDecodeString", &self.CrediUnmarshalandDecodeString.map(|f| f as usize))
-            .field("DummyFunction6", &self.DummyFunction6.map(|f| f as usize))
-            .field("GetExtendedCallFlags", &self.GetExtendedCallFlags.map(|f| f as usize))
-            .field("DuplicateTokenHandle", &self.DuplicateTokenHandle.map(|f| f as usize))
-            .field("GetServiceAccountPassword", &self.GetServiceAccountPassword.map(|f| f as usize))
-            .field("DummyFunction7", &self.DummyFunction7.map(|f| f as usize))
-            .field("AuditLogonEx", &self.AuditLogonEx.map(|f| f as usize))
-            .field("CheckProtectedUserByToken", &self.CheckProtectedUserByToken.map(|f| f as usize))
-            .field("QueryClientRequest", &self.QueryClientRequest.map(|f| f as usize))
-            .field("GetAppModeInfo", &self.GetAppModeInfo.map(|f| f as usize))
-            .field("SetAppModeInfo", &self.SetAppModeInfo.map(|f| f as usize))
-            .finish()
+        f.debug_struct("LSA_SECPKG_FUNCTION_TABLE").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 unsafe impl ::windows::core::Abi for LSA_SECPKG_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for LSA_SECPKG_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_SECPKG_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for LSA_SECPKG_FUNCTION_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for LSA_SECPKG_FUNCTION_TABLE {
     fn default() -> Self {
@@ -11390,7 +11282,7 @@ unsafe impl ::windows::core::Abi for LSA_TOKEN_INFORMATION_NULL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TOKEN_INFORMATION_NULL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TOKEN_INFORMATION_NULL>()) == 0 }
+        self.ExpirationTime == other.ExpirationTime && self.Groups == other.Groups
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11434,7 +11326,7 @@ unsafe impl ::windows::core::Abi for LSA_TOKEN_INFORMATION_V1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TOKEN_INFORMATION_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TOKEN_INFORMATION_V1>()) == 0 }
+        self.ExpirationTime == other.ExpirationTime && self.User == other.User && self.Groups == other.Groups && self.PrimaryGroup == other.PrimaryGroup && self.Privileges == other.Privileges && self.Owner == other.Owner && self.DefaultDacl == other.DefaultDacl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11481,7 +11373,7 @@ unsafe impl ::windows::core::Abi for LSA_TOKEN_INFORMATION_V3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TOKEN_INFORMATION_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TOKEN_INFORMATION_V3>()) == 0 }
+        self.ExpirationTime == other.ExpirationTime && self.User == other.User && self.Groups == other.Groups && self.PrimaryGroup == other.PrimaryGroup && self.Privileges == other.Privileges && self.Owner == other.Owner && self.DefaultDacl == other.DefaultDacl && self.UserClaims == other.UserClaims && self.DeviceClaims == other.DeviceClaims && self.DeviceGroups == other.DeviceGroups
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11521,7 +11413,7 @@ unsafe impl ::windows::core::Abi for LSA_TRANSLATED_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TRANSLATED_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TRANSLATED_NAME>()) == 0 }
+        self.Use == other.Use && self.Name == other.Name && self.DomainIndex == other.DomainIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11555,7 +11447,7 @@ unsafe impl ::windows::core::Abi for LSA_TRANSLATED_SID {
 }
 impl ::core::cmp::PartialEq for LSA_TRANSLATED_SID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TRANSLATED_SID>()) == 0 }
+        self.Use == other.Use && self.RelativeId == other.RelativeId && self.DomainIndex == other.DomainIndex
     }
 }
 impl ::core::cmp::Eq for LSA_TRANSLATED_SID {}
@@ -11594,7 +11486,7 @@ unsafe impl ::windows::core::Abi for LSA_TRANSLATED_SID2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TRANSLATED_SID2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TRANSLATED_SID2>()) == 0 }
+        self.Use == other.Use && self.Sid == other.Sid && self.DomainIndex == other.DomainIndex && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11633,7 +11525,7 @@ unsafe impl ::windows::core::Abi for LSA_TRUST_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LSA_TRUST_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LSA_TRUST_INFORMATION>()) == 0 }
+        self.Name == other.Name && self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11698,7 +11590,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_AV_PAIR {
 }
 impl ::core::cmp::PartialEq for MSV1_0_AV_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_AV_PAIR>()) == 0 }
+        self.AvId == other.AvId && self.AvLen == other.AvLen
     }
 }
 impl ::core::cmp::Eq for MSV1_0_AV_PAIR {}
@@ -11739,7 +11631,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_CHANGEPASSWORD_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_CHANGEPASSWORD_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_CHANGEPASSWORD_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.DomainName == other.DomainName && self.AccountName == other.AccountName && self.OldPassword == other.OldPassword && self.NewPassword == other.NewPassword && self.Impersonating == other.Impersonating
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11779,7 +11671,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_CHANGEPASSWORD_RESPONSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_CHANGEPASSWORD_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_CHANGEPASSWORD_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.PasswordInfoValid == other.PasswordInfoValid && self.DomainPasswordInfo == other.DomainPasswordInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11811,7 +11703,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_CREDENTIAL_KEY {
 }
 impl ::core::cmp::PartialEq for MSV1_0_CREDENTIAL_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_CREDENTIAL_KEY>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for MSV1_0_CREDENTIAL_KEY {}
@@ -11850,7 +11742,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_INTERACTIVE_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_INTERACTIVE_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_INTERACTIVE_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonDomainName == other.LogonDomainName && self.UserName == other.UserName && self.Password == other.Password
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11920,7 +11812,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_INTERACTIVE_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_INTERACTIVE_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_INTERACTIVE_PROFILE>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonCount == other.LogonCount && self.BadPasswordCount == other.BadPasswordCount && self.LogonTime == other.LogonTime && self.LogoffTime == other.LogoffTime && self.KickOffTime == other.KickOffTime && self.PasswordLastSet == other.PasswordLastSet && self.PasswordCanChange == other.PasswordCanChange && self.PasswordMustChange == other.PasswordMustChange && self.LogonScript == other.LogonScript && self.HomeDirectory == other.HomeDirectory && self.FullName == other.FullName && self.ProfilePath == other.ProfilePath && self.HomeDirectoryDrive == other.HomeDirectoryDrive && self.LogonServer == other.LogonServer && self.UserFlags == other.UserFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11954,7 +11846,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL>()) == 0 }
+        self.Version == other.Version && self.EncryptedCredsSize == other.EncryptedCredsSize && self.EncryptedCreds == other.EncryptedCreds
     }
 }
 impl ::core::cmp::Eq for MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL {}
@@ -11997,7 +11889,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_LM20_LOGON {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for MSV1_0_LM20_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_LM20_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonDomainName == other.LogonDomainName && self.UserName == other.UserName && self.Workstation == other.Workstation && self.ChallengeToClient == other.ChallengeToClient && self.CaseSensitiveChallengeResponse == other.CaseSensitiveChallengeResponse && self.CaseInsensitiveChallengeResponse == other.CaseInsensitiveChallengeResponse && self.ParameterControl == other.ParameterControl
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -12043,7 +11935,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_LM20_LOGON_PROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_LM20_LOGON_PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_LM20_LOGON_PROFILE>()) == 0 }
+        self.MessageType == other.MessageType && self.KickOffTime == other.KickOffTime && self.LogoffTime == other.LogoffTime && self.UserFlags == other.UserFlags && self.UserSessionKey == other.UserSessionKey && self.LogonDomainName == other.LogonDomainName && self.LanmanSessionKey == other.LanmanSessionKey && self.LogonServer == other.LogonServer && self.UserParameters == other.UserParameters
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12083,7 +11975,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_NTLM3_RESPONSE {
 }
 impl ::core::cmp::PartialEq for MSV1_0_NTLM3_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_NTLM3_RESPONSE>()) == 0 }
+        self.Response == other.Response && self.RespType == other.RespType && self.HiRespType == other.HiRespType && self.Flags == other.Flags && self.MsgWord == other.MsgWord && self.TimeStamp == other.TimeStamp && self.ChallengeFromClient == other.ChallengeFromClient && self.AvPairsOff == other.AvPairsOff && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for MSV1_0_NTLM3_RESPONSE {}
@@ -12124,7 +12016,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_PASSTHROUGH_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_PASSTHROUGH_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_PASSTHROUGH_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.DomainName == other.DomainName && self.PackageName == other.PackageName && self.DataLength == other.DataLength && self.LogonData == other.LogonData && self.Pad == other.Pad
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12159,7 +12051,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_PASSTHROUGH_RESPONSE {
 }
 impl ::core::cmp::PartialEq for MSV1_0_PASSTHROUGH_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_PASSTHROUGH_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.Pad == other.Pad && self.DataLength == other.DataLength && self.ValidationData == other.ValidationData
     }
 }
 impl ::core::cmp::Eq for MSV1_0_PASSTHROUGH_RESPONSE {}
@@ -12187,12 +12079,6 @@ impl ::core::clone::Clone for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
 unsafe impl ::windows::core::Abi for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {}
 impl ::core::default::Default for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12228,7 +12114,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_S4U_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSV1_0_S4U_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_S4U_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.UserPrincipalName == other.UserPrincipalName && self.DomainName == other.DomainName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12274,7 +12160,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUBAUTH_LOGON {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for MSV1_0_SUBAUTH_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUBAUTH_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonDomainName == other.LogonDomainName && self.UserName == other.UserName && self.Workstation == other.Workstation && self.ChallengeToClient == other.ChallengeToClient && self.AuthenticationInfo1 == other.AuthenticationInfo1 && self.AuthenticationInfo2 == other.AuthenticationInfo2 && self.ParameterControl == other.ParameterControl && self.SubAuthPackageId == other.SubAuthPackageId
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -12309,7 +12195,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUBAUTH_REQUEST {
 }
 impl ::core::cmp::PartialEq for MSV1_0_SUBAUTH_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUBAUTH_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.SubAuthPackageId == other.SubAuthPackageId && self.SubAuthInfoLength == other.SubAuthInfoLength && self.SubAuthSubmitBuffer == other.SubAuthSubmitBuffer
     }
 }
 impl ::core::cmp::Eq for MSV1_0_SUBAUTH_REQUEST {}
@@ -12341,7 +12227,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUBAUTH_RESPONSE {
 }
 impl ::core::cmp::PartialEq for MSV1_0_SUBAUTH_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUBAUTH_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.SubAuthInfoLength == other.SubAuthInfoLength && self.SubAuthReturnBuffer == other.SubAuthReturnBuffer
     }
 }
 impl ::core::cmp::Eq for MSV1_0_SUBAUTH_RESPONSE {}
@@ -12374,7 +12260,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUPPLEMENTAL_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for MSV1_0_SUPPLEMENTAL_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUPPLEMENTAL_CREDENTIAL>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.LmPassword == other.LmPassword && self.NtPassword == other.NtPassword
     }
 }
 impl ::core::cmp::Eq for MSV1_0_SUPPLEMENTAL_CREDENTIAL {}
@@ -12407,7 +12293,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {
 }
 impl ::core::cmp::PartialEq for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.NtPassword == other.NtPassword && self.CredentialKey == other.CredentialKey
     }
 }
 impl ::core::cmp::Eq for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {}
@@ -12442,7 +12328,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3 {
 }
 impl ::core::cmp::PartialEq for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.CredentialKeyType == other.CredentialKeyType && self.NtPassword == other.NtPassword && self.CredentialKey == other.CredentialKey && self.ShaPassword == other.ShaPassword
     }
 }
 impl ::core::cmp::Eq for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3 {}
@@ -12486,7 +12372,7 @@ unsafe impl ::windows::core::Abi for MSV1_0_VALIDATION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
 impl ::core::cmp::PartialEq for MSV1_0_VALIDATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSV1_0_VALIDATION_INFO>()) == 0 }
+        self.LogoffTime == other.LogoffTime && self.KickoffTime == other.KickoffTime && self.LogonServer == other.LogonServer && self.LogonDomainName == other.LogonDomainName && self.SessionKey == other.SessionKey && self.Authoritative == other.Authoritative && self.UserFlags == other.UserFlags && self.WhichFields == other.WhichFields && self.UserId == other.UserId
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
@@ -12525,7 +12411,7 @@ unsafe impl ::windows::core::Abi for NEGOTIATE_CALLER_NAME_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NEGOTIATE_CALLER_NAME_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEGOTIATE_CALLER_NAME_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.LogonId == other.LogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12558,7 +12444,7 @@ unsafe impl ::windows::core::Abi for NEGOTIATE_CALLER_NAME_RESPONSE {
 }
 impl ::core::cmp::PartialEq for NEGOTIATE_CALLER_NAME_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEGOTIATE_CALLER_NAME_RESPONSE>()) == 0 }
+        self.MessageType == other.MessageType && self.CallerName == other.CallerName
     }
 }
 impl ::core::cmp::Eq for NEGOTIATE_CALLER_NAME_RESPONSE {}
@@ -12592,7 +12478,7 @@ unsafe impl ::windows::core::Abi for NEGOTIATE_PACKAGE_PREFIX {
 }
 impl ::core::cmp::PartialEq for NEGOTIATE_PACKAGE_PREFIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEGOTIATE_PACKAGE_PREFIX>()) == 0 }
+        self.PackageId == other.PackageId && self.PackageDataA == other.PackageDataA && self.PackageDataW == other.PackageDataW && self.PrefixLen == other.PrefixLen && self.Prefix == other.Prefix
     }
 }
 impl ::core::cmp::Eq for NEGOTIATE_PACKAGE_PREFIX {}
@@ -12625,7 +12511,7 @@ unsafe impl ::windows::core::Abi for NEGOTIATE_PACKAGE_PREFIXES {
 }
 impl ::core::cmp::PartialEq for NEGOTIATE_PACKAGE_PREFIXES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEGOTIATE_PACKAGE_PREFIXES>()) == 0 }
+        self.MessageType == other.MessageType && self.PrefixCount == other.PrefixCount && self.Offset == other.Offset && self.Pad == other.Pad
     }
 }
 impl ::core::cmp::Eq for NEGOTIATE_PACKAGE_PREFIXES {}
@@ -12664,7 +12550,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_GENERIC_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NETLOGON_GENERIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_GENERIC_INFO>()) == 0 }
+        self.Identity == other.Identity && self.PackageName == other.PackageName && self.DataLength == other.DataLength && self.LogonData == other.LogonData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12704,7 +12590,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_INTERACTIVE_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
 impl ::core::cmp::PartialEq for NETLOGON_INTERACTIVE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_INTERACTIVE_INFO>()) == 0 }
+        self.Identity == other.Identity && self.LmOwfPassword == other.LmOwfPassword && self.NtOwfPassword == other.NtOwfPassword
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
@@ -12746,7 +12632,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_LOGON_IDENTITY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NETLOGON_LOGON_IDENTITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_LOGON_IDENTITY_INFO>()) == 0 }
+        self.LogonDomainName == other.LogonDomainName && self.ParameterControl == other.ParameterControl && self.LogonId == other.LogonId && self.UserName == other.UserName && self.Workstation == other.Workstation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12787,7 +12673,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_NETWORK_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for NETLOGON_NETWORK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_NETWORK_INFO>()) == 0 }
+        self.Identity == other.Identity && self.LmChallenge == other.LmChallenge && self.NtChallengeResponse == other.NtChallengeResponse && self.LmChallengeResponse == other.LmChallengeResponse
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -12827,7 +12713,7 @@ unsafe impl ::windows::core::Abi for NETLOGON_SERVICE_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
 impl ::core::cmp::PartialEq for NETLOGON_SERVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETLOGON_SERVICE_INFO>()) == 0 }
+        self.Identity == other.Identity && self.LmOwfPassword == other.LmOwfPassword && self.NtOwfPassword == other.NtOwfPassword
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
@@ -12870,7 +12756,7 @@ unsafe impl ::windows::core::Abi for PKU2U_CERTIFICATE_S4U_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PKU2U_CERTIFICATE_S4U_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PKU2U_CERTIFICATE_S4U_LOGON>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.UserPrincipalName == other.UserPrincipalName && self.DomainName == other.DomainName && self.CertificateLength == other.CertificateLength && self.Certificate == other.Certificate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12903,7 +12789,7 @@ unsafe impl ::windows::core::Abi for PKU2U_CERT_BLOB {
 }
 impl ::core::cmp::PartialEq for PKU2U_CERT_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PKU2U_CERT_BLOB>()) == 0 }
+        self.CertOffset == other.CertOffset && self.CertLength == other.CertLength
     }
 }
 impl ::core::cmp::Eq for PKU2U_CERT_BLOB {}
@@ -12937,7 +12823,7 @@ unsafe impl ::windows::core::Abi for PKU2U_CREDUI_CONTEXT {
 }
 impl ::core::cmp::PartialEq for PKU2U_CREDUI_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PKU2U_CREDUI_CONTEXT>()) == 0 }
+        self.Version == other.Version && self.cbHeaderLength == other.cbHeaderLength && self.cbStructureLength == other.cbStructureLength && self.CertArrayCount == other.CertArrayCount && self.CertArrayOffset == other.CertArrayOffset
     }
 }
 impl ::core::cmp::Eq for PKU2U_CREDUI_CONTEXT {}
@@ -12974,7 +12860,7 @@ unsafe impl ::windows::core::Abi for POLICY_ACCOUNT_DOMAIN_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_ACCOUNT_DOMAIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_ACCOUNT_DOMAIN_INFO>()) == 0 }
+        self.DomainName == other.DomainName && self.DomainSid == other.DomainSid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13007,7 +12893,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_CATEGORIES_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_AUDIT_CATEGORIES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_CATEGORIES_INFO>()) == 0 }
+        self.MaximumCategoryCount == other.MaximumCategoryCount && self.SubCategoriesInfo == other.SubCategoriesInfo
     }
 }
 impl ::core::cmp::Eq for POLICY_AUDIT_CATEGORIES_INFO {}
@@ -13045,7 +12931,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_EVENTS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_AUDIT_EVENTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_EVENTS_INFO>()) == 0 }
+        self.AuditingMode == other.AuditingMode && self.EventAuditingOptions == other.EventAuditingOptions && self.MaximumAuditEventCount == other.MaximumAuditEventCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13084,7 +12970,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_FULL_QUERY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_AUDIT_FULL_QUERY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_FULL_QUERY_INFO>()) == 0 }
+        self.ShutDownOnFull == other.ShutDownOnFull && self.LogIsFull == other.LogIsFull
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13122,7 +13008,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_FULL_SET_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_AUDIT_FULL_SET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_FULL_SET_INFO>()) == 0 }
+        self.ShutDownOnFull == other.ShutDownOnFull
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13165,7 +13051,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_LOG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_AUDIT_LOG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_LOG_INFO>()) == 0 }
+        self.AuditLogPercentFull == other.AuditLogPercentFull && self.MaximumLogSize == other.MaximumLogSize && self.AuditRetentionPeriod == other.AuditRetentionPeriod && self.AuditLogFullShutdownInProgress == other.AuditLogFullShutdownInProgress && self.TimeToShutdown == other.TimeToShutdown && self.NextAuditRecordId == other.NextAuditRecordId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13204,7 +13090,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_SID_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_AUDIT_SID_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_SID_ARRAY>()) == 0 }
+        self.UsersCount == other.UsersCount && self.UserSidArray == other.UserSidArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13237,7 +13123,7 @@ unsafe impl ::windows::core::Abi for POLICY_AUDIT_SUBCATEGORIES_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_AUDIT_SUBCATEGORIES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_AUDIT_SUBCATEGORIES_INFO>()) == 0 }
+        self.MaximumSubCategoryCount == other.MaximumSubCategoryCount && self.EventAuditingOptions == other.EventAuditingOptions
     }
 }
 impl ::core::cmp::Eq for POLICY_AUDIT_SUBCATEGORIES_INFO {}
@@ -13267,7 +13153,7 @@ unsafe impl ::windows::core::Abi for POLICY_DEFAULT_QUOTA_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_DEFAULT_QUOTA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DEFAULT_QUOTA_INFO>()) == 0 }
+        self.QuotaLimits == other.QuotaLimits
     }
 }
 impl ::core::cmp::Eq for POLICY_DEFAULT_QUOTA_INFO {}
@@ -13307,7 +13193,7 @@ unsafe impl ::windows::core::Abi for POLICY_DNS_DOMAIN_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_DNS_DOMAIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DNS_DOMAIN_INFO>()) == 0 }
+        self.Name == other.Name && self.DnsDomainName == other.DnsDomainName && self.DnsForestName == other.DnsForestName && self.DomainGuid == other.DomainGuid && self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13340,7 +13226,7 @@ unsafe impl ::windows::core::Abi for POLICY_DOMAIN_EFS_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_DOMAIN_EFS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DOMAIN_EFS_INFO>()) == 0 }
+        self.InfoLength == other.InfoLength && self.EfsBlob == other.EfsBlob
     }
 }
 impl ::core::cmp::Eq for POLICY_DOMAIN_EFS_INFO {}
@@ -13375,7 +13261,7 @@ unsafe impl ::windows::core::Abi for POLICY_DOMAIN_KERBEROS_TICKET_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_DOMAIN_KERBEROS_TICKET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_DOMAIN_KERBEROS_TICKET_INFO>()) == 0 }
+        self.AuthenticationOptions == other.AuthenticationOptions && self.MaxServiceTicketAge == other.MaxServiceTicketAge && self.MaxTicketAge == other.MaxTicketAge && self.MaxRenewAge == other.MaxRenewAge && self.MaxClockSkew == other.MaxClockSkew && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for POLICY_DOMAIN_KERBEROS_TICKET_INFO {}
@@ -13405,7 +13291,7 @@ unsafe impl ::windows::core::Abi for POLICY_LSA_SERVER_ROLE_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_LSA_SERVER_ROLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_LSA_SERVER_ROLE_INFO>()) == 0 }
+        self.LsaServerRole == other.LsaServerRole
     }
 }
 impl ::core::cmp::Eq for POLICY_LSA_SERVER_ROLE_INFO {}
@@ -13442,7 +13328,7 @@ unsafe impl ::windows::core::Abi for POLICY_MACHINE_ACCT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_MACHINE_ACCT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_MACHINE_ACCT_INFO>()) == 0 }
+        self.Rid == other.Rid && self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13475,7 +13361,7 @@ unsafe impl ::windows::core::Abi for POLICY_MODIFICATION_INFO {
 }
 impl ::core::cmp::PartialEq for POLICY_MODIFICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_MODIFICATION_INFO>()) == 0 }
+        self.ModifiedId == other.ModifiedId && self.DatabaseCreationTime == other.DatabaseCreationTime
     }
 }
 impl ::core::cmp::Eq for POLICY_MODIFICATION_INFO {}
@@ -13511,7 +13397,7 @@ unsafe impl ::windows::core::Abi for POLICY_PD_ACCOUNT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_PD_ACCOUNT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_PD_ACCOUNT_INFO>()) == 0 }
+        self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13550,7 +13436,7 @@ unsafe impl ::windows::core::Abi for POLICY_PRIMARY_DOMAIN_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_PRIMARY_DOMAIN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_PRIMARY_DOMAIN_INFO>()) == 0 }
+        self.Name == other.Name && self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13589,7 +13475,7 @@ unsafe impl ::windows::core::Abi for POLICY_REPLICA_SOURCE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_REPLICA_SOURCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_REPLICA_SOURCE_INFO>()) == 0 }
+        self.ReplicaSource == other.ReplicaSource && self.ReplicaAccountName == other.ReplicaAccountName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13623,7 +13509,7 @@ unsafe impl ::windows::core::Abi for PctPublicKey {
 }
 impl ::core::cmp::PartialEq for PctPublicKey {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PctPublicKey>()) == 0 }
+        self.Type == other.Type && self.cbKey == other.cbKey && self.pKey == other.pKey
     }
 }
 impl ::core::cmp::Eq for PctPublicKey {}
@@ -13661,7 +13547,7 @@ unsafe impl ::windows::core::Abi for SAM_REGISTER_MAPPING_ELEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAM_REGISTER_MAPPING_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAM_REGISTER_MAPPING_ELEMENT>()) == 0 }
+        self.Original == other.Original && self.Mapped == other.Mapped && self.Continuable == other.Continuable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13700,7 +13586,7 @@ unsafe impl ::windows::core::Abi for SAM_REGISTER_MAPPING_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAM_REGISTER_MAPPING_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAM_REGISTER_MAPPING_LIST>()) == 0 }
+        self.Count == other.Count && self.Elements == other.Elements
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13739,7 +13625,7 @@ unsafe impl ::windows::core::Abi for SAM_REGISTER_MAPPING_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SAM_REGISTER_MAPPING_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAM_REGISTER_MAPPING_TABLE>()) == 0 }
+        self.Count == other.Count && self.Lists == other.Lists
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13773,7 +13659,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_ALERT_TOKEN {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_ALERT_TOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_ALERT_TOKEN>()) == 0 }
+        self.dwTokenType == other.dwTokenType && self.dwAlertType == other.dwAlertType && self.dwAlertNumber == other.dwAlertNumber
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_ALERT_TOKEN {}
@@ -13806,7 +13692,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_CERT_HASH {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_CERT_HASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_CERT_HASH>()) == 0 }
+        self.dwLength == other.dwLength && self.dwFlags == other.dwFlags && self.hProv == other.hProv && self.ShaHash == other.ShaHash
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_CERT_HASH {}
@@ -13840,7 +13726,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_CERT_HASH_STORE {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_CERT_HASH_STORE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_CERT_HASH_STORE>()) == 0 }
+        self.dwLength == other.dwLength && self.dwFlags == other.dwFlags && self.hProv == other.hProv && self.ShaHash == other.ShaHash && self.pwszStoreName == other.pwszStoreName
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_CERT_HASH_STORE {}
@@ -13874,7 +13760,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_CLIENT_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_CLIENT_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_CLIENT_SIGNATURE>()) == 0 }
+        self.cbLength == other.cbLength && self.aiHash == other.aiHash && self.cbHash == other.cbHash && self.HashValue == other.HashValue && self.CertThumbprint == other.CertThumbprint
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_CLIENT_SIGNATURE {}
@@ -13938,7 +13824,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_CRED {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for SCHANNEL_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_CRED>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cCreds == other.cCreds && self.paCred == other.paCred && self.hRootStore == other.hRootStore && self.cMappers == other.cMappers && self.aphMappers == other.aphMappers && self.cSupportedAlgs == other.cSupportedAlgs && self.palgSupportedAlgs == other.palgSupportedAlgs && self.grbitEnabledProtocols == other.grbitEnabledProtocols && self.dwMinimumCipherStrength == other.dwMinimumCipherStrength && self.dwMaximumCipherStrength == other.dwMaximumCipherStrength && self.dwSessionLifespan == other.dwSessionLifespan && self.dwFlags == other.dwFlags && self.dwCredFormat == other.dwCredFormat
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -13971,7 +13857,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_SESSION_TOKEN {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_SESSION_TOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_SESSION_TOKEN>()) == 0 }
+        self.dwTokenType == other.dwTokenType && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_SESSION_TOKEN {}
@@ -14006,7 +13892,7 @@ unsafe impl ::windows::core::Abi for SCH_CRED {
 }
 impl ::core::cmp::PartialEq for SCH_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCH_CRED>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cCreds == other.cCreds && self.paSecret == other.paSecret && self.paPublic == other.paPublic && self.cMappers == other.cMappers && self.aphMappers == other.aphMappers
     }
 }
 impl ::core::cmp::Eq for SCH_CRED {}
@@ -14038,7 +13924,7 @@ unsafe impl ::windows::core::Abi for SCH_CRED_PUBLIC_CERTCHAIN {
 }
 impl ::core::cmp::PartialEq for SCH_CRED_PUBLIC_CERTCHAIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCH_CRED_PUBLIC_CERTCHAIN>()) == 0 }
+        self.dwType == other.dwType && self.cbCertChain == other.cbCertChain && self.pCertChain == other.pCertChain
     }
 }
 impl ::core::cmp::Eq for SCH_CRED_PUBLIC_CERTCHAIN {}
@@ -14069,7 +13955,7 @@ unsafe impl ::windows::core::Abi for SCH_CRED_SECRET_CAPI {
 }
 impl ::core::cmp::PartialEq for SCH_CRED_SECRET_CAPI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCH_CRED_SECRET_CAPI>()) == 0 }
+        self.dwType == other.dwType && self.hProv == other.hProv
     }
 }
 impl ::core::cmp::Eq for SCH_CRED_SECRET_CAPI {}
@@ -14102,7 +13988,7 @@ unsafe impl ::windows::core::Abi for SCH_CRED_SECRET_PRIVKEY {
 }
 impl ::core::cmp::PartialEq for SCH_CRED_SECRET_PRIVKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCH_CRED_SECRET_PRIVKEY>()) == 0 }
+        self.dwType == other.dwType && self.pPrivateKey == other.pPrivateKey && self.cbPrivateKey == other.cbPrivateKey && self.pszPassword == other.pszPassword
     }
 }
 impl ::core::cmp::Eq for SCH_CRED_SECRET_PRIVKEY {}
@@ -14134,7 +14020,7 @@ unsafe impl ::windows::core::Abi for SCH_EXTENSION_DATA {
 }
 impl ::core::cmp::PartialEq for SCH_EXTENSION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCH_EXTENSION_DATA>()) == 0 }
+        self.ExtensionType == other.ExtensionType && self.pExtData == other.pExtData && self.cbExtData == other.cbExtData
     }
 }
 impl ::core::cmp::Eq for SCH_EXTENSION_DATA {}
@@ -14174,7 +14060,7 @@ unsafe impl ::windows::core::Abi for SECPKG_APP_MODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_APP_MODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_APP_MODE_INFO>()) == 0 }
+        self.UserFunction == other.UserFunction && self.Argument1 == other.Argument1 && self.Argument2 == other.Argument2 && self.UserData == other.UserData && self.ReturnToLsa == other.ReturnToLsa
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14207,7 +14093,7 @@ unsafe impl ::windows::core::Abi for SECPKG_BYTE_VECTOR {
 }
 impl ::core::cmp::PartialEq for SECPKG_BYTE_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_BYTE_VECTOR>()) == 0 }
+        self.ByteArrayOffset == other.ByteArrayOffset && self.ByteArrayLength == other.ByteArrayLength
     }
 }
 impl ::core::cmp::Eq for SECPKG_BYTE_VECTOR {}
@@ -14241,7 +14127,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CALL_INFO {
 }
 impl ::core::cmp::PartialEq for SECPKG_CALL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CALL_INFO>()) == 0 }
+        self.ProcessId == other.ProcessId && self.ThreadId == other.ThreadId && self.Attributes == other.Attributes && self.CallCount == other.CallCount && self.MechOid == other.MechOid
     }
 }
 impl ::core::cmp::Eq for SECPKG_CALL_INFO {}
@@ -14281,7 +14167,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CALL_PACKAGE_PIN_DC_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_CALL_PACKAGE_PIN_DC_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CALL_PACKAGE_PIN_DC_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags && self.DomainName == other.DomainName && self.DcName == other.DcName && self.DcFlags == other.DcFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14322,7 +14208,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.OriginLogonId == other.OriginLogonId && self.DestinationLogonId == other.DestinationLogonId && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14355,7 +14241,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST {
 }
 impl ::core::cmp::PartialEq for SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST>()) == 0 }
+        self.MessageType == other.MessageType && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST {}
@@ -14399,7 +14285,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CLIENT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_CLIENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CLIENT_INFO>()) == 0 }
+        self.LogonId == other.LogonId && self.ProcessID == other.ProcessID && self.ThreadID == other.ThreadID && self.HasTcbPrivilege == other.HasTcbPrivilege && self.Impersonating == other.Impersonating && self.Restricted == other.Restricted && self.ClientFlags == other.ClientFlags && self.ImpersonationLevel == other.ImpersonationLevel && self.ClientToken == other.ClientToken
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14432,7 +14318,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CONTEXT_THUNKS {
 }
 impl ::core::cmp::PartialEq for SECPKG_CONTEXT_THUNKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CONTEXT_THUNKS>()) == 0 }
+        self.InfoLevelCount == other.InfoLevelCount && self.Levels == other.Levels
     }
 }
 impl ::core::cmp::Eq for SECPKG_CONTEXT_THUNKS {}
@@ -14496,7 +14382,7 @@ unsafe impl ::windows::core::Abi for SECPKG_CREDENTIAL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_CREDENTIAL>()) == 0 }
+        self.Version == other.Version && self.cbHeaderLength == other.cbHeaderLength && self.cbStructureLength == other.cbStructureLength && self.ClientProcess == other.ClientProcess && self.ClientThread == other.ClientThread && self.LogonId == other.LogonId && self.ClientToken == other.ClientToken && self.SessionId == other.SessionId && self.ModifiedId == other.ModifiedId && self.fCredentials == other.fCredentials && self.Flags == other.Flags && self.PrincipalName == other.PrincipalName && self.PackageList == other.PackageList && self.MarshaledSuppliedCreds == other.MarshaledSuppliedCreds
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14527,21 +14413,13 @@ impl ::core::clone::Clone for SECPKG_DLL_FUNCTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for SECPKG_DLL_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_DLL_FUNCTIONS").field("AllocateHeap", &self.AllocateHeap.map(|f| f as usize)).field("FreeHeap", &self.FreeHeap.map(|f| f as usize)).field("RegisterCallback", &self.RegisterCallback.map(|f| f as usize)).field("LocatePackageById", &self.LocatePackageById.map(|f| f as usize)).finish()
+        f.debug_struct("SECPKG_DLL_FUNCTIONS").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for SECPKG_DLL_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SECPKG_DLL_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_DLL_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SECPKG_DLL_FUNCTIONS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SECPKG_DLL_FUNCTIONS {
     fn default() -> Self {
@@ -14573,7 +14451,7 @@ unsafe impl ::windows::core::Abi for SECPKG_EVENT_NOTIFY {
 }
 impl ::core::cmp::PartialEq for SECPKG_EVENT_NOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EVENT_NOTIFY>()) == 0 }
+        self.EventClass == other.EventClass && self.Reserved == other.Reserved && self.EventDataSize == other.EventDataSize && self.EventData == other.EventData && self.PackageParameter == other.PackageParameter
     }
 }
 impl ::core::cmp::Eq for SECPKG_EVENT_NOTIFY {}
@@ -14611,7 +14489,7 @@ unsafe impl ::windows::core::Abi for SECPKG_EVENT_PACKAGE_CHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_EVENT_PACKAGE_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EVENT_PACKAGE_CHANGE>()) == 0 }
+        self.ChangeType == other.ChangeType && self.PackageId == other.PackageId && self.PackageName == other.PackageName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14644,7 +14522,7 @@ unsafe impl ::windows::core::Abi for SECPKG_EVENT_ROLE_CHANGE {
 }
 impl ::core::cmp::PartialEq for SECPKG_EVENT_ROLE_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EVENT_ROLE_CHANGE>()) == 0 }
+        self.PreviousRole == other.PreviousRole && self.NewRole == other.NewRole
     }
 }
 impl ::core::cmp::Eq for SECPKG_EVENT_ROLE_CHANGE {}
@@ -14672,14 +14550,6 @@ impl ::core::clone::Clone for SECPKG_EXTENDED_INFORMATION {
 unsafe impl ::windows::core::Abi for SECPKG_EXTENDED_INFORMATION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SECPKG_EXTENDED_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EXTENDED_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SECPKG_EXTENDED_INFORMATION {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SECPKG_EXTENDED_INFORMATION {
     fn default() -> Self {
@@ -14710,14 +14580,6 @@ unsafe impl ::windows::core::Abi for SECPKG_EXTENDED_INFORMATION_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SECPKG_EXTENDED_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EXTENDED_INFORMATION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SECPKG_EXTENDED_INFORMATION_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SECPKG_EXTENDED_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14745,7 +14607,7 @@ unsafe impl ::windows::core::Abi for SECPKG_EXTRA_OIDS {
 }
 impl ::core::cmp::PartialEq for SECPKG_EXTRA_OIDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_EXTRA_OIDS>()) == 0 }
+        self.OidCount == other.OidCount && self.Oids == other.Oids
     }
 }
 impl ::core::cmp::Eq for SECPKG_EXTRA_OIDS {}
@@ -14812,64 +14674,13 @@ impl ::core::clone::Clone for SECPKG_FUNCTION_TABLE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 impl ::core::fmt::Debug for SECPKG_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_FUNCTION_TABLE")
-            .field("InitializePackage", &self.InitializePackage.map(|f| f as usize))
-            .field("LogonUserA", &self.LogonUserA.map(|f| f as usize))
-            .field("CallPackage", &self.CallPackage.map(|f| f as usize))
-            .field("LogonTerminated", &self.LogonTerminated.map(|f| f as usize))
-            .field("CallPackageUntrusted", &self.CallPackageUntrusted.map(|f| f as usize))
-            .field("CallPackagePassthrough", &self.CallPackagePassthrough.map(|f| f as usize))
-            .field("LogonUserExA", &self.LogonUserExA.map(|f| f as usize))
-            .field("LogonUserEx2", &self.LogonUserEx2.map(|f| f as usize))
-            .field("Initialize", &self.Initialize.map(|f| f as usize))
-            .field("Shutdown", &self.Shutdown.map(|f| f as usize))
-            .field("GetInfo", &self.GetInfo.map(|f| f as usize))
-            .field("AcceptCredentials", &self.AcceptCredentials.map(|f| f as usize))
-            .field("AcquireCredentialsHandleA", &self.AcquireCredentialsHandleA.map(|f| f as usize))
-            .field("QueryCredentialsAttributesA", &self.QueryCredentialsAttributesA.map(|f| f as usize))
-            .field("FreeCredentialsHandle", &self.FreeCredentialsHandle.map(|f| f as usize))
-            .field("SaveCredentials", &self.SaveCredentials.map(|f| f as usize))
-            .field("GetCredentials", &self.GetCredentials.map(|f| f as usize))
-            .field("DeleteCredentials", &self.DeleteCredentials.map(|f| f as usize))
-            .field("InitLsaModeContext", &self.InitLsaModeContext.map(|f| f as usize))
-            .field("AcceptLsaModeContext", &self.AcceptLsaModeContext.map(|f| f as usize))
-            .field("DeleteContext", &self.DeleteContext.map(|f| f as usize))
-            .field("ApplyControlToken", &self.ApplyControlToken.map(|f| f as usize))
-            .field("GetUserInfo", &self.GetUserInfo.map(|f| f as usize))
-            .field("GetExtendedInformation", &self.GetExtendedInformation.map(|f| f as usize))
-            .field("QueryContextAttributesA", &self.QueryContextAttributesA.map(|f| f as usize))
-            .field("AddCredentialsA", &self.AddCredentialsA.map(|f| f as usize))
-            .field("SetExtendedInformation", &self.SetExtendedInformation.map(|f| f as usize))
-            .field("SetContextAttributesA", &self.SetContextAttributesA.map(|f| f as usize))
-            .field("SetCredentialsAttributesA", &self.SetCredentialsAttributesA.map(|f| f as usize))
-            .field("ChangeAccountPasswordA", &self.ChangeAccountPasswordA.map(|f| f as usize))
-            .field("QueryMetaData", &self.QueryMetaData.map(|f| f as usize))
-            .field("ExchangeMetaData", &self.ExchangeMetaData.map(|f| f as usize))
-            .field("GetCredUIContext", &self.GetCredUIContext.map(|f| f as usize))
-            .field("UpdateCredentials", &self.UpdateCredentials.map(|f| f as usize))
-            .field("ValidateTargetInfo", &self.ValidateTargetInfo.map(|f| f as usize))
-            .field("PostLogonUser", &self.PostLogonUser.map(|f| f as usize))
-            .field("GetRemoteCredGuardLogonBuffer", &self.GetRemoteCredGuardLogonBuffer.map(|f| f as usize))
-            .field("GetRemoteCredGuardSupplementalCreds", &self.GetRemoteCredGuardSupplementalCreds.map(|f| f as usize))
-            .field("GetTbalSupplementalCreds", &self.GetTbalSupplementalCreds.map(|f| f as usize))
-            .field("LogonUserEx3", &self.LogonUserEx3.map(|f| f as usize))
-            .field("PreLogonUserSurrogate", &self.PreLogonUserSurrogate.map(|f| f as usize))
-            .field("PostLogonUserSurrogate", &self.PostLogonUserSurrogate.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SECPKG_FUNCTION_TABLE").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 unsafe impl ::windows::core::Abi for SECPKG_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for SECPKG_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for SECPKG_FUNCTION_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials", feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for SECPKG_FUNCTION_TABLE {
     fn default() -> Self {
@@ -14898,7 +14709,7 @@ unsafe impl ::windows::core::Abi for SECPKG_GSS_INFO {
 }
 impl ::core::cmp::PartialEq for SECPKG_GSS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_GSS_INFO>()) == 0 }
+        self.EncodedIdLength == other.EncodedIdLength && self.EncodedId == other.EncodedId
     }
 }
 impl ::core::cmp::Eq for SECPKG_GSS_INFO {}
@@ -14932,31 +14743,13 @@ impl ::core::clone::Clone for SECPKG_KERNEL_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::fmt::Debug for SECPKG_KERNEL_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_KERNEL_FUNCTIONS")
-            .field("AllocateHeap", &self.AllocateHeap.map(|f| f as usize))
-            .field("FreeHeap", &self.FreeHeap.map(|f| f as usize))
-            .field("CreateContextList", &self.CreateContextList.map(|f| f as usize))
-            .field("InsertListEntry", &self.InsertListEntry.map(|f| f as usize))
-            .field("ReferenceListEntry", &self.ReferenceListEntry.map(|f| f as usize))
-            .field("DereferenceListEntry", &self.DereferenceListEntry.map(|f| f as usize))
-            .field("SerializeWinntAuthData", &self.SerializeWinntAuthData.map(|f| f as usize))
-            .field("SerializeSchannelAuthData", &self.SerializeSchannelAuthData.map(|f| f as usize))
-            .field("LocatePackageById", &self.LocatePackageById.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SECPKG_KERNEL_FUNCTIONS").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 unsafe impl ::windows::core::Abi for SECPKG_KERNEL_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for SECPKG_KERNEL_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_KERNEL_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for SECPKG_KERNEL_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for SECPKG_KERNEL_FUNCTIONS {
     fn default() -> Self {
@@ -14994,37 +14787,13 @@ impl ::core::clone::Clone for SECPKG_KERNEL_FUNCTION_TABLE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::fmt::Debug for SECPKG_KERNEL_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_KERNEL_FUNCTION_TABLE")
-            .field("Initialize", &self.Initialize.map(|f| f as usize))
-            .field("DeleteContext", &self.DeleteContext.map(|f| f as usize))
-            .field("InitContext", &self.InitContext.map(|f| f as usize))
-            .field("MapHandle", &self.MapHandle.map(|f| f as usize))
-            .field("Sign", &self.Sign.map(|f| f as usize))
-            .field("Verify", &self.Verify.map(|f| f as usize))
-            .field("Seal", &self.Seal.map(|f| f as usize))
-            .field("Unseal", &self.Unseal.map(|f| f as usize))
-            .field("GetToken", &self.GetToken.map(|f| f as usize))
-            .field("QueryAttributes", &self.QueryAttributes.map(|f| f as usize))
-            .field("CompleteToken", &self.CompleteToken.map(|f| f as usize))
-            .field("ExportContext", &self.ExportContext.map(|f| f as usize))
-            .field("ImportContext", &self.ImportContext.map(|f| f as usize))
-            .field("SetPackagePagingMode", &self.SetPackagePagingMode.map(|f| f as usize))
-            .field("SerializeAuthData", &self.SerializeAuthData.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SECPKG_KERNEL_FUNCTION_TABLE").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 unsafe impl ::windows::core::Abi for SECPKG_KERNEL_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for SECPKG_KERNEL_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_KERNEL_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for SECPKG_KERNEL_FUNCTION_TABLE {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for SECPKG_KERNEL_FUNCTION_TABLE {
     fn default() -> Self {
@@ -15052,7 +14821,7 @@ unsafe impl ::windows::core::Abi for SECPKG_MUTUAL_AUTH_LEVEL {
 }
 impl ::core::cmp::PartialEq for SECPKG_MUTUAL_AUTH_LEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_MUTUAL_AUTH_LEVEL>()) == 0 }
+        self.MutualAuthLevel == other.MutualAuthLevel
     }
 }
 impl ::core::cmp::Eq for SECPKG_MUTUAL_AUTH_LEVEL {}
@@ -15083,7 +14852,7 @@ unsafe impl ::windows::core::Abi for SECPKG_NEGO2_INFO {
 }
 impl ::core::cmp::PartialEq for SECPKG_NEGO2_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_NEGO2_INFO>()) == 0 }
+        self.AuthScheme == other.AuthScheme && self.PackageFlags == other.PackageFlags
     }
 }
 impl ::core::cmp::Eq for SECPKG_NEGO2_INFO {}
@@ -15125,7 +14894,7 @@ unsafe impl ::windows::core::Abi for SECPKG_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.MachineState == other.MachineState && self.SetupMode == other.SetupMode && self.DomainSid == other.DomainSid && self.DomainName == other.DomainName && self.DnsDomainName == other.DnsDomainName && self.DomainGuid == other.DomainGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15165,7 +14934,7 @@ unsafe impl ::windows::core::Abi for SECPKG_POST_LOGON_USER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_POST_LOGON_USER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_POST_LOGON_USER_INFO>()) == 0 }
+        self.Flags == other.Flags && self.LogonId == other.LogonId && self.LinkedLogonId == other.LinkedLogonId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15231,7 +15000,7 @@ unsafe impl ::windows::core::Abi for SECPKG_PRIMARY_CRED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_PRIMARY_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_PRIMARY_CRED>()) == 0 }
+        self.LogonId == other.LogonId && self.DownlevelName == other.DownlevelName && self.DomainName == other.DomainName && self.Password == other.Password && self.OldPassword == other.OldPassword && self.UserSid == other.UserSid && self.Flags == other.Flags && self.DnsDomainName == other.DnsDomainName && self.Upn == other.Upn && self.LogonServer == other.LogonServer && self.Spare1 == other.Spare1 && self.Spare2 == other.Spare2 && self.Spare3 == other.Spare3 && self.Spare4 == other.Spare4
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15303,7 +15072,7 @@ unsafe impl ::windows::core::Abi for SECPKG_PRIMARY_CRED_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_PRIMARY_CRED_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_PRIMARY_CRED_EX>()) == 0 }
+        self.LogonId == other.LogonId && self.DownlevelName == other.DownlevelName && self.DomainName == other.DomainName && self.Password == other.Password && self.OldPassword == other.OldPassword && self.UserSid == other.UserSid && self.Flags == other.Flags && self.DnsDomainName == other.DnsDomainName && self.Upn == other.Upn && self.LogonServer == other.LogonServer && self.Spare1 == other.Spare1 && self.Spare2 == other.Spare2 && self.Spare3 == other.Spare3 && self.Spare4 == other.Spare4 && self.PackageId == other.PackageId && self.PrevLogonId == other.PrevLogonId && self.FlagsEx == other.FlagsEx
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15337,29 +15106,13 @@ impl ::core::clone::Clone for SECPKG_REDIRECTED_LOGON_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for SECPKG_REDIRECTED_LOGON_BUFFER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_REDIRECTED_LOGON_BUFFER")
-            .field("RedirectedLogonGuid", &self.RedirectedLogonGuid)
-            .field("RedirectedLogonHandle", &self.RedirectedLogonHandle)
-            .field("Init", &self.Init.map(|f| f as usize))
-            .field("Callback", &self.Callback.map(|f| f as usize))
-            .field("CleanupCallback", &self.CleanupCallback.map(|f| f as usize))
-            .field("GetLogonCreds", &self.GetLogonCreds.map(|f| f as usize))
-            .field("GetSupplementalCreds", &self.GetSupplementalCreds.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SECPKG_REDIRECTED_LOGON_BUFFER").field("RedirectedLogonGuid", &self.RedirectedLogonGuid).field("RedirectedLogonHandle", &self.RedirectedLogonHandle).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for SECPKG_REDIRECTED_LOGON_BUFFER {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SECPKG_REDIRECTED_LOGON_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_REDIRECTED_LOGON_BUFFER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SECPKG_REDIRECTED_LOGON_BUFFER {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SECPKG_REDIRECTED_LOGON_BUFFER {
     fn default() -> Self {
@@ -15389,7 +15142,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SERIALIZED_OID {
 }
 impl ::core::cmp::PartialEq for SECPKG_SERIALIZED_OID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SERIALIZED_OID>()) == 0 }
+        self.OidLength == other.OidLength && self.OidAttributes == other.OidAttributes && self.OidValue == other.OidValue
     }
 }
 impl ::core::cmp::Eq for SECPKG_SERIALIZED_OID {}
@@ -15420,7 +15173,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SHORT_VECTOR {
 }
 impl ::core::cmp::PartialEq for SECPKG_SHORT_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SHORT_VECTOR>()) == 0 }
+        self.ShortArrayOffset == other.ShortArrayOffset && self.ShortArrayCount == other.ShortArrayCount
     }
 }
 impl ::core::cmp::Eq for SECPKG_SHORT_VECTOR {}
@@ -15458,7 +15211,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SUPPLEMENTAL_CRED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_SUPPLEMENTAL_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SUPPLEMENTAL_CRED>()) == 0 }
+        self.PackageName == other.PackageName && self.CredentialSize == other.CredentialSize && self.Credentials == other.Credentials
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15497,7 +15250,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SUPPLEMENTAL_CRED_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_SUPPLEMENTAL_CRED_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SUPPLEMENTAL_CRED_ARRAY>()) == 0 }
+        self.CredentialCount == other.CredentialCount && self.Credentials == other.Credentials
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15534,7 +15287,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SUPPLIED_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for SECPKG_SUPPLIED_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SUPPLIED_CREDENTIAL>()) == 0 }
+        self.cbHeaderLength == other.cbHeaderLength && self.cbStructureLength == other.cbStructureLength && self.UserName == other.UserName && self.DomainName == other.DomainName && self.PackedCredentials == other.PackedCredentials && self.CredFlags == other.CredFlags
     }
 }
 impl ::core::cmp::Eq for SECPKG_SUPPLIED_CREDENTIAL {}
@@ -15573,7 +15326,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SURROGATE_LOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_SURROGATE_LOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SURROGATE_LOGON>()) == 0 }
+        self.Version == other.Version && self.SurrogateLogonID == other.SurrogateLogonID && self.EntryCount == other.EntryCount && self.Entries == other.Entries
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15606,7 +15359,7 @@ unsafe impl ::windows::core::Abi for SECPKG_SURROGATE_LOGON_ENTRY {
 }
 impl ::core::cmp::PartialEq for SECPKG_SURROGATE_LOGON_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_SURROGATE_LOGON_ENTRY>()) == 0 }
+        self.Type == other.Type && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SECPKG_SURROGATE_LOGON_ENTRY {}
@@ -15643,7 +15396,7 @@ unsafe impl ::windows::core::Abi for SECPKG_TARGETINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_TARGETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_TARGETINFO>()) == 0 }
+        self.DomainSid == other.DomainSid && self.ComputerName == other.ComputerName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15685,37 +15438,13 @@ impl ::core::clone::Clone for SECPKG_USER_FUNCTION_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for SECPKG_USER_FUNCTION_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SECPKG_USER_FUNCTION_TABLE")
-            .field("InstanceInit", &self.InstanceInit.map(|f| f as usize))
-            .field("InitUserModeContext", &self.InitUserModeContext.map(|f| f as usize))
-            .field("MakeSignature", &self.MakeSignature.map(|f| f as usize))
-            .field("VerifySignature", &self.VerifySignature.map(|f| f as usize))
-            .field("SealMessage", &self.SealMessage.map(|f| f as usize))
-            .field("UnsealMessage", &self.UnsealMessage.map(|f| f as usize))
-            .field("GetContextToken", &self.GetContextToken.map(|f| f as usize))
-            .field("QueryContextAttributesA", &self.QueryContextAttributesA.map(|f| f as usize))
-            .field("CompleteAuthToken", &self.CompleteAuthToken.map(|f| f as usize))
-            .field("DeleteUserModeContext", &self.DeleteUserModeContext.map(|f| f as usize))
-            .field("FormatCredentials", &self.FormatCredentials.map(|f| f as usize))
-            .field("MarshallSupplementalCreds", &self.MarshallSupplementalCreds.map(|f| f as usize))
-            .field("ExportContext", &self.ExportContext.map(|f| f as usize))
-            .field("ImportContext", &self.ImportContext.map(|f| f as usize))
-            .field("MarshalAttributeData", &self.MarshalAttributeData.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SECPKG_USER_FUNCTION_TABLE").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for SECPKG_USER_FUNCTION_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SECPKG_USER_FUNCTION_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_USER_FUNCTION_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SECPKG_USER_FUNCTION_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SECPKG_USER_FUNCTION_TABLE {
     fn default() -> Self {
@@ -15749,7 +15478,7 @@ unsafe impl ::windows::core::Abi for SECPKG_WOW_CLIENT_DLL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECPKG_WOW_CLIENT_DLL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECPKG_WOW_CLIENT_DLL>()) == 0 }
+        self.WowClientDllPath == other.WowClientDllPath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15833,7 +15562,29 @@ unsafe impl ::windows::core::Abi for SECURITY_LOGON_SESSION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_LOGON_SESSION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_LOGON_SESSION_DATA>()) == 0 }
+        self.Size == other.Size
+            && self.LogonId == other.LogonId
+            && self.UserName == other.UserName
+            && self.LogonDomain == other.LogonDomain
+            && self.AuthenticationPackage == other.AuthenticationPackage
+            && self.LogonType == other.LogonType
+            && self.Session == other.Session
+            && self.Sid == other.Sid
+            && self.LogonTime == other.LogonTime
+            && self.LogonServer == other.LogonServer
+            && self.DnsDomainName == other.DnsDomainName
+            && self.Upn == other.Upn
+            && self.UserFlags == other.UserFlags
+            && self.LastLogonInfo == other.LastLogonInfo
+            && self.LogonScript == other.LogonScript
+            && self.ProfilePath == other.ProfilePath
+            && self.HomeDirectory == other.HomeDirectory
+            && self.HomeDirectoryDrive == other.HomeDirectoryDrive
+            && self.LogoffTime == other.LogoffTime
+            && self.KickOffTime == other.KickOffTime
+            && self.PasswordLastSet == other.PasswordLastSet
+            && self.PasswordCanChange == other.PasswordCanChange
+            && self.PasswordMustChange == other.PasswordMustChange
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15869,7 +15620,7 @@ unsafe impl ::windows::core::Abi for SECURITY_PACKAGE_OPTIONS {
 }
 impl ::core::cmp::PartialEq for SECURITY_PACKAGE_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_PACKAGE_OPTIONS>()) == 0 }
+        self.Size == other.Size && self.Type == other.Type && self.Flags == other.Flags && self.SignatureSize == other.SignatureSize && self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for SECURITY_PACKAGE_OPTIONS {}
@@ -15908,7 +15659,7 @@ unsafe impl ::windows::core::Abi for SECURITY_USER_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_USER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_USER_DATA>()) == 0 }
+        self.UserName == other.UserName && self.LogonDomainName == other.LogonDomainName && self.LogonServer == other.LogonServer && self.pSid == other.pSid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15941,7 +15692,7 @@ unsafe impl ::windows::core::Abi for SEC_APPLICATION_PROTOCOLS {
 }
 impl ::core::cmp::PartialEq for SEC_APPLICATION_PROTOCOLS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_APPLICATION_PROTOCOLS>()) == 0 }
+        self.ProtocolListsSize == other.ProtocolListsSize && self.ProtocolLists == other.ProtocolLists
     }
 }
 impl ::core::cmp::Eq for SEC_APPLICATION_PROTOCOLS {}
@@ -15973,7 +15724,7 @@ unsafe impl ::windows::core::Abi for SEC_APPLICATION_PROTOCOL_LIST {
 }
 impl ::core::cmp::PartialEq for SEC_APPLICATION_PROTOCOL_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_APPLICATION_PROTOCOL_LIST>()) == 0 }
+        self.ProtoNegoExt == other.ProtoNegoExt && self.ProtocolListSize == other.ProtocolListSize && self.ProtocolList == other.ProtocolList
     }
 }
 impl ::core::cmp::Eq for SEC_APPLICATION_PROTOCOL_LIST {}
@@ -16019,7 +15770,7 @@ unsafe impl ::windows::core::Abi for SEC_CHANNEL_BINDINGS {
 }
 impl ::core::cmp::PartialEq for SEC_CHANNEL_BINDINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_CHANNEL_BINDINGS>()) == 0 }
+        self.dwInitiatorAddrType == other.dwInitiatorAddrType && self.cbInitiatorLength == other.cbInitiatorLength && self.dwInitiatorOffset == other.dwInitiatorOffset && self.dwAcceptorAddrType == other.dwAcceptorAddrType && self.cbAcceptorLength == other.cbAcceptorLength && self.dwAcceptorOffset == other.dwAcceptorOffset && self.cbApplicationDataLength == other.cbApplicationDataLength && self.dwApplicationDataOffset == other.dwApplicationDataOffset
     }
 }
 impl ::core::cmp::Eq for SEC_CHANNEL_BINDINGS {}
@@ -16049,7 +15800,7 @@ unsafe impl ::windows::core::Abi for SEC_DTLS_MTU {
 }
 impl ::core::cmp::PartialEq for SEC_DTLS_MTU {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_DTLS_MTU>()) == 0 }
+        self.PathMTU == other.PathMTU
     }
 }
 impl ::core::cmp::Eq for SEC_DTLS_MTU {}
@@ -16079,7 +15830,7 @@ unsafe impl ::windows::core::Abi for SEC_FLAGS {
 }
 impl ::core::cmp::PartialEq for SEC_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_FLAGS>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SEC_FLAGS {}
@@ -16112,7 +15863,7 @@ unsafe impl ::windows::core::Abi for SEC_NEGOTIATION_INFO {
 }
 impl ::core::cmp::PartialEq for SEC_NEGOTIATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_NEGOTIATION_INFO>()) == 0 }
+        self.Size == other.Size && self.NameLength == other.NameLength && self.Name == other.Name && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for SEC_NEGOTIATION_INFO {}
@@ -16143,7 +15894,7 @@ unsafe impl ::windows::core::Abi for SEC_PRESHAREDKEY {
 }
 impl ::core::cmp::PartialEq for SEC_PRESHAREDKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_PRESHAREDKEY>()) == 0 }
+        self.KeySize == other.KeySize && self.Key == other.Key
     }
 }
 impl ::core::cmp::Eq for SEC_PRESHAREDKEY {}
@@ -16174,7 +15925,7 @@ unsafe impl ::windows::core::Abi for SEC_PRESHAREDKEY_IDENTITY {
 }
 impl ::core::cmp::PartialEq for SEC_PRESHAREDKEY_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_PRESHAREDKEY_IDENTITY>()) == 0 }
+        self.KeyIdentitySize == other.KeyIdentitySize && self.KeyIdentity == other.KeyIdentity
     }
 }
 impl ::core::cmp::Eq for SEC_PRESHAREDKEY_IDENTITY {}
@@ -16205,7 +15956,7 @@ unsafe impl ::windows::core::Abi for SEC_SRTP_MASTER_KEY_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for SEC_SRTP_MASTER_KEY_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_SRTP_MASTER_KEY_IDENTIFIER>()) == 0 }
+        self.MasterKeyIdentifierSize == other.MasterKeyIdentifierSize && self.MasterKeyIdentifier == other.MasterKeyIdentifier
     }
 }
 impl ::core::cmp::Eq for SEC_SRTP_MASTER_KEY_IDENTIFIER {}
@@ -16236,7 +15987,7 @@ unsafe impl ::windows::core::Abi for SEC_SRTP_PROTECTION_PROFILES {
 }
 impl ::core::cmp::PartialEq for SEC_SRTP_PROTECTION_PROFILES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_SRTP_PROTECTION_PROFILES>()) == 0 }
+        self.ProfilesSize == other.ProfilesSize && self.ProfilesList == other.ProfilesList
     }
 }
 impl ::core::cmp::Eq for SEC_SRTP_PROTECTION_PROFILES {}
@@ -16269,7 +16020,7 @@ unsafe impl ::windows::core::Abi for SEC_TOKEN_BINDING {
 }
 impl ::core::cmp::PartialEq for SEC_TOKEN_BINDING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_TOKEN_BINDING>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.KeyParametersSize == other.KeyParametersSize && self.KeyParameters == other.KeyParameters
     }
 }
 impl ::core::cmp::Eq for SEC_TOKEN_BINDING {}
@@ -16308,7 +16059,7 @@ unsafe impl ::windows::core::Abi for SEC_TRAFFIC_SECRETS {
 }
 impl ::core::cmp::PartialEq for SEC_TRAFFIC_SECRETS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_TRAFFIC_SECRETS>()) == 0 }
+        self.SymmetricAlgId == other.SymmetricAlgId && self.ChainingMode == other.ChainingMode && self.HashAlgId == other.HashAlgId && self.KeySize == other.KeySize && self.IvSize == other.IvSize && self.MsgSequenceStart == other.MsgSequenceStart && self.MsgSequenceEnd == other.MsgSequenceEnd && self.TrafficSecretType == other.TrafficSecretType && self.TrafficSecretSize == other.TrafficSecretSize && self.TrafficSecret == other.TrafficSecret
     }
 }
 impl ::core::cmp::Eq for SEC_TRAFFIC_SECRETS {}
@@ -16344,7 +16095,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY32 {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY32>()) == 0 }
+        self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY32 {}
@@ -16398,7 +16149,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_EX2 {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_EX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_EX2>()) == 0 }
+        self.Version == other.Version && self.cbHeaderLength == other.cbHeaderLength && self.cbStructureLength == other.cbStructureLength && self.UserOffset == other.UserOffset && self.UserLength == other.UserLength && self.DomainOffset == other.DomainOffset && self.DomainLength == other.DomainLength && self.PackedCredentialsOffset == other.PackedCredentialsOffset && self.PackedCredentialsLength == other.PackedCredentialsLength && self.Flags == other.Flags && self.PackageListOffset == other.PackageListOffset && self.PackageListLength == other.PackageListLength
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_EX2 {}
@@ -16438,7 +16189,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_EX32 {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_EX32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_EX32>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags && self.PackageList == other.PackageList && self.PackageListLength == other.PackageListLength
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_EX32 {}
@@ -16478,7 +16229,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_EXA {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_EXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_EXA>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags && self.PackageList == other.PackageList && self.PackageListLength == other.PackageListLength
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_EXA {}
@@ -16518,7 +16269,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_EXW {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_EXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_EXW>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags && self.PackageList == other.PackageList && self.PackageListLength == other.PackageListLength
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_EXW {}
@@ -16550,14 +16301,6 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Rpc")]
-impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Rpc")]
-impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_INFO {}
-#[cfg(feature = "Win32_System_Rpc")]
 impl ::core::default::Default for SEC_WINNT_AUTH_IDENTITY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16588,7 +16331,7 @@ unsafe impl ::windows::core::Abi for SEND_GENERIC_TLS_EXTENSION {
 }
 impl ::core::cmp::PartialEq for SEND_GENERIC_TLS_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEND_GENERIC_TLS_EXTENSION>()) == 0 }
+        self.ExtensionType == other.ExtensionType && self.HandshakeType == other.HandshakeType && self.Flags == other.Flags && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for SEND_GENERIC_TLS_EXTENSION {}
@@ -16622,7 +16365,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_ACCESS_REASON {
 }
 impl ::core::cmp::PartialEq for SE_ADT_ACCESS_REASON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_ACCESS_REASON>()) == 0 }
+        self.AccessMask == other.AccessMask && self.AccessReasons == other.AccessReasons && self.ObjectTypeIndex == other.ObjectTypeIndex && self.AccessGranted == other.AccessGranted && self.SecurityDescriptor == other.SecurityDescriptor
     }
 }
 impl ::core::cmp::Eq for SE_ADT_ACCESS_REASON {}
@@ -16653,7 +16396,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_CLAIMS {
 }
 impl ::core::cmp::PartialEq for SE_ADT_CLAIMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_CLAIMS>()) == 0 }
+        self.Length == other.Length && self.Claims == other.Claims
     }
 }
 impl ::core::cmp::Eq for SE_ADT_CLAIMS {}
@@ -16686,7 +16429,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_OBJECT_TYPE {
 }
 impl ::core::cmp::PartialEq for SE_ADT_OBJECT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_OBJECT_TYPE>()) == 0 }
+        self.ObjectType == other.ObjectType && self.Flags == other.Flags && self.Level == other.Level && self.AccessMask == other.AccessMask
     }
 }
 impl ::core::cmp::Eq for SE_ADT_OBJECT_TYPE {}
@@ -16723,7 +16466,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_PARAMETER_ARRAY {
 }
 impl ::core::cmp::PartialEq for SE_ADT_PARAMETER_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_PARAMETER_ARRAY>()) == 0 }
+        self.CategoryId == other.CategoryId && self.AuditId == other.AuditId && self.ParameterCount == other.ParameterCount && self.Length == other.Length && self.FlatSubCategoryId == other.FlatSubCategoryId && self.Type == other.Type && self.Flags == other.Flags && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for SE_ADT_PARAMETER_ARRAY {}
@@ -16756,7 +16499,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_PARAMETER_ARRAY_ENTRY {
 }
 impl ::core::cmp::PartialEq for SE_ADT_PARAMETER_ARRAY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_PARAMETER_ARRAY_ENTRY>()) == 0 }
+        self.Type == other.Type && self.Length == other.Length && self.Data == other.Data && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for SE_ADT_PARAMETER_ARRAY_ENTRY {}
@@ -16794,7 +16537,7 @@ unsafe impl ::windows::core::Abi for SE_ADT_PARAMETER_ARRAY_EX {
 }
 impl ::core::cmp::PartialEq for SE_ADT_PARAMETER_ARRAY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ADT_PARAMETER_ARRAY_EX>()) == 0 }
+        self.CategoryId == other.CategoryId && self.AuditId == other.AuditId && self.Version == other.Version && self.ParameterCount == other.ParameterCount && self.Length == other.Length && self.FlatSubCategoryId == other.FlatSubCategoryId && self.Type == other.Type && self.Flags == other.Flags && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for SE_ADT_PARAMETER_ARRAY_EX {}
@@ -16825,7 +16568,7 @@ unsafe impl ::windows::core::Abi for SL_ACTIVATION_INFO_HEADER {
 }
 impl ::core::cmp::PartialEq for SL_ACTIVATION_INFO_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SL_ACTIVATION_INFO_HEADER>()) == 0 }
+        self.cbSize == other.cbSize && self.r#type == other.r#type
     }
 }
 impl ::core::cmp::Eq for SL_ACTIVATION_INFO_HEADER {}
@@ -16857,7 +16600,7 @@ unsafe impl ::windows::core::Abi for SL_AD_ACTIVATION_INFO {
 }
 impl ::core::cmp::PartialEq for SL_AD_ACTIVATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SL_AD_ACTIVATION_INFO>()) == 0 }
+        self.header == other.header && self.pwszProductKey == other.pwszProductKey && self.pwszActivationObjectName == other.pwszActivationObjectName
     }
 }
 impl ::core::cmp::Eq for SL_AD_ACTIVATION_INFO {}
@@ -16892,7 +16635,7 @@ unsafe impl ::windows::core::Abi for SL_LICENSING_STATUS {
 }
 impl ::core::cmp::PartialEq for SL_LICENSING_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SL_LICENSING_STATUS>()) == 0 }
+        self.SkuId == other.SkuId && self.eStatus == other.eStatus && self.dwGraceTime == other.dwGraceTime && self.dwTotalGraceDays == other.dwTotalGraceDays && self.hrReason == other.hrReason && self.qwValidityExpiration == other.qwValidityExpiration
     }
 }
 impl ::core::cmp::Eq for SL_LICENSING_STATUS {}
@@ -16924,7 +16667,7 @@ unsafe impl ::windows::core::Abi for SL_NONGENUINE_UI_OPTIONS {
 }
 impl ::core::cmp::PartialEq for SL_NONGENUINE_UI_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SL_NONGENUINE_UI_OPTIONS>()) == 0 }
+        self.cbSize == other.cbSize && self.pComponentId == other.pComponentId && self.hResultUI == other.hResultUI
     }
 }
 impl ::core::cmp::Eq for SL_NONGENUINE_UI_OPTIONS {}
@@ -16955,7 +16698,7 @@ unsafe impl ::windows::core::Abi for SL_SYSTEM_POLICY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SL_SYSTEM_POLICY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SL_SYSTEM_POLICY_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for SL_SYSTEM_POLICY_INFORMATION {}
@@ -16986,7 +16729,7 @@ unsafe impl ::windows::core::Abi for SR_SECURITY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for SR_SECURITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SR_SECURITY_DESCRIPTOR>()) == 0 }
+        self.Length == other.Length && self.SecurityDescriptor == other.SecurityDescriptor
     }
 }
 impl ::core::cmp::Eq for SR_SECURITY_DESCRIPTOR {}
@@ -17020,7 +16763,7 @@ unsafe impl ::windows::core::Abi for SSL_CREDENTIAL_CERTIFICATE {
 }
 impl ::core::cmp::PartialEq for SSL_CREDENTIAL_CERTIFICATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_CREDENTIAL_CERTIFICATE>()) == 0 }
+        self.cbPrivateKey == other.cbPrivateKey && self.pPrivateKey == other.pPrivateKey && self.cbCertificate == other.cbCertificate && self.pCertificate == other.pCertificate && self.pszPassword == other.pszPassword
     }
 }
 impl ::core::cmp::Eq for SSL_CREDENTIAL_CERTIFICATE {}
@@ -17052,7 +16795,7 @@ unsafe impl ::windows::core::Abi for SUBSCRIBE_GENERIC_TLS_EXTENSION {
 }
 impl ::core::cmp::PartialEq for SUBSCRIBE_GENERIC_TLS_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SUBSCRIBE_GENERIC_TLS_EXTENSION>()) == 0 }
+        self.Flags == other.Flags && self.SubscriptionsCount == other.SubscriptionsCount && self.Subscriptions == other.Subscriptions
     }
 }
 impl ::core::cmp::Eq for SUBSCRIBE_GENERIC_TLS_EXTENSION {}
@@ -17084,7 +16827,7 @@ unsafe impl ::windows::core::Abi for SecBuffer {
 }
 impl ::core::cmp::PartialEq for SecBuffer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecBuffer>()) == 0 }
+        self.cbBuffer == other.cbBuffer && self.BufferType == other.BufferType && self.pvBuffer == other.pvBuffer
     }
 }
 impl ::core::cmp::Eq for SecBuffer {}
@@ -17116,7 +16859,7 @@ unsafe impl ::windows::core::Abi for SecBufferDesc {
 }
 impl ::core::cmp::PartialEq for SecBufferDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecBufferDesc>()) == 0 }
+        self.ulVersion == other.ulVersion && self.cBuffers == other.cBuffers && self.pBuffers == other.pBuffers
     }
 }
 impl ::core::cmp::Eq for SecBufferDesc {}
@@ -17146,7 +16889,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_AccessToken {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_AccessToken {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_AccessToken>()) == 0 }
+        self.AccessToken == other.AccessToken
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_AccessToken {}
@@ -17179,7 +16922,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ApplicationProtocol {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ApplicationProtocol {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ApplicationProtocol>()) == 0 }
+        self.ProtoNegoStatus == other.ProtoNegoStatus && self.ProtoNegoExt == other.ProtoNegoExt && self.ProtocolIdSize == other.ProtocolIdSize && self.ProtocolId == other.ProtocolId
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ApplicationProtocol {}
@@ -17209,7 +16952,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_AuthorityA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_AuthorityA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_AuthorityA>()) == 0 }
+        self.sAuthorityName == other.sAuthorityName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_AuthorityA {}
@@ -17239,7 +16982,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_AuthorityW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_AuthorityW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_AuthorityW>()) == 0 }
+        self.sAuthorityName == other.sAuthorityName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_AuthorityW {}
@@ -17270,7 +17013,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_AuthzID {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_AuthzID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_AuthzID>()) == 0 }
+        self.AuthzIDLength == other.AuthzIDLength && self.AuthzID == other.AuthzID
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_AuthzID {}
@@ -17301,7 +17044,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Bindings {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Bindings {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Bindings>()) == 0 }
+        self.BindingsLength == other.BindingsLength && self.Bindings == other.Bindings
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Bindings {}
@@ -17336,7 +17079,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CertInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CertInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CertInfo>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbSubjectName == other.cbSubjectName && self.pwszSubjectName == other.pwszSubjectName && self.cbIssuerName == other.cbIssuerName && self.pwszIssuerName == other.pwszIssuerName && self.dwKeySize == other.dwKeySize
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CertInfo {}
@@ -17367,7 +17110,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CertificateValidationResult {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CertificateValidationResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CertificateValidationResult>()) == 0 }
+        self.dwChainErrorStatus == other.dwChainErrorStatus && self.hrVerifyChainStatus == other.hrVerifyChainStatus
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CertificateValidationResult {}
@@ -17399,7 +17142,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Certificates {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Certificates {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Certificates>()) == 0 }
+        self.cCertificates == other.cCertificates && self.cbCertificateChain == other.cbCertificateChain && self.pbCertificateChain == other.pbCertificateChain
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Certificates {}
@@ -17459,7 +17202,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CipherInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CipherInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CipherInfo>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwProtocol == other.dwProtocol && self.dwCipherSuite == other.dwCipherSuite && self.dwBaseCipherSuite == other.dwBaseCipherSuite && self.szCipherSuite == other.szCipherSuite && self.szCipher == other.szCipher && self.dwCipherLen == other.dwCipherLen && self.dwCipherBlockLen == other.dwCipherBlockLen && self.szHash == other.szHash && self.dwHashLen == other.dwHashLen && self.szExchange == other.szExchange && self.dwMinExchangeLen == other.dwMinExchangeLen && self.dwMaxExchangeLen == other.dwMaxExchangeLen && self.szCertificate == other.szCertificate && self.dwKeyType == other.dwKeyType
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CipherInfo {}
@@ -17490,7 +17233,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ClientCertPolicyResult {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ClientCertPolicyResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ClientCertPolicyResult>()) == 0 }
+        self.dwPolicyResult == other.dwPolicyResult && self.guidPolicyId == other.guidPolicyId
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ClientCertPolicyResult {}
@@ -17520,7 +17263,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ClientSpecifiedTarget {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ClientSpecifiedTarget {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ClientSpecifiedTarget>()) == 0 }
+        self.sTargetName == other.sTargetName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ClientSpecifiedTarget {}
@@ -17556,7 +17299,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ConnectionInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ConnectionInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ConnectionInfo>()) == 0 }
+        self.dwProtocol == other.dwProtocol && self.aiCipher == other.aiCipher && self.dwCipherStrength == other.dwCipherStrength && self.aiHash == other.aiHash && self.dwHashStrength == other.dwHashStrength && self.aiExch == other.aiExch && self.dwExchStrength == other.dwExchStrength
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ConnectionInfo {}
@@ -17593,7 +17336,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ConnectionInfoEx {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ConnectionInfoEx {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ConnectionInfoEx>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwProtocol == other.dwProtocol && self.szCipher == other.szCipher && self.dwCipherStrength == other.dwCipherStrength && self.szHash == other.szHash && self.dwHashStrength == other.dwHashStrength && self.szExchange == other.szExchange && self.dwExchStrength == other.dwExchStrength
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ConnectionInfoEx {}
@@ -17624,7 +17367,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CredInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CredInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CredInfo>()) == 0 }
+        self.CredClass == other.CredClass && self.IsPromptingNeeded == other.IsPromptingNeeded
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CredInfo {}
@@ -17655,7 +17398,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CredentialNameA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CredentialNameA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CredentialNameA>()) == 0 }
+        self.CredentialType == other.CredentialType && self.sCredentialName == other.sCredentialName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CredentialNameA {}
@@ -17686,7 +17429,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_CredentialNameW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_CredentialNameW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_CredentialNameW>()) == 0 }
+        self.CredentialType == other.CredentialType && self.sCredentialName == other.sCredentialName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_CredentialNameW {}
@@ -17717,7 +17460,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_DceInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_DceInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_DceInfo>()) == 0 }
+        self.AuthzSvc == other.AuthzSvc && self.pPac == other.pPac
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_DceInfo {}
@@ -17748,7 +17491,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_EapKeyBlock {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_EapKeyBlock {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_EapKeyBlock>()) == 0 }
+        self.rgbKeys == other.rgbKeys && self.rgbIVs == other.rgbIVs
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_EapKeyBlock {}
@@ -17780,7 +17523,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_EapPrfInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_EapPrfInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_EapPrfInfo>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbPrfData == other.cbPrfData && self.pbPrfData == other.pbPrfData
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_EapPrfInfo {}
@@ -17810,7 +17553,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_EarlyStart {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_EarlyStart {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_EarlyStart>()) == 0 }
+        self.dwEarlyStartFlags == other.dwEarlyStartFlags
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_EarlyStart {}
@@ -17840,7 +17583,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Flags {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Flags {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Flags>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Flags {}
@@ -17877,7 +17620,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_IssuerListInfoEx {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SecPkgContext_IssuerListInfoEx {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_IssuerListInfoEx>()) == 0 }
+        self.aIssuers == other.aIssuers && self.cIssuers == other.cIssuers
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -17913,7 +17656,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_KeyInfoA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_KeyInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_KeyInfoA>()) == 0 }
+        self.sSignatureAlgorithmName == other.sSignatureAlgorithmName && self.sEncryptAlgorithmName == other.sEncryptAlgorithmName && self.KeySize == other.KeySize && self.SignatureAlgorithm == other.SignatureAlgorithm && self.EncryptAlgorithm == other.EncryptAlgorithm
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_KeyInfoA {}
@@ -17947,7 +17690,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_KeyInfoW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_KeyInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_KeyInfoW>()) == 0 }
+        self.sSignatureAlgorithmName == other.sSignatureAlgorithmName && self.sEncryptAlgorithmName == other.sEncryptAlgorithmName && self.KeySize == other.KeySize && self.SignatureAlgorithm == other.SignatureAlgorithm && self.EncryptAlgorithm == other.EncryptAlgorithm
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_KeyInfoW {}
@@ -17978,7 +17721,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_KeyingMaterial {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_KeyingMaterial {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_KeyingMaterial>()) == 0 }
+        self.cbKeyingMaterial == other.cbKeyingMaterial && self.pbKeyingMaterial == other.pbKeyingMaterial
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_KeyingMaterial {}
@@ -18012,7 +17755,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_KeyingMaterialInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_KeyingMaterialInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_KeyingMaterialInfo>()) == 0 }
+        self.cbLabel == other.cbLabel && self.pszLabel == other.pszLabel && self.cbContextValue == other.cbContextValue && self.pbContextValue == other.pbContextValue && self.cbKeyingMaterial == other.cbKeyingMaterial
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_KeyingMaterialInfo {}
@@ -18047,7 +17790,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_KeyingMaterial_Inproc {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_KeyingMaterial_Inproc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_KeyingMaterial_Inproc>()) == 0 }
+        self.cbLabel == other.cbLabel && self.pszLabel == other.pszLabel && self.cbContextValue == other.cbContextValue && self.pbContextValue == other.pbContextValue && self.cbKeyingMaterial == other.cbKeyingMaterial && self.pbKeyingMaterial == other.pbKeyingMaterial
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_KeyingMaterial_Inproc {}
@@ -18077,7 +17820,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_LastClientTokenStatus {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_LastClientTokenStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_LastClientTokenStatus>()) == 0 }
+        self.LastClientTokenStatus == other.LastClientTokenStatus
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_LastClientTokenStatus {}
@@ -18108,7 +17851,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Lifespan {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Lifespan {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Lifespan>()) == 0 }
+        self.tsStart == other.tsStart && self.tsExpiry == other.tsExpiry
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Lifespan {}
@@ -18142,7 +17885,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_LocalCredentialInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_LocalCredentialInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_LocalCredentialInfo>()) == 0 }
+        self.cbCertificateChain == other.cbCertificateChain && self.pbCertificateChain == other.pbCertificateChain && self.cCertificates == other.cCertificates && self.fFlags == other.fFlags && self.dwBits == other.dwBits
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_LocalCredentialInfo {}
@@ -18172,7 +17915,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_LogoffTime {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_LogoffTime {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_LogoffTime>()) == 0 }
+        self.tsLogoffTime == other.tsLogoffTime
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_LogoffTime {}
@@ -18203,7 +17946,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_MappedCredAttr {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_MappedCredAttr {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_MappedCredAttr>()) == 0 }
+        self.dwAttribute == other.dwAttribute && self.pvBuffer == other.pvBuffer
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_MappedCredAttr {}
@@ -18233,7 +17976,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NamesA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NamesA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NamesA>()) == 0 }
+        self.sUserName == other.sUserName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NamesA {}
@@ -18263,7 +18006,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NamesW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NamesW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NamesW>()) == 0 }
+        self.sUserName == other.sUserName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NamesW {}
@@ -18294,7 +18037,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NativeNamesA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NativeNamesA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NativeNamesA>()) == 0 }
+        self.sClientName == other.sClientName && self.sServerName == other.sServerName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NativeNamesA {}
@@ -18325,7 +18068,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NativeNamesW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NativeNamesW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NativeNamesW>()) == 0 }
+        self.sClientName == other.sClientName && self.sServerName == other.sServerName
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NativeNamesW {}
@@ -18360,7 +18103,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegoKeys {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegoKeys {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegoKeys>()) == 0 }
+        self.KeyType == other.KeyType && self.KeyLength == other.KeyLength && self.KeyValue == other.KeyValue && self.VerifyKeyType == other.VerifyKeyType && self.VerifyKeyLength == other.VerifyKeyLength && self.VerifyKeyValue == other.VerifyKeyValue
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegoKeys {}
@@ -18390,7 +18133,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegoPackageInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegoPackageInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegoPackageInfo>()) == 0 }
+        self.PackageMask == other.PackageMask
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegoPackageInfo {}
@@ -18420,7 +18163,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegoStatus {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegoStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegoStatus>()) == 0 }
+        self.LastStatus == other.LastStatus
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegoStatus {}
@@ -18451,7 +18194,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegotiatedTlsExtensions {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegotiatedTlsExtensions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegotiatedTlsExtensions>()) == 0 }
+        self.ExtensionsCount == other.ExtensionsCount && self.Extensions == other.Extensions
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegotiatedTlsExtensions {}
@@ -18482,7 +18225,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegotiationInfoA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegotiationInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegotiationInfoA>()) == 0 }
+        self.PackageInfo == other.PackageInfo && self.NegotiationState == other.NegotiationState
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegotiationInfoA {}
@@ -18513,7 +18256,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_NegotiationInfoW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_NegotiationInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_NegotiationInfoW>()) == 0 }
+        self.PackageInfo == other.PackageInfo && self.NegotiationState == other.NegotiationState
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_NegotiationInfoW {}
@@ -18543,7 +18286,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_PackageInfoA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_PackageInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_PackageInfoA>()) == 0 }
+        self.PackageInfo == other.PackageInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_PackageInfoA {}
@@ -18573,7 +18316,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_PackageInfoW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_PackageInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_PackageInfoW>()) == 0 }
+        self.PackageInfo == other.PackageInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_PackageInfoW {}
@@ -18603,7 +18346,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_PasswordExpiry {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_PasswordExpiry {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_PasswordExpiry>()) == 0 }
+        self.tsPasswordExpires == other.tsPasswordExpires
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_PasswordExpiry {}
@@ -18635,7 +18378,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ProtoInfoA {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ProtoInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ProtoInfoA>()) == 0 }
+        self.sProtocolName == other.sProtocolName && self.majorVersion == other.majorVersion && self.minorVersion == other.minorVersion
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ProtoInfoA {}
@@ -18667,7 +18410,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ProtoInfoW {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ProtoInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ProtoInfoW>()) == 0 }
+        self.sProtocolName == other.sProtocolName && self.majorVersion == other.majorVersion && self.minorVersion == other.minorVersion
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ProtoInfoW {}
@@ -18701,7 +18444,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_RemoteCredentialInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_RemoteCredentialInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_RemoteCredentialInfo>()) == 0 }
+        self.cbCertificateChain == other.cbCertificateChain && self.pbCertificateChain == other.pbCertificateChain && self.cCertificates == other.cCertificates && self.fFlags == other.fFlags && self.dwBits == other.dwBits
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_RemoteCredentialInfo {}
@@ -18731,7 +18474,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SaslContext {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SaslContext {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SaslContext>()) == 0 }
+        self.SaslContext == other.SaslContext
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SaslContext {}
@@ -18763,7 +18506,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SessionAppData {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SessionAppData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SessionAppData>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cbAppData == other.cbAppData && self.pbAppData == other.pbAppData
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SessionAppData {}
@@ -18795,7 +18538,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SessionInfo {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SessionInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SessionInfo>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cbSessionId == other.cbSessionId && self.rgbSessionId == other.rgbSessionId
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SessionInfo {}
@@ -18826,7 +18569,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SessionKey {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SessionKey {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SessionKey>()) == 0 }
+        self.SessionKeyLength == other.SessionKeyLength && self.SessionKey == other.SessionKey
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SessionKey {}
@@ -18859,7 +18602,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Sizes {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Sizes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Sizes>()) == 0 }
+        self.cbMaxToken == other.cbMaxToken && self.cbMaxSignature == other.cbMaxSignature && self.cbBlockSize == other.cbBlockSize && self.cbSecurityTrailer == other.cbSecurityTrailer
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Sizes {}
@@ -18891,7 +18634,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SrtpParameters {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SrtpParameters {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SrtpParameters>()) == 0 }
+        self.ProtectionProfile == other.ProtectionProfile && self.MasterKeyIdentifierSize == other.MasterKeyIdentifierSize && self.MasterKeyIdentifier == other.MasterKeyIdentifier
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SrtpParameters {}
@@ -18925,7 +18668,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_StreamSizes {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_StreamSizes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_StreamSizes>()) == 0 }
+        self.cbHeader == other.cbHeader && self.cbTrailer == other.cbTrailer && self.cbMaximumMessage == other.cbMaximumMessage && self.cBuffers == other.cBuffers && self.cbBlockSize == other.cbBlockSize
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_StreamSizes {}
@@ -18955,7 +18698,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SubjectAttributes {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SubjectAttributes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SubjectAttributes>()) == 0 }
+        self.AttributeInfo == other.AttributeInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SubjectAttributes {}
@@ -18986,7 +18729,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_SupportedSignatures {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_SupportedSignatures {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_SupportedSignatures>()) == 0 }
+        self.cSignatureAndHashAlgorithms == other.cSignatureAndHashAlgorithms && self.pSignatureAndHashAlgorithms == other.pSignatureAndHashAlgorithms
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_SupportedSignatures {}
@@ -19017,7 +18760,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_Target {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_Target {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_Target>()) == 0 }
+        self.TargetLength == other.TargetLength && self.Target == other.Target
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_Target {}
@@ -19048,7 +18791,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_TargetInformation {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_TargetInformation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_TargetInformation>()) == 0 }
+        self.MarshalledTargetInfoLength == other.MarshalledTargetInfoLength && self.MarshalledTargetInfo == other.MarshalledTargetInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_TargetInformation {}
@@ -19081,7 +18824,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_TokenBinding {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_TokenBinding {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_TokenBinding>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.KeyParametersSize == other.KeyParametersSize && self.KeyParameters == other.KeyParameters
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_TokenBinding {}
@@ -19117,7 +18860,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_UiInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SecPkgContext_UiInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_UiInfo>()) == 0 }
+        self.hParentWindow == other.hParentWindow
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19149,7 +18892,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_UserFlags {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_UserFlags {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_UserFlags>()) == 0 }
+        self.UserFlags == other.UserFlags
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_UserFlags {}
@@ -19180,7 +18923,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_CipherStrengths {
 }
 impl ::core::cmp::PartialEq for SecPkgCred_CipherStrengths {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_CipherStrengths>()) == 0 }
+        self.dwMinimumCipherStrength == other.dwMinimumCipherStrength && self.dwMaximumCipherStrength == other.dwMaximumCipherStrength
     }
 }
 impl ::core::cmp::Eq for SecPkgCred_CipherStrengths {}
@@ -19234,7 +18977,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_ClientCertPolicy {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SecPkgCred_ClientCertPolicy {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_ClientCertPolicy>()) == 0 }
+        self.dwFlags == other.dwFlags && self.guidPolicyId == other.guidPolicyId && self.dwCertFlags == other.dwCertFlags && self.dwUrlRetrievalTimeout == other.dwUrlRetrievalTimeout && self.fCheckRevocationFreshnessTime == other.fCheckRevocationFreshnessTime && self.dwRevocationFreshnessTime == other.dwRevocationFreshnessTime && self.fOmitUsageCheck == other.fOmitUsageCheck && self.pwszSslCtlStoreName == other.pwszSslCtlStoreName && self.pwszSslCtlIdentifier == other.pwszSslCtlIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19269,7 +19012,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_SessionTicketKey {
 }
 impl ::core::cmp::PartialEq for SecPkgCred_SessionTicketKey {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_SessionTicketKey>()) == 0 }
+        self.TicketInfoVersion == other.TicketInfoVersion && self.KeyId == other.KeyId && self.KeyingMaterial == other.KeyingMaterial && self.KeyingMaterialSize == other.KeyingMaterialSize
     }
 }
 impl ::core::cmp::Eq for SecPkgCred_SessionTicketKey {}
@@ -19300,7 +19043,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_SessionTicketKeys {
 }
 impl ::core::cmp::PartialEq for SecPkgCred_SessionTicketKeys {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_SessionTicketKeys>()) == 0 }
+        self.cSessionTicketKeys == other.cSessionTicketKeys && self.pSessionTicketKeys == other.pSessionTicketKeys
     }
 }
 impl ::core::cmp::Eq for SecPkgCred_SessionTicketKeys {}
@@ -19331,7 +19074,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_SupportedAlgs {
 }
 impl ::core::cmp::PartialEq for SecPkgCred_SupportedAlgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_SupportedAlgs>()) == 0 }
+        self.cSupportedAlgs == other.cSupportedAlgs && self.palgSupportedAlgs == other.palgSupportedAlgs
     }
 }
 impl ::core::cmp::Eq for SecPkgCred_SupportedAlgs {}
@@ -19361,7 +19104,7 @@ unsafe impl ::windows::core::Abi for SecPkgCred_SupportedProtocols {
 }
 impl ::core::cmp::PartialEq for SecPkgCred_SupportedProtocols {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCred_SupportedProtocols>()) == 0 }
+        self.grbitProtocol == other.grbitProtocol
     }
 }
 impl ::core::cmp::Eq for SecPkgCred_SupportedProtocols {}
@@ -19392,7 +19135,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_Cert {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_Cert {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_Cert>()) == 0 }
+        self.EncodedCertSize == other.EncodedCertSize && self.EncodedCert == other.EncodedCert
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_Cert {}
@@ -19427,7 +19170,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_KdcProxySettingsW {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_KdcProxySettingsW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_KdcProxySettingsW>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.ProxyServerOffset == other.ProxyServerOffset && self.ProxyServerLength == other.ProxyServerLength && self.ClientTlsCredOffset == other.ClientTlsCredOffset && self.ClientTlsCredLength == other.ClientTlsCredLength
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_KdcProxySettingsW {}
@@ -19457,7 +19200,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_NamesA {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_NamesA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_NamesA>()) == 0 }
+        self.sUserName == other.sUserName
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_NamesA {}
@@ -19487,7 +19230,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_NamesW {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_NamesW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_NamesW>()) == 0 }
+        self.sUserName == other.sUserName
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_NamesW {}
@@ -19519,7 +19262,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_SSIProviderA {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_SSIProviderA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_SSIProviderA>()) == 0 }
+        self.sProviderName == other.sProviderName && self.ProviderInfoLength == other.ProviderInfoLength && self.ProviderInfo == other.ProviderInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_SSIProviderA {}
@@ -19551,7 +19294,7 @@ unsafe impl ::windows::core::Abi for SecPkgCredentials_SSIProviderW {
 }
 impl ::core::cmp::PartialEq for SecPkgCredentials_SSIProviderW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgCredentials_SSIProviderW>()) == 0 }
+        self.sProviderName == other.sProviderName && self.ProviderInfoLength == other.ProviderInfoLength && self.ProviderInfo == other.ProviderInfo
     }
 }
 impl ::core::cmp::Eq for SecPkgCredentials_SSIProviderW {}
@@ -19586,7 +19329,7 @@ unsafe impl ::windows::core::Abi for SecPkgInfoA {
 }
 impl ::core::cmp::PartialEq for SecPkgInfoA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgInfoA>()) == 0 }
+        self.fCapabilities == other.fCapabilities && self.wVersion == other.wVersion && self.wRPCID == other.wRPCID && self.cbMaxToken == other.cbMaxToken && self.Name == other.Name && self.Comment == other.Comment
     }
 }
 impl ::core::cmp::Eq for SecPkgInfoA {}
@@ -19621,7 +19364,7 @@ unsafe impl ::windows::core::Abi for SecPkgInfoW {
 }
 impl ::core::cmp::PartialEq for SecPkgInfoW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgInfoW>()) == 0 }
+        self.fCapabilities == other.fCapabilities && self.wVersion == other.wVersion && self.wRPCID == other.wRPCID && self.cbMaxToken == other.cbMaxToken && self.Name == other.Name && self.Comment == other.Comment
     }
 }
 impl ::core::cmp::Eq for SecPkgInfoW {}
@@ -19678,54 +19421,13 @@ impl ::core::clone::Clone for SecurityFunctionTableA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::fmt::Debug for SecurityFunctionTableA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SecurityFunctionTableA")
-            .field("dwVersion", &self.dwVersion)
-            .field("EnumerateSecurityPackagesA", &self.EnumerateSecurityPackagesA.map(|f| f as usize))
-            .field("QueryCredentialsAttributesA", &self.QueryCredentialsAttributesA.map(|f| f as usize))
-            .field("AcquireCredentialsHandleA", &self.AcquireCredentialsHandleA.map(|f| f as usize))
-            .field("FreeCredentialsHandle", &self.FreeCredentialsHandle.map(|f| f as usize))
-            .field("Reserved2", &self.Reserved2)
-            .field("InitializeSecurityContextA", &self.InitializeSecurityContextA.map(|f| f as usize))
-            .field("AcceptSecurityContext", &self.AcceptSecurityContext.map(|f| f as usize))
-            .field("CompleteAuthToken", &self.CompleteAuthToken.map(|f| f as usize))
-            .field("DeleteSecurityContext", &self.DeleteSecurityContext.map(|f| f as usize))
-            .field("ApplyControlToken", &self.ApplyControlToken.map(|f| f as usize))
-            .field("QueryContextAttributesA", &self.QueryContextAttributesA.map(|f| f as usize))
-            .field("ImpersonateSecurityContext", &self.ImpersonateSecurityContext.map(|f| f as usize))
-            .field("RevertSecurityContext", &self.RevertSecurityContext.map(|f| f as usize))
-            .field("MakeSignature", &self.MakeSignature.map(|f| f as usize))
-            .field("VerifySignature", &self.VerifySignature.map(|f| f as usize))
-            .field("FreeContextBuffer", &self.FreeContextBuffer.map(|f| f as usize))
-            .field("QuerySecurityPackageInfoA", &self.QuerySecurityPackageInfoA.map(|f| f as usize))
-            .field("Reserved3", &self.Reserved3)
-            .field("Reserved4", &self.Reserved4)
-            .field("ExportSecurityContext", &self.ExportSecurityContext.map(|f| f as usize))
-            .field("ImportSecurityContextA", &self.ImportSecurityContextA.map(|f| f as usize))
-            .field("AddCredentialsA", &self.AddCredentialsA.map(|f| f as usize))
-            .field("Reserved8", &self.Reserved8)
-            .field("QuerySecurityContextToken", &self.QuerySecurityContextToken.map(|f| f as usize))
-            .field("EncryptMessage", &self.EncryptMessage.map(|f| f as usize))
-            .field("DecryptMessage", &self.DecryptMessage.map(|f| f as usize))
-            .field("SetContextAttributesA", &self.SetContextAttributesA.map(|f| f as usize))
-            .field("SetCredentialsAttributesA", &self.SetCredentialsAttributesA.map(|f| f as usize))
-            .field("ChangeAccountPasswordA", &self.ChangeAccountPasswordA.map(|f| f as usize))
-            .field("QueryContextAttributesExA", &self.QueryContextAttributesExA.map(|f| f as usize))
-            .field("QueryCredentialsAttributesExA", &self.QueryCredentialsAttributesExA.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SecurityFunctionTableA").field("dwVersion", &self.dwVersion).field("Reserved2", &self.Reserved2).field("Reserved3", &self.Reserved3).field("Reserved4", &self.Reserved4).field("Reserved8", &self.Reserved8).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 unsafe impl ::windows::core::Abi for SecurityFunctionTableA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
-impl ::core::cmp::PartialEq for SecurityFunctionTableA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecurityFunctionTableA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
-impl ::core::cmp::Eq for SecurityFunctionTableA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::default::Default for SecurityFunctionTableA {
     fn default() -> Self {
@@ -19780,54 +19482,13 @@ impl ::core::clone::Clone for SecurityFunctionTableW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::fmt::Debug for SecurityFunctionTableW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SecurityFunctionTableW")
-            .field("dwVersion", &self.dwVersion)
-            .field("EnumerateSecurityPackagesW", &self.EnumerateSecurityPackagesW.map(|f| f as usize))
-            .field("QueryCredentialsAttributesW", &self.QueryCredentialsAttributesW.map(|f| f as usize))
-            .field("AcquireCredentialsHandleW", &self.AcquireCredentialsHandleW.map(|f| f as usize))
-            .field("FreeCredentialsHandle", &self.FreeCredentialsHandle.map(|f| f as usize))
-            .field("Reserved2", &self.Reserved2)
-            .field("InitializeSecurityContextW", &self.InitializeSecurityContextW.map(|f| f as usize))
-            .field("AcceptSecurityContext", &self.AcceptSecurityContext.map(|f| f as usize))
-            .field("CompleteAuthToken", &self.CompleteAuthToken.map(|f| f as usize))
-            .field("DeleteSecurityContext", &self.DeleteSecurityContext.map(|f| f as usize))
-            .field("ApplyControlToken", &self.ApplyControlToken.map(|f| f as usize))
-            .field("QueryContextAttributesW", &self.QueryContextAttributesW.map(|f| f as usize))
-            .field("ImpersonateSecurityContext", &self.ImpersonateSecurityContext.map(|f| f as usize))
-            .field("RevertSecurityContext", &self.RevertSecurityContext.map(|f| f as usize))
-            .field("MakeSignature", &self.MakeSignature.map(|f| f as usize))
-            .field("VerifySignature", &self.VerifySignature.map(|f| f as usize))
-            .field("FreeContextBuffer", &self.FreeContextBuffer.map(|f| f as usize))
-            .field("QuerySecurityPackageInfoW", &self.QuerySecurityPackageInfoW.map(|f| f as usize))
-            .field("Reserved3", &self.Reserved3)
-            .field("Reserved4", &self.Reserved4)
-            .field("ExportSecurityContext", &self.ExportSecurityContext.map(|f| f as usize))
-            .field("ImportSecurityContextW", &self.ImportSecurityContextW.map(|f| f as usize))
-            .field("AddCredentialsW", &self.AddCredentialsW.map(|f| f as usize))
-            .field("Reserved8", &self.Reserved8)
-            .field("QuerySecurityContextToken", &self.QuerySecurityContextToken.map(|f| f as usize))
-            .field("EncryptMessage", &self.EncryptMessage.map(|f| f as usize))
-            .field("DecryptMessage", &self.DecryptMessage.map(|f| f as usize))
-            .field("SetContextAttributesW", &self.SetContextAttributesW.map(|f| f as usize))
-            .field("SetCredentialsAttributesW", &self.SetCredentialsAttributesW.map(|f| f as usize))
-            .field("ChangeAccountPasswordW", &self.ChangeAccountPasswordW.map(|f| f as usize))
-            .field("QueryContextAttributesExW", &self.QueryContextAttributesExW.map(|f| f as usize))
-            .field("QueryCredentialsAttributesExW", &self.QueryCredentialsAttributesExW.map(|f| f as usize))
-            .finish()
+        f.debug_struct("SecurityFunctionTableW").field("dwVersion", &self.dwVersion).field("Reserved2", &self.Reserved2).field("Reserved3", &self.Reserved3).field("Reserved4", &self.Reserved4).field("Reserved8", &self.Reserved8).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 unsafe impl ::windows::core::Abi for SecurityFunctionTableW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
-impl ::core::cmp::PartialEq for SecurityFunctionTableW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecurityFunctionTableW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
-impl ::core::cmp::Eq for SecurityFunctionTableW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Credentials"))]
 impl ::core::default::Default for SecurityFunctionTableW {
     fn default() -> Self {
@@ -19856,7 +19517,7 @@ unsafe impl ::windows::core::Abi for TLS_EXTENSION_SUBSCRIPTION {
 }
 impl ::core::cmp::PartialEq for TLS_EXTENSION_SUBSCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TLS_EXTENSION_SUBSCRIPTION>()) == 0 }
+        self.ExtensionType == other.ExtensionType && self.HandshakeType == other.HandshakeType
     }
 }
 impl ::core::cmp::Eq for TLS_EXTENSION_SUBSCRIPTION {}
@@ -19886,7 +19547,7 @@ unsafe impl ::windows::core::Abi for TOKENBINDING_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for TOKENBINDING_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKENBINDING_IDENTIFIER>()) == 0 }
+        self.keyType == other.keyType
     }
 }
 impl ::core::cmp::Eq for TOKENBINDING_IDENTIFIER {}
@@ -19917,7 +19578,7 @@ unsafe impl ::windows::core::Abi for TOKENBINDING_KEY_TYPES {
 }
 impl ::core::cmp::PartialEq for TOKENBINDING_KEY_TYPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKENBINDING_KEY_TYPES>()) == 0 }
+        self.keyCount == other.keyCount && self.keyType == other.keyType
     }
 }
 impl ::core::cmp::Eq for TOKENBINDING_KEY_TYPES {}
@@ -19952,7 +19613,7 @@ unsafe impl ::windows::core::Abi for TOKENBINDING_RESULT_DATA {
 }
 impl ::core::cmp::PartialEq for TOKENBINDING_RESULT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKENBINDING_RESULT_DATA>()) == 0 }
+        self.bindingType == other.bindingType && self.identifierSize == other.identifierSize && self.identifierData == other.identifierData && self.extensionFormat == other.extensionFormat && self.extensionSize == other.extensionSize && self.extensionData == other.extensionData
     }
 }
 impl ::core::cmp::Eq for TOKENBINDING_RESULT_DATA {}
@@ -19983,7 +19644,7 @@ unsafe impl ::windows::core::Abi for TOKENBINDING_RESULT_LIST {
 }
 impl ::core::cmp::PartialEq for TOKENBINDING_RESULT_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKENBINDING_RESULT_LIST>()) == 0 }
+        self.resultCount == other.resultCount && self.resultData == other.resultData
     }
 }
 impl ::core::cmp::Eq for TOKENBINDING_RESULT_LIST {}
@@ -20020,7 +19681,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_CONTROLLERS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_CONTROLLERS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_CONTROLLERS_INFO>()) == 0 }
+        self.Entries == other.Entries && self.Names == other.Names
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20064,7 +19725,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_AUTH_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_AUTH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_AUTH_INFORMATION>()) == 0 }
+        self.IncomingAuthInfos == other.IncomingAuthInfos && self.IncomingAuthenticationInformation == other.IncomingAuthenticationInformation && self.IncomingPreviousAuthenticationInformation == other.IncomingPreviousAuthenticationInformation && self.OutgoingAuthInfos == other.OutgoingAuthInfos && self.OutgoingAuthenticationInformation == other.OutgoingAuthenticationInformation && self.OutgoingPreviousAuthenticationInformation == other.OutgoingPreviousAuthenticationInformation
     }
 }
 impl ::core::cmp::Eq for TRUSTED_DOMAIN_AUTH_INFORMATION {}
@@ -20102,7 +19763,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_FULL_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_FULL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_FULL_INFORMATION>()) == 0 }
+        self.Information == other.Information && self.PosixOffset == other.PosixOffset && self.AuthInformation == other.AuthInformation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20142,7 +19803,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_FULL_INFORMATION2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_FULL_INFORMATION2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_FULL_INFORMATION2>()) == 0 }
+        self.Information == other.Information && self.PosixOffset == other.PosixOffset && self.AuthInformation == other.AuthInformation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20185,7 +19846,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_INFORMATION_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_INFORMATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_INFORMATION_EX>()) == 0 }
+        self.Name == other.Name && self.FlatName == other.FlatName && self.Sid == other.Sid && self.TrustDirection == other.TrustDirection && self.TrustType == other.TrustType && self.TrustAttributes == other.TrustAttributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20230,7 +19891,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_INFORMATION_EX2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_INFORMATION_EX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_INFORMATION_EX2>()) == 0 }
+        self.Name == other.Name && self.FlatName == other.FlatName && self.Sid == other.Sid && self.TrustDirection == other.TrustDirection && self.TrustType == other.TrustType && self.TrustAttributes == other.TrustAttributes && self.ForestTrustLength == other.ForestTrustLength && self.ForestTrustInfo == other.ForestTrustInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20268,7 +19929,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_NAME_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_NAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_NAME_INFO>()) == 0 }
+        self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20300,7 +19961,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {
 }
 impl ::core::cmp::PartialEq for TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES>()) == 0 }
+        self.SupportedEncryptionTypes == other.SupportedEncryptionTypes
     }
 }
 impl ::core::cmp::Eq for TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {}
@@ -20337,7 +19998,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_PASSWORD_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRUSTED_PASSWORD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_PASSWORD_INFO>()) == 0 }
+        self.Password == other.Password && self.OldPassword == other.OldPassword
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20369,7 +20030,7 @@ unsafe impl ::windows::core::Abi for TRUSTED_POSIX_OFFSET_INFO {
 }
 impl ::core::cmp::PartialEq for TRUSTED_POSIX_OFFSET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTED_POSIX_OFFSET_INFO>()) == 0 }
+        self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for TRUSTED_POSIX_OFFSET_INFO {}
@@ -20429,14 +20090,6 @@ unsafe impl ::windows::core::Abi for USER_ALL_INFORMATION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for USER_ALL_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_ALL_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for USER_ALL_INFORMATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for USER_ALL_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20469,7 +20122,7 @@ unsafe impl ::windows::core::Abi for USER_SESSION_KEY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
 impl ::core::cmp::PartialEq for USER_SESSION_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_SESSION_KEY>()) == 0 }
+        self.data == other.data
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_PasswordManagement"))]
@@ -20514,7 +20167,7 @@ unsafe impl ::windows::core::Abi for X509Certificate {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for X509Certificate {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<X509Certificate>()) == 0 }
+        self.Version == other.Version && self.SerialNumber == other.SerialNumber && self.SignatureAlgorithm == other.SignatureAlgorithm && self.ValidFrom == other.ValidFrom && self.ValidUntil == other.ValidUntil && self.pszIssuer == other.pszIssuer && self.pszSubject == other.pszSubject && self.pPublicKey == other.pPublicKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -736,7 +736,7 @@ unsafe impl ::windows::core::Abi for EFFPERM_RESULT_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EFFPERM_RESULT_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFFPERM_RESULT_LIST>()) == 0 }
+        self.fEvaluated == other.fEvaluated && self.cObjectTypeListLength == other.cObjectTypeListLength && self.pObjectTypeList == other.pObjectTypeList && self.pGrantedAccessList == other.pGrantedAccessList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -780,7 +780,7 @@ unsafe impl ::windows::core::Abi for SECURITY_OBJECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_OBJECT>()) == 0 }
+        self.pwszName == other.pwszName && self.pData == other.pData && self.cbData == other.cbData && self.pData2 == other.pData2 && self.cbData2 == other.cbData2 && self.Id == other.Id && self.fWellKnown == other.fWellKnown
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -821,7 +821,7 @@ unsafe impl ::windows::core::Abi for SID_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID_INFO>()) == 0 }
+        self.pSid == other.pSid && self.pwzCommonName == other.pwzCommonName && self.pwzClass == other.pwzClass && self.pwzUPN == other.pwzUPN
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -860,7 +860,7 @@ unsafe impl ::windows::core::Abi for SID_INFO_LIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SID_INFO_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID_INFO_LIST>()) == 0 }
+        self.cItems == other.cItems && self.aSidInfo == other.aSidInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -895,7 +895,7 @@ unsafe impl ::windows::core::Abi for SI_ACCESS {
 }
 impl ::core::cmp::PartialEq for SI_ACCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SI_ACCESS>()) == 0 }
+        self.pguid == other.pguid && self.mask == other.mask && self.pszName == other.pszName && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for SI_ACCESS {}
@@ -927,7 +927,7 @@ unsafe impl ::windows::core::Abi for SI_INHERIT_TYPE {
 }
 impl ::core::cmp::PartialEq for SI_INHERIT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SI_INHERIT_TYPE>()) == 0 }
+        self.pguid == other.pguid && self.dwFlags == other.dwFlags && self.pszName == other.pszName
     }
 }
 impl ::core::cmp::Eq for SI_INHERIT_TYPE {}
@@ -968,7 +968,7 @@ unsafe impl ::windows::core::Abi for SI_OBJECT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SI_OBJECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SI_OBJECT_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.hInstance == other.hInstance && self.pszServerName == other.pszServerName && self.pszObjectName == other.pszObjectName && self.pszPageTitle == other.pszPageTitle && self.guidObjectType == other.guidObjectType
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -9983,7 +9983,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESSA {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESSA>()) == 0 }
+        self.cEntries == other.cEntries && self.pPropertyAccessList == other.pPropertyAccessList
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESSA {}
@@ -10014,7 +10014,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESSW {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESSW>()) == 0 }
+        self.cEntries == other.cEntries && self.pPropertyAccessList == other.pPropertyAccessList
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESSW {}
@@ -10049,7 +10049,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_ENTRYA {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_ENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_ENTRYA>()) == 0 }
+        self.Trustee == other.Trustee && self.fAccessFlags == other.fAccessFlags && self.Access == other.Access && self.ProvSpecificAccess == other.ProvSpecificAccess && self.Inheritance == other.Inheritance && self.lpInheritProperty == other.lpInheritProperty
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_ENTRYA {}
@@ -10084,7 +10084,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_ENTRYW {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_ENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_ENTRYW>()) == 0 }
+        self.Trustee == other.Trustee && self.fAccessFlags == other.fAccessFlags && self.Access == other.Access && self.ProvSpecificAccess == other.ProvSpecificAccess && self.Inheritance == other.Inheritance && self.lpInheritProperty == other.lpInheritProperty
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_ENTRYW {}
@@ -10115,7 +10115,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_ENTRY_LISTA {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_ENTRY_LISTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_ENTRY_LISTA>()) == 0 }
+        self.cEntries == other.cEntries && self.pAccessList == other.pAccessList
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_ENTRY_LISTA {}
@@ -10146,7 +10146,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_ENTRY_LISTW {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_ENTRY_LISTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_ENTRY_LISTW>()) == 0 }
+        self.cEntries == other.cEntries && self.pAccessList == other.pAccessList
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_ENTRY_LISTW {}
@@ -10177,7 +10177,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_INFOA {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_INFOA>()) == 0 }
+        self.fAccessPermission == other.fAccessPermission && self.lpAccessPermissionName == other.lpAccessPermissionName
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_INFOA {}
@@ -10208,7 +10208,7 @@ unsafe impl ::windows::core::Abi for ACTRL_ACCESS_INFOW {
 }
 impl ::core::cmp::PartialEq for ACTRL_ACCESS_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_ACCESS_INFOW>()) == 0 }
+        self.fAccessPermission == other.fAccessPermission && self.lpAccessPermissionName == other.lpAccessPermissionName
     }
 }
 impl ::core::cmp::Eq for ACTRL_ACCESS_INFOW {}
@@ -10239,7 +10239,7 @@ unsafe impl ::windows::core::Abi for ACTRL_CONTROL_INFOA {
 }
 impl ::core::cmp::PartialEq for ACTRL_CONTROL_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_CONTROL_INFOA>()) == 0 }
+        self.lpControlId == other.lpControlId && self.lpControlName == other.lpControlName
     }
 }
 impl ::core::cmp::Eq for ACTRL_CONTROL_INFOA {}
@@ -10270,7 +10270,7 @@ unsafe impl ::windows::core::Abi for ACTRL_CONTROL_INFOW {
 }
 impl ::core::cmp::PartialEq for ACTRL_CONTROL_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_CONTROL_INFOW>()) == 0 }
+        self.lpControlId == other.lpControlId && self.lpControlName == other.lpControlName
     }
 }
 impl ::core::cmp::Eq for ACTRL_CONTROL_INFOW {}
@@ -10300,14 +10300,6 @@ unsafe impl ::windows::core::Abi for ACTRL_OVERLAPPED {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACTRL_OVERLAPPED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_OVERLAPPED>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACTRL_OVERLAPPED {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACTRL_OVERLAPPED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10332,14 +10324,6 @@ impl ::core::clone::Clone for ACTRL_OVERLAPPED_0 {
 unsafe impl ::windows::core::Abi for ACTRL_OVERLAPPED_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ACTRL_OVERLAPPED_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_OVERLAPPED_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ACTRL_OVERLAPPED_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ACTRL_OVERLAPPED_0 {
     fn default() -> Self {
@@ -10369,7 +10353,7 @@ unsafe impl ::windows::core::Abi for ACTRL_PROPERTY_ENTRYA {
 }
 impl ::core::cmp::PartialEq for ACTRL_PROPERTY_ENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_PROPERTY_ENTRYA>()) == 0 }
+        self.lpProperty == other.lpProperty && self.pAccessEntryList == other.pAccessEntryList && self.fListFlags == other.fListFlags
     }
 }
 impl ::core::cmp::Eq for ACTRL_PROPERTY_ENTRYA {}
@@ -10401,7 +10385,7 @@ unsafe impl ::windows::core::Abi for ACTRL_PROPERTY_ENTRYW {
 }
 impl ::core::cmp::PartialEq for ACTRL_PROPERTY_ENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTRL_PROPERTY_ENTRYW>()) == 0 }
+        self.lpProperty == other.lpProperty && self.pAccessEntryList == other.pAccessEntryList && self.fListFlags == other.fListFlags
     }
 }
 impl ::core::cmp::Eq for ACTRL_PROPERTY_ENTRYW {}
@@ -10431,7 +10415,7 @@ unsafe impl ::windows::core::Abi for AUDIT_IP_ADDRESS {
 }
 impl ::core::cmp::PartialEq for AUDIT_IP_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_IP_ADDRESS>()) == 0 }
+        self.pIpAddress == other.pIpAddress
     }
 }
 impl ::core::cmp::Eq for AUDIT_IP_ADDRESS {}
@@ -10464,7 +10448,7 @@ unsafe impl ::windows::core::Abi for AUDIT_OBJECT_TYPE {
 }
 impl ::core::cmp::PartialEq for AUDIT_OBJECT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_OBJECT_TYPE>()) == 0 }
+        self.ObjectType == other.ObjectType && self.Flags == other.Flags && self.Level == other.Level && self.AccessMask == other.AccessMask
     }
 }
 impl ::core::cmp::Eq for AUDIT_OBJECT_TYPE {}
@@ -10496,7 +10480,7 @@ unsafe impl ::windows::core::Abi for AUDIT_OBJECT_TYPES {
 }
 impl ::core::cmp::PartialEq for AUDIT_OBJECT_TYPES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_OBJECT_TYPES>()) == 0 }
+        self.Count == other.Count && self.Flags == other.Flags && self.pObjectTypes == other.pObjectTypes
     }
 }
 impl ::core::cmp::Eq for AUDIT_OBJECT_TYPES {}
@@ -10523,12 +10507,6 @@ impl ::core::clone::Clone for AUDIT_PARAM {
 unsafe impl ::windows::core::Abi for AUDIT_PARAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIT_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_PARAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIT_PARAM {}
 impl ::core::default::Default for AUDIT_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10555,12 +10533,6 @@ impl ::core::clone::Clone for AUDIT_PARAM_0 {
 unsafe impl ::windows::core::Abi for AUDIT_PARAM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIT_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_PARAM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIT_PARAM_0 {}
 impl ::core::default::Default for AUDIT_PARAM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10581,12 +10553,6 @@ impl ::core::clone::Clone for AUDIT_PARAM_1 {
 unsafe impl ::windows::core::Abi for AUDIT_PARAM_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUDIT_PARAM_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_PARAM_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUDIT_PARAM_1 {}
 impl ::core::default::Default for AUDIT_PARAM_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10616,7 +10582,7 @@ unsafe impl ::windows::core::Abi for AUDIT_PARAMS {
 }
 impl ::core::cmp::PartialEq for AUDIT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIT_PARAMS>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags && self.Count == other.Count && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for AUDIT_PARAMS {}
@@ -10681,7 +10647,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_ACCESS_REPLY {
 }
 impl ::core::cmp::PartialEq for AUTHZ_ACCESS_REPLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_ACCESS_REPLY>()) == 0 }
+        self.ResultListLength == other.ResultListLength && self.GrantedAccessMask == other.GrantedAccessMask && self.SaclEvaluationResults == other.SaclEvaluationResults && self.Error == other.Error
     }
 }
 impl ::core::cmp::Eq for AUTHZ_ACCESS_REPLY {}
@@ -10721,7 +10687,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_ACCESS_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUTHZ_ACCESS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_ACCESS_REQUEST>()) == 0 }
+        self.DesiredAccess == other.DesiredAccess && self.PrincipalSelfSid == other.PrincipalSelfSid && self.ObjectTypeList == other.ObjectTypeList && self.ObjectTypeListLength == other.ObjectTypeListLength && self.OptionalArguments == other.OptionalArguments
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10819,7 +10785,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_AUDIT_EVENT_TYPE_LEGACY {
 }
 impl ::core::cmp::PartialEq for AUTHZ_AUDIT_EVENT_TYPE_LEGACY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_AUDIT_EVENT_TYPE_LEGACY>()) == 0 }
+        self.CategoryId == other.CategoryId && self.AuditId == other.AuditId && self.ParameterCount == other.ParameterCount
     }
 }
 impl ::core::cmp::Eq for AUTHZ_AUDIT_EVENT_TYPE_LEGACY {}
@@ -10852,14 +10818,6 @@ unsafe impl ::windows::core::Abi for AUTHZ_AUDIT_EVENT_TYPE_OLD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AUTHZ_AUDIT_EVENT_TYPE_OLD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_AUDIT_EVENT_TYPE_OLD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AUTHZ_AUDIT_EVENT_TYPE_OLD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AUTHZ_AUDIT_EVENT_TYPE_OLD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10879,12 +10837,6 @@ impl ::core::clone::Clone for AUTHZ_AUDIT_EVENT_TYPE_UNION {
 unsafe impl ::windows::core::Abi for AUTHZ_AUDIT_EVENT_TYPE_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_AUDIT_EVENT_TYPE_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_AUDIT_EVENT_TYPE_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_AUDIT_EVENT_TYPE_UNION {}
 impl ::core::default::Default for AUTHZ_AUDIT_EVENT_TYPE_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10911,7 +10863,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE__ {
 }
 impl ::core::cmp::PartialEq for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE__ {}
@@ -10975,29 +10927,13 @@ impl ::core::clone::Clone for AUTHZ_INIT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for AUTHZ_INIT_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("AUTHZ_INIT_INFO")
-            .field("version", &self.version)
-            .field("szResourceManagerName", &self.szResourceManagerName)
-            .field("pfnDynamicAccessCheck", &self.pfnDynamicAccessCheck.map(|f| f as usize))
-            .field("pfnComputeDynamicGroups", &self.pfnComputeDynamicGroups.map(|f| f as usize))
-            .field("pfnFreeDynamicGroups", &self.pfnFreeDynamicGroups.map(|f| f as usize))
-            .field("pfnGetCentralAccessPolicy", &self.pfnGetCentralAccessPolicy.map(|f| f as usize))
-            .field("pfnFreeCentralAccessPolicy", &self.pfnFreeCentralAccessPolicy.map(|f| f as usize))
-            .finish()
+        f.debug_struct("AUTHZ_INIT_INFO").field("version", &self.version).field("szResourceManagerName", &self.szResourceManagerName).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for AUTHZ_INIT_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AUTHZ_INIT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_INIT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AUTHZ_INIT_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AUTHZ_INIT_INFO {
     fn default() -> Self {
@@ -11026,7 +10962,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET 
 }
 impl ::core::cmp::PartialEq for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET>()) == 0 }
+        self.szObjectTypeName == other.szObjectTypeName && self.dwOffset == other.dwOffset
     }
 }
 impl ::core::cmp::Eq for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET {}
@@ -11094,7 +11030,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_RPC_INIT_INFO_CLIENT {
 }
 impl ::core::cmp::PartialEq for AUTHZ_RPC_INIT_INFO_CLIENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_RPC_INIT_INFO_CLIENT>()) == 0 }
+        self.version == other.version && self.ObjectUuid == other.ObjectUuid && self.ProtSeq == other.ProtSeq && self.NetworkAddr == other.NetworkAddr && self.Endpoint == other.Endpoint && self.Options == other.Options && self.ServerSpn == other.ServerSpn
     }
 }
 impl ::core::cmp::Eq for AUTHZ_RPC_INIT_INFO_CLIENT {}
@@ -11120,12 +11056,6 @@ impl ::core::clone::Clone for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
 unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTES_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {}
 impl ::core::default::Default for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11145,12 +11075,6 @@ impl ::core::clone::Clone for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {}
 impl ::core::default::Default for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11178,7 +11102,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE {
 }
 impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE>()) == 0 }
+        self.Version == other.Version && self.pName == other.pName
     }
 }
 impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE {}
@@ -11209,7 +11133,7 @@ unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE
 }
 impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE>()) == 0 }
+        self.pValue == other.pValue && self.ValueLength == other.ValueLength
     }
 }
 impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {}
@@ -11237,12 +11161,6 @@ impl ::core::clone::Clone for AUTHZ_SECURITY_ATTRIBUTE_V1 {
 unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTE_V1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTE_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTE_V1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTE_V1 {}
 impl ::core::default::Default for AUTHZ_SECURITY_ATTRIBUTE_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11266,12 +11184,6 @@ impl ::core::clone::Clone for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
 unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SECURITY_ATTRIBUTE_V1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {}
 impl ::core::default::Default for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11331,12 +11243,6 @@ impl ::core::clone::Clone for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
 unsafe impl ::windows::core::Abi for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SOURCE_SCHEMA_REGISTRATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SOURCE_SCHEMA_REGISTRATION {}
 impl ::core::default::Default for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11357,12 +11263,6 @@ impl ::core::clone::Clone for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
 unsafe impl ::windows::core::Abi for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHZ_SOURCE_SCHEMA_REGISTRATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {}
 impl ::core::default::Default for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11392,7 +11292,7 @@ unsafe impl ::windows::core::Abi for EXPLICIT_ACCESS_A {
 }
 impl ::core::cmp::PartialEq for EXPLICIT_ACCESS_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXPLICIT_ACCESS_A>()) == 0 }
+        self.grfAccessPermissions == other.grfAccessPermissions && self.grfAccessMode == other.grfAccessMode && self.grfInheritance == other.grfInheritance && self.Trustee == other.Trustee
     }
 }
 impl ::core::cmp::Eq for EXPLICIT_ACCESS_A {}
@@ -11425,7 +11325,7 @@ unsafe impl ::windows::core::Abi for EXPLICIT_ACCESS_W {
 }
 impl ::core::cmp::PartialEq for EXPLICIT_ACCESS_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXPLICIT_ACCESS_W>()) == 0 }
+        self.grfAccessPermissions == other.grfAccessPermissions && self.grfAccessMode == other.grfAccessMode && self.grfInheritance == other.grfInheritance && self.Trustee == other.Trustee
     }
 }
 impl ::core::cmp::Eq for EXPLICIT_ACCESS_W {}
@@ -11455,7 +11355,7 @@ unsafe impl ::windows::core::Abi for FN_OBJECT_MGR_FUNCTS {
 }
 impl ::core::cmp::PartialEq for FN_OBJECT_MGR_FUNCTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FN_OBJECT_MGR_FUNCTS>()) == 0 }
+        self.Placeholder == other.Placeholder
     }
 }
 impl ::core::cmp::Eq for FN_OBJECT_MGR_FUNCTS {}
@@ -11486,7 +11386,7 @@ unsafe impl ::windows::core::Abi for INHERITED_FROMA {
 }
 impl ::core::cmp::PartialEq for INHERITED_FROMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INHERITED_FROMA>()) == 0 }
+        self.GenerationGap == other.GenerationGap && self.AncestorName == other.AncestorName
     }
 }
 impl ::core::cmp::Eq for INHERITED_FROMA {}
@@ -11517,7 +11417,7 @@ unsafe impl ::windows::core::Abi for INHERITED_FROMW {
 }
 impl ::core::cmp::PartialEq for INHERITED_FROMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INHERITED_FROMW>()) == 0 }
+        self.GenerationGap == other.GenerationGap && self.AncestorName == other.AncestorName
     }
 }
 impl ::core::cmp::Eq for INHERITED_FROMW {}
@@ -11551,7 +11451,7 @@ unsafe impl ::windows::core::Abi for OBJECTS_AND_NAME_A {
 }
 impl ::core::cmp::PartialEq for OBJECTS_AND_NAME_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTS_AND_NAME_A>()) == 0 }
+        self.ObjectsPresent == other.ObjectsPresent && self.ObjectType == other.ObjectType && self.ObjectTypeName == other.ObjectTypeName && self.InheritedObjectTypeName == other.InheritedObjectTypeName && self.ptstrName == other.ptstrName
     }
 }
 impl ::core::cmp::Eq for OBJECTS_AND_NAME_A {}
@@ -11585,7 +11485,7 @@ unsafe impl ::windows::core::Abi for OBJECTS_AND_NAME_W {
 }
 impl ::core::cmp::PartialEq for OBJECTS_AND_NAME_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTS_AND_NAME_W>()) == 0 }
+        self.ObjectsPresent == other.ObjectsPresent && self.ObjectType == other.ObjectType && self.ObjectTypeName == other.ObjectTypeName && self.InheritedObjectTypeName == other.InheritedObjectTypeName && self.ptstrName == other.ptstrName
     }
 }
 impl ::core::cmp::Eq for OBJECTS_AND_NAME_W {}
@@ -11618,7 +11518,7 @@ unsafe impl ::windows::core::Abi for OBJECTS_AND_SID {
 }
 impl ::core::cmp::PartialEq for OBJECTS_AND_SID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTS_AND_SID>()) == 0 }
+        self.ObjectsPresent == other.ObjectsPresent && self.ObjectTypeGuid == other.ObjectTypeGuid && self.InheritedObjectTypeGuid == other.InheritedObjectTypeGuid && self.pSid == other.pSid
     }
 }
 impl ::core::cmp::Eq for OBJECTS_AND_SID {}
@@ -11652,7 +11552,7 @@ unsafe impl ::windows::core::Abi for TRUSTEE_A {
 }
 impl ::core::cmp::PartialEq for TRUSTEE_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTEE_A>()) == 0 }
+        self.pMultipleTrustee == other.pMultipleTrustee && self.MultipleTrusteeOperation == other.MultipleTrusteeOperation && self.TrusteeForm == other.TrusteeForm && self.TrusteeType == other.TrusteeType && self.ptstrName == other.ptstrName
     }
 }
 impl ::core::cmp::Eq for TRUSTEE_A {}
@@ -11685,7 +11585,7 @@ unsafe impl ::windows::core::Abi for TRUSTEE_ACCESSA {
 }
 impl ::core::cmp::PartialEq for TRUSTEE_ACCESSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTEE_ACCESSA>()) == 0 }
+        self.lpProperty == other.lpProperty && self.Access == other.Access && self.fAccessFlags == other.fAccessFlags && self.fReturnedAccess == other.fReturnedAccess
     }
 }
 impl ::core::cmp::Eq for TRUSTEE_ACCESSA {}
@@ -11718,7 +11618,7 @@ unsafe impl ::windows::core::Abi for TRUSTEE_ACCESSW {
 }
 impl ::core::cmp::PartialEq for TRUSTEE_ACCESSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTEE_ACCESSW>()) == 0 }
+        self.lpProperty == other.lpProperty && self.Access == other.Access && self.fAccessFlags == other.fAccessFlags && self.fReturnedAccess == other.fReturnedAccess
     }
 }
 impl ::core::cmp::Eq for TRUSTEE_ACCESSW {}
@@ -11752,7 +11652,7 @@ unsafe impl ::windows::core::Abi for TRUSTEE_W {
 }
 impl ::core::cmp::PartialEq for TRUSTEE_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRUSTEE_W>()) == 0 }
+        self.pMultipleTrustee == other.pMultipleTrustee && self.MultipleTrusteeOperation == other.MultipleTrusteeOperation && self.TrusteeForm == other.TrusteeForm && self.TrusteeType == other.TrusteeType && self.ptstrName == other.ptstrName
     }
 }
 impl ::core::cmp::Eq for TRUSTEE_W {}

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
@@ -247,7 +247,7 @@ unsafe impl ::windows::core::Abi for SCESVC_ANALYSIS_INFO {
 }
 impl ::core::cmp::PartialEq for SCESVC_ANALYSIS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCESVC_ANALYSIS_INFO>()) == 0 }
+        self.Count == other.Count && self.Lines == other.Lines
     }
 }
 impl ::core::cmp::Eq for SCESVC_ANALYSIS_INFO {}
@@ -279,7 +279,7 @@ unsafe impl ::windows::core::Abi for SCESVC_ANALYSIS_LINE {
 }
 impl ::core::cmp::PartialEq for SCESVC_ANALYSIS_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCESVC_ANALYSIS_LINE>()) == 0 }
+        self.Key == other.Key && self.Value == other.Value && self.ValueLen == other.ValueLen
     }
 }
 impl ::core::cmp::Eq for SCESVC_ANALYSIS_LINE {}
@@ -309,21 +309,13 @@ impl ::core::clone::Clone for SCESVC_CALLBACK_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for SCESVC_CALLBACK_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SCESVC_CALLBACK_INFO").field("sceHandle", &self.sceHandle).field("pfQueryInfo", &self.pfQueryInfo.map(|f| f as usize)).field("pfSetInfo", &self.pfSetInfo.map(|f| f as usize)).field("pfFreeInfo", &self.pfFreeInfo.map(|f| f as usize)).field("pfLogInfo", &self.pfLogInfo.map(|f| f as usize)).finish()
+        f.debug_struct("SCESVC_CALLBACK_INFO").field("sceHandle", &self.sceHandle).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for SCESVC_CALLBACK_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SCESVC_CALLBACK_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCESVC_CALLBACK_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SCESVC_CALLBACK_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SCESVC_CALLBACK_INFO {
     fn default() -> Self {
@@ -352,7 +344,7 @@ unsafe impl ::windows::core::Abi for SCESVC_CONFIGURATION_INFO {
 }
 impl ::core::cmp::PartialEq for SCESVC_CONFIGURATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCESVC_CONFIGURATION_INFO>()) == 0 }
+        self.Count == other.Count && self.Lines == other.Lines
     }
 }
 impl ::core::cmp::Eq for SCESVC_CONFIGURATION_INFO {}
@@ -384,7 +376,7 @@ unsafe impl ::windows::core::Abi for SCESVC_CONFIGURATION_LINE {
 }
 impl ::core::cmp::PartialEq for SCESVC_CONFIGURATION_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCESVC_CONFIGURATION_LINE>()) == 0 }
+        self.Key == other.Key && self.Value == other.Value && self.ValueLen == other.ValueLen
     }
 }
 impl ::core::cmp::Eq for SCESVC_CONFIGURATION_LINE {}

--- a/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
@@ -2138,7 +2138,7 @@ unsafe impl ::windows::core::Abi for BINARY_BLOB_CREDENTIAL_INFO {
 }
 impl ::core::cmp::PartialEq for BINARY_BLOB_CREDENTIAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BINARY_BLOB_CREDENTIAL_INFO>()) == 0 }
+        self.cbBlob == other.cbBlob && self.pbBlob == other.pbBlob
     }
 }
 impl ::core::cmp::Eq for BINARY_BLOB_CREDENTIAL_INFO {}
@@ -2169,7 +2169,7 @@ unsafe impl ::windows::core::Abi for CERT_CREDENTIAL_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_CREDENTIAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CREDENTIAL_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rgbHashOfCert == other.rgbHashOfCert
     }
 }
 impl ::core::cmp::Eq for CERT_CREDENTIAL_INFO {}
@@ -2229,7 +2229,7 @@ unsafe impl ::windows::core::Abi for CREDENTIALA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREDENTIALA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIALA>()) == 0 }
+        self.Flags == other.Flags && self.Type == other.Type && self.TargetName == other.TargetName && self.Comment == other.Comment && self.LastWritten == other.LastWritten && self.CredentialBlobSize == other.CredentialBlobSize && self.CredentialBlob == other.CredentialBlob && self.Persist == other.Persist && self.AttributeCount == other.AttributeCount && self.Attributes == other.Attributes && self.TargetAlias == other.TargetAlias && self.UserName == other.UserName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2291,7 +2291,7 @@ unsafe impl ::windows::core::Abi for CREDENTIALW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREDENTIALW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIALW>()) == 0 }
+        self.Flags == other.Flags && self.Type == other.Type && self.TargetName == other.TargetName && self.Comment == other.Comment && self.LastWritten == other.LastWritten && self.CredentialBlobSize == other.CredentialBlobSize && self.CredentialBlob == other.CredentialBlob && self.Persist == other.Persist && self.AttributeCount == other.AttributeCount && self.Attributes == other.Attributes && self.TargetAlias == other.TargetAlias && self.UserName == other.UserName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2326,7 +2326,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_ATTRIBUTEA {
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_ATTRIBUTEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_ATTRIBUTEA>()) == 0 }
+        self.Keyword == other.Keyword && self.Flags == other.Flags && self.ValueSize == other.ValueSize && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_ATTRIBUTEA {}
@@ -2359,7 +2359,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_ATTRIBUTEW {
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_ATTRIBUTEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_ATTRIBUTEW>()) == 0 }
+        self.Keyword == other.Keyword && self.Flags == other.Flags && self.ValueSize == other.ValueSize && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_ATTRIBUTEW {}
@@ -2398,7 +2398,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_TARGET_INFORMATIONA {
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_TARGET_INFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_TARGET_INFORMATIONA>()) == 0 }
+        self.TargetName == other.TargetName && self.NetbiosServerName == other.NetbiosServerName && self.DnsServerName == other.DnsServerName && self.NetbiosDomainName == other.NetbiosDomainName && self.DnsDomainName == other.DnsDomainName && self.DnsTreeName == other.DnsTreeName && self.PackageName == other.PackageName && self.Flags == other.Flags && self.CredTypeCount == other.CredTypeCount && self.CredTypes == other.CredTypes
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_TARGET_INFORMATIONA {}
@@ -2437,7 +2437,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_TARGET_INFORMATIONW {
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_TARGET_INFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_TARGET_INFORMATIONW>()) == 0 }
+        self.TargetName == other.TargetName && self.NetbiosServerName == other.NetbiosServerName && self.DnsServerName == other.DnsServerName && self.NetbiosDomainName == other.NetbiosDomainName && self.DnsDomainName == other.DnsDomainName && self.DnsTreeName == other.DnsTreeName && self.PackageName == other.PackageName && self.Flags == other.Flags && self.CredTypeCount == other.CredTypeCount && self.CredTypes == other.CredTypes
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_TARGET_INFORMATIONW {}
@@ -2469,7 +2469,7 @@ unsafe impl ::windows::core::Abi for CREDSSP_CRED {
 }
 impl ::core::cmp::PartialEq for CREDSSP_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDSSP_CRED>()) == 0 }
+        self.Type == other.Type && self.pSchannelCred == other.pSchannelCred && self.pSpnegoCred == other.pSpnegoCred
     }
 }
 impl ::core::cmp::Eq for CREDSSP_CRED {}
@@ -2503,7 +2503,7 @@ unsafe impl ::windows::core::Abi for CREDSSP_CRED_EX {
 }
 impl ::core::cmp::PartialEq for CREDSSP_CRED_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDSSP_CRED_EX>()) == 0 }
+        self.Type == other.Type && self.Version == other.Version && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Cred == other.Cred
     }
 }
 impl ::core::cmp::Eq for CREDSSP_CRED_EX {}
@@ -2543,7 +2543,7 @@ unsafe impl ::windows::core::Abi for CREDUI_INFOA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for CREDUI_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDUI_INFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.hwndParent == other.hwndParent && self.pszMessageText == other.pszMessageText && self.pszCaptionText == other.pszCaptionText && self.hbmBanner == other.hbmBanner
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -2585,7 +2585,7 @@ unsafe impl ::windows::core::Abi for CREDUI_INFOW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for CREDUI_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDUI_INFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.hwndParent == other.hwndParent && self.pszMessageText == other.pszMessageText && self.pszCaptionText == other.pszCaptionText && self.hbmBanner == other.hbmBanner
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -2617,7 +2617,7 @@ unsafe impl ::windows::core::Abi for KeyCredentialManagerInfo {
 }
 impl ::core::cmp::PartialEq for KeyCredentialManagerInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KeyCredentialManagerInfo>()) == 0 }
+        self.containerId == other.containerId
     }
 }
 impl ::core::cmp::Eq for KeyCredentialManagerInfo {}
@@ -2685,9 +2685,6 @@ impl ::core::fmt::Debug for OPENCARDNAMEA {
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
             .field("dwActiveProtocol", &self.dwActiveProtocol)
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
-            .field("lpfnCheck", &self.lpfnCheck.map(|f| f as usize))
-            .field("lpfnDisconnect", &self.lpfnDisconnect.map(|f| f as usize))
             .field("hCardHandle", &self.hCardHandle)
             .finish()
     }
@@ -2696,14 +2693,6 @@ impl ::core::fmt::Debug for OPENCARDNAMEA {
 unsafe impl ::windows::core::Abi for OPENCARDNAMEA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENCARDNAMEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARDNAMEA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENCARDNAMEA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENCARDNAMEA {
     fn default() -> Self {
@@ -2769,9 +2758,6 @@ impl ::core::fmt::Debug for OPENCARDNAMEW {
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
             .field("dwActiveProtocol", &self.dwActiveProtocol)
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
-            .field("lpfnCheck", &self.lpfnCheck.map(|f| f as usize))
-            .field("lpfnDisconnect", &self.lpfnDisconnect.map(|f| f as usize))
             .field("hCardHandle", &self.hCardHandle)
             .finish()
     }
@@ -2780,14 +2766,6 @@ impl ::core::fmt::Debug for OPENCARDNAMEW {
 unsafe impl ::windows::core::Abi for OPENCARDNAMEW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENCARDNAMEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARDNAMEW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENCARDNAMEW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENCARDNAMEW {
     fn default() -> Self {
@@ -2837,7 +2815,6 @@ impl ::core::fmt::Debug for OPENCARDNAME_EXA {
             .field("lpstrSearchDesc", &self.lpstrSearchDesc)
             .field("hIcon", &self.hIcon)
             .field("pOpenCardSearchCriteria", &self.pOpenCardSearchCriteria)
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
             .field("pvUserData", &self.pvUserData)
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
@@ -2854,14 +2831,6 @@ impl ::core::fmt::Debug for OPENCARDNAME_EXA {
 unsafe impl ::windows::core::Abi for OPENCARDNAME_EXA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OPENCARDNAME_EXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARDNAME_EXA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OPENCARDNAME_EXA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OPENCARDNAME_EXA {
     fn default() -> Self {
@@ -2911,7 +2880,6 @@ impl ::core::fmt::Debug for OPENCARDNAME_EXW {
             .field("lpstrSearchDesc", &self.lpstrSearchDesc)
             .field("hIcon", &self.hIcon)
             .field("pOpenCardSearchCriteria", &self.pOpenCardSearchCriteria)
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
             .field("pvUserData", &self.pvUserData)
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
@@ -2928,14 +2896,6 @@ impl ::core::fmt::Debug for OPENCARDNAME_EXW {
 unsafe impl ::windows::core::Abi for OPENCARDNAME_EXW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OPENCARDNAME_EXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARDNAME_EXW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OPENCARDNAME_EXW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OPENCARDNAME_EXW {
     fn default() -> Self {
@@ -2979,9 +2939,6 @@ impl ::core::fmt::Debug for OPENCARD_SEARCH_CRITERIAA {
             .field("cguidInterfaces", &self.cguidInterfaces)
             .field("lpstrCardNames", &self.lpstrCardNames)
             .field("nMaxCardNames", &self.nMaxCardNames)
-            .field("lpfnCheck", &self.lpfnCheck.map(|f| f as usize))
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
-            .field("lpfnDisconnect", &self.lpfnDisconnect.map(|f| f as usize))
             .field("pvUserData", &self.pvUserData)
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
@@ -2992,14 +2949,6 @@ impl ::core::fmt::Debug for OPENCARD_SEARCH_CRITERIAA {
 unsafe impl ::windows::core::Abi for OPENCARD_SEARCH_CRITERIAA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENCARD_SEARCH_CRITERIAA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARD_SEARCH_CRITERIAA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENCARD_SEARCH_CRITERIAA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENCARD_SEARCH_CRITERIAA {
     fn default() -> Self {
@@ -3043,9 +2992,6 @@ impl ::core::fmt::Debug for OPENCARD_SEARCH_CRITERIAW {
             .field("cguidInterfaces", &self.cguidInterfaces)
             .field("lpstrCardNames", &self.lpstrCardNames)
             .field("nMaxCardNames", &self.nMaxCardNames)
-            .field("lpfnCheck", &self.lpfnCheck.map(|f| f as usize))
-            .field("lpfnConnect", &self.lpfnConnect.map(|f| f as usize))
-            .field("lpfnDisconnect", &self.lpfnDisconnect.map(|f| f as usize))
             .field("pvUserData", &self.pvUserData)
             .field("dwShareMode", &self.dwShareMode)
             .field("dwPreferredProtocols", &self.dwPreferredProtocols)
@@ -3056,14 +3002,6 @@ impl ::core::fmt::Debug for OPENCARD_SEARCH_CRITERIAW {
 unsafe impl ::windows::core::Abi for OPENCARD_SEARCH_CRITERIAW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENCARD_SEARCH_CRITERIAW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENCARD_SEARCH_CRITERIAW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENCARD_SEARCH_CRITERIAW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENCARD_SEARCH_CRITERIAW {
     fn default() -> Self {
@@ -3087,12 +3025,6 @@ impl ::core::clone::Clone for READER_SEL_REQUEST {
 unsafe impl ::windows::core::Abi for READER_SEL_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for READER_SEL_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READER_SEL_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for READER_SEL_REQUEST {}
 impl ::core::default::Default for READER_SEL_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3113,12 +3045,6 @@ impl ::core::clone::Clone for READER_SEL_REQUEST_0 {
 unsafe impl ::windows::core::Abi for READER_SEL_REQUEST_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for READER_SEL_REQUEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READER_SEL_REQUEST_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for READER_SEL_REQUEST_0 {}
 impl ::core::default::Default for READER_SEL_REQUEST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3150,7 +3076,7 @@ unsafe impl ::windows::core::Abi for READER_SEL_REQUEST_0_0 {
 }
 impl ::core::cmp::PartialEq for READER_SEL_REQUEST_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READER_SEL_REQUEST_0_0>()) == 0 }
+        self.cbReaderNameOffset == other.cbReaderNameOffset && self.cchReaderNameLength == other.cchReaderNameLength && self.cbContainerNameOffset == other.cbContainerNameOffset && self.cchContainerNameLength == other.cchContainerNameLength && self.dwDesiredCardModuleVersion == other.dwDesiredCardModuleVersion && self.dwCspFlags == other.dwCspFlags
     }
 }
 impl ::core::cmp::Eq for READER_SEL_REQUEST_0_0 {}
@@ -3182,7 +3108,7 @@ unsafe impl ::windows::core::Abi for READER_SEL_REQUEST_0_1 {
 }
 impl ::core::cmp::PartialEq for READER_SEL_REQUEST_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READER_SEL_REQUEST_0_1>()) == 0 }
+        self.cbSerialNumberOffset == other.cbSerialNumberOffset && self.cbSerialNumberLength == other.cbSerialNumberLength && self.dwDesiredCardModuleVersion == other.dwDesiredCardModuleVersion
     }
 }
 impl ::core::cmp::Eq for READER_SEL_REQUEST_0_1 {}
@@ -3215,7 +3141,7 @@ unsafe impl ::windows::core::Abi for READER_SEL_RESPONSE {
 }
 impl ::core::cmp::PartialEq for READER_SEL_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READER_SEL_RESPONSE>()) == 0 }
+        self.cbReaderNameOffset == other.cbReaderNameOffset && self.cchReaderNameLength == other.cchReaderNameLength && self.cbCardNameOffset == other.cbCardNameOffset && self.cchCardNameLength == other.cchCardNameLength
     }
 }
 impl ::core::cmp::Eq for READER_SEL_RESPONSE {}
@@ -3247,7 +3173,7 @@ unsafe impl ::windows::core::Abi for SCARD_ATRMASK {
 }
 impl ::core::cmp::PartialEq for SCARD_ATRMASK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_ATRMASK>()) == 0 }
+        self.cbAtr == other.cbAtr && self.rgbAtr == other.rgbAtr && self.rgbMask == other.rgbMask
     }
 }
 impl ::core::cmp::Eq for SCARD_ATRMASK {}
@@ -3278,7 +3204,7 @@ unsafe impl ::windows::core::Abi for SCARD_IO_REQUEST {
 }
 impl ::core::cmp::PartialEq for SCARD_IO_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_IO_REQUEST>()) == 0 }
+        self.dwProtocol == other.dwProtocol && self.cbPciLength == other.cbPciLength
     }
 }
 impl ::core::cmp::Eq for SCARD_IO_REQUEST {}
@@ -3313,7 +3239,7 @@ unsafe impl ::windows::core::Abi for SCARD_READERSTATEA {
 }
 impl ::core::cmp::PartialEq for SCARD_READERSTATEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_READERSTATEA>()) == 0 }
+        self.szReader == other.szReader && self.pvUserData == other.pvUserData && self.dwCurrentState == other.dwCurrentState && self.dwEventState == other.dwEventState && self.cbAtr == other.cbAtr && self.rgbAtr == other.rgbAtr
     }
 }
 impl ::core::cmp::Eq for SCARD_READERSTATEA {}
@@ -3348,7 +3274,7 @@ unsafe impl ::windows::core::Abi for SCARD_READERSTATEW {
 }
 impl ::core::cmp::PartialEq for SCARD_READERSTATEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_READERSTATEW>()) == 0 }
+        self.szReader == other.szReader && self.pvUserData == other.pvUserData && self.dwCurrentState == other.dwCurrentState && self.dwEventState == other.dwEventState && self.cbAtr == other.cbAtr && self.rgbAtr == other.rgbAtr
     }
 }
 impl ::core::cmp::Eq for SCARD_READERSTATEW {}
@@ -3382,7 +3308,7 @@ unsafe impl ::windows::core::Abi for SCARD_T0_COMMAND {
 }
 impl ::core::cmp::PartialEq for SCARD_T0_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_T0_COMMAND>()) == 0 }
+        self.bCla == other.bCla && self.bIns == other.bIns && self.bP1 == other.bP1 && self.bP2 == other.bP2 && self.bP3 == other.bP3
     }
 }
 impl ::core::cmp::Eq for SCARD_T0_COMMAND {}
@@ -3408,12 +3334,6 @@ impl ::core::clone::Clone for SCARD_T0_REQUEST {
 unsafe impl ::windows::core::Abi for SCARD_T0_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SCARD_T0_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_T0_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SCARD_T0_REQUEST {}
 impl ::core::default::Default for SCARD_T0_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3434,12 +3354,6 @@ impl ::core::clone::Clone for SCARD_T0_REQUEST_0 {
 unsafe impl ::windows::core::Abi for SCARD_T0_REQUEST_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SCARD_T0_REQUEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_T0_REQUEST_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SCARD_T0_REQUEST_0 {}
 impl ::core::default::Default for SCARD_T0_REQUEST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3466,7 +3380,7 @@ unsafe impl ::windows::core::Abi for SCARD_T1_REQUEST {
 }
 impl ::core::cmp::PartialEq for SCARD_T1_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCARD_T1_REQUEST>()) == 0 }
+        self.ioRequest == other.ioRequest
     }
 }
 impl ::core::cmp::Eq for SCARD_T1_REQUEST {}
@@ -3497,7 +3411,7 @@ unsafe impl ::windows::core::Abi for SecHandle {
 }
 impl ::core::cmp::PartialEq for SecHandle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecHandle>()) == 0 }
+        self.dwLower == other.dwLower && self.dwUpper == other.dwUpper
     }
 }
 impl ::core::cmp::Eq for SecHandle {}
@@ -3528,7 +3442,7 @@ unsafe impl ::windows::core::Abi for SecPkgContext_ClientCreds {
 }
 impl ::core::cmp::PartialEq for SecPkgContext_ClientCreds {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SecPkgContext_ClientCreds>()) == 0 }
+        self.AuthBufferLen == other.AuthBufferLen && self.AuthBuffer == other.AuthBuffer
     }
 }
 impl ::core::cmp::Eq for SecPkgContext_ClientCreds {}
@@ -3558,7 +3472,7 @@ unsafe impl ::windows::core::Abi for USERNAME_TARGET_CREDENTIAL_INFO {
 }
 impl ::core::cmp::PartialEq for USERNAME_TARGET_CREDENTIAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USERNAME_TARGET_CREDENTIAL_INFO>()) == 0 }
+        self.UserName == other.UserName
     }
 }
 impl ::core::cmp::Eq for USERNAME_TARGET_CREDENTIAL_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
@@ -490,7 +490,7 @@ unsafe impl ::windows::core::Abi for CATALOG_INFO {
 }
 impl ::core::cmp::PartialEq for CATALOG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATALOG_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.wszCatalogFile == other.wszCatalogFile
     }
 }
 impl ::core::cmp::Eq for CATALOG_INFO {}
@@ -525,7 +525,7 @@ unsafe impl ::windows::core::Abi for CRYPTCATATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for CRYPTCATATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTCATATTRIBUTE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pwszReferenceTag == other.pwszReferenceTag && self.dwAttrTypeAndAction == other.dwAttrTypeAndAction && self.cbValue == other.cbValue && self.pbValue == other.pbValue && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for CRYPTCATATTRIBUTE {}
@@ -567,7 +567,7 @@ unsafe impl ::windows::core::Abi for CRYPTCATCDF {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTCATCDF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTCATCDF>()) == 0 }
+        self.cbStruct == other.cbStruct && self.hFile == other.hFile && self.dwCurFilePos == other.dwCurFilePos && self.dwLastMemberOffset == other.dwLastMemberOffset && self.fEOF == other.fEOF && self.pwszResultDir == other.pwszResultDir && self.hCATStore == other.hCATStore
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -627,7 +627,7 @@ unsafe impl ::windows::core::Abi for CRYPTCATMEMBER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::cmp::PartialEq for CRYPTCATMEMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTCATMEMBER>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pwszReferenceTag == other.pwszReferenceTag && self.pwszFileName == other.pwszFileName && self.gSubjectType == other.gSubjectType && self.fdwMemberFlags == other.fdwMemberFlags && self.pIndirectData == other.pIndirectData && self.dwCertVersion == other.dwCertVersion && self.dwReserved == other.dwReserved && self.hReserved == other.hReserved && self.sEncodedIndirectData == other.sEncodedIndirectData && self.sEncodedMemberInfo == other.sEncodedMemberInfo
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Sip"))]
@@ -674,7 +674,7 @@ unsafe impl ::windows::core::Abi for CRYPTCATSTORE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTCATSTORE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTCATSTORE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwPublicVersion == other.dwPublicVersion && self.pwszP7File == other.pwszP7File && self.hProv == other.hProv && self.dwEncodingType == other.dwEncodingType && self.fdwStoreFlags == other.fdwStoreFlags && self.hReserved == other.hReserved && self.hAttrs == other.hAttrs && self.hCryptMsg == other.hCryptMsg && self.hSorted == other.hSorted
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -714,7 +714,7 @@ unsafe impl ::windows::core::Abi for MS_ADDINFO_CATALOGMEMBER {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::cmp::PartialEq for MS_ADDINFO_CATALOGMEMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MS_ADDINFO_CATALOGMEMBER>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pStore == other.pStore && self.pMember == other.pMember
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Sip"))]

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -26076,7 +26076,7 @@ unsafe impl ::windows::core::Abi for CAINFO {
 }
 impl ::core::cmp::PartialEq for CAINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.CAType == other.CAType && self.cCASignatureCerts == other.cCASignatureCerts && self.cCAExchangeCerts == other.cCAExchangeCerts && self.cExitModules == other.cExitModules && self.lPropIdMax == other.lPropIdMax && self.lRoleSeparationEnabled == other.lRoleSeparationEnabled && self.cKRACertUsedCount == other.cKRACertUsedCount && self.cKRACertCount == other.cKRACertCount && self.fAdvancedServer == other.fAdvancedServer
     }
 }
 impl ::core::cmp::Eq for CAINFO {}
@@ -26107,7 +26107,7 @@ unsafe impl ::windows::core::Abi for CERTTRANSBLOB {
 }
 impl ::core::cmp::PartialEq for CERTTRANSBLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERTTRANSBLOB>()) == 0 }
+        self.cb == other.cb && self.pb == other.pb
     }
 }
 impl ::core::cmp::Eq for CERTTRANSBLOB {}
@@ -26141,7 +26141,7 @@ unsafe impl ::windows::core::Abi for CERTVIEWRESTRICTION {
 }
 impl ::core::cmp::PartialEq for CERTVIEWRESTRICTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERTVIEWRESTRICTION>()) == 0 }
+        self.ColumnIndex == other.ColumnIndex && self.SeekOperator == other.SeekOperator && self.SortOrder == other.SortOrder && self.pbValue == other.pbValue && self.cbValue == other.cbValue
     }
 }
 impl ::core::cmp::Eq for CERTVIEWRESTRICTION {}
@@ -26172,7 +26172,7 @@ unsafe impl ::windows::core::Abi for CSEDB_RSTMAPW {
 }
 impl ::core::cmp::PartialEq for CSEDB_RSTMAPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSEDB_RSTMAPW>()) == 0 }
+        self.pwszDatabaseName == other.pwszDatabaseName && self.pwszNewDatabaseName == other.pwszNewDatabaseName
     }
 }
 impl ::core::cmp::Eq for CSEDB_RSTMAPW {}

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Sip/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Sip/mod.rs
@@ -163,7 +163,7 @@ unsafe impl ::windows::core::Abi for MS_ADDINFO_BLOB {
 }
 impl ::core::cmp::PartialEq for MS_ADDINFO_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MS_ADDINFO_BLOB>()) == 0 }
+        self.cbStruct == other.cbStruct && self.cbMemObject == other.cbMemObject && self.pbMemObject == other.pbMemObject && self.cbMemSignedMsg == other.cbMemSignedMsg && self.pbMemSignedMsg == other.pbMemSignedMsg
     }
 }
 impl ::core::cmp::Eq for MS_ADDINFO_BLOB {}
@@ -194,7 +194,7 @@ unsafe impl ::windows::core::Abi for MS_ADDINFO_FLAT {
 }
 impl ::core::cmp::PartialEq for MS_ADDINFO_FLAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MS_ADDINFO_FLAT>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pIndirectData == other.pIndirectData
     }
 }
 impl ::core::cmp::Eq for MS_ADDINFO_FLAT {}
@@ -248,7 +248,7 @@ unsafe impl ::windows::core::Abi for SIP_ADD_NEWPROVIDER {
 }
 impl ::core::cmp::PartialEq for SIP_ADD_NEWPROVIDER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_ADD_NEWPROVIDER>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pgSubject == other.pgSubject && self.pwszDLLFileName == other.pwszDLLFileName && self.pwszMagicNumber == other.pwszMagicNumber && self.pwszIsFunctionName == other.pwszIsFunctionName && self.pwszGetFuncName == other.pwszGetFuncName && self.pwszPutFuncName == other.pwszPutFuncName && self.pwszCreateFuncName == other.pwszCreateFuncName && self.pwszVerifyFuncName == other.pwszVerifyFuncName && self.pwszRemoveFuncName == other.pwszRemoveFuncName && self.pwszIsFunctionNameFmt2 == other.pwszIsFunctionNameFmt2 && self.pwszGetCapFuncName == other.pwszGetCapFuncName
     }
 }
 impl ::core::cmp::Eq for SIP_ADD_NEWPROVIDER {}
@@ -287,7 +287,7 @@ unsafe impl ::windows::core::Abi for SIP_CAP_SET_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SIP_CAP_SET_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_CAP_SET_V2>()) == 0 }
+        self.cbSize == other.cbSize && self.dwVersion == other.dwVersion && self.isMultiSign == other.isMultiSign && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -320,14 +320,6 @@ unsafe impl ::windows::core::Abi for SIP_CAP_SET_V3 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SIP_CAP_SET_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_CAP_SET_V3>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SIP_CAP_SET_V3 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SIP_CAP_SET_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -352,14 +344,6 @@ impl ::core::clone::Clone for SIP_CAP_SET_V3_0 {
 unsafe impl ::windows::core::Abi for SIP_CAP_SET_V3_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SIP_CAP_SET_V3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_CAP_SET_V3_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SIP_CAP_SET_V3_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SIP_CAP_SET_V3_0 {
     fn default() -> Self {
@@ -389,21 +373,13 @@ impl ::core::clone::Clone for SIP_DISPATCH_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
 impl ::core::fmt::Debug for SIP_DISPATCH_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SIP_DISPATCH_INFO").field("cbSize", &self.cbSize).field("hSIP", &self.hSIP).field("pfGet", &self.pfGet.map(|f| f as usize)).field("pfPut", &self.pfPut.map(|f| f as usize)).field("pfCreate", &self.pfCreate.map(|f| f as usize)).field("pfVerify", &self.pfVerify.map(|f| f as usize)).field("pfRemove", &self.pfRemove.map(|f| f as usize)).finish()
+        f.debug_struct("SIP_DISPATCH_INFO").field("cbSize", &self.cbSize).field("hSIP", &self.hSIP).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
 unsafe impl ::windows::core::Abi for SIP_DISPATCH_INFO {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::PartialEq for SIP_DISPATCH_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_DISPATCH_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::Eq for SIP_DISPATCH_INFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
 impl ::core::default::Default for SIP_DISPATCH_INFO {
     fn default() -> Self {
@@ -433,7 +409,7 @@ unsafe impl ::windows::core::Abi for SIP_INDIRECT_DATA {
 }
 impl ::core::cmp::PartialEq for SIP_INDIRECT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_INDIRECT_DATA>()) == 0 }
+        self.Data == other.Data && self.DigestAlgorithm == other.DigestAlgorithm && self.Digest == other.Digest
     }
 }
 impl ::core::cmp::Eq for SIP_INDIRECT_DATA {}
@@ -478,14 +454,6 @@ unsafe impl ::windows::core::Abi for SIP_SUBJECTINFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::PartialEq for SIP_SUBJECTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_SUBJECTINFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::Eq for SIP_SUBJECTINFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
 impl ::core::default::Default for SIP_SUBJECTINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -511,14 +479,6 @@ impl ::core::clone::Clone for SIP_SUBJECTINFO_0 {
 unsafe impl ::windows::core::Abi for SIP_SUBJECTINFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::PartialEq for SIP_SUBJECTINFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SIP_SUBJECTINFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
-impl ::core::cmp::Eq for SIP_SUBJECTINFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog"))]
 impl ::core::default::Default for SIP_SUBJECTINFO_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
@@ -846,7 +846,7 @@ unsafe impl ::windows::core::Abi for CERT_FILTER_DATA {
 }
 impl ::core::cmp::PartialEq for CERT_FILTER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_FILTER_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.cExtensionChecks == other.cExtensionChecks && self.arrayExtensionChecks == other.arrayExtensionChecks && self.dwCheckingFlags == other.dwCheckingFlags
     }
 }
 impl ::core::cmp::Eq for CERT_FILTER_DATA {}
@@ -879,7 +879,7 @@ unsafe impl ::windows::core::Abi for CERT_FILTER_EXTENSION_MATCH {
 }
 impl ::core::cmp::PartialEq for CERT_FILTER_EXTENSION_MATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_FILTER_EXTENSION_MATCH>()) == 0 }
+        self.szExtensionOID == other.szExtensionOID && self.dwTestOperation == other.dwTestOperation && self.pbTestData == other.pbTestData && self.cbTestData == other.cbTestData
     }
 }
 impl ::core::cmp::Eq for CERT_FILTER_EXTENSION_MATCH {}
@@ -917,7 +917,7 @@ unsafe impl ::windows::core::Abi for CERT_SELECTUI_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_SELECTUI_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SELECTUI_INPUT>()) == 0 }
+        self.hStore == other.hStore && self.prgpChain == other.prgpChain && self.cChain == other.cChain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -974,8 +974,6 @@ impl ::core::fmt::Debug for CERT_SELECT_STRUCT_A {
             .field("cCertContext", &self.cCertContext)
             .field("arrayCertContext", &self.arrayCertContext)
             .field("lCustData", &self.lCustData)
-            .field("pfnHook", &self.pfnHook.map(|f| f as usize))
-            .field("pfnFilter", &self.pfnFilter.map(|f| f as usize))
             .field("szHelpFileName", &self.szHelpFileName)
             .field("dwHelpId", &self.dwHelpId)
             .field("hprov", &self.hprov)
@@ -986,14 +984,6 @@ impl ::core::fmt::Debug for CERT_SELECT_STRUCT_A {
 unsafe impl ::windows::core::Abi for CERT_SELECT_STRUCT_A {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_SELECT_STRUCT_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SELECT_STRUCT_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_SELECT_STRUCT_A {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_SELECT_STRUCT_A {
     fn default() -> Self {
@@ -1046,8 +1036,6 @@ impl ::core::fmt::Debug for CERT_SELECT_STRUCT_W {
             .field("cCertContext", &self.cCertContext)
             .field("arrayCertContext", &self.arrayCertContext)
             .field("lCustData", &self.lCustData)
-            .field("pfnHook", &self.pfnHook.map(|f| f as usize))
-            .field("pfnFilter", &self.pfnFilter.map(|f| f as usize))
             .field("szHelpFileName", &self.szHelpFileName)
             .field("dwHelpId", &self.dwHelpId)
             .field("hprov", &self.hprov)
@@ -1058,14 +1046,6 @@ impl ::core::fmt::Debug for CERT_SELECT_STRUCT_W {
 unsafe impl ::windows::core::Abi for CERT_SELECT_STRUCT_W {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_SELECT_STRUCT_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SELECT_STRUCT_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_SELECT_STRUCT_W {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_SELECT_STRUCT_W {
     fn default() -> Self {
@@ -1122,7 +1102,6 @@ impl ::core::fmt::Debug for CERT_VERIFY_CERTIFICATE_TRUST {
             .field("cTrustStores", &self.cTrustStores)
             .field("rghstoreTrust", &self.rghstoreTrust)
             .field("lCustData", &self.lCustData)
-            .field("pfnTrustHelper", &self.pfnTrustHelper.map(|f| f as usize))
             .field("pcChain", &self.pcChain)
             .field("prgChain", &self.prgChain)
             .field("prgdwErrors", &self.prgdwErrors)
@@ -1134,14 +1113,6 @@ impl ::core::fmt::Debug for CERT_VERIFY_CERTIFICATE_TRUST {
 unsafe impl ::windows::core::Abi for CERT_VERIFY_CERTIFICATE_TRUST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_VERIFY_CERTIFICATE_TRUST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_VERIFY_CERTIFICATE_TRUST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_VERIFY_CERTIFICATE_TRUST {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_VERIFY_CERTIFICATE_TRUST {
     fn default() -> Self {
@@ -1219,7 +1190,28 @@ unsafe impl ::windows::core::Abi for CERT_VIEWPROPERTIES_STRUCT_A {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for CERT_VIEWPROPERTIES_STRUCT_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_VIEWPROPERTIES_STRUCT_A>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.hwndParent == other.hwndParent
+            && self.hInstance == other.hInstance
+            && self.dwFlags == other.dwFlags
+            && self.szTitle == other.szTitle
+            && self.pCertContext == other.pCertContext
+            && self.arrayPurposes == other.arrayPurposes
+            && self.cArrayPurposes == other.cArrayPurposes
+            && self.cRootStores == other.cRootStores
+            && self.rghstoreRoots == other.rghstoreRoots
+            && self.cStores == other.cStores
+            && self.rghstoreCAs == other.rghstoreCAs
+            && self.cTrustStores == other.cTrustStores
+            && self.rghstoreTrust == other.rghstoreTrust
+            && self.hprov == other.hprov
+            && self.lCustData == other.lCustData
+            && self.dwPad == other.dwPad
+            && self.szHelpFileName == other.szHelpFileName
+            && self.dwHelpId == other.dwHelpId
+            && self.nStartPage == other.nStartPage
+            && self.cArrayPropSheetPages == other.cArrayPropSheetPages
+            && self.arrayPropSheetPages == other.arrayPropSheetPages
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -1301,7 +1293,28 @@ unsafe impl ::windows::core::Abi for CERT_VIEWPROPERTIES_STRUCT_W {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for CERT_VIEWPROPERTIES_STRUCT_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_VIEWPROPERTIES_STRUCT_W>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.hwndParent == other.hwndParent
+            && self.hInstance == other.hInstance
+            && self.dwFlags == other.dwFlags
+            && self.szTitle == other.szTitle
+            && self.pCertContext == other.pCertContext
+            && self.arrayPurposes == other.arrayPurposes
+            && self.cArrayPurposes == other.cArrayPurposes
+            && self.cRootStores == other.cRootStores
+            && self.rghstoreRoots == other.rghstoreRoots
+            && self.cStores == other.cStores
+            && self.rghstoreCAs == other.rghstoreCAs
+            && self.cTrustStores == other.cTrustStores
+            && self.rghstoreTrust == other.rghstoreTrust
+            && self.hprov == other.hprov
+            && self.lCustData == other.lCustData
+            && self.dwPad == other.dwPad
+            && self.szHelpFileName == other.szHelpFileName
+            && self.dwHelpId == other.dwHelpId
+            && self.nStartPage == other.nStartPage
+            && self.cArrayPropSheetPages == other.cArrayPropSheetPages
+            && self.arrayPropSheetPages == other.arrayPropSheetPages
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -1343,7 +1356,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_CERT_MGR_STRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTUI_CERT_MGR_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_CERT_MGR_STRUCT>()) == 0 }
+        self.dwSize == other.dwSize && self.hwndParent == other.hwndParent && self.dwFlags == other.dwFlags && self.pwszTitle == other.pwszTitle && self.pszInitUsageOID == other.pszInitUsageOID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1382,7 +1395,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_INITDIALOG_STRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTUI_INITDIALOG_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_INITDIALOG_STRUCT>()) == 0 }
+        self.lParam == other.lParam && self.pCertContext == other.pCertContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1429,14 +1442,6 @@ unsafe impl ::windows::core::Abi for CRYPTUI_VIEWCERTIFICATE_STRUCTA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CRYPTUI_VIEWCERTIFICATE_STRUCTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_VIEWCERTIFICATE_STRUCTA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CRYPTUI_VIEWCERTIFICATE_STRUCTA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CRYPTUI_VIEWCERTIFICATE_STRUCTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1461,14 +1466,6 @@ impl ::core::clone::Clone for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_VIEWCERTIFICATE_STRUCTA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
     fn default() -> Self {
@@ -1511,14 +1508,6 @@ unsafe impl ::windows::core::Abi for CRYPTUI_VIEWCERTIFICATE_STRUCTW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CRYPTUI_VIEWCERTIFICATE_STRUCTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_VIEWCERTIFICATE_STRUCTW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CRYPTUI_VIEWCERTIFICATE_STRUCTW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CRYPTUI_VIEWCERTIFICATE_STRUCTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1543,14 +1532,6 @@ impl ::core::clone::Clone for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_VIEWCERTIFICATE_STRUCTW_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
     fn default() -> Self {
@@ -1582,7 +1563,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pGuidSubject == other.pGuidSubject && self.cbBlob == other.cbBlob && self.pbBlob == other.pbBlob && self.pwszDisplayName == other.pwszDisplayName
     }
 }
 impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO {}
@@ -1608,12 +1589,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {}
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1634,12 +1609,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {}
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1668,7 +1637,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT {
 }
 impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT>()) == 0 }
+        self.dwSize == other.dwSize && self.cbBlob == other.cbBlob && self.pbBlob == other.pbBlob
     }
 }
 impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT {}
@@ -1716,7 +1685,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwAttrFlags == other.dwAttrFlags && self.pwszDescription == other.pwszDescription && self.pwszMoreInfoLocation == other.pwszMoreInfoLocation && self.pszHashAlg == other.pszHashAlg && self.pwszSigningCertDisplayString == other.pwszSigningCertDisplayString && self.hAdditionalCertStore == other.hAdditionalCertStore && self.psAuthenticated == other.psAuthenticated && self.psUnauthenticated == other.psUnauthenticated
     }
 }
 impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO {}
@@ -1751,14 +1720,6 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1783,14 +1744,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
     fn default() -> Self {
@@ -1817,14 +1770,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
     fn default() -> Self {
@@ -1855,7 +1800,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pwszPvkFileName == other.pwszPvkFileName && self.pwszProvName == other.pwszProvName && self.dwProvType == other.dwProvType
     }
 }
 impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO {}
@@ -1885,21 +1830,13 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO").field("dwSize", &self.dwSize).field("cCertStore", &self.cCertStore).field("rghCertStore", &self.rghCertStore).field("pFilterCallback", &self.pFilterCallback.map(|f| f as usize)).field("pvCallbackData", &self.pvCallbackData).finish()
+        f.debug_struct("CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO").field("dwSize", &self.dwSize).field("cCertStore", &self.cCertStore).field("rghCertStore", &self.rghCertStore).field("pvCallbackData", &self.pvCallbackData).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
     fn default() -> Self {
@@ -1938,7 +1875,7 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_EXPORT_CERTCONTEXT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTUI_WIZ_EXPORT_CERTCONTEXT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_EXPORT_CERTCONTEXT_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwExportFormat == other.dwExportFormat && self.fExportChain == other.fExportChain && self.fExportPrivateKeys == other.fExportPrivateKeys && self.pwszPassword == other.pwszPassword && self.fStrongEncryption == other.fStrongEncryption
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1973,14 +1910,6 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_EXPORT_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_EXPORT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_EXPORT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_EXPORT_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_EXPORT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2007,14 +1936,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_EXPORT_INFO_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_EXPORT_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_EXPORT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_EXPORT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_EXPORT_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_EXPORT_INFO_0 {
     fn default() -> Self {
@@ -2044,14 +1965,6 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_IMPORT_SRC_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_IMPORT_SRC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_IMPORT_SRC_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_IMPORT_SRC_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_IMPORT_SRC_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2079,14 +1992,6 @@ impl ::core::clone::Clone for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
 unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTUI_WIZ_IMPORT_SRC_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
     fn default() -> Self {
@@ -2122,7 +2027,7 @@ unsafe impl ::windows::core::Abi for CTL_MODIFY_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_MODIFY_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_MODIFY_REQUEST>()) == 0 }
+        self.pccert == other.pccert && self.dwOperation == other.dwOperation && self.dwError == other.dwError
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -13523,7 +13523,7 @@ unsafe impl ::windows::core::Abi for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA {
 }
 impl ::core::cmp::PartialEq for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRegPolicySettings == other.dwRegPolicySettings && self.pSignerInfo == other.pSignerInfo
     }
 }
 impl ::core::cmp::Eq for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA {}
@@ -13560,7 +13560,7 @@ unsafe impl ::windows::core::Abi for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.fCommercial == other.fCommercial
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13600,7 +13600,7 @@ unsafe impl ::windows::core::Abi for AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PAR
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRegPolicySettings == other.dwRegPolicySettings && self.fCommercial == other.fCommercial
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13634,7 +13634,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_ALGORITHM_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for BCRYPT_ALGORITHM_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_ALGORITHM_IDENTIFIER>()) == 0 }
+        self.pszName == other.pszName && self.dwClass == other.dwClass && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for BCRYPT_ALGORITHM_IDENTIFIER {}
@@ -13727,7 +13727,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO {
 }
 impl ::core::cmp::PartialEq for BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwInfoVersion == other.dwInfoVersion && self.pbNonce == other.pbNonce && self.cbNonce == other.cbNonce && self.pbAuthData == other.pbAuthData && self.cbAuthData == other.cbAuthData && self.pbTag == other.pbTag && self.cbTag == other.cbTag && self.pbMacContext == other.pbMacContext && self.cbMacContext == other.cbMacContext && self.cbAAD == other.cbAAD && self.cbData == other.cbData && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO {}
@@ -13758,7 +13758,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DH_KEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DH_KEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DH_KEY_BLOB>()) == 0 }
+        self.dwMagic == other.dwMagic && self.cbKey == other.cbKey
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DH_KEY_BLOB {}
@@ -13790,7 +13790,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DH_PARAMETER_HEADER {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DH_PARAMETER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DH_PARAMETER_HEADER>()) == 0 }
+        self.cbLength == other.cbLength && self.dwMagic == other.dwMagic && self.cbKeyLength == other.cbKeyLength
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DH_PARAMETER_HEADER {}
@@ -13824,7 +13824,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DSA_KEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DSA_KEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DSA_KEY_BLOB>()) == 0 }
+        self.dwMagic == other.dwMagic && self.cbKey == other.cbKey && self.Count == other.Count && self.Seed == other.Seed && self.q == other.q
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DSA_KEY_BLOB {}
@@ -13860,7 +13860,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DSA_KEY_BLOB_V2 {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DSA_KEY_BLOB_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DSA_KEY_BLOB_V2>()) == 0 }
+        self.dwMagic == other.dwMagic && self.cbKey == other.cbKey && self.hashAlgorithm == other.hashAlgorithm && self.standardVersion == other.standardVersion && self.cbSeedLength == other.cbSeedLength && self.cbGroupSize == other.cbGroupSize && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DSA_KEY_BLOB_V2 {}
@@ -13895,7 +13895,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DSA_PARAMETER_HEADER {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DSA_PARAMETER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DSA_PARAMETER_HEADER>()) == 0 }
+        self.cbLength == other.cbLength && self.dwMagic == other.dwMagic && self.cbKeyLength == other.cbKeyLength && self.Count == other.Count && self.Seed == other.Seed && self.q == other.q
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DSA_PARAMETER_HEADER {}
@@ -13932,7 +13932,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_DSA_PARAMETER_HEADER_V2 {
 }
 impl ::core::cmp::PartialEq for BCRYPT_DSA_PARAMETER_HEADER_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_DSA_PARAMETER_HEADER_V2>()) == 0 }
+        self.cbLength == other.cbLength && self.dwMagic == other.dwMagic && self.cbKeyLength == other.cbKeyLength && self.hashAlgorithm == other.hashAlgorithm && self.standardVersion == other.standardVersion && self.cbSeedLength == other.cbSeedLength && self.cbGroupSize == other.cbGroupSize && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for BCRYPT_DSA_PARAMETER_HEADER_V2 {}
@@ -13969,7 +13969,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_ECCFULLKEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_ECCFULLKEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_ECCFULLKEY_BLOB>()) == 0 }
+        self.dwMagic == other.dwMagic && self.dwVersion == other.dwVersion && self.dwCurveType == other.dwCurveType && self.dwCurveGenerationAlgId == other.dwCurveGenerationAlgId && self.cbFieldLength == other.cbFieldLength && self.cbSubgroupOrder == other.cbSubgroupOrder && self.cbCofactor == other.cbCofactor && self.cbSeed == other.cbSeed
     }
 }
 impl ::core::cmp::Eq for BCRYPT_ECCFULLKEY_BLOB {}
@@ -14000,7 +14000,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_ECCKEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_ECCKEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_ECCKEY_BLOB>()) == 0 }
+        self.dwMagic == other.dwMagic && self.cbKey == other.cbKey
     }
 }
 impl ::core::cmp::Eq for BCRYPT_ECCKEY_BLOB {}
@@ -14031,7 +14031,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_ECC_CURVE_NAMES {
 }
 impl ::core::cmp::PartialEq for BCRYPT_ECC_CURVE_NAMES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_ECC_CURVE_NAMES>()) == 0 }
+        self.dwEccCurveNames == other.dwEccCurveNames && self.pEccCurveNames == other.pEccCurveNames
     }
 }
 impl ::core::cmp::Eq for BCRYPT_ECC_CURVE_NAMES {}
@@ -14131,7 +14131,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_INTERFACE_VERSION {
 }
 impl ::core::cmp::PartialEq for BCRYPT_INTERFACE_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_INTERFACE_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for BCRYPT_INTERFACE_VERSION {}
@@ -14161,7 +14161,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_KEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_KEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_KEY_BLOB>()) == 0 }
+        self.Magic == other.Magic
     }
 }
 impl ::core::cmp::Eq for BCRYPT_KEY_BLOB {}
@@ -14193,7 +14193,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_KEY_DATA_BLOB_HEADER {
 }
 impl ::core::cmp::PartialEq for BCRYPT_KEY_DATA_BLOB_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_KEY_DATA_BLOB_HEADER>()) == 0 }
+        self.dwMagic == other.dwMagic && self.dwVersion == other.dwVersion && self.cbKeyData == other.cbKeyData
     }
 }
 impl ::core::cmp::Eq for BCRYPT_KEY_DATA_BLOB_HEADER {}
@@ -14262,7 +14262,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_KEY_LENGTHS_STRUCT {
 }
 impl ::core::cmp::PartialEq for BCRYPT_KEY_LENGTHS_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_KEY_LENGTHS_STRUCT>()) == 0 }
+        self.dwMinLength == other.dwMinLength && self.dwMaxLength == other.dwMaxLength && self.dwIncrement == other.dwIncrement
     }
 }
 impl ::core::cmp::Eq for BCRYPT_KEY_LENGTHS_STRUCT {}
@@ -14295,7 +14295,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_MULTI_HASH_OPERATION {
 }
 impl ::core::cmp::PartialEq for BCRYPT_MULTI_HASH_OPERATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_MULTI_HASH_OPERATION>()) == 0 }
+        self.iHash == other.iHash && self.hashOperation == other.hashOperation && self.pbBuffer == other.pbBuffer && self.cbBuffer == other.cbBuffer
     }
 }
 impl ::core::cmp::Eq for BCRYPT_MULTI_HASH_OPERATION {}
@@ -14326,7 +14326,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_MULTI_OBJECT_LENGTH_STRUCT {
 }
 impl ::core::cmp::PartialEq for BCRYPT_MULTI_OBJECT_LENGTH_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_MULTI_OBJECT_LENGTH_STRUCT>()) == 0 }
+        self.cbPerObject == other.cbPerObject && self.cbPerElement == other.cbPerElement
     }
 }
 impl ::core::cmp::Eq for BCRYPT_MULTI_OBJECT_LENGTH_STRUCT {}
@@ -14358,7 +14358,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_OAEP_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for BCRYPT_OAEP_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_OAEP_PADDING_INFO>()) == 0 }
+        self.pszAlgId == other.pszAlgId && self.pbLabel == other.pbLabel && self.cbLabel == other.cbLabel
     }
 }
 impl ::core::cmp::Eq for BCRYPT_OAEP_PADDING_INFO {}
@@ -14389,7 +14389,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_OID {
 }
 impl ::core::cmp::PartialEq for BCRYPT_OID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_OID>()) == 0 }
+        self.cbOID == other.cbOID && self.pbOID == other.pbOID
     }
 }
 impl ::core::cmp::Eq for BCRYPT_OID {}
@@ -14420,7 +14420,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_OID_LIST {
 }
 impl ::core::cmp::PartialEq for BCRYPT_OID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_OID_LIST>()) == 0 }
+        self.dwOIDCount == other.dwOIDCount && self.pOIDs == other.pOIDs
     }
 }
 impl ::core::cmp::Eq for BCRYPT_OID_LIST {}
@@ -14450,7 +14450,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_PKCS1_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for BCRYPT_PKCS1_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_PKCS1_PADDING_INFO>()) == 0 }
+        self.pszAlgId == other.pszAlgId
     }
 }
 impl ::core::cmp::Eq for BCRYPT_PKCS1_PADDING_INFO {}
@@ -14480,7 +14480,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_PROVIDER_NAME {
 }
 impl ::core::cmp::PartialEq for BCRYPT_PROVIDER_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_PROVIDER_NAME>()) == 0 }
+        self.pszProviderName == other.pszProviderName
     }
 }
 impl ::core::cmp::Eq for BCRYPT_PROVIDER_NAME {}
@@ -14511,7 +14511,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_PSS_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for BCRYPT_PSS_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_PSS_PADDING_INFO>()) == 0 }
+        self.pszAlgId == other.pszAlgId && self.cbSalt == other.cbSalt
     }
 }
 impl ::core::cmp::Eq for BCRYPT_PSS_PADDING_INFO {}
@@ -14546,7 +14546,7 @@ unsafe impl ::windows::core::Abi for BCRYPT_RSAKEY_BLOB {
 }
 impl ::core::cmp::PartialEq for BCRYPT_RSAKEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCRYPT_RSAKEY_BLOB>()) == 0 }
+        self.Magic == other.Magic && self.BitLength == other.BitLength && self.cbPublicExp == other.cbPublicExp && self.cbModulus == other.cbModulus && self.cbPrime1 == other.cbPrime1 && self.cbPrime2 == other.cbPrime2
     }
 }
 impl ::core::cmp::Eq for BCRYPT_RSAKEY_BLOB {}
@@ -14615,7 +14615,7 @@ unsafe impl ::windows::core::Abi for BCryptBuffer {
 }
 impl ::core::cmp::PartialEq for BCryptBuffer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCryptBuffer>()) == 0 }
+        self.cbBuffer == other.cbBuffer && self.BufferType == other.BufferType && self.pvBuffer == other.pvBuffer
     }
 }
 impl ::core::cmp::Eq for BCryptBuffer {}
@@ -14647,7 +14647,7 @@ unsafe impl ::windows::core::Abi for BCryptBufferDesc {
 }
 impl ::core::cmp::PartialEq for BCryptBufferDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BCryptBufferDesc>()) == 0 }
+        self.ulVersion == other.ulVersion && self.cBuffers == other.cBuffers && self.pBuffers == other.pBuffers
     }
 }
 impl ::core::cmp::Eq for BCryptBufferDesc {}
@@ -14678,7 +14678,7 @@ unsafe impl ::windows::core::Abi for CERTIFICATE_CHAIN_BLOB {
 }
 impl ::core::cmp::PartialEq for CERTIFICATE_CHAIN_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERTIFICATE_CHAIN_BLOB>()) == 0 }
+        self.certCount == other.certCount && self.rawCertificates == other.rawCertificates
     }
 }
 impl ::core::cmp::Eq for CERTIFICATE_CHAIN_BLOB {}
@@ -14702,12 +14702,6 @@ impl ::core::clone::Clone for CERT_ACCESS_DESCRIPTION {
 unsafe impl ::windows::core::Abi for CERT_ACCESS_DESCRIPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_ACCESS_DESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ACCESS_DESCRIPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_ACCESS_DESCRIPTION {}
 impl ::core::default::Default for CERT_ACCESS_DESCRIPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14728,12 +14722,6 @@ impl ::core::clone::Clone for CERT_ALT_NAME_ENTRY {
 unsafe impl ::windows::core::Abi for CERT_ALT_NAME_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_ALT_NAME_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ALT_NAME_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_ALT_NAME_ENTRY {}
 impl ::core::default::Default for CERT_ALT_NAME_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14759,12 +14747,6 @@ impl ::core::clone::Clone for CERT_ALT_NAME_ENTRY_0 {
 unsafe impl ::windows::core::Abi for CERT_ALT_NAME_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_ALT_NAME_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ALT_NAME_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_ALT_NAME_ENTRY_0 {}
 impl ::core::default::Default for CERT_ALT_NAME_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14792,7 +14774,7 @@ unsafe impl ::windows::core::Abi for CERT_ALT_NAME_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_ALT_NAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ALT_NAME_INFO>()) == 0 }
+        self.cAltEntry == other.cAltEntry && self.rgAltEntry == other.rgAltEntry
     }
 }
 impl ::core::cmp::Eq for CERT_ALT_NAME_INFO {}
@@ -14823,7 +14805,7 @@ unsafe impl ::windows::core::Abi for CERT_AUTHORITY_INFO_ACCESS {
 }
 impl ::core::cmp::PartialEq for CERT_AUTHORITY_INFO_ACCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_AUTHORITY_INFO_ACCESS>()) == 0 }
+        self.cAccDescr == other.cAccDescr && self.rgAccDescr == other.rgAccDescr
     }
 }
 impl ::core::cmp::Eq for CERT_AUTHORITY_INFO_ACCESS {}
@@ -14855,7 +14837,7 @@ unsafe impl ::windows::core::Abi for CERT_AUTHORITY_KEY_ID2_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_AUTHORITY_KEY_ID2_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_AUTHORITY_KEY_ID2_INFO>()) == 0 }
+        self.KeyId == other.KeyId && self.AuthorityCertIssuer == other.AuthorityCertIssuer && self.AuthorityCertSerialNumber == other.AuthorityCertSerialNumber
     }
 }
 impl ::core::cmp::Eq for CERT_AUTHORITY_KEY_ID2_INFO {}
@@ -14887,7 +14869,7 @@ unsafe impl ::windows::core::Abi for CERT_AUTHORITY_KEY_ID_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_AUTHORITY_KEY_ID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_AUTHORITY_KEY_ID_INFO>()) == 0 }
+        self.KeyId == other.KeyId && self.CertIssuer == other.CertIssuer && self.CertSerialNumber == other.CertSerialNumber
     }
 }
 impl ::core::cmp::Eq for CERT_AUTHORITY_KEY_ID_INFO {}
@@ -14925,7 +14907,7 @@ unsafe impl ::windows::core::Abi for CERT_BASIC_CONSTRAINTS2_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_BASIC_CONSTRAINTS2_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_BASIC_CONSTRAINTS2_INFO>()) == 0 }
+        self.fCA == other.fCA && self.fPathLenConstraint == other.fPathLenConstraint && self.dwPathLenConstraint == other.dwPathLenConstraint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14967,7 +14949,7 @@ unsafe impl ::windows::core::Abi for CERT_BASIC_CONSTRAINTS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_BASIC_CONSTRAINTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_BASIC_CONSTRAINTS_INFO>()) == 0 }
+        self.SubjectType == other.SubjectType && self.fPathLenConstraint == other.fPathLenConstraint && self.dwPathLenConstraint == other.dwPathLenConstraint && self.cSubtreesConstraint == other.cSubtreesConstraint && self.rgSubtreesConstraint == other.rgSubtreesConstraint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14994,12 +14976,6 @@ impl ::core::clone::Clone for CERT_BIOMETRIC_DATA {
 unsafe impl ::windows::core::Abi for CERT_BIOMETRIC_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_BIOMETRIC_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_BIOMETRIC_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_BIOMETRIC_DATA {}
 impl ::core::default::Default for CERT_BIOMETRIC_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15020,12 +14996,6 @@ impl ::core::clone::Clone for CERT_BIOMETRIC_DATA_0 {
 unsafe impl ::windows::core::Abi for CERT_BIOMETRIC_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_BIOMETRIC_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_BIOMETRIC_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_BIOMETRIC_DATA_0 {}
 impl ::core::default::Default for CERT_BIOMETRIC_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15053,7 +15023,7 @@ unsafe impl ::windows::core::Abi for CERT_BIOMETRIC_EXT_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_BIOMETRIC_EXT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_BIOMETRIC_EXT_INFO>()) == 0 }
+        self.cBiometricData == other.cBiometricData && self.rgBiometricData == other.rgBiometricData
     }
 }
 impl ::core::cmp::Eq for CERT_BIOMETRIC_EXT_INFO {}
@@ -15085,7 +15055,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN {
 }
 impl ::core::cmp::PartialEq for CERT_CHAIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN>()) == 0 }
+        self.cCerts == other.cCerts && self.certs == other.certs && self.keyLocatorInfo == other.keyLocatorInfo
     }
 }
 impl ::core::cmp::Eq for CERT_CHAIN {}
@@ -15141,7 +15111,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_CHAIN_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_CONTEXT>()) == 0 }
+        self.cbSize == other.cbSize && self.TrustStatus == other.TrustStatus && self.cChain == other.cChain && self.rgpChain == other.rgpChain && self.cLowerQualityChainContext == other.cLowerQualityChainContext && self.rgpLowerQualityChainContext == other.rgpLowerQualityChainContext && self.fHasRevocationFreshnessTime == other.fHasRevocationFreshnessTime && self.dwRevocationFreshnessTime == other.dwRevocationFreshnessTime && self.dwCreateFlags == other.dwCreateFlags && self.ChainId == other.ChainId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15185,7 +15155,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_ELEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_CHAIN_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_ELEMENT>()) == 0 }
+        self.cbSize == other.cbSize && self.pCertContext == other.pCertContext && self.TrustStatus == other.TrustStatus && self.pRevocationInfo == other.pRevocationInfo && self.pIssuanceUsage == other.pIssuanceUsage && self.pApplicationUsage == other.pApplicationUsage && self.pwszExtendedErrorInfo == other.pwszExtendedErrorInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15243,7 +15213,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_ENGINE_CONFIG {
 }
 impl ::core::cmp::PartialEq for CERT_CHAIN_ENGINE_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_ENGINE_CONFIG>()) == 0 }
+        self.cbSize == other.cbSize && self.hRestrictedRoot == other.hRestrictedRoot && self.hRestrictedTrust == other.hRestrictedTrust && self.hRestrictedOther == other.hRestrictedOther && self.cAdditionalStore == other.cAdditionalStore && self.rghAdditionalStore == other.rghAdditionalStore && self.dwFlags == other.dwFlags && self.dwUrlRetrievalTimeout == other.dwUrlRetrievalTimeout && self.MaximumCachedCertificates == other.MaximumCachedCertificates && self.CycleDetectionModulus == other.CycleDetectionModulus && self.hExclusiveRoot == other.hExclusiveRoot && self.hExclusiveTrustedPeople == other.hExclusiveTrustedPeople && self.dwExclusiveFlags == other.dwExclusiveFlags
     }
 }
 impl ::core::cmp::Eq for CERT_CHAIN_ENGINE_CONFIG {}
@@ -15276,21 +15246,13 @@ impl ::core::clone::Clone for CERT_CHAIN_FIND_BY_ISSUER_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CERT_CHAIN_FIND_BY_ISSUER_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CERT_CHAIN_FIND_BY_ISSUER_PARA").field("cbSize", &self.cbSize).field("pszUsageIdentifier", &self.pszUsageIdentifier).field("dwKeySpec", &self.dwKeySpec).field("dwAcquirePrivateKeyFlags", &self.dwAcquirePrivateKeyFlags).field("cIssuer", &self.cIssuer).field("rgIssuer", &self.rgIssuer).field("pfnFindCallback", &self.pfnFindCallback.map(|f| f as usize)).field("pvFindArg", &self.pvFindArg).finish()
+        f.debug_struct("CERT_CHAIN_FIND_BY_ISSUER_PARA").field("cbSize", &self.cbSize).field("pszUsageIdentifier", &self.pszUsageIdentifier).field("dwKeySpec", &self.dwKeySpec).field("dwAcquirePrivateKeyFlags", &self.dwAcquirePrivateKeyFlags).field("cIssuer", &self.cIssuer).field("rgIssuer", &self.rgIssuer).field("pvFindArg", &self.pvFindArg).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CERT_CHAIN_FIND_BY_ISSUER_PARA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_CHAIN_FIND_BY_ISSUER_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_FIND_BY_ISSUER_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_CHAIN_FIND_BY_ISSUER_PARA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_CHAIN_FIND_BY_ISSUER_PARA {
     fn default() -> Self {
@@ -15319,7 +15281,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_PARA {
 }
 impl ::core::cmp::PartialEq for CERT_CHAIN_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.RequestedUsage == other.RequestedUsage
     }
 }
 impl ::core::cmp::Eq for CERT_CHAIN_PARA {}
@@ -15351,7 +15313,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_POLICY_PARA {
 }
 impl ::core::cmp::PartialEq for CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.pvExtraPolicyPara == other.pvExtraPolicyPara
     }
 }
 impl ::core::cmp::Eq for CERT_CHAIN_POLICY_PARA {}
@@ -15385,7 +15347,7 @@ unsafe impl ::windows::core::Abi for CERT_CHAIN_POLICY_STATUS {
 }
 impl ::core::cmp::PartialEq for CERT_CHAIN_POLICY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CHAIN_POLICY_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwError == other.dwError && self.lChainIndex == other.lChainIndex && self.lElementIndex == other.lElementIndex && self.pvExtraPolicyStatus == other.pvExtraPolicyStatus
     }
 }
 impl ::core::cmp::Eq for CERT_CHAIN_POLICY_STATUS {}
@@ -15425,7 +15387,7 @@ unsafe impl ::windows::core::Abi for CERT_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CONTEXT>()) == 0 }
+        self.dwCertEncodingType == other.dwCertEncodingType && self.pbCertEncoded == other.pbCertEncoded && self.cbCertEncoded == other.cbCertEncoded && self.pCertInfo == other.pCertInfo && self.hCertStore == other.hCertStore
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15457,21 +15419,13 @@ impl ::core::clone::Clone for CERT_CREATE_CONTEXT_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CERT_CREATE_CONTEXT_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CERT_CREATE_CONTEXT_PARA").field("cbSize", &self.cbSize).field("pfnFree", &self.pfnFree.map(|f| f as usize)).field("pvFree", &self.pvFree).field("pfnSort", &self.pfnSort.map(|f| f as usize)).field("pvSort", &self.pvSort).finish()
+        f.debug_struct("CERT_CREATE_CONTEXT_PARA").field("cbSize", &self.cbSize).field("pvFree", &self.pvFree).field("pvSort", &self.pvSort).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CERT_CREATE_CONTEXT_PARA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_CREATE_CONTEXT_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CREATE_CONTEXT_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_CREATE_CONTEXT_PARA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_CREATE_CONTEXT_PARA {
     fn default() -> Self {
@@ -15506,7 +15460,7 @@ unsafe impl ::windows::core::Abi for CERT_CRL_CONTEXT_PAIR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_CRL_CONTEXT_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CRL_CONTEXT_PAIR>()) == 0 }
+        self.pCertContext == other.pCertContext && self.pCrlContext == other.pCrlContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15539,7 +15493,7 @@ unsafe impl ::windows::core::Abi for CERT_DH_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for CERT_DH_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_DH_PARAMETERS>()) == 0 }
+        self.p == other.p && self.g == other.g
     }
 }
 impl ::core::cmp::Eq for CERT_DH_PARAMETERS {}
@@ -15571,7 +15525,7 @@ unsafe impl ::windows::core::Abi for CERT_DSS_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for CERT_DSS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_DSS_PARAMETERS>()) == 0 }
+        self.p == other.p && self.q == other.q && self.g == other.g
     }
 }
 impl ::core::cmp::Eq for CERT_DSS_PARAMETERS {}
@@ -15602,7 +15556,7 @@ unsafe impl ::windows::core::Abi for CERT_ECC_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for CERT_ECC_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ECC_SIGNATURE>()) == 0 }
+        self.r == other.r && self.s == other.s
     }
 }
 impl ::core::cmp::Eq for CERT_ECC_SIGNATURE {}
@@ -15640,7 +15594,7 @@ unsafe impl ::windows::core::Abi for CERT_EXTENSION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_EXTENSION>()) == 0 }
+        self.pszObjId == other.pszObjId && self.fCritical == other.fCritical && self.Value == other.Value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15679,7 +15633,7 @@ unsafe impl ::windows::core::Abi for CERT_EXTENSIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_EXTENSIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_EXTENSIONS>()) == 0 }
+        self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15713,7 +15667,7 @@ unsafe impl ::windows::core::Abi for CERT_FORTEZZA_DATA_PROP {
 }
 impl ::core::cmp::PartialEq for CERT_FORTEZZA_DATA_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_FORTEZZA_DATA_PROP>()) == 0 }
+        self.SerialNumber == other.SerialNumber && self.CertIndex == other.CertIndex && self.CertLabel == other.CertLabel
     }
 }
 impl ::core::cmp::Eq for CERT_FORTEZZA_DATA_PROP {}
@@ -15744,14 +15698,6 @@ unsafe impl ::windows::core::Abi for CERT_GENERAL_SUBTREE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_GENERAL_SUBTREE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_GENERAL_SUBTREE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_GENERAL_SUBTREE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_GENERAL_SUBTREE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15780,7 +15726,7 @@ unsafe impl ::windows::core::Abi for CERT_HASHED_URL {
 }
 impl ::core::cmp::PartialEq for CERT_HASHED_URL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_HASHED_URL>()) == 0 }
+        self.HashAlgorithm == other.HashAlgorithm && self.Hash == other.Hash && self.pwszUrl == other.pwszUrl
     }
 }
 impl ::core::cmp::Eq for CERT_HASHED_URL {}
@@ -15804,12 +15750,6 @@ impl ::core::clone::Clone for CERT_ID {
 unsafe impl ::windows::core::Abi for CERT_ID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_ID {}
 impl ::core::default::Default for CERT_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15831,12 +15771,6 @@ impl ::core::clone::Clone for CERT_ID_0 {
 unsafe impl ::windows::core::Abi for CERT_ID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_ID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_ID_0 {}
 impl ::core::default::Default for CERT_ID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15893,7 +15827,7 @@ unsafe impl ::windows::core::Abi for CERT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.SerialNumber == other.SerialNumber && self.SignatureAlgorithm == other.SignatureAlgorithm && self.Issuer == other.Issuer && self.NotBefore == other.NotBefore && self.NotAfter == other.NotAfter && self.Subject == other.Subject && self.SubjectPublicKeyInfo == other.SubjectPublicKeyInfo && self.IssuerUniqueId == other.IssuerUniqueId && self.SubjectUniqueId == other.SubjectUniqueId && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15926,7 +15860,7 @@ unsafe impl ::windows::core::Abi for CERT_ISSUER_SERIAL_NUMBER {
 }
 impl ::core::cmp::PartialEq for CERT_ISSUER_SERIAL_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_ISSUER_SERIAL_NUMBER>()) == 0 }
+        self.Issuer == other.Issuer && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for CERT_ISSUER_SERIAL_NUMBER {}
@@ -15958,7 +15892,7 @@ unsafe impl ::windows::core::Abi for CERT_KEYGEN_REQUEST_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_KEYGEN_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_KEYGEN_REQUEST_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.SubjectPublicKeyInfo == other.SubjectPublicKeyInfo && self.pwszChallengeString == other.pwszChallengeString
     }
 }
 impl ::core::cmp::Eq for CERT_KEYGEN_REQUEST_INFO {}
@@ -15996,7 +15930,7 @@ unsafe impl ::windows::core::Abi for CERT_KEY_ATTRIBUTES_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_KEY_ATTRIBUTES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_KEY_ATTRIBUTES_INFO>()) == 0 }
+        self.KeyId == other.KeyId && self.IntendedKeyUsage == other.IntendedKeyUsage && self.pPrivateKeyUsagePeriod == other.pPrivateKeyUsagePeriod
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16023,12 +15957,6 @@ impl ::core::clone::Clone for CERT_KEY_CONTEXT {
 unsafe impl ::windows::core::Abi for CERT_KEY_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_KEY_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_KEY_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_KEY_CONTEXT {}
 impl ::core::default::Default for CERT_KEY_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16049,12 +15977,6 @@ impl ::core::clone::Clone for CERT_KEY_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for CERT_KEY_CONTEXT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_KEY_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_KEY_CONTEXT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_KEY_CONTEXT_0 {}
 impl ::core::default::Default for CERT_KEY_CONTEXT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16083,7 +16005,7 @@ unsafe impl ::windows::core::Abi for CERT_KEY_USAGE_RESTRICTION_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_KEY_USAGE_RESTRICTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_KEY_USAGE_RESTRICTION_INFO>()) == 0 }
+        self.cCertPolicyId == other.cCertPolicyId && self.rgCertPolicyId == other.rgCertPolicyId && self.RestrictedKeyUsage == other.RestrictedKeyUsage
     }
 }
 impl ::core::cmp::Eq for CERT_KEY_USAGE_RESTRICTION_INFO {}
@@ -16114,7 +16036,7 @@ unsafe impl ::windows::core::Abi for CERT_LDAP_STORE_OPENED_PARA {
 }
 impl ::core::cmp::PartialEq for CERT_LDAP_STORE_OPENED_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LDAP_STORE_OPENED_PARA>()) == 0 }
+        self.pvLdapSessionHandle == other.pvLdapSessionHandle && self.pwszLdapUrl == other.pwszLdapUrl
     }
 }
 impl ::core::cmp::Eq for CERT_LDAP_STORE_OPENED_PARA {}
@@ -16145,7 +16067,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_AUDIO {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_AUDIO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_AUDIO>()) == 0 }
+        self.LogotypeDetails == other.LogotypeDetails && self.pLogotypeAudioInfo == other.pLogotypeAudioInfo
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_AUDIO {}
@@ -16179,7 +16101,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_AUDIO_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_AUDIO_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_AUDIO_INFO>()) == 0 }
+        self.dwFileSize == other.dwFileSize && self.dwPlayTime == other.dwPlayTime && self.dwChannels == other.dwChannels && self.dwSampleRate == other.dwSampleRate && self.pwszLanguage == other.pwszLanguage
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_AUDIO_INFO {}
@@ -16212,7 +16134,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_DATA {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_DATA>()) == 0 }
+        self.cLogotypeImage == other.cLogotypeImage && self.rgLogotypeImage == other.rgLogotypeImage && self.cLogotypeAudio == other.cLogotypeAudio && self.rgLogotypeAudio == other.rgLogotypeAudio
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_DATA {}
@@ -16244,7 +16166,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_DETAILS {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_DETAILS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_DETAILS>()) == 0 }
+        self.pwszMimeType == other.pwszMimeType && self.cHashedUrl == other.cHashedUrl && self.rgHashedUrl == other.rgHashedUrl
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_DETAILS {}
@@ -16279,7 +16201,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_EXT_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_EXT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_EXT_INFO>()) == 0 }
+        self.cCommunityLogo == other.cCommunityLogo && self.rgCommunityLogo == other.rgCommunityLogo && self.pIssuerLogo == other.pIssuerLogo && self.pSubjectLogo == other.pSubjectLogo && self.cOtherLogo == other.cOtherLogo && self.rgOtherLogo == other.rgOtherLogo
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_EXT_INFO {}
@@ -16310,7 +16232,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_IMAGE {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_IMAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_IMAGE>()) == 0 }
+        self.LogotypeDetails == other.LogotypeDetails && self.pLogotypeImageInfo == other.pLogotypeImageInfo
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_IMAGE {}
@@ -16339,12 +16261,6 @@ impl ::core::clone::Clone for CERT_LOGOTYPE_IMAGE_INFO {
 unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_IMAGE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_LOGOTYPE_IMAGE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_IMAGE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_LOGOTYPE_IMAGE_INFO {}
 impl ::core::default::Default for CERT_LOGOTYPE_IMAGE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16365,12 +16281,6 @@ impl ::core::clone::Clone for CERT_LOGOTYPE_IMAGE_INFO_0 {
 unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_IMAGE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_LOGOTYPE_IMAGE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_IMAGE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_LOGOTYPE_IMAGE_INFO_0 {}
 impl ::core::default::Default for CERT_LOGOTYPE_IMAGE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16391,12 +16301,6 @@ impl ::core::clone::Clone for CERT_LOGOTYPE_INFO {
 unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_LOGOTYPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_LOGOTYPE_INFO {}
 impl ::core::default::Default for CERT_LOGOTYPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16417,12 +16321,6 @@ impl ::core::clone::Clone for CERT_LOGOTYPE_INFO_0 {
 unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_LOGOTYPE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_LOGOTYPE_INFO_0 {}
 impl ::core::default::Default for CERT_LOGOTYPE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16450,7 +16348,7 @@ unsafe impl ::windows::core::Abi for CERT_LOGOTYPE_REFERENCE {
 }
 impl ::core::cmp::PartialEq for CERT_LOGOTYPE_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_LOGOTYPE_REFERENCE>()) == 0 }
+        self.cHashedUrl == other.cHashedUrl && self.rgHashedUrl == other.rgHashedUrl
     }
 }
 impl ::core::cmp::Eq for CERT_LOGOTYPE_REFERENCE {}
@@ -16489,7 +16387,7 @@ unsafe impl ::windows::core::Abi for CERT_NAME_CONSTRAINTS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_NAME_CONSTRAINTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_NAME_CONSTRAINTS_INFO>()) == 0 }
+        self.cPermittedSubtree == other.cPermittedSubtree && self.rgPermittedSubtree == other.rgPermittedSubtree && self.cExcludedSubtree == other.cExcludedSubtree && self.rgExcludedSubtree == other.rgExcludedSubtree
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16522,7 +16420,7 @@ unsafe impl ::windows::core::Abi for CERT_NAME_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_NAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_NAME_INFO>()) == 0 }
+        self.cRDN == other.cRDN && self.rgRDN == other.rgRDN
     }
 }
 impl ::core::cmp::Eq for CERT_NAME_INFO {}
@@ -16553,7 +16451,7 @@ unsafe impl ::windows::core::Abi for CERT_NAME_VALUE {
 }
 impl ::core::cmp::PartialEq for CERT_NAME_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_NAME_VALUE>()) == 0 }
+        self.dwValueType == other.dwValueType && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CERT_NAME_VALUE {}
@@ -16585,7 +16483,7 @@ unsafe impl ::windows::core::Abi for CERT_OR_CRL_BLOB {
 }
 impl ::core::cmp::PartialEq for CERT_OR_CRL_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_OR_CRL_BLOB>()) == 0 }
+        self.dwChoice == other.dwChoice && self.cbEncoded == other.cbEncoded && self.pbEncoded == other.pbEncoded
     }
 }
 impl ::core::cmp::Eq for CERT_OR_CRL_BLOB {}
@@ -16616,7 +16514,7 @@ unsafe impl ::windows::core::Abi for CERT_OR_CRL_BUNDLE {
 }
 impl ::core::cmp::PartialEq for CERT_OR_CRL_BUNDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_OR_CRL_BUNDLE>()) == 0 }
+        self.cItem == other.cItem && self.rgItem == other.rgItem
     }
 }
 impl ::core::cmp::Eq for CERT_OR_CRL_BUNDLE {}
@@ -16640,12 +16538,6 @@ impl ::core::clone::Clone for CERT_OTHER_LOGOTYPE_INFO {
 unsafe impl ::windows::core::Abi for CERT_OTHER_LOGOTYPE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_OTHER_LOGOTYPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_OTHER_LOGOTYPE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_OTHER_LOGOTYPE_INFO {}
 impl ::core::default::Default for CERT_OTHER_LOGOTYPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16673,7 +16565,7 @@ unsafe impl ::windows::core::Abi for CERT_OTHER_NAME {
 }
 impl ::core::cmp::PartialEq for CERT_OTHER_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_OTHER_NAME>()) == 0 }
+        self.pszObjId == other.pszObjId && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CERT_OTHER_NAME {}
@@ -16704,7 +16596,7 @@ unsafe impl ::windows::core::Abi for CERT_PAIR {
 }
 impl ::core::cmp::PartialEq for CERT_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_PAIR>()) == 0 }
+        self.Forward == other.Forward && self.Reverse == other.Reverse
     }
 }
 impl ::core::cmp::Eq for CERT_PAIR {}
@@ -16740,7 +16632,7 @@ unsafe impl ::windows::core::Abi for CERT_PHYSICAL_STORE_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_PHYSICAL_STORE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_PHYSICAL_STORE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pszOpenStoreProvider == other.pszOpenStoreProvider && self.dwOpenEncodingType == other.dwOpenEncodingType && self.dwOpenFlags == other.dwOpenFlags && self.OpenParameters == other.OpenParameters && self.dwFlags == other.dwFlags && self.dwPriority == other.dwPriority
     }
 }
 impl ::core::cmp::Eq for CERT_PHYSICAL_STORE_INFO {}
@@ -16771,7 +16663,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICIES_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_POLICIES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICIES_INFO>()) == 0 }
+        self.cPolicyInfo == other.cPolicyInfo && self.rgPolicyInfo == other.rgPolicyInfo
     }
 }
 impl ::core::cmp::Eq for CERT_POLICIES_INFO {}
@@ -16805,7 +16697,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY95_QUALIFIER1 {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY95_QUALIFIER1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY95_QUALIFIER1>()) == 0 }
+        self.pszPracticesReference == other.pszPracticesReference && self.pszNoticeIdentifier == other.pszNoticeIdentifier && self.pszNSINoticeIdentifier == other.pszNSINoticeIdentifier && self.cCPSURLs == other.cCPSURLs && self.rgCPSURLs == other.rgCPSURLs
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY95_QUALIFIER1 {}
@@ -16844,7 +16736,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_CONSTRAINTS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_POLICY_CONSTRAINTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_CONSTRAINTS_INFO>()) == 0 }
+        self.fRequireExplicitPolicy == other.fRequireExplicitPolicy && self.dwRequireExplicitPolicySkipCerts == other.dwRequireExplicitPolicySkipCerts && self.fInhibitPolicyMapping == other.fInhibitPolicyMapping && self.dwInhibitPolicyMappingSkipCerts == other.dwInhibitPolicyMappingSkipCerts
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16877,7 +16769,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_ID {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_ID>()) == 0 }
+        self.cCertPolicyElementId == other.cCertPolicyElementId && self.rgpszCertPolicyElementId == other.rgpszCertPolicyElementId
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_ID {}
@@ -16909,7 +16801,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_INFO>()) == 0 }
+        self.pszPolicyIdentifier == other.pszPolicyIdentifier && self.cPolicyQualifier == other.cPolicyQualifier && self.rgPolicyQualifier == other.rgPolicyQualifier
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_INFO {}
@@ -16940,7 +16832,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_MAPPING {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_MAPPING>()) == 0 }
+        self.pszIssuerDomainPolicy == other.pszIssuerDomainPolicy && self.pszSubjectDomainPolicy == other.pszSubjectDomainPolicy
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_MAPPING {}
@@ -16971,7 +16863,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_MAPPINGS_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_MAPPINGS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_MAPPINGS_INFO>()) == 0 }
+        self.cPolicyMapping == other.cPolicyMapping && self.rgPolicyMapping == other.rgPolicyMapping
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_MAPPINGS_INFO {}
@@ -17002,7 +16894,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_QUALIFIER_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_QUALIFIER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_QUALIFIER_INFO>()) == 0 }
+        self.pszPolicyQualifierId == other.pszPolicyQualifierId && self.Qualifier == other.Qualifier
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_QUALIFIER_INFO {}
@@ -17034,7 +16926,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_QUALIFIER_NOTICE_REFERENCE {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_QUALIFIER_NOTICE_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_QUALIFIER_NOTICE_REFERENCE>()) == 0 }
+        self.pszOrganization == other.pszOrganization && self.cNoticeNumbers == other.cNoticeNumbers && self.rgNoticeNumbers == other.rgNoticeNumbers
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_QUALIFIER_NOTICE_REFERENCE {}
@@ -17065,7 +16957,7 @@ unsafe impl ::windows::core::Abi for CERT_POLICY_QUALIFIER_USER_NOTICE {
 }
 impl ::core::cmp::PartialEq for CERT_POLICY_QUALIFIER_USER_NOTICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_POLICY_QUALIFIER_USER_NOTICE>()) == 0 }
+        self.pNoticeReference == other.pNoticeReference && self.pszDisplayText == other.pszDisplayText
     }
 }
 impl ::core::cmp::Eq for CERT_POLICY_QUALIFIER_USER_NOTICE {}
@@ -17102,7 +16994,7 @@ unsafe impl ::windows::core::Abi for CERT_PRIVATE_KEY_VALIDITY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_PRIVATE_KEY_VALIDITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_PRIVATE_KEY_VALIDITY>()) == 0 }
+        self.NotBefore == other.NotBefore && self.NotAfter == other.NotAfter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17135,7 +17027,7 @@ unsafe impl ::windows::core::Abi for CERT_PUBLIC_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_PUBLIC_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_PUBLIC_KEY_INFO>()) == 0 }
+        self.Algorithm == other.Algorithm && self.PublicKey == other.PublicKey
     }
 }
 impl ::core::cmp::Eq for CERT_PUBLIC_KEY_INFO {}
@@ -17166,7 +17058,7 @@ unsafe impl ::windows::core::Abi for CERT_QC_STATEMENT {
 }
 impl ::core::cmp::PartialEq for CERT_QC_STATEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_QC_STATEMENT>()) == 0 }
+        self.pszStatementId == other.pszStatementId && self.StatementInfo == other.StatementInfo
     }
 }
 impl ::core::cmp::Eq for CERT_QC_STATEMENT {}
@@ -17197,7 +17089,7 @@ unsafe impl ::windows::core::Abi for CERT_QC_STATEMENTS_EXT_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_QC_STATEMENTS_EXT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_QC_STATEMENTS_EXT_INFO>()) == 0 }
+        self.cStatement == other.cStatement && self.rgStatement == other.rgStatement
     }
 }
 impl ::core::cmp::Eq for CERT_QC_STATEMENTS_EXT_INFO {}
@@ -17228,7 +17120,7 @@ unsafe impl ::windows::core::Abi for CERT_RDN {
 }
 impl ::core::cmp::PartialEq for CERT_RDN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_RDN>()) == 0 }
+        self.cRDNAttr == other.cRDNAttr && self.rgRDNAttr == other.rgRDNAttr
     }
 }
 impl ::core::cmp::Eq for CERT_RDN {}
@@ -17260,7 +17152,7 @@ unsafe impl ::windows::core::Abi for CERT_RDN_ATTR {
 }
 impl ::core::cmp::PartialEq for CERT_RDN_ATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_RDN_ATTR>()) == 0 }
+        self.pszObjId == other.pszObjId && self.dwValueType == other.dwValueType && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CERT_RDN_ATTR {}
@@ -17297,7 +17189,7 @@ unsafe impl ::windows::core::Abi for CERT_REGISTRY_STORE_CLIENT_GPT_PARA {
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::cmp::PartialEq for CERT_REGISTRY_STORE_CLIENT_GPT_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REGISTRY_STORE_CLIENT_GPT_PARA>()) == 0 }
+        self.hKeyBase == other.hKeyBase && self.pwszRegPath == other.pwszRegPath
     }
 }
 #[cfg(feature = "Win32_System_Registry")]
@@ -17336,7 +17228,7 @@ unsafe impl ::windows::core::Abi for CERT_REGISTRY_STORE_ROAMING_PARA {
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::cmp::PartialEq for CERT_REGISTRY_STORE_ROAMING_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REGISTRY_STORE_ROAMING_PARA>()) == 0 }
+        self.hKey == other.hKey && self.pwszStoreDirectory == other.pwszStoreDirectory
     }
 }
 #[cfg(feature = "Win32_System_Registry")]
@@ -17372,7 +17264,7 @@ unsafe impl ::windows::core::Abi for CERT_REQUEST_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REQUEST_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Subject == other.Subject && self.SubjectPublicKeyInfo == other.SubjectPublicKeyInfo && self.cAttribute == other.cAttribute && self.rgAttribute == other.rgAttribute
     }
 }
 impl ::core::cmp::Eq for CERT_REQUEST_INFO {}
@@ -17415,7 +17307,7 @@ unsafe impl ::windows::core::Abi for CERT_REVOCATION_CHAIN_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_REVOCATION_CHAIN_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REVOCATION_CHAIN_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.hChainEngine == other.hChainEngine && self.hAdditionalStore == other.hAdditionalStore && self.dwChainFlags == other.dwChainFlags && self.dwUrlRetrievalTimeout == other.dwUrlRetrievalTimeout && self.pftCurrentTime == other.pftCurrentTime && self.pftCacheResync == other.pftCacheResync && self.cbMaxUrlRetrievalByteCount == other.cbMaxUrlRetrievalByteCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17457,7 +17349,7 @@ unsafe impl ::windows::core::Abi for CERT_REVOCATION_CRL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_REVOCATION_CRL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REVOCATION_CRL_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pBaseCrlContext == other.pBaseCrlContext && self.pDeltaCrlContext == other.pDeltaCrlContext && self.pCrlEntry == other.pCrlEntry && self.fDeltaCrlEntry == other.fDeltaCrlEntry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17501,7 +17393,7 @@ unsafe impl ::windows::core::Abi for CERT_REVOCATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_REVOCATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REVOCATION_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRevocationResult == other.dwRevocationResult && self.pszRevocationOid == other.pszRevocationOid && self.pvOidSpecificInfo == other.pvOidSpecificInfo && self.fHasFreshnessTime == other.fHasFreshnessTime && self.dwFreshnessTime == other.dwFreshnessTime && self.pCrlInfo == other.pCrlInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17544,7 +17436,7 @@ unsafe impl ::windows::core::Abi for CERT_REVOCATION_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_REVOCATION_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REVOCATION_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.pIssuerCert == other.pIssuerCert && self.cCertStore == other.cCertStore && self.rgCertStore == other.rgCertStore && self.hCrlStore == other.hCrlStore && self.pftTimeToUse == other.pftTimeToUse
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17587,7 +17479,7 @@ unsafe impl ::windows::core::Abi for CERT_REVOCATION_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_REVOCATION_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_REVOCATION_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwIndex == other.dwIndex && self.dwError == other.dwError && self.dwReason == other.dwReason && self.fHasFreshnessTime == other.fHasFreshnessTime && self.dwFreshnessTime == other.dwFreshnessTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17629,7 +17521,7 @@ unsafe impl ::windows::core::Abi for CERT_SELECT_CHAIN_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_SELECT_CHAIN_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SELECT_CHAIN_PARA>()) == 0 }
+        self.hChainEngine == other.hChainEngine && self.pTime == other.pTime && self.hAdditionalStore == other.hAdditionalStore && self.pChainPara == other.pChainPara && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17663,7 +17555,7 @@ unsafe impl ::windows::core::Abi for CERT_SELECT_CRITERIA {
 }
 impl ::core::cmp::PartialEq for CERT_SELECT_CRITERIA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SELECT_CRITERIA>()) == 0 }
+        self.dwType == other.dwType && self.cPara == other.cPara && self.ppPara == other.ppPara
     }
 }
 impl ::core::cmp::Eq for CERT_SELECT_CRITERIA {}
@@ -17695,7 +17587,7 @@ unsafe impl ::windows::core::Abi for CERT_SERVER_OCSP_RESPONSE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for CERT_SERVER_OCSP_RESPONSE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SERVER_OCSP_RESPONSE_CONTEXT>()) == 0 }
+        self.cbSize == other.cbSize && self.pbEncodedOcspResponse == other.pbEncodedOcspResponse && self.cbEncodedOcspResponse == other.cbEncodedOcspResponse
     }
 }
 impl ::core::cmp::Eq for CERT_SERVER_OCSP_RESPONSE_CONTEXT {}
@@ -17726,21 +17618,13 @@ impl ::core::clone::Clone for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CERT_SERVER_OCSP_RESPONSE_OPEN_PARA").field("cbSize", &self.cbSize).field("dwFlags", &self.dwFlags).field("pcbUsedSize", &self.pcbUsedSize).field("pwszOcspDirectory", &self.pwszOcspDirectory).field("pfnUpdateCallback", &self.pfnUpdateCallback.map(|f| f as usize)).field("pvUpdateCallbackArg", &self.pvUpdateCallbackArg).finish()
+        f.debug_struct("CERT_SERVER_OCSP_RESPONSE_OPEN_PARA").field("cbSize", &self.cbSize).field("dwFlags", &self.dwFlags).field("pcbUsedSize", &self.pcbUsedSize).field("pwszOcspDirectory", &self.pwszOcspDirectory).field("pvUpdateCallbackArg", &self.pvUpdateCallbackArg).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SERVER_OCSP_RESPONSE_OPEN_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
     fn default() -> Self {
@@ -17770,7 +17654,7 @@ unsafe impl ::windows::core::Abi for CERT_SIGNED_CONTENT_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_SIGNED_CONTENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SIGNED_CONTENT_INFO>()) == 0 }
+        self.ToBeSigned == other.ToBeSigned && self.SignatureAlgorithm == other.SignatureAlgorithm && self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for CERT_SIGNED_CONTENT_INFO {}
@@ -17812,7 +17696,7 @@ unsafe impl ::windows::core::Abi for CERT_SIMPLE_CHAIN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_SIMPLE_CHAIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SIMPLE_CHAIN>()) == 0 }
+        self.cbSize == other.cbSize && self.TrustStatus == other.TrustStatus && self.cElement == other.cElement && self.rgpElement == other.rgpElement && self.pTrustListInfo == other.pTrustListInfo && self.fHasRevocationFreshnessTime == other.fHasRevocationFreshnessTime && self.dwRevocationFreshnessTime == other.dwRevocationFreshnessTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17848,7 +17732,7 @@ unsafe impl ::windows::core::Abi for CERT_STORE_PROV_FIND_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_STORE_PROV_FIND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_STORE_PROV_FIND_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgAndCertEncodingType == other.dwMsgAndCertEncodingType && self.dwFindFlags == other.dwFindFlags && self.dwFindType == other.dwFindType && self.pvFindPara == other.pvFindPara
     }
 }
 impl ::core::cmp::Eq for CERT_STORE_PROV_FIND_INFO {}
@@ -17883,7 +17767,7 @@ unsafe impl ::windows::core::Abi for CERT_STORE_PROV_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_STORE_PROV_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_STORE_PROV_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.cStoreProvFunc == other.cStoreProvFunc && self.rgpvStoreProvFunc == other.rgpvStoreProvFunc && self.hStoreProv == other.hStoreProv && self.dwStoreProvFlags == other.dwStoreProvFlags && self.hStoreProvFuncAddr2 == other.hStoreProvFuncAddr2
     }
 }
 impl ::core::cmp::Eq for CERT_STORE_PROV_INFO {}
@@ -17908,12 +17792,6 @@ impl ::core::clone::Clone for CERT_STRONG_SIGN_PARA {
 unsafe impl ::windows::core::Abi for CERT_STRONG_SIGN_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_STRONG_SIGN_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_STRONG_SIGN_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_STRONG_SIGN_PARA {}
 impl ::core::default::Default for CERT_STRONG_SIGN_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17935,12 +17813,6 @@ impl ::core::clone::Clone for CERT_STRONG_SIGN_PARA_0 {
 unsafe impl ::windows::core::Abi for CERT_STRONG_SIGN_PARA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CERT_STRONG_SIGN_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_STRONG_SIGN_PARA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CERT_STRONG_SIGN_PARA_0 {}
 impl ::core::default::Default for CERT_STRONG_SIGN_PARA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17969,7 +17841,7 @@ unsafe impl ::windows::core::Abi for CERT_STRONG_SIGN_SERIALIZED_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_STRONG_SIGN_SERIALIZED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_STRONG_SIGN_SERIALIZED_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pwszCNGSignHashAlgids == other.pwszCNGSignHashAlgids && self.pwszCNGPubKeyMinBitLengths == other.pwszCNGPubKeyMinBitLengths
     }
 }
 impl ::core::cmp::Eq for CERT_STRONG_SIGN_SERIALIZED_INFO {}
@@ -18001,7 +17873,7 @@ unsafe impl ::windows::core::Abi for CERT_SUPPORTED_ALGORITHM_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_SUPPORTED_ALGORITHM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SUPPORTED_ALGORITHM_INFO>()) == 0 }
+        self.Algorithm == other.Algorithm && self.IntendedKeyUsage == other.IntendedKeyUsage && self.IntendedCertPolicies == other.IntendedCertPolicies
     }
 }
 impl ::core::cmp::Eq for CERT_SUPPORTED_ALGORITHM_INFO {}
@@ -18031,7 +17903,7 @@ unsafe impl ::windows::core::Abi for CERT_SYSTEM_STORE_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_SYSTEM_STORE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SYSTEM_STORE_INFO>()) == 0 }
+        self.cbSize == other.cbSize
     }
 }
 impl ::core::cmp::Eq for CERT_SYSTEM_STORE_INFO {}
@@ -18060,14 +17932,6 @@ unsafe impl ::windows::core::Abi for CERT_SYSTEM_STORE_RELOCATE_PARA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::PartialEq for CERT_SYSTEM_STORE_RELOCATE_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SYSTEM_STORE_RELOCATE_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::Eq for CERT_SYSTEM_STORE_RELOCATE_PARA {}
-#[cfg(feature = "Win32_System_Registry")]
 impl ::core::default::Default for CERT_SYSTEM_STORE_RELOCATE_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18092,14 +17956,6 @@ impl ::core::clone::Clone for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
 unsafe impl ::windows::core::Abi for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::PartialEq for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SYSTEM_STORE_RELOCATE_PARA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::Eq for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {}
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::default::Default for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
     fn default() -> Self {
@@ -18126,14 +17982,6 @@ impl ::core::clone::Clone for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
 unsafe impl ::windows::core::Abi for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::PartialEq for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_SYSTEM_STORE_RELOCATE_PARA_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::Eq for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {}
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::default::Default for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
     fn default() -> Self {
@@ -18170,7 +18018,7 @@ unsafe impl ::windows::core::Abi for CERT_TEMPLATE_EXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_TEMPLATE_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_TEMPLATE_EXT>()) == 0 }
+        self.pszObjId == other.pszObjId && self.dwMajorVersion == other.dwMajorVersion && self.fMinorVersion == other.fMinorVersion && self.dwMinorVersion == other.dwMinorVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18204,7 +18052,7 @@ unsafe impl ::windows::core::Abi for CERT_TPM_SPECIFICATION_INFO {
 }
 impl ::core::cmp::PartialEq for CERT_TPM_SPECIFICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_TPM_SPECIFICATION_INFO>()) == 0 }
+        self.pwszFamily == other.pwszFamily && self.dwLevel == other.dwLevel && self.dwRevision == other.dwRevision
     }
 }
 impl ::core::cmp::Eq for CERT_TPM_SPECIFICATION_INFO {}
@@ -18242,7 +18090,7 @@ unsafe impl ::windows::core::Abi for CERT_TRUST_LIST_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CERT_TRUST_LIST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_TRUST_LIST_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pCtlEntry == other.pCtlEntry && self.pCtlContext == other.pCtlContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18275,7 +18123,7 @@ unsafe impl ::windows::core::Abi for CERT_TRUST_STATUS {
 }
 impl ::core::cmp::PartialEq for CERT_TRUST_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_TRUST_STATUS>()) == 0 }
+        self.dwErrorStatus == other.dwErrorStatus && self.dwInfoStatus == other.dwInfoStatus
     }
 }
 impl ::core::cmp::Eq for CERT_TRUST_STATUS {}
@@ -18306,7 +18154,7 @@ unsafe impl ::windows::core::Abi for CERT_USAGE_MATCH {
 }
 impl ::core::cmp::PartialEq for CERT_USAGE_MATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_USAGE_MATCH>()) == 0 }
+        self.dwType == other.dwType && self.Usage == other.Usage
     }
 }
 impl ::core::cmp::Eq for CERT_USAGE_MATCH {}
@@ -18340,7 +18188,7 @@ unsafe impl ::windows::core::Abi for CERT_X942_DH_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for CERT_X942_DH_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_X942_DH_PARAMETERS>()) == 0 }
+        self.p == other.p && self.g == other.g && self.q == other.q && self.j == other.j && self.pValidationParams == other.pValidationParams
     }
 }
 impl ::core::cmp::Eq for CERT_X942_DH_PARAMETERS {}
@@ -18371,7 +18219,7 @@ unsafe impl ::windows::core::Abi for CERT_X942_DH_VALIDATION_PARAMS {
 }
 impl ::core::cmp::PartialEq for CERT_X942_DH_VALIDATION_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_X942_DH_VALIDATION_PARAMS>()) == 0 }
+        self.seed == other.seed && self.pgenCounter == other.pgenCounter
     }
 }
 impl ::core::cmp::Eq for CERT_X942_DH_VALIDATION_PARAMS {}
@@ -18402,7 +18250,7 @@ unsafe impl ::windows::core::Abi for CLAIMLIST {
 }
 impl ::core::cmp::PartialEq for CLAIMLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIMLIST>()) == 0 }
+        self.count == other.count && self.claims == other.claims
     }
 }
 impl ::core::cmp::Eq for CLAIMLIST {}
@@ -18436,7 +18284,7 @@ unsafe impl ::windows::core::Abi for CMC_ADD_ATTRIBUTES_INFO {
 }
 impl ::core::cmp::PartialEq for CMC_ADD_ATTRIBUTES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_ADD_ATTRIBUTES_INFO>()) == 0 }
+        self.dwCmcDataReference == other.dwCmcDataReference && self.cCertReference == other.cCertReference && self.rgdwCertReference == other.rgdwCertReference && self.cAttribute == other.cAttribute && self.rgAttribute == other.rgAttribute
     }
 }
 impl ::core::cmp::Eq for CMC_ADD_ATTRIBUTES_INFO {}
@@ -18476,7 +18324,7 @@ unsafe impl ::windows::core::Abi for CMC_ADD_EXTENSIONS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMC_ADD_EXTENSIONS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_ADD_EXTENSIONS_INFO>()) == 0 }
+        self.dwCmcDataReference == other.dwCmcDataReference && self.cCertReference == other.cCertReference && self.rgdwCertReference == other.rgdwCertReference && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18515,7 +18363,7 @@ unsafe impl ::windows::core::Abi for CMC_DATA_INFO {
 }
 impl ::core::cmp::PartialEq for CMC_DATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_DATA_INFO>()) == 0 }
+        self.cTaggedAttribute == other.cTaggedAttribute && self.rgTaggedAttribute == other.rgTaggedAttribute && self.cTaggedRequest == other.cTaggedRequest && self.rgTaggedRequest == other.rgTaggedRequest && self.cTaggedContentInfo == other.cTaggedContentInfo && self.rgTaggedContentInfo == other.rgTaggedContentInfo && self.cTaggedOtherMsg == other.cTaggedOtherMsg && self.rgTaggedOtherMsg == other.rgTaggedOtherMsg
     }
 }
 impl ::core::cmp::Eq for CMC_DATA_INFO {}
@@ -18552,7 +18400,7 @@ unsafe impl ::windows::core::Abi for CMC_PEND_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMC_PEND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_PEND_INFO>()) == 0 }
+        self.PendToken == other.PendToken && self.PendTime == other.PendTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18589,7 +18437,7 @@ unsafe impl ::windows::core::Abi for CMC_RESPONSE_INFO {
 }
 impl ::core::cmp::PartialEq for CMC_RESPONSE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_RESPONSE_INFO>()) == 0 }
+        self.cTaggedAttribute == other.cTaggedAttribute && self.rgTaggedAttribute == other.rgTaggedAttribute && self.cTaggedContentInfo == other.cTaggedContentInfo && self.rgTaggedContentInfo == other.rgTaggedContentInfo && self.cTaggedOtherMsg == other.cTaggedOtherMsg && self.rgTaggedOtherMsg == other.rgTaggedOtherMsg
     }
 }
 impl ::core::cmp::Eq for CMC_RESPONSE_INFO {}
@@ -18622,14 +18470,6 @@ unsafe impl ::windows::core::Abi for CMC_STATUS_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMC_STATUS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_STATUS_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMC_STATUS_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMC_STATUS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18654,14 +18494,6 @@ impl ::core::clone::Clone for CMC_STATUS_INFO_0 {
 unsafe impl ::windows::core::Abi for CMC_STATUS_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMC_STATUS_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_STATUS_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMC_STATUS_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMC_STATUS_INFO_0 {
     fn default() -> Self {
@@ -18690,7 +18522,7 @@ unsafe impl ::windows::core::Abi for CMC_TAGGED_ATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for CMC_TAGGED_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_ATTRIBUTE>()) == 0 }
+        self.dwBodyPartID == other.dwBodyPartID && self.Attribute == other.Attribute
     }
 }
 impl ::core::cmp::Eq for CMC_TAGGED_ATTRIBUTE {}
@@ -18721,7 +18553,7 @@ unsafe impl ::windows::core::Abi for CMC_TAGGED_CERT_REQUEST {
 }
 impl ::core::cmp::PartialEq for CMC_TAGGED_CERT_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_CERT_REQUEST>()) == 0 }
+        self.dwBodyPartID == other.dwBodyPartID && self.SignedCertRequest == other.SignedCertRequest
     }
 }
 impl ::core::cmp::Eq for CMC_TAGGED_CERT_REQUEST {}
@@ -18752,7 +18584,7 @@ unsafe impl ::windows::core::Abi for CMC_TAGGED_CONTENT_INFO {
 }
 impl ::core::cmp::PartialEq for CMC_TAGGED_CONTENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_CONTENT_INFO>()) == 0 }
+        self.dwBodyPartID == other.dwBodyPartID && self.EncodedContentInfo == other.EncodedContentInfo
     }
 }
 impl ::core::cmp::Eq for CMC_TAGGED_CONTENT_INFO {}
@@ -18784,7 +18616,7 @@ unsafe impl ::windows::core::Abi for CMC_TAGGED_OTHER_MSG {
 }
 impl ::core::cmp::PartialEq for CMC_TAGGED_OTHER_MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_OTHER_MSG>()) == 0 }
+        self.dwBodyPartID == other.dwBodyPartID && self.pszObjId == other.pszObjId && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CMC_TAGGED_OTHER_MSG {}
@@ -18808,12 +18640,6 @@ impl ::core::clone::Clone for CMC_TAGGED_REQUEST {
 unsafe impl ::windows::core::Abi for CMC_TAGGED_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMC_TAGGED_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMC_TAGGED_REQUEST {}
 impl ::core::default::Default for CMC_TAGGED_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18833,12 +18659,6 @@ impl ::core::clone::Clone for CMC_TAGGED_REQUEST_0 {
 unsafe impl ::windows::core::Abi for CMC_TAGGED_REQUEST_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMC_TAGGED_REQUEST_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMC_TAGGED_REQUEST_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMC_TAGGED_REQUEST_0 {}
 impl ::core::default::Default for CMC_TAGGED_REQUEST_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18863,14 +18683,6 @@ impl ::core::clone::Clone for CMSG_CMS_RECIPIENT_INFO {
 unsafe impl ::windows::core::Abi for CMSG_CMS_RECIPIENT_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CMS_RECIPIENT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CMS_RECIPIENT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CMS_RECIPIENT_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CMS_RECIPIENT_INFO {
     fn default() -> Self {
@@ -18898,14 +18710,6 @@ unsafe impl ::windows::core::Abi for CMSG_CMS_RECIPIENT_INFO_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CMS_RECIPIENT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CMS_RECIPIENT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CMS_RECIPIENT_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CMS_RECIPIENT_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18931,12 +18735,6 @@ impl ::core::clone::Clone for CMSG_CMS_SIGNER_INFO {
 unsafe impl ::windows::core::Abi for CMSG_CMS_SIGNER_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CMS_SIGNER_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CMS_SIGNER_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CMS_SIGNER_INFO {}
 impl ::core::default::Default for CMSG_CMS_SIGNER_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18963,28 +18761,12 @@ impl ::core::clone::Clone for CMSG_CNG_CONTENT_DECRYPT_INFO {
 }
 impl ::core::fmt::Debug for CMSG_CNG_CONTENT_DECRYPT_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CMSG_CNG_CONTENT_DECRYPT_INFO")
-            .field("cbSize", &self.cbSize)
-            .field("ContentEncryptionAlgorithm", &self.ContentEncryptionAlgorithm)
-            .field("pfnAlloc", &self.pfnAlloc.map(|f| f as usize))
-            .field("pfnFree", &self.pfnFree.map(|f| f as usize))
-            .field("hNCryptKey", &self.hNCryptKey)
-            .field("pbContentEncryptKey", &self.pbContentEncryptKey)
-            .field("cbContentEncryptKey", &self.cbContentEncryptKey)
-            .field("hCNGContentEncryptKey", &self.hCNGContentEncryptKey)
-            .field("pbCNGContentEncryptKeyObject", &self.pbCNGContentEncryptKeyObject)
-            .finish()
+        f.debug_struct("CMSG_CNG_CONTENT_DECRYPT_INFO").field("cbSize", &self.cbSize).field("ContentEncryptionAlgorithm", &self.ContentEncryptionAlgorithm).field("hNCryptKey", &self.hNCryptKey).field("pbContentEncryptKey", &self.pbContentEncryptKey).field("cbContentEncryptKey", &self.cbContentEncryptKey).field("hCNGContentEncryptKey", &self.hCNGContentEncryptKey).field("pbCNGContentEncryptKeyObject", &self.pbCNGContentEncryptKeyObject).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CMSG_CNG_CONTENT_DECRYPT_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CNG_CONTENT_DECRYPT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CNG_CONTENT_DECRYPT_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CNG_CONTENT_DECRYPT_INFO {}
 impl ::core::default::Default for CMSG_CNG_CONTENT_DECRYPT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19023,14 +18805,6 @@ unsafe impl ::windows::core::Abi for CMSG_CONTENT_ENCRYPT_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CONTENT_ENCRYPT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CONTENT_ENCRYPT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CONTENT_ENCRYPT_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CONTENT_ENCRYPT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19055,14 +18829,6 @@ impl ::core::clone::Clone for CMSG_CONTENT_ENCRYPT_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_CONTENT_ENCRYPT_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CONTENT_ENCRYPT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CONTENT_ENCRYPT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CONTENT_ENCRYPT_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CONTENT_ENCRYPT_INFO_0 {
     fn default() -> Self {
@@ -19092,7 +18858,7 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA {
 }
 impl ::core::cmp::PartialEq for CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwSignerIndex == other.dwSignerIndex && self.blob == other.blob
     }
 }
 impl ::core::cmp::Eq for CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA {}
@@ -19118,12 +18884,6 @@ impl ::core::clone::Clone for CMSG_CTRL_DECRYPT_PARA {
 unsafe impl ::windows::core::Abi for CMSG_CTRL_DECRYPT_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CTRL_DECRYPT_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_DECRYPT_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CTRL_DECRYPT_PARA {}
 impl ::core::default::Default for CMSG_CTRL_DECRYPT_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19144,12 +18904,6 @@ impl ::core::clone::Clone for CMSG_CTRL_DECRYPT_PARA_0 {
 unsafe impl ::windows::core::Abi for CMSG_CTRL_DECRYPT_PARA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CTRL_DECRYPT_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_DECRYPT_PARA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CTRL_DECRYPT_PARA_0 {}
 impl ::core::default::Default for CMSG_CTRL_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19178,7 +18932,7 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA {
 }
 impl ::core::cmp::PartialEq for CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwSignerIndex == other.dwSignerIndex && self.dwUnauthAttrIndex == other.dwUnauthAttrIndex
     }
 }
 impl ::core::cmp::Eq for CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA {}
@@ -19212,14 +18966,6 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_KEY_AGREE_DECRYPT_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19245,14 +18991,6 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19276,12 +19014,6 @@ impl ::core::clone::Clone for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
 unsafe impl ::windows::core::Abi for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_KEY_TRANS_DECRYPT_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {}
 impl ::core::default::Default for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19302,12 +19034,6 @@ impl ::core::clone::Clone for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
 unsafe impl ::windows::core::Abi for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {}
 impl ::core::default::Default for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19337,14 +19063,6 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_MAIL_LIST_DECRYPT_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19369,14 +19087,6 @@ impl ::core::clone::Clone for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
 unsafe impl ::windows::core::Abi for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
     fn default() -> Self {
@@ -19408,7 +19118,7 @@ unsafe impl ::windows::core::Abi for CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA {
 }
 impl ::core::cmp::PartialEq for CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.hCryptProv == other.hCryptProv && self.dwSignerIndex == other.dwSignerIndex && self.dwSignerType == other.dwSignerType && self.pvSigner == other.pvSigner
     }
 }
 impl ::core::cmp::Eq for CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA {}
@@ -19440,7 +19150,7 @@ unsafe impl ::windows::core::Abi for CMSG_ENCRYPTED_ENCODE_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_ENCRYPTED_ENCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_ENCRYPTED_ENCODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.ContentEncryptionAlgorithm == other.ContentEncryptionAlgorithm && self.pvEncryptionAuxInfo == other.pvEncryptionAuxInfo
     }
 }
 impl ::core::cmp::Eq for CMSG_ENCRYPTED_ENCODE_INFO {}
@@ -19481,7 +19191,7 @@ unsafe impl ::windows::core::Abi for CMSG_ENVELOPED_ENCODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMSG_ENVELOPED_ENCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_ENVELOPED_ENCODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hCryptProv == other.hCryptProv && self.ContentEncryptionAlgorithm == other.ContentEncryptionAlgorithm && self.pvEncryptionAuxInfo == other.pvEncryptionAuxInfo && self.cRecipients == other.cRecipients && self.rgpRecipients == other.rgpRecipients
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19516,7 +19226,7 @@ unsafe impl ::windows::core::Abi for CMSG_HASHED_ENCODE_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_HASHED_ENCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_HASHED_ENCODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hCryptProv == other.hCryptProv && self.HashAlgorithm == other.HashAlgorithm && self.pvHashAuxInfo == other.pvHashAuxInfo
     }
 }
 impl ::core::cmp::Eq for CMSG_HASHED_ENCODE_INFO {}
@@ -19547,12 +19257,6 @@ impl ::core::clone::Clone for CMSG_KEY_AGREE_ENCRYPT_INFO {
 unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_ENCRYPT_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_ENCRYPT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_ENCRYPT_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_ENCRYPT_INFO {}
 impl ::core::default::Default for CMSG_KEY_AGREE_ENCRYPT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19573,12 +19277,6 @@ impl ::core::clone::Clone for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_ENCRYPT_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {}
 impl ::core::default::Default for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19606,7 +19304,7 @@ unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_KEY_ENCRYPT_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_KEY_ENCRYPT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_KEY_ENCRYPT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.EncryptedKey == other.EncryptedKey
     }
 }
 impl ::core::cmp::Eq for CMSG_KEY_AGREE_KEY_ENCRYPT_INFO {}
@@ -19645,14 +19343,6 @@ unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19677,14 +19367,6 @@ impl ::core::clone::Clone for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
@@ -19716,14 +19398,6 @@ unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_RECIPIENT_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_RECIPIENT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_RECIPIENT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_RECIPIENT_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_KEY_AGREE_RECIPIENT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19748,14 +19422,6 @@ impl ::core::clone::Clone for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_AGREE_RECIPIENT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
     fn default() -> Self {
@@ -19787,7 +19453,7 @@ unsafe impl ::windows::core::Abi for CMSG_KEY_TRANS_ENCRYPT_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_KEY_TRANS_ENCRYPT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_TRANS_ENCRYPT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRecipientIndex == other.dwRecipientIndex && self.KeyEncryptionAlgorithm == other.KeyEncryptionAlgorithm && self.EncryptedKey == other.EncryptedKey && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CMSG_KEY_TRANS_ENCRYPT_INFO {}
@@ -19815,12 +19481,6 @@ impl ::core::clone::Clone for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
 unsafe impl ::windows::core::Abi for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {}
 impl ::core::default::Default for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19843,12 +19503,6 @@ impl ::core::clone::Clone for CMSG_KEY_TRANS_RECIPIENT_INFO {
 unsafe impl ::windows::core::Abi for CMSG_KEY_TRANS_RECIPIENT_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CMSG_KEY_TRANS_RECIPIENT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_KEY_TRANS_RECIPIENT_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CMSG_KEY_TRANS_RECIPIENT_INFO {}
 impl ::core::default::Default for CMSG_KEY_TRANS_RECIPIENT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19879,7 +19533,7 @@ unsafe impl ::windows::core::Abi for CMSG_MAIL_LIST_ENCRYPT_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_MAIL_LIST_ENCRYPT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_MAIL_LIST_ENCRYPT_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRecipientIndex == other.dwRecipientIndex && self.KeyEncryptionAlgorithm == other.KeyEncryptionAlgorithm && self.EncryptedKey == other.EncryptedKey && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CMSG_MAIL_LIST_ENCRYPT_INFO {}
@@ -19915,14 +19569,6 @@ unsafe impl ::windows::core::Abi for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19947,14 +19593,6 @@ impl ::core::clone::Clone for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
@@ -19993,7 +19631,7 @@ unsafe impl ::windows::core::Abi for CMSG_MAIL_LIST_RECIPIENT_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMSG_MAIL_LIST_RECIPIENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_MAIL_LIST_RECIPIENT_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.KeyId == other.KeyId && self.KeyEncryptionAlgorithm == other.KeyEncryptionAlgorithm && self.EncryptedKey == other.EncryptedKey && self.Date == other.Date && self.pOtherAttr == other.pOtherAttr
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20026,7 +19664,7 @@ unsafe impl ::windows::core::Abi for CMSG_RC2_AUX_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_RC2_AUX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RC2_AUX_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwBitLen == other.dwBitLen
     }
 }
 impl ::core::cmp::Eq for CMSG_RC2_AUX_INFO {}
@@ -20057,7 +19695,7 @@ unsafe impl ::windows::core::Abi for CMSG_RC4_AUX_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_RC4_AUX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RC4_AUX_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwBitLen == other.dwBitLen
     }
 }
 impl ::core::cmp::Eq for CMSG_RC4_AUX_INFO {}
@@ -20086,14 +19724,6 @@ unsafe impl ::windows::core::Abi for CMSG_RECIPIENT_ENCODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_RECIPIENT_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RECIPIENT_ENCODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_RECIPIENT_ENCODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_RECIPIENT_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20119,14 +19749,6 @@ impl ::core::clone::Clone for CMSG_RECIPIENT_ENCODE_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_RECIPIENT_ENCODE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_RECIPIENT_ENCODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RECIPIENT_ENCODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_RECIPIENT_ENCODE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
@@ -20156,14 +19778,6 @@ unsafe impl ::windows::core::Abi for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20190,14 +19804,6 @@ impl ::core::clone::Clone for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
 unsafe impl ::windows::core::Abi for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_RECIPIENT_ENCRYPTED_KEY_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
     fn default() -> Self {
@@ -20233,7 +19839,7 @@ unsafe impl ::windows::core::Abi for CMSG_SIGNED_AND_ENVELOPED_ENCODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMSG_SIGNED_AND_ENVELOPED_ENCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SIGNED_AND_ENVELOPED_ENCODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.SignedInfo == other.SignedInfo && self.EnvelopedInfo == other.EnvelopedInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20277,7 +19883,7 @@ unsafe impl ::windows::core::Abi for CMSG_SIGNED_ENCODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMSG_SIGNED_ENCODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SIGNED_ENCODE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.cSigners == other.cSigners && self.rgSigners == other.rgSigners && self.cCertEncoded == other.cCertEncoded && self.rgCertEncoded == other.rgCertEncoded && self.cCrlEncoded == other.cCrlEncoded && self.rgCrlEncoded == other.rgCrlEncoded
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20316,14 +19922,6 @@ unsafe impl ::windows::core::Abi for CMSG_SIGNER_ENCODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_SIGNER_ENCODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SIGNER_ENCODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_SIGNER_ENCODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_SIGNER_ENCODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20348,14 +19946,6 @@ impl ::core::clone::Clone for CMSG_SIGNER_ENCODE_INFO_0 {
 unsafe impl ::windows::core::Abi for CMSG_SIGNER_ENCODE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_SIGNER_ENCODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SIGNER_ENCODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_SIGNER_ENCODE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_SIGNER_ENCODE_INFO_0 {
     fn default() -> Self {
@@ -20390,7 +19980,7 @@ unsafe impl ::windows::core::Abi for CMSG_SIGNER_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_SIGNER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SIGNER_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Issuer == other.Issuer && self.SerialNumber == other.SerialNumber && self.HashAlgorithm == other.HashAlgorithm && self.HashEncryptionAlgorithm == other.HashEncryptionAlgorithm && self.EncryptedHash == other.EncryptedHash && self.AuthAttrs == other.AuthAttrs && self.UnauthAttrs == other.UnauthAttrs
     }
 }
 impl ::core::cmp::Eq for CMSG_SIGNER_INFO {}
@@ -20421,7 +20011,7 @@ unsafe impl ::windows::core::Abi for CMSG_SP3_COMPATIBLE_AUX_INFO {
 }
 impl ::core::cmp::PartialEq for CMSG_SP3_COMPATIBLE_AUX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_SP3_COMPATIBLE_AUX_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CMSG_SP3_COMPATIBLE_AUX_INFO {}
@@ -20449,21 +20039,13 @@ impl ::core::clone::Clone for CMSG_STREAM_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CMSG_STREAM_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CMSG_STREAM_INFO").field("cbContent", &self.cbContent).field("pfnStreamOutput", &self.pfnStreamOutput.map(|f| f as usize)).field("pvArg", &self.pvArg).finish()
+        f.debug_struct("CMSG_STREAM_INFO").field("cbContent", &self.cbContent).field("pvArg", &self.pvArg).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CMSG_STREAM_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CMSG_STREAM_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMSG_STREAM_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CMSG_STREAM_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CMSG_STREAM_INFO {
     fn default() -> Self {
@@ -20495,7 +20077,7 @@ unsafe impl ::windows::core::Abi for CMS_DH_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CMS_DH_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMS_DH_KEY_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Algid == other.Algid && self.pszContentEncObjId == other.pszContentEncObjId && self.PubInfo == other.PubInfo && self.pReserved == other.pReserved
     }
 }
 impl ::core::cmp::Eq for CMS_DH_KEY_INFO {}
@@ -20528,7 +20110,7 @@ unsafe impl ::windows::core::Abi for CMS_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CMS_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMS_KEY_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Algid == other.Algid && self.pbOID == other.pbOID && self.cbOID == other.cbOID
     }
 }
 impl ::core::cmp::Eq for CMS_KEY_INFO {}
@@ -20560,7 +20142,7 @@ unsafe impl ::windows::core::Abi for CPS_URLS {
 }
 impl ::core::cmp::PartialEq for CPS_URLS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPS_URLS>()) == 0 }
+        self.pszURL == other.pszURL && self.pAlgorithm == other.pAlgorithm && self.pDigest == other.pDigest
     }
 }
 impl ::core::cmp::Eq for CPS_URLS {}
@@ -20600,7 +20182,7 @@ unsafe impl ::windows::core::Abi for CRL_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRL_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_CONTEXT>()) == 0 }
+        self.dwCertEncodingType == other.dwCertEncodingType && self.pbCrlEncoded == other.pbCrlEncoded && self.cbCrlEncoded == other.cbCrlEncoded && self.pCrlInfo == other.pCrlInfo && self.hCertStore == other.hCertStore
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20627,12 +20209,6 @@ impl ::core::clone::Clone for CRL_DIST_POINT {
 unsafe impl ::windows::core::Abi for CRL_DIST_POINT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRL_DIST_POINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_DIST_POINT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRL_DIST_POINT {}
 impl ::core::default::Default for CRL_DIST_POINT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20660,7 +20236,7 @@ unsafe impl ::windows::core::Abi for CRL_DIST_POINTS_INFO {
 }
 impl ::core::cmp::PartialEq for CRL_DIST_POINTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_DIST_POINTS_INFO>()) == 0 }
+        self.cDistPoint == other.cDistPoint && self.rgDistPoint == other.rgDistPoint
     }
 }
 impl ::core::cmp::Eq for CRL_DIST_POINTS_INFO {}
@@ -20684,12 +20260,6 @@ impl ::core::clone::Clone for CRL_DIST_POINT_NAME {
 unsafe impl ::windows::core::Abi for CRL_DIST_POINT_NAME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRL_DIST_POINT_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_DIST_POINT_NAME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRL_DIST_POINT_NAME {}
 impl ::core::default::Default for CRL_DIST_POINT_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20709,12 +20279,6 @@ impl ::core::clone::Clone for CRL_DIST_POINT_NAME_0 {
 unsafe impl ::windows::core::Abi for CRL_DIST_POINT_NAME_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRL_DIST_POINT_NAME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_DIST_POINT_NAME_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRL_DIST_POINT_NAME_0 {}
 impl ::core::default::Default for CRL_DIST_POINT_NAME_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20750,7 +20314,7 @@ unsafe impl ::windows::core::Abi for CRL_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRL_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_ENTRY>()) == 0 }
+        self.SerialNumber == other.SerialNumber && self.RevocationDate == other.RevocationDate && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20789,7 +20353,7 @@ unsafe impl ::windows::core::Abi for CRL_FIND_ISSUED_FOR_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRL_FIND_ISSUED_FOR_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_FIND_ISSUED_FOR_PARA>()) == 0 }
+        self.pSubjectCert == other.pSubjectCert && self.pIssuerCert == other.pIssuerCert
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20835,7 +20399,7 @@ unsafe impl ::windows::core::Abi for CRL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.SignatureAlgorithm == other.SignatureAlgorithm && self.Issuer == other.Issuer && self.ThisUpdate == other.ThisUpdate && self.NextUpdate == other.NextUpdate && self.cCRLEntry == other.cCRLEntry && self.rgCRLEntry == other.rgCRLEntry && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20868,14 +20432,6 @@ impl ::core::clone::Clone for CRL_ISSUING_DIST_POINT {
 unsafe impl ::windows::core::Abi for CRL_ISSUING_DIST_POINT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRL_ISSUING_DIST_POINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_ISSUING_DIST_POINT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRL_ISSUING_DIST_POINT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRL_ISSUING_DIST_POINT {
     fn default() -> Self {
@@ -20911,7 +20467,7 @@ unsafe impl ::windows::core::Abi for CRL_REVOCATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRL_REVOCATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRL_REVOCATION_INFO>()) == 0 }
+        self.pCrlEntry == other.pCrlEntry && self.pCrlContext == other.pCrlContext && self.pCrlIssuerChain == other.pCrlIssuerChain
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20945,7 +20501,7 @@ unsafe impl ::windows::core::Abi for CROSS_CERT_DIST_POINTS_INFO {
 }
 impl ::core::cmp::PartialEq for CROSS_CERT_DIST_POINTS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CROSS_CERT_DIST_POINTS_INFO>()) == 0 }
+        self.dwSyncDeltaTime == other.dwSyncDeltaTime && self.cDistPoint == other.cDistPoint && self.rgDistPoint == other.rgDistPoint
     }
 }
 impl ::core::cmp::Eq for CROSS_CERT_DIST_POINTS_INFO {}
@@ -20983,7 +20539,7 @@ unsafe impl ::windows::core::Abi for CRYPTNET_URL_CACHE_FLUSH_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTNET_URL_CACHE_FLUSH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTNET_URL_CACHE_FLUSH_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwExemptSeconds == other.dwExemptSeconds && self.ExpireTime == other.ExpireTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21027,7 +20583,7 @@ unsafe impl ::windows::core::Abi for CRYPTNET_URL_CACHE_PRE_FETCH_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTNET_URL_CACHE_PRE_FETCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTNET_URL_CACHE_PRE_FETCH_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwObjectType == other.dwObjectType && self.dwError == other.dwError && self.dwReserved == other.dwReserved && self.ThisUpdateTime == other.ThisUpdateTime && self.NextUpdateTime == other.NextUpdateTime && self.PublishTime == other.PublishTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21071,7 +20627,7 @@ unsafe impl ::windows::core::Abi for CRYPTNET_URL_CACHE_RESPONSE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTNET_URL_CACHE_RESPONSE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTNET_URL_CACHE_RESPONSE_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wResponseType == other.wResponseType && self.wResponseFlags == other.wResponseFlags && self.LastModifiedTime == other.LastModifiedTime && self.dwMaxAge == other.dwMaxAge && self.pwszETag == other.pwszETag && self.dwProxyId == other.dwProxyId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21112,7 +20668,7 @@ unsafe impl ::windows::core::Abi for CRYPTPROTECT_PROMPTSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPTPROTECT_PROMPTSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPTPROTECT_PROMPTSTRUCT>()) == 0 }
+        self.cbSize == other.cbSize && self.dwPromptFlags == other.dwPromptFlags && self.hwndApp == other.hwndApp && self.szPrompt == other.szPrompt
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21146,7 +20702,7 @@ unsafe impl ::windows::core::Abi for CRYPT_3DES_KEY_STATE {
 }
 impl ::core::cmp::PartialEq for CRYPT_3DES_KEY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_3DES_KEY_STATE>()) == 0 }
+        self.Key == other.Key && self.IV == other.IV && self.Feedback == other.Feedback
     }
 }
 impl ::core::cmp::Eq for CRYPT_3DES_KEY_STATE {}
@@ -21180,7 +20736,7 @@ unsafe impl ::windows::core::Abi for CRYPT_AES_128_KEY_STATE {
 }
 impl ::core::cmp::PartialEq for CRYPT_AES_128_KEY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_AES_128_KEY_STATE>()) == 0 }
+        self.Key == other.Key && self.IV == other.IV && self.EncryptionState == other.EncryptionState && self.DecryptionState == other.DecryptionState && self.Feedback == other.Feedback
     }
 }
 impl ::core::cmp::Eq for CRYPT_AES_128_KEY_STATE {}
@@ -21214,7 +20770,7 @@ unsafe impl ::windows::core::Abi for CRYPT_AES_256_KEY_STATE {
 }
 impl ::core::cmp::PartialEq for CRYPT_AES_256_KEY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_AES_256_KEY_STATE>()) == 0 }
+        self.Key == other.Key && self.IV == other.IV && self.EncryptionState == other.EncryptionState && self.DecryptionState == other.DecryptionState && self.Feedback == other.Feedback
     }
 }
 impl ::core::cmp::Eq for CRYPT_AES_256_KEY_STATE {}
@@ -21245,7 +20801,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ALGORITHM_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for CRYPT_ALGORITHM_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ALGORITHM_IDENTIFIER>()) == 0 }
+        self.pszObjId == other.pszObjId && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for CRYPT_ALGORITHM_IDENTIFIER {}
@@ -21268,18 +20824,12 @@ impl ::core::clone::Clone for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
 }
 impl ::core::fmt::Debug for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_ASYNC_RETRIEVAL_COMPLETION").field("pfnCompletion", &self.pfnCompletion.map(|f| f as usize)).field("pvCompletion", &self.pvCompletion).finish()
+        f.debug_struct("CRYPT_ASYNC_RETRIEVAL_COMPLETION").field("pvCompletion", &self.pvCompletion).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ASYNC_RETRIEVAL_COMPLETION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_ASYNC_RETRIEVAL_COMPLETION {}
 impl ::core::default::Default for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21308,7 +20858,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for CRYPT_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ATTRIBUTE>()) == 0 }
+        self.pszObjId == other.pszObjId && self.cValue == other.cValue && self.rgValue == other.rgValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_ATTRIBUTE {}
@@ -21339,7 +20889,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for CRYPT_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ATTRIBUTES>()) == 0 }
+        self.cAttr == other.cAttr && self.rgAttr == other.rgAttr
     }
 }
 impl ::core::cmp::Eq for CRYPT_ATTRIBUTES {}
@@ -21370,7 +20920,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ATTRIBUTE_TYPE_VALUE {
 }
 impl ::core::cmp::PartialEq for CRYPT_ATTRIBUTE_TYPE_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ATTRIBUTE_TYPE_VALUE>()) == 0 }
+        self.pszObjId == other.pszObjId && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for CRYPT_ATTRIBUTE_TYPE_VALUE {}
@@ -21402,7 +20952,7 @@ unsafe impl ::windows::core::Abi for CRYPT_BIT_BLOB {
 }
 impl ::core::cmp::PartialEq for CRYPT_BIT_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_BIT_BLOB>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData && self.cUnusedBits == other.cUnusedBits
     }
 }
 impl ::core::cmp::Eq for CRYPT_BIT_BLOB {}
@@ -21433,7 +20983,7 @@ unsafe impl ::windows::core::Abi for CRYPT_BLOB_ARRAY {
 }
 impl ::core::cmp::PartialEq for CRYPT_BLOB_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_BLOB_ARRAY>()) == 0 }
+        self.cBlob == other.cBlob && self.rgBlob == other.rgBlob
     }
 }
 impl ::core::cmp::Eq for CRYPT_BLOB_ARRAY {}
@@ -21464,7 +21014,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTENT_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTENT_INFO>()) == 0 }
+        self.pszObjId == other.pszObjId && self.Content == other.Content
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTENT_INFO {}
@@ -21496,7 +21046,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY>()) == 0 }
+        self.pszObjId == other.pszObjId && self.cValue == other.cValue && self.rgValue == other.rgValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {}
@@ -21527,7 +21077,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTEXTS {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTEXTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTEXTS>()) == 0 }
+        self.cContexts == other.cContexts && self.rgpszContexts == other.rgpszContexts
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTEXTS {}
@@ -21558,7 +21108,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTEXT_CONFIG {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTEXT_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTEXT_CONFIG>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTEXT_CONFIG {}
@@ -21589,7 +21139,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTEXT_FUNCTIONS {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTEXT_FUNCTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTEXT_FUNCTIONS>()) == 0 }
+        self.cFunctions == other.cFunctions && self.rgpszFunctions == other.rgpszFunctions
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTEXT_FUNCTIONS {}
@@ -21620,7 +21170,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTEXT_FUNCTION_CONFIG {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTEXT_FUNCTION_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTEXT_FUNCTION_CONFIG>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTEXT_FUNCTION_CONFIG {}
@@ -21651,7 +21201,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CONTEXT_FUNCTION_PROVIDERS {
 }
 impl ::core::cmp::PartialEq for CRYPT_CONTEXT_FUNCTION_PROVIDERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CONTEXT_FUNCTION_PROVIDERS>()) == 0 }
+        self.cProviders == other.cProviders && self.rgpszProviders == other.rgpszProviders
     }
 }
 impl ::core::cmp::Eq for CRYPT_CONTEXT_FUNCTION_PROVIDERS {}
@@ -21683,7 +21233,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CREDENTIALS {
 }
 impl ::core::cmp::PartialEq for CRYPT_CREDENTIALS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CREDENTIALS>()) == 0 }
+        self.cbSize == other.cbSize && self.pszCredentialsOid == other.pszCredentialsOid && self.pvCredentials == other.pvCredentials
     }
 }
 impl ::core::cmp::Eq for CRYPT_CREDENTIALS {}
@@ -21715,7 +21265,7 @@ unsafe impl ::windows::core::Abi for CRYPT_CSP_PROVIDER {
 }
 impl ::core::cmp::PartialEq for CRYPT_CSP_PROVIDER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_CSP_PROVIDER>()) == 0 }
+        self.dwKeySpec == other.dwKeySpec && self.pwszProviderName == other.pwszProviderName && self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for CRYPT_CSP_PROVIDER {}
@@ -21739,18 +21289,12 @@ impl ::core::clone::Clone for CRYPT_DECODE_PARA {
 }
 impl ::core::fmt::Debug for CRYPT_DECODE_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_DECODE_PARA").field("cbSize", &self.cbSize).field("pfnAlloc", &self.pfnAlloc.map(|f| f as usize)).field("pfnFree", &self.pfnFree.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_DECODE_PARA").field("cbSize", &self.cbSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_DECODE_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_DECODE_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_DECODE_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_DECODE_PARA {}
 impl ::core::default::Default for CRYPT_DECODE_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21780,7 +21324,7 @@ unsafe impl ::windows::core::Abi for CRYPT_DECRYPT_MESSAGE_PARA {
 }
 impl ::core::cmp::PartialEq for CRYPT_DECRYPT_MESSAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_DECRYPT_MESSAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgAndCertEncodingType == other.dwMsgAndCertEncodingType && self.cCertStore == other.cCertStore && self.rghCertStore == other.rghCertStore
     }
 }
 impl ::core::cmp::Eq for CRYPT_DECRYPT_MESSAGE_PARA {}
@@ -21811,7 +21355,7 @@ unsafe impl ::windows::core::Abi for CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA {
 }
 impl ::core::cmp::PartialEq for CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA>()) == 0 }
+        self.cOID == other.cOID && self.rgpszOID == other.rgpszOID
     }
 }
 impl ::core::cmp::Eq for CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA {}
@@ -21843,7 +21387,7 @@ unsafe impl ::windows::core::Abi for CRYPT_DES_KEY_STATE {
 }
 impl ::core::cmp::PartialEq for CRYPT_DES_KEY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_DES_KEY_STATE>()) == 0 }
+        self.Key == other.Key && self.IV == other.IV && self.Feedback == other.Feedback
     }
 }
 impl ::core::cmp::Eq for CRYPT_DES_KEY_STATE {}
@@ -21875,7 +21419,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ECC_CMS_SHARED_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_ECC_CMS_SHARED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ECC_CMS_SHARED_INFO>()) == 0 }
+        self.Algorithm == other.Algorithm && self.EntityUInfo == other.EntityUInfo && self.rgbSuppPubInfo == other.rgbSuppPubInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_ECC_CMS_SHARED_INFO {}
@@ -21908,7 +21452,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ECC_PRIVATE_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_ECC_PRIVATE_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ECC_PRIVATE_KEY_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.PrivateKey == other.PrivateKey && self.szCurveOid == other.szCurveOid && self.PublicKey == other.PublicKey
     }
 }
 impl ::core::cmp::Eq for CRYPT_ECC_PRIVATE_KEY_INFO {}
@@ -21932,18 +21476,12 @@ impl ::core::clone::Clone for CRYPT_ENCODE_PARA {
 }
 impl ::core::fmt::Debug for CRYPT_ENCODE_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_ENCODE_PARA").field("cbSize", &self.cbSize).field("pfnAlloc", &self.pfnAlloc.map(|f| f as usize)).field("pfnFree", &self.pfnFree.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_ENCODE_PARA").field("cbSize", &self.cbSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_ENCODE_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_ENCODE_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ENCODE_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_ENCODE_PARA {}
 impl ::core::default::Default for CRYPT_ENCODE_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21971,7 +21509,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ENCRYPTED_PRIVATE_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_ENCRYPTED_PRIVATE_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ENCRYPTED_PRIVATE_KEY_INFO>()) == 0 }
+        self.EncryptionAlgorithm == other.EncryptionAlgorithm && self.EncryptedPrivateKey == other.EncryptedPrivateKey
     }
 }
 impl ::core::cmp::Eq for CRYPT_ENCRYPTED_PRIVATE_KEY_INFO {}
@@ -22007,7 +21545,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ENCRYPT_MESSAGE_PARA {
 }
 impl ::core::cmp::PartialEq for CRYPT_ENCRYPT_MESSAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ENCRYPT_MESSAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgEncodingType == other.dwMsgEncodingType && self.hCryptProv == other.hCryptProv && self.ContentEncryptionAlgorithm == other.ContentEncryptionAlgorithm && self.pvEncryptionAuxInfo == other.pvEncryptionAuxInfo && self.dwFlags == other.dwFlags && self.dwInnerContentType == other.dwInnerContentType
     }
 }
 impl ::core::cmp::Eq for CRYPT_ENCRYPT_MESSAGE_PARA {}
@@ -22038,7 +21576,7 @@ unsafe impl ::windows::core::Abi for CRYPT_ENROLLMENT_NAME_VALUE_PAIR {
 }
 impl ::core::cmp::PartialEq for CRYPT_ENROLLMENT_NAME_VALUE_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_ENROLLMENT_NAME_VALUE_PAIR>()) == 0 }
+        self.pwszName == other.pwszName && self.pwszValue == other.pwszValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_ENROLLMENT_NAME_VALUE_PAIR {}
@@ -22080,7 +21618,7 @@ unsafe impl ::windows::core::Abi for CRYPT_GET_TIME_VALID_OBJECT_EXTRA_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_GET_TIME_VALID_OBJECT_EXTRA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_GET_TIME_VALID_OBJECT_EXTRA_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.iDeltaCrlIndicator == other.iDeltaCrlIndicator && self.pftCacheResync == other.pftCacheResync && self.pLastSyncTime == other.pLastSyncTime && self.pMaxAgeTime == other.pMaxAgeTime && self.pChainPara == other.pChainPara && self.pDeltaCrlIndicator == other.pDeltaCrlIndicator
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22113,7 +21651,7 @@ unsafe impl ::windows::core::Abi for CRYPT_HASH_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_HASH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_HASH_INFO>()) == 0 }
+        self.HashAlgorithm == other.HashAlgorithm && self.Hash == other.Hash
     }
 }
 impl ::core::cmp::Eq for CRYPT_HASH_INFO {}
@@ -22147,7 +21685,7 @@ unsafe impl ::windows::core::Abi for CRYPT_HASH_MESSAGE_PARA {
 }
 impl ::core::cmp::PartialEq for CRYPT_HASH_MESSAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_HASH_MESSAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgEncodingType == other.dwMsgEncodingType && self.hCryptProv == other.hCryptProv && self.HashAlgorithm == other.HashAlgorithm && self.pvHashAuxInfo == other.pvHashAuxInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_HASH_MESSAGE_PARA {}
@@ -22178,7 +21716,7 @@ unsafe impl ::windows::core::Abi for CRYPT_IMAGE_REF {
 }
 impl ::core::cmp::PartialEq for CRYPT_IMAGE_REF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_IMAGE_REF>()) == 0 }
+        self.pszImage == other.pszImage && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CRYPT_IMAGE_REF {}
@@ -22210,7 +21748,7 @@ unsafe impl ::windows::core::Abi for CRYPT_IMAGE_REG {
 }
 impl ::core::cmp::PartialEq for CRYPT_IMAGE_REG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_IMAGE_REG>()) == 0 }
+        self.pszImage == other.pszImage && self.cInterfaces == other.cInterfaces && self.rgpInterfaces == other.rgpInterfaces
     }
 }
 impl ::core::cmp::Eq for CRYPT_IMAGE_REG {}
@@ -22241,7 +21779,7 @@ unsafe impl ::windows::core::Abi for CRYPT_INTEGER_BLOB {
 }
 impl ::core::cmp::PartialEq for CRYPT_INTEGER_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_INTEGER_BLOB>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for CRYPT_INTEGER_BLOB {}
@@ -22274,7 +21812,7 @@ unsafe impl ::windows::core::Abi for CRYPT_INTERFACE_REG {
 }
 impl ::core::cmp::PartialEq for CRYPT_INTERFACE_REG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_INTERFACE_REG>()) == 0 }
+        self.dwInterface == other.dwInterface && self.dwFlags == other.dwFlags && self.cFunctions == other.cFunctions && self.rgpszFunctions == other.rgpszFunctions
     }
 }
 impl ::core::cmp::Eq for CRYPT_INTERFACE_REG {}
@@ -22310,7 +21848,7 @@ unsafe impl ::windows::core::Abi for CRYPT_KEY_PROV_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_KEY_PROV_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_KEY_PROV_INFO>()) == 0 }
+        self.pwszContainerName == other.pwszContainerName && self.pwszProvName == other.pwszProvName && self.dwProvType == other.dwProvType && self.dwFlags == other.dwFlags && self.cProvParam == other.cProvParam && self.rgProvParam == other.rgProvParam && self.dwKeySpec == other.dwKeySpec
     }
 }
 impl ::core::cmp::Eq for CRYPT_KEY_PROV_INFO {}
@@ -22343,7 +21881,7 @@ unsafe impl ::windows::core::Abi for CRYPT_KEY_PROV_PARAM {
 }
 impl ::core::cmp::PartialEq for CRYPT_KEY_PROV_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_KEY_PROV_PARAM>()) == 0 }
+        self.dwParam == other.dwParam && self.pbData == other.pbData && self.cbData == other.cbData && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CRYPT_KEY_PROV_PARAM {}
@@ -22372,12 +21910,6 @@ impl ::core::clone::Clone for CRYPT_KEY_SIGN_MESSAGE_PARA {
 unsafe impl ::windows::core::Abi for CRYPT_KEY_SIGN_MESSAGE_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_KEY_SIGN_MESSAGE_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_KEY_SIGN_MESSAGE_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_KEY_SIGN_MESSAGE_PARA {}
 impl ::core::default::Default for CRYPT_KEY_SIGN_MESSAGE_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22398,12 +21930,6 @@ impl ::core::clone::Clone for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
 unsafe impl ::windows::core::Abi for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_KEY_SIGN_MESSAGE_PARA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {}
 impl ::core::default::Default for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22432,7 +21958,7 @@ unsafe impl ::windows::core::Abi for CRYPT_KEY_VERIFY_MESSAGE_PARA {
 }
 impl ::core::cmp::PartialEq for CRYPT_KEY_VERIFY_MESSAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_KEY_VERIFY_MESSAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgEncodingType == other.dwMsgEncodingType && self.hCryptProv == other.hCryptProv
     }
 }
 impl ::core::cmp::Eq for CRYPT_KEY_VERIFY_MESSAGE_PARA {}
@@ -22463,7 +21989,7 @@ unsafe impl ::windows::core::Abi for CRYPT_MASK_GEN_ALGORITHM {
 }
 impl ::core::cmp::PartialEq for CRYPT_MASK_GEN_ALGORITHM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_MASK_GEN_ALGORITHM>()) == 0 }
+        self.pszObjId == other.pszObjId && self.HashAlgorithm == other.HashAlgorithm
     }
 }
 impl ::core::cmp::Eq for CRYPT_MASK_GEN_ALGORITHM {}
@@ -22494,21 +22020,13 @@ impl ::core::clone::Clone for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE").field("cbSize", &self.cbSize).field("pfnGet", &self.pfnGet.map(|f| f as usize)).field("pfnRelease", &self.pfnRelease.map(|f| f as usize)).field("pfnFreePassword", &self.pfnFreePassword.map(|f| f as usize)).field("pfnFree", &self.pfnFree.map(|f| f as usize)).field("pfnFreeIdentifier", &self.pfnFreeIdentifier.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE").field("cbSize", &self.cbSize).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
     fn default() -> Self {
@@ -22537,7 +22055,7 @@ unsafe impl ::windows::core::Abi for CRYPT_OBJID_TABLE {
 }
 impl ::core::cmp::PartialEq for CRYPT_OBJID_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_OBJID_TABLE>()) == 0 }
+        self.dwAlgId == other.dwAlgId && self.pszObjId == other.pszObjId
     }
 }
 impl ::core::cmp::Eq for CRYPT_OBJID_TABLE {}
@@ -22568,7 +22086,7 @@ unsafe impl ::windows::core::Abi for CRYPT_OID_FUNC_ENTRY {
 }
 impl ::core::cmp::PartialEq for CRYPT_OID_FUNC_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_OID_FUNC_ENTRY>()) == 0 }
+        self.pszOID == other.pszOID && self.pvFuncAddr == other.pvFuncAddr
     }
 }
 impl ::core::cmp::Eq for CRYPT_OID_FUNC_ENTRY {}
@@ -22596,12 +22114,6 @@ impl ::core::clone::Clone for CRYPT_OID_INFO {
 unsafe impl ::windows::core::Abi for CRYPT_OID_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_OID_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_OID_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_OID_INFO {}
 impl ::core::default::Default for CRYPT_OID_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22623,12 +22135,6 @@ impl ::core::clone::Clone for CRYPT_OID_INFO_0 {
 unsafe impl ::windows::core::Abi for CRYPT_OID_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_OID_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_OID_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_OID_INFO_0 {}
 impl ::core::default::Default for CRYPT_OID_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22657,7 +22163,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PASSWORD_CREDENTIALSA {
 }
 impl ::core::cmp::PartialEq for CRYPT_PASSWORD_CREDENTIALSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PASSWORD_CREDENTIALSA>()) == 0 }
+        self.cbSize == other.cbSize && self.pszUsername == other.pszUsername && self.pszPassword == other.pszPassword
     }
 }
 impl ::core::cmp::Eq for CRYPT_PASSWORD_CREDENTIALSA {}
@@ -22689,7 +22195,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PASSWORD_CREDENTIALSW {
 }
 impl ::core::cmp::PartialEq for CRYPT_PASSWORD_CREDENTIALSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PASSWORD_CREDENTIALSW>()) == 0 }
+        self.cbSize == other.cbSize && self.pszUsername == other.pszUsername && self.pszPassword == other.pszPassword
     }
 }
 impl ::core::cmp::Eq for CRYPT_PASSWORD_CREDENTIALSW {}
@@ -22720,7 +22226,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PKCS12_PBE_PARAMS {
 }
 impl ::core::cmp::PartialEq for CRYPT_PKCS12_PBE_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PKCS12_PBE_PARAMS>()) == 0 }
+        self.iIterations == other.iIterations && self.cbSalt == other.cbSalt
     }
 }
 impl ::core::cmp::Eq for CRYPT_PKCS12_PBE_PARAMS {}
@@ -22750,21 +22256,13 @@ impl ::core::clone::Clone for CRYPT_PKCS8_EXPORT_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CRYPT_PKCS8_EXPORT_PARAMS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_PKCS8_EXPORT_PARAMS").field("hCryptProv", &self.hCryptProv).field("dwKeySpec", &self.dwKeySpec).field("pszPrivateKeyObjId", &self.pszPrivateKeyObjId).field("pEncryptPrivateKeyFunc", &self.pEncryptPrivateKeyFunc.map(|f| f as usize)).field("pVoidEncryptFunc", &self.pVoidEncryptFunc).finish()
+        f.debug_struct("CRYPT_PKCS8_EXPORT_PARAMS").field("hCryptProv", &self.hCryptProv).field("dwKeySpec", &self.dwKeySpec).field("pszPrivateKeyObjId", &self.pszPrivateKeyObjId).field("pVoidEncryptFunc", &self.pVoidEncryptFunc).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CRYPT_PKCS8_EXPORT_PARAMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPT_PKCS8_EXPORT_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PKCS8_EXPORT_PARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPT_PKCS8_EXPORT_PARAMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPT_PKCS8_EXPORT_PARAMS {
     fn default() -> Self {
@@ -22792,21 +22290,13 @@ impl ::core::clone::Clone for CRYPT_PKCS8_IMPORT_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CRYPT_PKCS8_IMPORT_PARAMS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_PKCS8_IMPORT_PARAMS").field("PrivateKey", &self.PrivateKey).field("pResolvehCryptProvFunc", &self.pResolvehCryptProvFunc.map(|f| f as usize)).field("pVoidResolveFunc", &self.pVoidResolveFunc).field("pDecryptPrivateKeyFunc", &self.pDecryptPrivateKeyFunc.map(|f| f as usize)).field("pVoidDecryptFunc", &self.pVoidDecryptFunc).finish()
+        f.debug_struct("CRYPT_PKCS8_IMPORT_PARAMS").field("PrivateKey", &self.PrivateKey).field("pVoidResolveFunc", &self.pVoidResolveFunc).field("pVoidDecryptFunc", &self.pVoidDecryptFunc).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CRYPT_PKCS8_IMPORT_PARAMS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPT_PKCS8_IMPORT_PARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PKCS8_IMPORT_PARAMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPT_PKCS8_IMPORT_PARAMS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPT_PKCS8_IMPORT_PARAMS {
     fn default() -> Self {
@@ -22837,7 +22327,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PRIVATE_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_PRIVATE_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PRIVATE_KEY_INFO>()) == 0 }
+        self.Version == other.Version && self.Algorithm == other.Algorithm && self.PrivateKey == other.PrivateKey && self.pAttributes == other.pAttributes
     }
 }
 impl ::core::cmp::Eq for CRYPT_PRIVATE_KEY_INFO {}
@@ -22869,7 +22359,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROPERTY_REF {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROPERTY_REF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROPERTY_REF>()) == 0 }
+        self.pszProperty == other.pszProperty && self.cbValue == other.cbValue && self.pbValue == other.pbValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROPERTY_REF {}
@@ -22900,7 +22390,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDERS {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDERS>()) == 0 }
+        self.cProviders == other.cProviders && self.rgpszProviders == other.rgpszProviders
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDERS {}
@@ -22936,7 +22426,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_REF {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_REF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_REF>()) == 0 }
+        self.dwInterface == other.dwInterface && self.pszFunction == other.pszFunction && self.pszProvider == other.pszProvider && self.cProperties == other.cProperties && self.rgpProperties == other.rgpProperties && self.pUM == other.pUM && self.pKM == other.pKM
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_REF {}
@@ -22967,7 +22457,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_REFS {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_REFS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_REFS>()) == 0 }
+        self.cProviders == other.cProviders && self.rgpProviders == other.rgpProviders
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_REFS {}
@@ -23000,7 +22490,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_REG {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_REG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_REG>()) == 0 }
+        self.cAliases == other.cAliases && self.rgpszAliases == other.rgpszAliases && self.pUM == other.pUM && self.pKM == other.pKM
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_REG {}
@@ -23031,7 +22521,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PSOURCE_ALGORITHM {
 }
 impl ::core::cmp::PartialEq for CRYPT_PSOURCE_ALGORITHM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PSOURCE_ALGORITHM>()) == 0 }
+        self.pszObjId == other.pszObjId && self.EncodingParameters == other.EncodingParameters
     }
 }
 impl ::core::cmp::Eq for CRYPT_PSOURCE_ALGORITHM {}
@@ -23069,7 +22559,7 @@ unsafe impl ::windows::core::Abi for CRYPT_RC2_CBC_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_RC2_CBC_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_RC2_CBC_PARAMETERS>()) == 0 }
+        self.dwVersion == other.dwVersion && self.fIV == other.fIV && self.rgbIV == other.rgbIV
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23104,7 +22594,7 @@ unsafe impl ::windows::core::Abi for CRYPT_RC4_KEY_STATE {
 }
 impl ::core::cmp::PartialEq for CRYPT_RC4_KEY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_RC4_KEY_STATE>()) == 0 }
+        self.Key == other.Key && self.SBox == other.SBox && self.i == other.i && self.j == other.j
     }
 }
 impl ::core::cmp::Eq for CRYPT_RC4_KEY_STATE {}
@@ -23164,7 +22654,7 @@ unsafe impl ::windows::core::Abi for CRYPT_RETRIEVE_AUX_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_RETRIEVE_AUX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_RETRIEVE_AUX_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pLastSyncTime == other.pLastSyncTime && self.dwMaxUrlRetrievalByteCount == other.dwMaxUrlRetrievalByteCount && self.pPreFetchInfo == other.pPreFetchInfo && self.pFlushInfo == other.pFlushInfo && self.ppResponseInfo == other.ppResponseInfo && self.pwszCacheFileNamePrefix == other.pwszCacheFileNamePrefix && self.pftCacheResync == other.pftCacheResync && self.fProxyCacheRetrieval == other.fProxyCacheRetrieval && self.dwHttpStatusCode == other.dwHttpStatusCode && self.ppwszErrorResponseHeaders == other.ppwszErrorResponseHeaders && self.ppErrorContentBlob == other.ppErrorContentBlob
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23198,7 +22688,7 @@ unsafe impl ::windows::core::Abi for CRYPT_RSAES_OAEP_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for CRYPT_RSAES_OAEP_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_RSAES_OAEP_PARAMETERS>()) == 0 }
+        self.HashAlgorithm == other.HashAlgorithm && self.MaskGenAlgorithm == other.MaskGenAlgorithm && self.PSourceAlgorithm == other.PSourceAlgorithm
     }
 }
 impl ::core::cmp::Eq for CRYPT_RSAES_OAEP_PARAMETERS {}
@@ -23231,7 +22721,7 @@ unsafe impl ::windows::core::Abi for CRYPT_RSA_SSA_PSS_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for CRYPT_RSA_SSA_PSS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_RSA_SSA_PSS_PARAMETERS>()) == 0 }
+        self.HashAlgorithm == other.HashAlgorithm && self.MaskGenAlgorithm == other.MaskGenAlgorithm && self.dwSaltLength == other.dwSaltLength && self.dwTrailerField == other.dwTrailerField
     }
 }
 impl ::core::cmp::Eq for CRYPT_RSA_SSA_PSS_PARAMETERS {}
@@ -23262,7 +22752,7 @@ unsafe impl ::windows::core::Abi for CRYPT_SEQUENCE_OF_ANY {
 }
 impl ::core::cmp::PartialEq for CRYPT_SEQUENCE_OF_ANY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_SEQUENCE_OF_ANY>()) == 0 }
+        self.cValue == other.cValue && self.rgValue == other.rgValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_SEQUENCE_OF_ANY {}
@@ -23328,7 +22818,7 @@ unsafe impl ::windows::core::Abi for CRYPT_SIGN_MESSAGE_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_SIGN_MESSAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_SIGN_MESSAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMsgEncodingType == other.dwMsgEncodingType && self.pSigningCert == other.pSigningCert && self.HashAlgorithm == other.HashAlgorithm && self.pvHashAuxInfo == other.pvHashAuxInfo && self.cMsgCert == other.cMsgCert && self.rgpMsgCert == other.rgpMsgCert && self.cMsgCrl == other.cMsgCrl && self.rgpMsgCrl == other.rgpMsgCrl && self.cAuthAttr == other.cAuthAttr && self.rgAuthAttr == other.rgAuthAttr && self.cUnauthAttr == other.cUnauthAttr && self.rgUnauthAttr == other.rgUnauthAttr && self.dwFlags == other.dwFlags && self.dwInnerContentType == other.dwInnerContentType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23361,7 +22851,7 @@ unsafe impl ::windows::core::Abi for CRYPT_SMART_CARD_ROOT_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_SMART_CARD_ROOT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_SMART_CARD_ROOT_INFO>()) == 0 }
+        self.rgbCardID == other.rgbCardID && self.luid == other.luid
     }
 }
 impl ::core::cmp::Eq for CRYPT_SMART_CARD_ROOT_INFO {}
@@ -23392,7 +22882,7 @@ unsafe impl ::windows::core::Abi for CRYPT_SMIME_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for CRYPT_SMIME_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_SMIME_CAPABILITIES>()) == 0 }
+        self.cCapability == other.cCapability && self.rgCapability == other.rgCapability
     }
 }
 impl ::core::cmp::Eq for CRYPT_SMIME_CAPABILITIES {}
@@ -23423,7 +22913,7 @@ unsafe impl ::windows::core::Abi for CRYPT_SMIME_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for CRYPT_SMIME_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_SMIME_CAPABILITY>()) == 0 }
+        self.pszObjId == other.pszObjId && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for CRYPT_SMIME_CAPABILITY {}
@@ -23455,7 +22945,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_ACCURACY {
 }
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_ACCURACY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_ACCURACY>()) == 0 }
+        self.dwSeconds == other.dwSeconds && self.dwMillis == other.dwMillis && self.dwMicros == other.dwMicros
     }
 }
 impl ::core::cmp::Eq for CRYPT_TIMESTAMP_ACCURACY {}
@@ -23493,7 +22983,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_CONTEXT>()) == 0 }
+        self.cbEncoded == other.cbEncoded && self.pbEncoded == other.pbEncoded && self.pTimeStamp == other.pTimeStamp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23555,7 +23045,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.pszTSAPolicyId == other.pszTSAPolicyId && self.HashAlgorithm == other.HashAlgorithm && self.HashedMessage == other.HashedMessage && self.SerialNumber == other.SerialNumber && self.ftTime == other.ftTime && self.pvAccuracy == other.pvAccuracy && self.fOrdering == other.fOrdering && self.Nonce == other.Nonce && self.Tsa == other.Tsa && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23597,7 +23087,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_PARA>()) == 0 }
+        self.pszTSAPolicyId == other.pszTSAPolicyId && self.fRequestCerts == other.fRequestCerts && self.Nonce == other.Nonce && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23642,7 +23132,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_REQUEST>()) == 0 }
+        self.dwVersion == other.dwVersion && self.HashAlgorithm == other.HashAlgorithm && self.HashedMessage == other.HashedMessage && self.pszTSAPolicyId == other.pszTSAPolicyId && self.Nonce == other.Nonce && self.fCertReq == other.fCertReq && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23678,7 +23168,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIMESTAMP_RESPONSE {
 }
 impl ::core::cmp::PartialEq for CRYPT_TIMESTAMP_RESPONSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIMESTAMP_RESPONSE>()) == 0 }
+        self.dwStatus == other.dwStatus && self.cFreeText == other.cFreeText && self.rgFreeText == other.rgFreeText && self.FailureInfo == other.FailureInfo && self.ContentInfo == other.ContentInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_TIMESTAMP_RESPONSE {}
@@ -23712,7 +23202,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TIME_STAMP_REQUEST_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_TIME_STAMP_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TIME_STAMP_REQUEST_INFO>()) == 0 }
+        self.pszTimeStampAlgorithm == other.pszTimeStampAlgorithm && self.pszContentType == other.pszContentType && self.Content == other.Content && self.cAttribute == other.cAttribute && self.rgAttribute == other.rgAttribute
     }
 }
 impl ::core::cmp::Eq for CRYPT_TIME_STAMP_REQUEST_INFO {}
@@ -23743,7 +23233,7 @@ unsafe impl ::windows::core::Abi for CRYPT_URL_ARRAY {
 }
 impl ::core::cmp::PartialEq for CRYPT_URL_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_URL_ARRAY>()) == 0 }
+        self.cUrl == other.cUrl && self.rgwszUrl == other.rgwszUrl
     }
 }
 impl ::core::cmp::Eq for CRYPT_URL_ARRAY {}
@@ -23776,7 +23266,7 @@ unsafe impl ::windows::core::Abi for CRYPT_URL_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_URL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_URL_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwSyncDeltaTime == other.dwSyncDeltaTime && self.cGroup == other.cGroup && self.rgcGroupEntry == other.rgcGroupEntry
     }
 }
 impl ::core::cmp::Eq for CRYPT_URL_INFO {}
@@ -23807,7 +23297,7 @@ unsafe impl ::windows::core::Abi for CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_IN
 }
 impl ::core::cmp::PartialEq for CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_INFO>()) == 0 }
+        self.CertSignHashCNGAlgPropData == other.CertSignHashCNGAlgPropData && self.CertIssuerPubKeyBitLengthPropData == other.CertIssuerPubKeyBitLengthPropData
     }
 }
 impl ::core::cmp::Eq for CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_INFO {}
@@ -23839,7 +23329,7 @@ unsafe impl ::windows::core::Abi for CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO>()) == 0 }
+        self.cCNGHashAlgid == other.cCNGHashAlgid && self.rgpwszCNGHashAlgid == other.rgpwszCNGHashAlgid && self.dwWeakIndex == other.dwWeakIndex
     }
 }
 impl ::core::cmp::Eq for CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO {}
@@ -23869,21 +23359,13 @@ impl ::core::clone::Clone for CRYPT_VERIFY_MESSAGE_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CRYPT_VERIFY_MESSAGE_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_VERIFY_MESSAGE_PARA").field("cbSize", &self.cbSize).field("dwMsgAndCertEncodingType", &self.dwMsgAndCertEncodingType).field("hCryptProv", &self.hCryptProv).field("pfnGetSignerCertificate", &self.pfnGetSignerCertificate.map(|f| f as usize)).field("pvGetArg", &self.pvGetArg).finish()
+        f.debug_struct("CRYPT_VERIFY_MESSAGE_PARA").field("cbSize", &self.cbSize).field("dwMsgAndCertEncodingType", &self.dwMsgAndCertEncodingType).field("hCryptProv", &self.hCryptProv).field("pvGetArg", &self.pvGetArg).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CRYPT_VERIFY_MESSAGE_PARA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CRYPT_VERIFY_MESSAGE_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_VERIFY_MESSAGE_PARA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CRYPT_VERIFY_MESSAGE_PARA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CRYPT_VERIFY_MESSAGE_PARA {
     fn default() -> Self {
@@ -23914,7 +23396,7 @@ unsafe impl ::windows::core::Abi for CRYPT_X942_OTHER_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_X942_OTHER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_X942_OTHER_INFO>()) == 0 }
+        self.pszContentEncryptionObjId == other.pszContentEncryptionObjId && self.rgbCounter == other.rgbCounter && self.rgbKeyLength == other.rgbKeyLength && self.PubInfo == other.PubInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_X942_OTHER_INFO {}
@@ -23946,7 +23428,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_ALGORITHM {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_ALGORITHM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_ALGORITHM>()) == 0 }
+        self.cbSize == other.cbSize && self.wszAlgorithm == other.wszAlgorithm && self.Encoded == other.Encoded
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_ALGORITHM {}
@@ -23985,7 +23467,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_ALGORITHM_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_ALGORITHM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_ALGORITHM_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wszAlgorithmURI == other.wszAlgorithmURI && self.wszName == other.wszName && self.dwGroupId == other.dwGroupId && self.wszCNGAlgid == other.wszCNGAlgid && self.wszCNGExtraAlgid == other.wszCNGExtraAlgid && self.dwSignFlags == other.dwSignFlags && self.dwVerifyFlags == other.dwVerifyFlags && self.pvPaddingInfo == other.pvPaddingInfo && self.pvExtraInfo == other.pvExtraInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_ALGORITHM_INFO {}
@@ -24017,7 +23499,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_BLOB {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_BLOB>()) == 0 }
+        self.dwCharset == other.dwCharset && self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_BLOB {}
@@ -24047,28 +23529,12 @@ impl ::core::clone::Clone for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
 }
 impl ::core::fmt::Debug for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_XML_CRYPTOGRAPHIC_INTERFACE")
-            .field("cbSize", &self.cbSize)
-            .field("fpCryptXmlEncodeAlgorithm", &self.fpCryptXmlEncodeAlgorithm.map(|f| f as usize))
-            .field("fpCryptXmlCreateDigest", &self.fpCryptXmlCreateDigest.map(|f| f as usize))
-            .field("fpCryptXmlDigestData", &self.fpCryptXmlDigestData.map(|f| f as usize))
-            .field("fpCryptXmlFinalizeDigest", &self.fpCryptXmlFinalizeDigest.map(|f| f as usize))
-            .field("fpCryptXmlCloseDigest", &self.fpCryptXmlCloseDigest.map(|f| f as usize))
-            .field("fpCryptXmlSignData", &self.fpCryptXmlSignData.map(|f| f as usize))
-            .field("fpCryptXmlVerifySignature", &self.fpCryptXmlVerifySignature.map(|f| f as usize))
-            .field("fpCryptXmlGetAlgorithmInfo", &self.fpCryptXmlGetAlgorithmInfo.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CRYPT_XML_CRYPTOGRAPHIC_INTERFACE").field("cbSize", &self.cbSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_CRYPTOGRAPHIC_INTERFACE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {}
 impl ::core::default::Default for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24096,7 +23562,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_DATA_BLOB {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_DATA_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_DATA_BLOB>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_DATA_BLOB {}
@@ -24121,18 +23587,12 @@ impl ::core::clone::Clone for CRYPT_XML_DATA_PROVIDER {
 }
 impl ::core::fmt::Debug for CRYPT_XML_DATA_PROVIDER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_XML_DATA_PROVIDER").field("pvCallbackState", &self.pvCallbackState).field("cbBufferSize", &self.cbBufferSize).field("pfnRead", &self.pfnRead.map(|f| f as usize)).field("pfnClose", &self.pfnClose.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_XML_DATA_PROVIDER").field("pvCallbackState", &self.pvCallbackState).field("cbBufferSize", &self.cbBufferSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_XML_DATA_PROVIDER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_DATA_PROVIDER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_DATA_PROVIDER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_DATA_PROVIDER {}
 impl ::core::default::Default for CRYPT_XML_DATA_PROVIDER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24163,7 +23623,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_DOC_CTXT {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_DOC_CTXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_DOC_CTXT>()) == 0 }
+        self.cbSize == other.cbSize && self.hDocCtxt == other.hDocCtxt && self.pTransformsConfig == other.pTransformsConfig && self.cSignature == other.cSignature && self.rgpSignature == other.rgpSignature
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_DOC_CTXT {}
@@ -24194,7 +23654,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_ISSUER_SERIAL {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_ISSUER_SERIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_ISSUER_SERIAL>()) == 0 }
+        self.wszIssuer == other.wszIssuer && self.wszSerial == other.wszSerial
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_ISSUER_SERIAL {}
@@ -24231,7 +23691,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_KEYINFO_PARAM {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_KEYINFO_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEYINFO_PARAM>()) == 0 }
+        self.wszId == other.wszId && self.wszKeyName == other.wszKeyName && self.SKI == other.SKI && self.wszSubjectName == other.wszSubjectName && self.cCertificate == other.cCertificate && self.rgCertificate == other.rgCertificate && self.cCRL == other.cCRL && self.rgCRL == other.rgCRL
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_KEYINFO_PARAM {}
@@ -24267,7 +23727,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_DSA_KEY_VALUE {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_KEY_DSA_KEY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_DSA_KEY_VALUE>()) == 0 }
+        self.P == other.P && self.Q == other.Q && self.G == other.G && self.Y == other.Y && self.J == other.J && self.Seed == other.Seed && self.Counter == other.Counter
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_KEY_DSA_KEY_VALUE {}
@@ -24300,7 +23760,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_ECDSA_KEY_VALUE {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_KEY_ECDSA_KEY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_ECDSA_KEY_VALUE>()) == 0 }
+        self.wszNamedCurve == other.wszNamedCurve && self.X == other.X && self.Y == other.Y && self.ExplicitPara == other.ExplicitPara
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_KEY_ECDSA_KEY_VALUE {}
@@ -24334,7 +23794,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wszId == other.wszId && self.cKeyInfo == other.cKeyInfo && self.rgKeyInfo == other.rgKeyInfo && self.hVerifyKey == other.hVerifyKey
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_KEY_INFO {}
@@ -24358,12 +23818,6 @@ impl ::core::clone::Clone for CRYPT_XML_KEY_INFO_ITEM {
 unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_INFO_ITEM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_KEY_INFO_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_INFO_ITEM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_KEY_INFO_ITEM {}
 impl ::core::default::Default for CRYPT_XML_KEY_INFO_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24387,12 +23841,6 @@ impl ::core::clone::Clone for CRYPT_XML_KEY_INFO_ITEM_0 {
 unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_INFO_ITEM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_KEY_INFO_ITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_INFO_ITEM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_KEY_INFO_ITEM_0 {}
 impl ::core::default::Default for CRYPT_XML_KEY_INFO_ITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24420,7 +23868,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_RSA_KEY_VALUE {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_KEY_RSA_KEY_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_RSA_KEY_VALUE>()) == 0 }
+        self.Modulus == other.Modulus && self.Exponent == other.Exponent
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_KEY_RSA_KEY_VALUE {}
@@ -24444,12 +23892,6 @@ impl ::core::clone::Clone for CRYPT_XML_KEY_VALUE {
 unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_KEY_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_KEY_VALUE {}
 impl ::core::default::Default for CRYPT_XML_KEY_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24472,12 +23914,6 @@ impl ::core::clone::Clone for CRYPT_XML_KEY_VALUE_0 {
 unsafe impl ::windows::core::Abi for CRYPT_XML_KEY_VALUE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_KEY_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_KEY_VALUE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_KEY_VALUE_0 {}
 impl ::core::default::Default for CRYPT_XML_KEY_VALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24510,7 +23946,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_OBJECT {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_OBJECT>()) == 0 }
+        self.cbSize == other.cbSize && self.hObject == other.hObject && self.wszId == other.wszId && self.wszMimeType == other.wszMimeType && self.wszEncoding == other.wszEncoding && self.Manifest == other.Manifest && self.Encoded == other.Encoded
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_OBJECT {}
@@ -24542,7 +23978,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_PROPERTY {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_PROPERTY>()) == 0 }
+        self.dwPropId == other.dwPropId && self.pvValue == other.pvValue && self.cbValue == other.cbValue
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_PROPERTY {}
@@ -24580,7 +24016,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_REFERENCE {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_REFERENCE>()) == 0 }
+        self.cbSize == other.cbSize && self.hReference == other.hReference && self.wszId == other.wszId && self.wszUri == other.wszUri && self.wszType == other.wszType && self.DigestMethod == other.DigestMethod && self.DigestValue == other.DigestValue && self.cTransform == other.cTransform && self.rgTransform == other.rgTransform
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_REFERENCE {}
@@ -24611,7 +24047,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_REFERENCES {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_REFERENCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_REFERENCES>()) == 0 }
+        self.cReference == other.cReference && self.rgpReference == other.rgpReference
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_REFERENCES {}
@@ -24648,7 +24084,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_SIGNATURE>()) == 0 }
+        self.cbSize == other.cbSize && self.hSignature == other.hSignature && self.wszId == other.wszId && self.SignedInfo == other.SignedInfo && self.SignatureValue == other.SignatureValue && self.pKeyInfo == other.pKeyInfo && self.cObject == other.cObject && self.rgpObject == other.rgpObject
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_SIGNATURE {}
@@ -24684,7 +24120,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_SIGNED_INFO {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_SIGNED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_SIGNED_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.wszId == other.wszId && self.Canonicalization == other.Canonicalization && self.SignatureMethod == other.SignatureMethod && self.cReference == other.cReference && self.rgpReference == other.rgpReference && self.Encoded == other.Encoded
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_SIGNED_INFO {}
@@ -24716,7 +24152,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_STATUS {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwErrorStatus == other.dwErrorStatus && self.dwInfoStatus == other.dwInfoStatus
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_STATUS {}
@@ -24748,7 +24184,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_TRANSFORM_CHAIN_CONFIG {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_TRANSFORM_CHAIN_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_TRANSFORM_CHAIN_CONFIG>()) == 0 }
+        self.cbSize == other.cbSize && self.cTransformInfo == other.cTransformInfo && self.rgpTransformInfo == other.rgpTransformInfo
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_TRANSFORM_CHAIN_CONFIG {}
@@ -24774,18 +24210,12 @@ impl ::core::clone::Clone for CRYPT_XML_TRANSFORM_INFO {
 }
 impl ::core::fmt::Debug for CRYPT_XML_TRANSFORM_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_XML_TRANSFORM_INFO").field("cbSize", &self.cbSize).field("wszAlgorithm", &self.wszAlgorithm).field("cbBufferSize", &self.cbBufferSize).field("dwFlags", &self.dwFlags).field("pfnCreateTransform", &self.pfnCreateTransform.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_XML_TRANSFORM_INFO").field("cbSize", &self.cbSize).field("wszAlgorithm", &self.wszAlgorithm).field("cbBufferSize", &self.cbBufferSize).field("dwFlags", &self.dwFlags).finish()
     }
 }
 unsafe impl ::windows::core::Abi for CRYPT_XML_TRANSFORM_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_TRANSFORM_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_TRANSFORM_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_TRANSFORM_INFO {}
 impl ::core::default::Default for CRYPT_XML_TRANSFORM_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24813,7 +24243,7 @@ unsafe impl ::windows::core::Abi for CRYPT_XML_X509DATA {
 }
 impl ::core::cmp::PartialEq for CRYPT_XML_X509DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_X509DATA>()) == 0 }
+        self.cX509Data == other.cX509Data && self.rgX509Data == other.rgX509Data
     }
 }
 impl ::core::cmp::Eq for CRYPT_XML_X509DATA {}
@@ -24837,12 +24267,6 @@ impl ::core::clone::Clone for CRYPT_XML_X509DATA_ITEM {
 unsafe impl ::windows::core::Abi for CRYPT_XML_X509DATA_ITEM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_X509DATA_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_X509DATA_ITEM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_X509DATA_ITEM {}
 impl ::core::default::Default for CRYPT_XML_X509DATA_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24867,12 +24291,6 @@ impl ::core::clone::Clone for CRYPT_XML_X509DATA_ITEM_0 {
 unsafe impl ::windows::core::Abi for CRYPT_XML_X509DATA_ITEM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CRYPT_XML_X509DATA_ITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_XML_X509DATA_ITEM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CRYPT_XML_X509DATA_ITEM_0 {}
 impl ::core::default::Default for CRYPT_XML_X509DATA_ITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24900,7 +24318,7 @@ unsafe impl ::windows::core::Abi for CTL_ANY_SUBJECT_INFO {
 }
 impl ::core::cmp::PartialEq for CTL_ANY_SUBJECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_ANY_SUBJECT_INFO>()) == 0 }
+        self.SubjectAlgorithm == other.SubjectAlgorithm && self.SubjectIdentifier == other.SubjectIdentifier
     }
 }
 impl ::core::cmp::Eq for CTL_ANY_SUBJECT_INFO {}
@@ -24943,7 +24361,7 @@ unsafe impl ::windows::core::Abi for CTL_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_CONTEXT>()) == 0 }
+        self.dwMsgAndCertEncodingType == other.dwMsgAndCertEncodingType && self.pbCtlEncoded == other.pbCtlEncoded && self.cbCtlEncoded == other.cbCtlEncoded && self.pCtlInfo == other.pCtlInfo && self.hCertStore == other.hCertStore && self.hCryptMsg == other.hCryptMsg && self.pbCtlContent == other.pbCtlContent && self.cbCtlContent == other.cbCtlContent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24977,7 +24395,7 @@ unsafe impl ::windows::core::Abi for CTL_ENTRY {
 }
 impl ::core::cmp::PartialEq for CTL_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_ENTRY>()) == 0 }
+        self.SubjectIdentifier == other.SubjectIdentifier && self.cAttribute == other.cAttribute && self.rgAttribute == other.rgAttribute
     }
 }
 impl ::core::cmp::Eq for CTL_ENTRY {}
@@ -25016,7 +24434,7 @@ unsafe impl ::windows::core::Abi for CTL_FIND_SUBJECT_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_FIND_SUBJECT_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_FIND_SUBJECT_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.pUsagePara == other.pUsagePara && self.dwSubjectType == other.dwSubjectType && self.pvSubject == other.pvSubject
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25057,7 +24475,7 @@ unsafe impl ::windows::core::Abi for CTL_FIND_USAGE_PARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_FIND_USAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_FIND_USAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.SubjectUsage == other.SubjectUsage && self.ListIdentifier == other.ListIdentifier && self.pSigner == other.pSigner
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25117,7 +24535,7 @@ unsafe impl ::windows::core::Abi for CTL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.SubjectUsage == other.SubjectUsage && self.ListIdentifier == other.ListIdentifier && self.SequenceNumber == other.SequenceNumber && self.ThisUpdate == other.ThisUpdate && self.NextUpdate == other.NextUpdate && self.SubjectAlgorithm == other.SubjectAlgorithm && self.cCTLEntry == other.cCTLEntry && self.rgCTLEntry == other.rgCTLEntry && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25150,7 +24568,7 @@ unsafe impl ::windows::core::Abi for CTL_USAGE {
 }
 impl ::core::cmp::PartialEq for CTL_USAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_USAGE>()) == 0 }
+        self.cUsageIdentifier == other.cUsageIdentifier && self.rgpszUsageIdentifier == other.rgpszUsageIdentifier
     }
 }
 impl ::core::cmp::Eq for CTL_USAGE {}
@@ -25181,7 +24599,7 @@ unsafe impl ::windows::core::Abi for CTL_USAGE_MATCH {
 }
 impl ::core::cmp::PartialEq for CTL_USAGE_MATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_USAGE_MATCH>()) == 0 }
+        self.dwType == other.dwType && self.Usage == other.Usage
     }
 }
 impl ::core::cmp::Eq for CTL_USAGE_MATCH {}
@@ -25216,7 +24634,7 @@ unsafe impl ::windows::core::Abi for CTL_VERIFY_USAGE_PARA {
 }
 impl ::core::cmp::PartialEq for CTL_VERIFY_USAGE_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_VERIFY_USAGE_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.ListIdentifier == other.ListIdentifier && self.cCtlStore == other.cCtlStore && self.rghCtlStore == other.rghCtlStore && self.cSignerStore == other.cSignerStore && self.rghSignerStore == other.rghSignerStore
     }
 }
 impl ::core::cmp::Eq for CTL_VERIFY_USAGE_PARA {}
@@ -25258,7 +24676,7 @@ unsafe impl ::windows::core::Abi for CTL_VERIFY_USAGE_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CTL_VERIFY_USAGE_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CTL_VERIFY_USAGE_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwError == other.dwError && self.dwFlags == other.dwFlags && self.ppCtl == other.ppCtl && self.dwCtlEntryIndex == other.dwCtlEntryIndex && self.ppSigner == other.ppSigner && self.dwSignerIndex == other.dwSignerIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25291,7 +24709,7 @@ unsafe impl ::windows::core::Abi for DSSSEED {
 }
 impl ::core::cmp::PartialEq for DSSSEED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSSSEED>()) == 0 }
+        self.counter == other.counter && self.seed == other.seed
     }
 }
 impl ::core::cmp::Eq for DSSSEED {}
@@ -25323,7 +24741,7 @@ unsafe impl ::windows::core::Abi for ENDPOINTADDRESS {
 }
 impl ::core::cmp::PartialEq for ENDPOINTADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENDPOINTADDRESS>()) == 0 }
+        self.serviceUrl == other.serviceUrl && self.policyUrl == other.policyUrl && self.rawCertificate == other.rawCertificate
     }
 }
 impl ::core::cmp::Eq for ENDPOINTADDRESS {}
@@ -25356,7 +24774,7 @@ unsafe impl ::windows::core::Abi for ENDPOINTADDRESS2 {
 }
 impl ::core::cmp::PartialEq for ENDPOINTADDRESS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENDPOINTADDRESS2>()) == 0 }
+        self.serviceUrl == other.serviceUrl && self.policyUrl == other.policyUrl && self.identityType == other.identityType && self.identityBytes == other.identityBytes
     }
 }
 impl ::core::cmp::Eq for ENDPOINTADDRESS2 {}
@@ -25387,7 +24805,7 @@ unsafe impl ::windows::core::Abi for EV_EXTRA_CERT_CHAIN_POLICY_PARA {
 }
 impl ::core::cmp::PartialEq for EV_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EV_EXTRA_CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwRootProgramQualifierFlags == other.dwRootProgramQualifierFlags
     }
 }
 impl ::core::cmp::Eq for EV_EXTRA_CERT_CHAIN_POLICY_PARA {}
@@ -25419,7 +24837,7 @@ unsafe impl ::windows::core::Abi for EV_EXTRA_CERT_CHAIN_POLICY_STATUS {
 }
 impl ::core::cmp::PartialEq for EV_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EV_EXTRA_CERT_CHAIN_POLICY_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwQualifiers == other.dwQualifiers && self.dwIssuanceUsageIndex == other.dwIssuanceUsageIndex
     }
 }
 impl ::core::cmp::Eq for EV_EXTRA_CERT_CHAIN_POLICY_STATUS {}
@@ -25450,14 +24868,6 @@ impl ::core::clone::Clone for GENERIC_XML_TOKEN {
 unsafe impl ::windows::core::Abi for GENERIC_XML_TOKEN {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GENERIC_XML_TOKEN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GENERIC_XML_TOKEN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GENERIC_XML_TOKEN {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GENERIC_XML_TOKEN {
     fn default() -> Self {
@@ -25681,7 +25091,7 @@ unsafe impl ::windows::core::Abi for HMAC_INFO {
 }
 impl ::core::cmp::PartialEq for HMAC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HMAC_INFO>()) == 0 }
+        self.HashAlgid == other.HashAlgid && self.pbInnerString == other.pbInnerString && self.cbInnerString == other.cbInnerString && self.pbOuterString == other.pbOuterString && self.cbOuterString == other.cbOuterString
     }
 }
 impl ::core::cmp::Eq for HMAC_INFO {}
@@ -25707,12 +25117,6 @@ impl ::core::clone::Clone for HTTPSPolicyCallbackData {
 unsafe impl ::windows::core::Abi for HTTPSPolicyCallbackData {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HTTPSPolicyCallbackData {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTPSPolicyCallbackData>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HTTPSPolicyCallbackData {}
 impl ::core::default::Default for HTTPSPolicyCallbackData {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25733,12 +25137,6 @@ impl ::core::clone::Clone for HTTPSPolicyCallbackData_0 {
 unsafe impl ::windows::core::Abi for HTTPSPolicyCallbackData_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HTTPSPolicyCallbackData_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTPSPolicyCallbackData_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HTTPSPolicyCallbackData_0 {}
 impl ::core::default::Default for HTTPSPolicyCallbackData_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25767,7 +25165,7 @@ unsafe impl ::windows::core::Abi for INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETER
 }
 impl ::core::cmp::PartialEq for INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETERS>()) == 0 }
+        self.keySize == other.keySize && self.keyExchangeAlgorithm == other.keyExchangeAlgorithm && self.signatureAlgorithm == other.signatureAlgorithm
     }
 }
 impl ::core::cmp::Eq for INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETERS {}
@@ -25799,7 +25197,7 @@ unsafe impl ::windows::core::Abi for INFORMATIONCARD_CRYPTO_HANDLE {
 }
 impl ::core::cmp::PartialEq for INFORMATIONCARD_CRYPTO_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFORMATIONCARD_CRYPTO_HANDLE>()) == 0 }
+        self.r#type == other.r#type && self.expiration == other.expiration && self.cryptoParameters == other.cryptoParameters
     }
 }
 impl ::core::cmp::Eq for INFORMATIONCARD_CRYPTO_HANDLE {}
@@ -25836,7 +25234,7 @@ unsafe impl ::windows::core::Abi for INFORMATIONCARD_HASH_CRYPTO_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INFORMATIONCARD_HASH_CRYPTO_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFORMATIONCARD_HASH_CRYPTO_PARAMETERS>()) == 0 }
+        self.hashSize == other.hashSize && self.transform == other.transform
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25870,7 +25268,7 @@ unsafe impl ::windows::core::Abi for INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS
 }
 impl ::core::cmp::PartialEq for INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS>()) == 0 }
+        self.keySize == other.keySize && self.blockSize == other.blockSize && self.feedbackSize == other.feedbackSize
     }
 }
 impl ::core::cmp::Eq for INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS {}
@@ -25909,7 +25307,7 @@ unsafe impl ::windows::core::Abi for INFORMATIONCARD_TRANSFORM_CRYPTO_PARAMETERS
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INFORMATIONCARD_TRANSFORM_CRYPTO_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INFORMATIONCARD_TRANSFORM_CRYPTO_PARAMETERS>()) == 0 }
+        self.inputBlockSize == other.inputBlockSize && self.outputBlockSize == other.outputBlockSize && self.canTransformMultipleBlocks == other.canTransformMultipleBlocks && self.canReuseTransform == other.canReuseTransform
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25943,7 +25341,7 @@ unsafe impl ::windows::core::Abi for KEY_TYPE_SUBTYPE {
 }
 impl ::core::cmp::PartialEq for KEY_TYPE_SUBTYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEY_TYPE_SUBTYPE>()) == 0 }
+        self.dwKeySpec == other.dwKeySpec && self.Type == other.Type && self.Subtype == other.Subtype
     }
 }
 impl ::core::cmp::Eq for KEY_TYPE_SUBTYPE {}
@@ -25967,18 +25365,12 @@ impl ::core::clone::Clone for NCRYPT_ALLOC_PARA {
 }
 impl ::core::fmt::Debug for NCRYPT_ALLOC_PARA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NCRYPT_ALLOC_PARA").field("cbSize", &self.cbSize).field("pfnAlloc", &self.pfnAlloc.map(|f| f as usize)).field("pfnFree", &self.pfnFree.map(|f| f as usize)).finish()
+        f.debug_struct("NCRYPT_ALLOC_PARA").field("cbSize", &self.cbSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for NCRYPT_ALLOC_PARA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NCRYPT_ALLOC_PARA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_ALLOC_PARA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NCRYPT_ALLOC_PARA {}
 impl ::core::default::Default for NCRYPT_ALLOC_PARA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26010,7 +25402,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_CIPHER_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_CIPHER_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_CIPHER_PADDING_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.pbIV == other.pbIV && self.cbIV == other.cbIV && self.pbOtherInfo == other.pbOtherInfo && self.cbOtherInfo == other.cbOtherInfo
     }
 }
 impl ::core::cmp::Eq for NCRYPT_CIPHER_PADDING_INFO {}
@@ -26040,7 +25432,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE {
 }
 impl ::core::cmp::PartialEq for NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE>()) == 0 }
+        self.Header == other.Header
     }
 }
 impl ::core::cmp::Eq for NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE {}
@@ -26077,7 +25469,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
 }
 impl ::core::cmp::PartialEq for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_EXPORTED_ISOLATED_KEY_HEADER>()) == 0 }
+        self.Version == other.Version && self.KeyUsage == other.KeyUsage && self._bitfield == other._bitfield && self.cbAlgName == other.cbAlgName && self.cbNonce == other.cbNonce && self.cbAuthTag == other.cbAuthTag && self.cbWrappingKey == other.cbWrappingKey && self.cbIsolatedKey == other.cbIsolatedKey
     }
 }
 impl ::core::cmp::Eq for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {}
@@ -26173,7 +25565,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.cbPublicKeyBlob == other.cbPublicKeyBlob
     }
 }
 impl ::core::cmp::Eq for NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES {}
@@ -26206,7 +25598,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_KEY_ACCESS_POLICY_BLOB {
 }
 impl ::core::cmp::PartialEq for NCRYPT_KEY_ACCESS_POLICY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_KEY_ACCESS_POLICY_BLOB>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwPolicyFlags == other.dwPolicyFlags && self.cbUserSid == other.cbUserSid && self.cbApplicationSid == other.cbApplicationSid
     }
 }
 impl ::core::cmp::Eq for NCRYPT_KEY_ACCESS_POLICY_BLOB {}
@@ -26240,7 +25632,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_KEY_ATTEST_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_KEY_ATTEST_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_KEY_ATTEST_PADDING_INFO>()) == 0 }
+        self.magic == other.magic && self.pbKeyBlob == other.pbKeyBlob && self.cbKeyBlob == other.cbKeyBlob && self.pbKeyAuth == other.pbKeyAuth && self.cbKeyAuth == other.cbKeyAuth
     }
 }
 impl ::core::cmp::Eq for NCRYPT_KEY_ATTEST_PADDING_INFO {}
@@ -26273,7 +25665,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_KEY_BLOB_HEADER {
 }
 impl ::core::cmp::PartialEq for NCRYPT_KEY_BLOB_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_KEY_BLOB_HEADER>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMagic == other.dwMagic && self.cbAlgName == other.cbAlgName && self.cbKeyData == other.cbKeyData
     }
 }
 impl ::core::cmp::Eq for NCRYPT_KEY_BLOB_HEADER {}
@@ -26339,7 +25731,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.iExpiration == other.iExpiration && self.pabNonce == other.pabNonce && self.pabPolicyRef == other.pabPolicyRef && self.pabHMAC == other.pabHMAC
     }
 }
 impl ::core::cmp::Eq for NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO {}
@@ -26370,7 +25762,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_PCP_RAW_POLICYDIGEST_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_PCP_RAW_POLICYDIGEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PCP_RAW_POLICYDIGEST_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.cbDigest == other.cbDigest
     }
 }
 impl ::core::cmp::Eq for NCRYPT_PCP_RAW_POLICYDIGEST_INFO {}
@@ -26403,7 +25795,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_PCP_TPM_FW_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_PCP_TPM_FW_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PCP_TPM_FW_VERSION_INFO>()) == 0 }
+        self.major1 == other.major1 && self.major2 == other.major2 && self.minor1 == other.minor1 && self.minor2 == other.minor2
     }
 }
 impl ::core::cmp::Eq for NCRYPT_PCP_TPM_FW_VERSION_INFO {}
@@ -26438,7 +25830,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEM
 }
 impl ::core::cmp::PartialEq for NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEMENT>()) == 0 }
+        self.Magic == other.Magic && self.Version == other.Version && self.HeaderSize == other.HeaderSize && self.cbCertifyInfo == other.cbCertifyInfo && self.cbSignature == other.cbSignature && self.cbTpmPublic == other.cbTpmPublic
     }
 }
 impl ::core::cmp::Eq for NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEMENT {}
@@ -26469,7 +25861,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_PLATFORM_ATTEST_PADDING_INFO {
 }
 impl ::core::cmp::PartialEq for NCRYPT_PLATFORM_ATTEST_PADDING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PLATFORM_ATTEST_PADDING_INFO>()) == 0 }
+        self.magic == other.magic && self.pcrMask == other.pcrMask
     }
 }
 impl ::core::cmp::Eq for NCRYPT_PLATFORM_ATTEST_PADDING_INFO {}
@@ -26496,21 +25888,13 @@ impl ::core::clone::Clone for NCRYPT_PROTECT_STREAM_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for NCRYPT_PROTECT_STREAM_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NCRYPT_PROTECT_STREAM_INFO").field("pfnStreamOutput", &self.pfnStreamOutput.map(|f| f as usize)).field("pvCallbackCtxt", &self.pvCallbackCtxt).finish()
+        f.debug_struct("NCRYPT_PROTECT_STREAM_INFO").field("pvCallbackCtxt", &self.pvCallbackCtxt).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for NCRYPT_PROTECT_STREAM_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NCRYPT_PROTECT_STREAM_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PROTECT_STREAM_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NCRYPT_PROTECT_STREAM_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NCRYPT_PROTECT_STREAM_INFO {
     fn default() -> Self {
@@ -26535,21 +25919,13 @@ impl ::core::clone::Clone for NCRYPT_PROTECT_STREAM_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for NCRYPT_PROTECT_STREAM_INFO_EX {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NCRYPT_PROTECT_STREAM_INFO_EX").field("pfnStreamOutput", &self.pfnStreamOutput.map(|f| f as usize)).field("pvCallbackCtxt", &self.pvCallbackCtxt).finish()
+        f.debug_struct("NCRYPT_PROTECT_STREAM_INFO_EX").field("pvCallbackCtxt", &self.pvCallbackCtxt).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for NCRYPT_PROTECT_STREAM_INFO_EX {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NCRYPT_PROTECT_STREAM_INFO_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_PROTECT_STREAM_INFO_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NCRYPT_PROTECT_STREAM_INFO_EX {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NCRYPT_PROTECT_STREAM_INFO_EX {
     fn default() -> Self {
@@ -26644,7 +26020,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_SUPPORTED_LENGTHS {
 }
 impl ::core::cmp::PartialEq for NCRYPT_SUPPORTED_LENGTHS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_SUPPORTED_LENGTHS>()) == 0 }
+        self.dwMinLength == other.dwMinLength && self.dwMaxLength == other.dwMaxLength && self.dwIncrement == other.dwIncrement && self.dwDefaultLength == other.dwDefaultLength
     }
 }
 impl ::core::cmp::Eq for NCRYPT_SUPPORTED_LENGTHS {}
@@ -26678,7 +26054,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER {
 }
 impl ::core::cmp::PartialEq for NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER>()) == 0 }
+        self.magic == other.magic && self.cbHeader == other.cbHeader && self.cbPublic == other.cbPublic && self.cbPrivate == other.cbPrivate && self.cbName == other.cbName
     }
 }
 impl ::core::cmp::Eq for NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER {}
@@ -26713,7 +26089,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT {
 }
 impl ::core::cmp::PartialEq for NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT>()) == 0 }
+        self.Magic == other.Magic && self.Version == other.Version && self.pcrAlg == other.pcrAlg && self.cbSignature == other.cbSignature && self.cbQuote == other.cbQuote && self.cbPcrs == other.cbPcrs
     }
 }
 impl ::core::cmp::Eq for NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT {}
@@ -26747,7 +26123,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_UI_POLICY {
 }
 impl ::core::cmp::PartialEq for NCRYPT_UI_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_UI_POLICY>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwFlags == other.dwFlags && self.pszCreationTitle == other.pszCreationTitle && self.pszFriendlyName == other.pszFriendlyName && self.pszDescription == other.pszDescription
     }
 }
 impl ::core::cmp::Eq for NCRYPT_UI_POLICY {}
@@ -26782,7 +26158,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIO
 }
 impl ::core::cmp::PartialEq for NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS>()) == 0 }
+        self.Version == other.Version && self.TrustletId == other.TrustletId && self.MinSvn == other.MinSvn && self.FlagsMask == other.FlagsMask && self.FlagsExpected == other.FlagsExpected && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS {}
@@ -26816,7 +26192,7 @@ unsafe impl ::windows::core::Abi for NCRYPT_VSM_KEY_ATTESTATION_STATEMENT {
 }
 impl ::core::cmp::PartialEq for NCRYPT_VSM_KEY_ATTESTATION_STATEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCRYPT_VSM_KEY_ATTESTATION_STATEMENT>()) == 0 }
+        self.Magic == other.Magic && self.Version == other.Version && self.cbSignature == other.cbSignature && self.cbReport == other.cbReport && self.cbAttributes == other.cbAttributes
     }
 }
 impl ::core::cmp::Eq for NCRYPT_VSM_KEY_ATTESTATION_STATEMENT {}
@@ -26849,7 +26225,7 @@ unsafe impl ::windows::core::Abi for NCryptAlgorithmName {
 }
 impl ::core::cmp::PartialEq for NCryptAlgorithmName {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCryptAlgorithmName>()) == 0 }
+        self.pszName == other.pszName && self.dwClass == other.dwClass && self.dwAlgOperations == other.dwAlgOperations && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for NCryptAlgorithmName {}
@@ -26882,7 +26258,7 @@ unsafe impl ::windows::core::Abi for NCryptKeyName {
 }
 impl ::core::cmp::PartialEq for NCryptKeyName {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCryptKeyName>()) == 0 }
+        self.pszName == other.pszName && self.pszAlgid == other.pszAlgid && self.dwLegacyKeySpec == other.dwLegacyKeySpec && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for NCryptKeyName {}
@@ -26913,7 +26289,7 @@ unsafe impl ::windows::core::Abi for NCryptProviderName {
 }
 impl ::core::cmp::PartialEq for NCryptProviderName {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCryptProviderName>()) == 0 }
+        self.pszName == other.pszName && self.pszComment == other.pszComment
     }
 }
 impl ::core::cmp::Eq for NCryptProviderName {}
@@ -26947,14 +26323,6 @@ unsafe impl ::windows::core::Abi for OCSP_BASIC_RESPONSE_ENTRY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OCSP_BASIC_RESPONSE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_RESPONSE_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OCSP_BASIC_RESPONSE_ENTRY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OCSP_BASIC_RESPONSE_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26978,14 +26346,6 @@ impl ::core::clone::Clone for OCSP_BASIC_RESPONSE_ENTRY_0 {
 unsafe impl ::windows::core::Abi for OCSP_BASIC_RESPONSE_ENTRY_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OCSP_BASIC_RESPONSE_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_RESPONSE_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OCSP_BASIC_RESPONSE_ENTRY_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OCSP_BASIC_RESPONSE_ENTRY_0 {
     fn default() -> Self {
@@ -27018,14 +26378,6 @@ unsafe impl ::windows::core::Abi for OCSP_BASIC_RESPONSE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OCSP_BASIC_RESPONSE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_RESPONSE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OCSP_BASIC_RESPONSE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OCSP_BASIC_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27050,14 +26402,6 @@ impl ::core::clone::Clone for OCSP_BASIC_RESPONSE_INFO_0 {
 unsafe impl ::windows::core::Abi for OCSP_BASIC_RESPONSE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OCSP_BASIC_RESPONSE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_RESPONSE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OCSP_BASIC_RESPONSE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OCSP_BASIC_RESPONSE_INFO_0 {
     fn default() -> Self {
@@ -27092,7 +26436,7 @@ unsafe impl ::windows::core::Abi for OCSP_BASIC_REVOKED_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OCSP_BASIC_REVOKED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_REVOKED_INFO>()) == 0 }
+        self.RevocationDate == other.RevocationDate && self.dwCrlReasonCode == other.dwCrlReasonCode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27125,7 +26469,7 @@ unsafe impl ::windows::core::Abi for OCSP_BASIC_SIGNED_RESPONSE_INFO {
 }
 impl ::core::cmp::PartialEq for OCSP_BASIC_SIGNED_RESPONSE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_BASIC_SIGNED_RESPONSE_INFO>()) == 0 }
+        self.ToBeSigned == other.ToBeSigned && self.SignatureInfo == other.SignatureInfo
     }
 }
 impl ::core::cmp::Eq for OCSP_BASIC_SIGNED_RESPONSE_INFO {}
@@ -27158,7 +26502,7 @@ unsafe impl ::windows::core::Abi for OCSP_CERT_ID {
 }
 impl ::core::cmp::PartialEq for OCSP_CERT_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_CERT_ID>()) == 0 }
+        self.HashAlgorithm == other.HashAlgorithm && self.IssuerNameHash == other.IssuerNameHash && self.IssuerKeyHash == other.IssuerKeyHash && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for OCSP_CERT_ID {}
@@ -27196,7 +26540,7 @@ unsafe impl ::windows::core::Abi for OCSP_REQUEST_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OCSP_REQUEST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_REQUEST_ENTRY>()) == 0 }
+        self.CertId == other.CertId && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27239,7 +26583,7 @@ unsafe impl ::windows::core::Abi for OCSP_REQUEST_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OCSP_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_REQUEST_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.pRequestorName == other.pRequestorName && self.cRequestEntry == other.cRequestEntry && self.rgRequestEntry == other.rgRequestEntry && self.cExtension == other.cExtension && self.rgExtension == other.rgExtension
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27273,7 +26617,7 @@ unsafe impl ::windows::core::Abi for OCSP_RESPONSE_INFO {
 }
 impl ::core::cmp::PartialEq for OCSP_RESPONSE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_RESPONSE_INFO>()) == 0 }
+        self.dwStatus == other.dwStatus && self.pszObjId == other.pszObjId && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for OCSP_RESPONSE_INFO {}
@@ -27306,7 +26650,7 @@ unsafe impl ::windows::core::Abi for OCSP_SIGNATURE_INFO {
 }
 impl ::core::cmp::PartialEq for OCSP_SIGNATURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_SIGNATURE_INFO>()) == 0 }
+        self.SignatureAlgorithm == other.SignatureAlgorithm && self.Signature == other.Signature && self.cCertEncoded == other.cCertEncoded && self.rgCertEncoded == other.rgCertEncoded
     }
 }
 impl ::core::cmp::Eq for OCSP_SIGNATURE_INFO {}
@@ -27337,7 +26681,7 @@ unsafe impl ::windows::core::Abi for OCSP_SIGNED_REQUEST_INFO {
 }
 impl ::core::cmp::PartialEq for OCSP_SIGNED_REQUEST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCSP_SIGNED_REQUEST_INFO>()) == 0 }
+        self.ToBeSigned == other.ToBeSigned && self.pOptionalSignatureInfo == other.pOptionalSignatureInfo
     }
 }
 impl ::core::cmp::Eq for OCSP_SIGNED_REQUEST_INFO {}
@@ -27369,7 +26713,7 @@ unsafe impl ::windows::core::Abi for PKCS12_PBES2_EXPORT_PARAMS {
 }
 impl ::core::cmp::PartialEq for PKCS12_PBES2_EXPORT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PKCS12_PBES2_EXPORT_PARAMS>()) == 0 }
+        self.dwSize == other.dwSize && self.hNcryptDescriptor == other.hNcryptDescriptor && self.pwszPbes2Alg == other.pwszPbes2Alg
     }
 }
 impl ::core::cmp::Eq for PKCS12_PBES2_EXPORT_PARAMS {}
@@ -27410,7 +26754,7 @@ unsafe impl ::windows::core::Abi for POLICY_ELEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICY_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICY_ELEMENT>()) == 0 }
+        self.targetEndpointAddress == other.targetEndpointAddress && self.issuerEndpointAddress == other.issuerEndpointAddress && self.issuedTokenParameters == other.issuedTokenParameters && self.privacyNoticeLink == other.privacyNoticeLink && self.privacyNoticeVersion == other.privacyNoticeVersion && self.useManagedPresentation == other.useManagedPresentation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27447,7 +26791,7 @@ unsafe impl ::windows::core::Abi for PRIVKEYVER3 {
 }
 impl ::core::cmp::PartialEq for PRIVKEYVER3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRIVKEYVER3>()) == 0 }
+        self.magic == other.magic && self.bitlenP == other.bitlenP && self.bitlenQ == other.bitlenQ && self.bitlenJ == other.bitlenJ && self.bitlenX == other.bitlenX && self.DSSSeed == other.DSSSeed
     }
 }
 impl ::core::cmp::Eq for PRIVKEYVER3 {}
@@ -27486,7 +26830,7 @@ unsafe impl ::windows::core::Abi for PROV_ENUMALGS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROV_ENUMALGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROV_ENUMALGS>()) == 0 }
+        self.aiAlgid == other.aiAlgid && self.dwBitLen == other.dwBitLen && self.dwNameLen == other.dwNameLen && self.szName == other.szName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27532,7 +26876,7 @@ unsafe impl ::windows::core::Abi for PROV_ENUMALGS_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROV_ENUMALGS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROV_ENUMALGS_EX>()) == 0 }
+        self.aiAlgid == other.aiAlgid && self.dwDefaultLen == other.dwDefaultLen && self.dwMinLen == other.dwMinLen && self.dwMaxLen == other.dwMaxLen && self.dwProtocols == other.dwProtocols && self.dwNameLen == other.dwNameLen && self.szName == other.szName && self.dwLongNameLen == other.dwLongNameLen && self.szLongName == other.szLongName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27565,7 +26909,7 @@ unsafe impl ::windows::core::Abi for PUBKEY {
 }
 impl ::core::cmp::PartialEq for PUBKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBKEY>()) == 0 }
+        self.magic == other.magic && self.bitlen == other.bitlen
     }
 }
 impl ::core::cmp::Eq for PUBKEY {}
@@ -27599,7 +26943,7 @@ unsafe impl ::windows::core::Abi for PUBKEYVER3 {
 }
 impl ::core::cmp::PartialEq for PUBKEYVER3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBKEYVER3>()) == 0 }
+        self.magic == other.magic && self.bitlenP == other.bitlenP && self.bitlenQ == other.bitlenQ && self.bitlenJ == other.bitlenJ && self.DSSSeed == other.DSSSeed
     }
 }
 impl ::core::cmp::Eq for PUBKEYVER3 {}
@@ -27632,7 +26976,7 @@ unsafe impl ::windows::core::Abi for PUBLICKEYSTRUC {
 }
 impl ::core::cmp::PartialEq for PUBLICKEYSTRUC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBLICKEYSTRUC>()) == 0 }
+        self.bType == other.bType && self.bVersion == other.bVersion && self.reserved == other.reserved && self.aiKeyAlg == other.aiKeyAlg
     }
 }
 impl ::core::cmp::Eq for PUBLICKEYSTRUC {}
@@ -27668,7 +27012,7 @@ unsafe impl ::windows::core::Abi for RECIPIENTPOLICY {
 }
 impl ::core::cmp::PartialEq for RECIPIENTPOLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECIPIENTPOLICY>()) == 0 }
+        self.recipient == other.recipient && self.issuer == other.issuer && self.tokenType == other.tokenType && self.requiredClaims == other.requiredClaims && self.optionalClaims == other.optionalClaims && self.privacyUrl == other.privacyUrl && self.privacyVersion == other.privacyVersion
     }
 }
 impl ::core::cmp::Eq for RECIPIENTPOLICY {}
@@ -27704,7 +27048,7 @@ unsafe impl ::windows::core::Abi for RECIPIENTPOLICY2 {
 }
 impl ::core::cmp::PartialEq for RECIPIENTPOLICY2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECIPIENTPOLICY2>()) == 0 }
+        self.recipient == other.recipient && self.issuer == other.issuer && self.tokenType == other.tokenType && self.requiredClaims == other.requiredClaims && self.optionalClaims == other.optionalClaims && self.privacyUrl == other.privacyUrl && self.privacyVersion == other.privacyVersion
     }
 }
 impl ::core::cmp::Eq for RECIPIENTPOLICY2 {}
@@ -27735,7 +27079,7 @@ unsafe impl ::windows::core::Abi for ROOT_INFO_LUID {
 }
 impl ::core::cmp::PartialEq for ROOT_INFO_LUID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ROOT_INFO_LUID>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for ROOT_INFO_LUID {}
@@ -27767,7 +27111,7 @@ unsafe impl ::windows::core::Abi for RSAPUBKEY {
 }
 impl ::core::cmp::PartialEq for RSAPUBKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RSAPUBKEY>()) == 0 }
+        self.magic == other.magic && self.bitlen == other.bitlen && self.pubexp == other.pubexp
     }
 }
 impl ::core::cmp::Eq for RSAPUBKEY {}
@@ -27801,7 +27145,7 @@ unsafe impl ::windows::core::Abi for SCHANNEL_ALG {
 }
 impl ::core::cmp::PartialEq for SCHANNEL_ALG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCHANNEL_ALG>()) == 0 }
+        self.dwUse == other.dwUse && self.Algid == other.Algid && self.cBits == other.cBits && self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for SCHANNEL_ALG {}
@@ -27832,7 +27176,7 @@ unsafe impl ::windows::core::Abi for SSL_ECCKEY_BLOB {
 }
 impl ::core::cmp::PartialEq for SSL_ECCKEY_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_ECCKEY_BLOB>()) == 0 }
+        self.dwCurveType == other.dwCurveType && self.cbKey == other.cbKey
     }
 }
 impl ::core::cmp::Eq for SSL_ECCKEY_BLOB {}
@@ -27866,7 +27210,7 @@ unsafe impl ::windows::core::Abi for SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS {
 }
 impl ::core::cmp::PartialEq for SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwErrorLevel == other.dwErrorLevel && self.dwErrorCategory == other.dwErrorCategory && self.dwReserved == other.dwReserved && self.wszErrorText == other.wszErrorText
     }
 }
 impl ::core::cmp::Eq for SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS {}
@@ -27899,7 +27243,7 @@ unsafe impl ::windows::core::Abi for SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PAR
 }
 impl ::core::cmp::PartialEq for SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwReserved == other.dwReserved && self.pwszServerName == other.pwszServerName && self.rgpszHpkpValue == other.rgpszHpkpValue
     }
 }
 impl ::core::cmp::Eq for SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PARA {}
@@ -27931,7 +27275,7 @@ unsafe impl ::windows::core::Abi for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA {
 }
 impl ::core::cmp::PartialEq for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwReserved == other.dwReserved && self.pwszServerName == other.pwszServerName
     }
 }
 impl ::core::cmp::Eq for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA {}
@@ -27963,7 +27307,7 @@ unsafe impl ::windows::core::Abi for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS 
 }
 impl ::core::cmp::PartialEq for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS>()) == 0 }
+        self.cbSize == other.cbSize && self.lError == other.lError && self.wszErrorText == other.wszErrorText
     }
 }
 impl ::core::cmp::Eq for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS {}

--- a/crates/libs/windows/src/Windows/Win32/Security/DiagnosticDataQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/DiagnosticDataQuery/mod.rs
@@ -394,7 +394,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_BINARY_STATS {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_BINARY_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_BINARY_STATS>()) == 0 }
+        self.moduleName == other.moduleName && self.friendlyModuleName == other.friendlyModuleName && self.eventCount == other.eventCount && self.uploadSizeBytes == other.uploadSizeBytes
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_BINARY_STATS {}
@@ -425,7 +425,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION 
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION>()) == 0 }
+        self.id == other.id && self.name == other.name
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION {}
@@ -455,7 +455,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION 
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION>()) == 0 }
+        self.name == other.name
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION {}
@@ -487,7 +487,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION>()) == 0 }
+        self.privacyTag == other.privacyTag && self.name == other.name && self.description == other.description
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION {}
@@ -518,7 +518,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_TAG_STATS {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_TAG_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_TAG_STATS>()) == 0 }
+        self.privacyTag == other.privacyTag && self.eventCount == other.eventCount
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_TAG_STATS {}
@@ -550,7 +550,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURAT
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURATION>()) == 0 }
+        self.hoursOfHistoryToKeep == other.hoursOfHistoryToKeep && self.maxStoreMegabytes == other.maxStoreMegabytes && self.requestedMaxStoreMegabytes == other.requestedMaxStoreMegabytes
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURATION {}
@@ -584,7 +584,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_GENERAL_STATS {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_GENERAL_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_GENERAL_STATS>()) == 0 }
+        self.optInLevel == other.optInLevel && self.transcriptSizeBytes == other.transcriptSizeBytes && self.oldestEventTimestamp == other.oldestEventTimestamp && self.totalEventCountLast24Hours == other.totalEventCountLast24Hours && self.averageDailyEvents == other.averageDailyEvents
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_DATA_GENERAL_STATS {}
@@ -648,7 +648,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_RECORD>()) == 0 }
+        self.rowId == other.rowId && self.timestamp == other.timestamp && self.eventKeywords == other.eventKeywords && self.fullEventName == other.fullEventName && self.providerGroupGuid == other.providerGroupGuid && self.producerName == other.producerName && self.privacyTags == other.privacyTags && self.privacyTagCount == other.privacyTagCount && self.categoryIds == other.categoryIds && self.categoryIdCount == other.categoryIdCount && self.isCoreData == other.isCoreData && self.extra1 == other.extra1 && self.extra2 == other.extra2 && self.extra3 == other.extra3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -693,7 +693,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_DATA_SEARCH_CRITERIA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIAGNOSTIC_DATA_SEARCH_CRITERIA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_DATA_SEARCH_CRITERIA>()) == 0 }
+        self.producerNames == other.producerNames && self.producerNameCount == other.producerNameCount && self.textToMatch == other.textToMatch && self.categoryIds == other.categoryIds && self.categoryIdCount == other.categoryIdCount && self.privacyTags == other.privacyTags && self.privacyTagCount == other.privacyTagCount && self.coreDataOnly == other.coreDataOnly
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -765,7 +765,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_REPORT_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DIAGNOSTIC_REPORT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_REPORT_DATA>()) == 0 }
+        self.signature == other.signature && self.bucketId == other.bucketId && self.reportId == other.reportId && self.creationTime == other.creationTime && self.sizeInBytes == other.sizeInBytes && self.cabId == other.cabId && self.reportStatus == other.reportStatus && self.reportIntegratorId == other.reportIntegratorId && self.fileNames == other.fileNames && self.fileCount == other.fileCount && self.friendlyEventName == other.friendlyEventName && self.applicationName == other.applicationName && self.applicationPath == other.applicationPath && self.description == other.description && self.bucketIdString == other.bucketIdString && self.legacyBucketId == other.legacyBucketId && self.reportKey == other.reportKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -798,7 +798,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_REPORT_PARAMETER {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_REPORT_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_REPORT_PARAMETER>()) == 0 }
+        self.name == other.name && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_REPORT_PARAMETER {}
@@ -829,7 +829,7 @@ unsafe impl ::windows::core::Abi for DIAGNOSTIC_REPORT_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for DIAGNOSTIC_REPORT_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DIAGNOSTIC_REPORT_SIGNATURE>()) == 0 }
+        self.eventName == other.eventName && self.parameters == other.parameters
     }
 }
 impl ::core::cmp::Eq for DIAGNOSTIC_REPORT_SIGNATURE {}

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
@@ -541,7 +541,7 @@ unsafe impl ::windows::core::Abi for FILE_UNPROTECT_OPTIONS {
 }
 impl ::core::cmp::PartialEq for FILE_UNPROTECT_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_UNPROTECT_OPTIONS>()) == 0 }
+        self.audit == other.audit
     }
 }
 impl ::core::cmp::Eq for FILE_UNPROTECT_OPTIONS {}
@@ -578,7 +578,7 @@ unsafe impl ::windows::core::Abi for HTHREAD_NETWORK_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTHREAD_NETWORK_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTHREAD_NETWORK_CONTEXT>()) == 0 }
+        self.ThreadId == other.ThreadId && self.ThreadContext == other.ThreadContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
@@ -2189,7 +2189,7 @@ unsafe impl ::windows::core::Abi for EAPHOST_AUTH_INFO {
 }
 impl ::core::cmp::PartialEq for EAPHOST_AUTH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAPHOST_AUTH_INFO>()) == 0 }
+        self.status == other.status && self.dwErrorCode == other.dwErrorCode && self.dwReasonCode == other.dwReasonCode
     }
 }
 impl ::core::cmp::Eq for EAPHOST_AUTH_INFO {}
@@ -2241,7 +2241,7 @@ unsafe impl ::windows::core::Abi for EAPHOST_IDENTITY_UI_PARAMS {
 }
 impl ::core::cmp::PartialEq for EAPHOST_IDENTITY_UI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAPHOST_IDENTITY_UI_PARAMS>()) == 0 }
+        self.eapMethodType == other.eapMethodType && self.dwFlags == other.dwFlags && self.dwSizeofConnectionData == other.dwSizeofConnectionData && self.pConnectionData == other.pConnectionData && self.dwSizeofUserData == other.dwSizeofUserData && self.pUserData == other.pUserData && self.dwSizeofUserDataOut == other.dwSizeofUserDataOut && self.pUserDataOut == other.pUserDataOut && self.pwszIdentity == other.pwszIdentity && self.dwError == other.dwError && self.pEapError == other.pEapError
     }
 }
 impl ::core::cmp::Eq for EAPHOST_IDENTITY_UI_PARAMS {}
@@ -2276,7 +2276,7 @@ unsafe impl ::windows::core::Abi for EAPHOST_INTERACTIVE_UI_PARAMS {
 }
 impl ::core::cmp::PartialEq for EAPHOST_INTERACTIVE_UI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAPHOST_INTERACTIVE_UI_PARAMS>()) == 0 }
+        self.dwSizeofContextData == other.dwSizeofContextData && self.pContextData == other.pContextData && self.dwSizeofInteractiveUIData == other.dwSizeofInteractiveUIData && self.pInteractiveUIData == other.pInteractiveUIData && self.dwError == other.dwError && self.pEapError == other.pEapError
     }
 }
 impl ::core::cmp::Eq for EAPHOST_INTERACTIVE_UI_PARAMS {}
@@ -2308,7 +2308,7 @@ unsafe impl ::windows::core::Abi for EAP_ATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for EAP_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_ATTRIBUTE>()) == 0 }
+        self.eaType == other.eaType && self.dwLength == other.dwLength && self.pValue == other.pValue
     }
 }
 impl ::core::cmp::Eq for EAP_ATTRIBUTE {}
@@ -2339,7 +2339,7 @@ unsafe impl ::windows::core::Abi for EAP_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for EAP_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_ATTRIBUTES>()) == 0 }
+        self.dwNumberOfAttributes == other.dwNumberOfAttributes && self.pAttribs == other.pAttribs
     }
 }
 impl ::core::cmp::Eq for EAP_ATTRIBUTES {}
@@ -2393,7 +2393,18 @@ unsafe impl ::windows::core::Abi for EAP_AUTHENTICATOR_METHOD_ROUTINES {
 }
 impl ::core::cmp::PartialEq for EAP_AUTHENTICATOR_METHOD_ROUTINES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_AUTHENTICATOR_METHOD_ROUTINES>()) == 0 }
+        self.dwSizeInBytes == other.dwSizeInBytes
+            && self.pEapType == other.pEapType
+            && self.EapMethodAuthenticatorInitialize == other.EapMethodAuthenticatorInitialize
+            && self.EapMethodAuthenticatorBeginSession == other.EapMethodAuthenticatorBeginSession
+            && self.EapMethodAuthenticatorUpdateInnerMethodParams == other.EapMethodAuthenticatorUpdateInnerMethodParams
+            && self.EapMethodAuthenticatorReceivePacket == other.EapMethodAuthenticatorReceivePacket
+            && self.EapMethodAuthenticatorSendPacket == other.EapMethodAuthenticatorSendPacket
+            && self.EapMethodAuthenticatorGetAttributes == other.EapMethodAuthenticatorGetAttributes
+            && self.EapMethodAuthenticatorSetAttributes == other.EapMethodAuthenticatorSetAttributes
+            && self.EapMethodAuthenticatorGetResult == other.EapMethodAuthenticatorGetResult
+            && self.EapMethodAuthenticatorEndSession == other.EapMethodAuthenticatorEndSession
+            && self.EapMethodAuthenticatorShutdown == other.EapMethodAuthenticatorShutdown
     }
 }
 impl ::core::cmp::Eq for EAP_AUTHENTICATOR_METHOD_ROUTINES {}
@@ -2425,7 +2436,7 @@ unsafe impl ::windows::core::Abi for EAP_CONFIG_INPUT_FIELD_ARRAY {
 }
 impl ::core::cmp::PartialEq for EAP_CONFIG_INPUT_FIELD_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_CONFIG_INPUT_FIELD_ARRAY>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwNumberOfFields == other.dwNumberOfFields && self.pFields == other.pFields
     }
 }
 impl ::core::cmp::Eq for EAP_CONFIG_INPUT_FIELD_ARRAY {}
@@ -2461,7 +2472,7 @@ unsafe impl ::windows::core::Abi for EAP_CONFIG_INPUT_FIELD_DATA {
 }
 impl ::core::cmp::PartialEq for EAP_CONFIG_INPUT_FIELD_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_CONFIG_INPUT_FIELD_DATA>()) == 0 }
+        self.dwSize == other.dwSize && self.Type == other.Type && self.dwFlagProps == other.dwFlagProps && self.pwszLabel == other.pwszLabel && self.pwszData == other.pwszData && self.dwMinDataLength == other.dwMinDataLength && self.dwMaxDataLength == other.dwMaxDataLength
     }
 }
 impl ::core::cmp::Eq for EAP_CONFIG_INPUT_FIELD_DATA {}
@@ -2492,7 +2503,7 @@ unsafe impl ::windows::core::Abi for EAP_CRED_EXPIRY_REQ {
 }
 impl ::core::cmp::PartialEq for EAP_CRED_EXPIRY_REQ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_CRED_EXPIRY_REQ>()) == 0 }
+        self.curCreds == other.curCreds && self.newCreds == other.newCreds
     }
 }
 impl ::core::cmp::Eq for EAP_CRED_EXPIRY_REQ {}
@@ -2529,7 +2540,7 @@ unsafe impl ::windows::core::Abi for EAP_ERROR {
 }
 impl ::core::cmp::PartialEq for EAP_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_ERROR>()) == 0 }
+        self.dwWinError == other.dwWinError && self.r#type == other.r#type && self.dwReasonCode == other.dwReasonCode && self.rootCauseGuid == other.rootCauseGuid && self.repairGuid == other.repairGuid && self.helpLinkGuid == other.helpLinkGuid && self.pRootCauseString == other.pRootCauseString && self.pRepairString == other.pRepairString
     }
 }
 impl ::core::cmp::Eq for EAP_ERROR {}
@@ -2556,12 +2567,6 @@ impl ::core::clone::Clone for EAP_INTERACTIVE_UI_DATA {
 unsafe impl ::windows::core::Abi for EAP_INTERACTIVE_UI_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EAP_INTERACTIVE_UI_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_INTERACTIVE_UI_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EAP_INTERACTIVE_UI_DATA {}
 impl ::core::default::Default for EAP_INTERACTIVE_UI_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2596,7 +2601,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_AUTHENTICATOR_RESULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EAP_METHOD_AUTHENTICATOR_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_AUTHENTICATOR_RESULT>()) == 0 }
+        self.fIsSuccess == other.fIsSuccess && self.dwFailureReason == other.dwFailureReason && self.pAuthAttribs == other.pAuthAttribs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2632,7 +2637,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_INFO {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_INFO>()) == 0 }
+        self.eaptype == other.eaptype && self.pwszAuthorName == other.pwszAuthorName && self.pwszFriendlyName == other.pwszFriendlyName && self.eapProperties == other.eapProperties && self.pInnerMethodInfo == other.pInnerMethodInfo
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_INFO {}
@@ -2663,7 +2668,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_INFO_ARRAY {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_INFO_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_INFO_ARRAY>()) == 0 }
+        self.dwNumberOfMethods == other.dwNumberOfMethods && self.pEapMethods == other.pEapMethods
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_INFO_ARRAY {}
@@ -2694,7 +2699,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_INFO_ARRAY_EX {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_INFO_ARRAY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_INFO_ARRAY_EX>()) == 0 }
+        self.dwNumberOfMethods == other.dwNumberOfMethods && self.pEapMethods == other.pEapMethods
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_INFO_ARRAY_EX {}
@@ -2728,7 +2733,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_INFO_EX {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_INFO_EX>()) == 0 }
+        self.eaptype == other.eaptype && self.pwszAuthorName == other.pwszAuthorName && self.pwszFriendlyName == other.pwszFriendlyName && self.eapProperties == other.eapProperties && self.pInnerMethodInfoArray == other.pInnerMethodInfoArray
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_INFO_EX {}
@@ -2757,14 +2762,6 @@ impl ::core::clone::Clone for EAP_METHOD_PROPERTY {
 unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EAP_METHOD_PROPERTY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EAP_METHOD_PROPERTY {
     fn default() -> Self {
@@ -2799,7 +2796,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY_ARRAY>()) == 0 }
+        self.dwNumberOfProperties == other.dwNumberOfProperties && self.pMethodProperty == other.pMethodProperty
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2830,14 +2827,6 @@ impl ::core::clone::Clone for EAP_METHOD_PROPERTY_VALUE {
 unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY_VALUE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY_VALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EAP_METHOD_PROPERTY_VALUE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EAP_METHOD_PROPERTY_VALUE {
     fn default() -> Self {
@@ -2872,7 +2861,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY_VALUE_BOOL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY_VALUE_BOOL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY_VALUE_BOOL>()) == 0 }
+        self.length == other.length && self.value == other.value
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2905,7 +2894,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY_VALUE_DWORD {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY_VALUE_DWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY_VALUE_DWORD>()) == 0 }
+        self.length == other.length && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_PROPERTY_VALUE_DWORD {}
@@ -2936,7 +2925,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_PROPERTY_VALUE_STRING {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_PROPERTY_VALUE_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_PROPERTY_VALUE_STRING>()) == 0 }
+        self.length == other.length && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_PROPERTY_VALUE_STRING {}
@@ -2967,7 +2956,7 @@ unsafe impl ::windows::core::Abi for EAP_METHOD_TYPE {
 }
 impl ::core::cmp::PartialEq for EAP_METHOD_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_METHOD_TYPE>()) == 0 }
+        self.eapType == other.eapType && self.dwAuthorId == other.dwAuthorId
     }
 }
 impl ::core::cmp::Eq for EAP_METHOD_TYPE {}
@@ -3027,7 +3016,21 @@ unsafe impl ::windows::core::Abi for EAP_PEER_METHOD_ROUTINES {
 }
 impl ::core::cmp::PartialEq for EAP_PEER_METHOD_ROUTINES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_PEER_METHOD_ROUTINES>()) == 0 }
+        self.dwVersion == other.dwVersion
+            && self.pEapType == other.pEapType
+            && self.EapPeerInitialize == other.EapPeerInitialize
+            && self.EapPeerGetIdentity == other.EapPeerGetIdentity
+            && self.EapPeerBeginSession == other.EapPeerBeginSession
+            && self.EapPeerSetCredentials == other.EapPeerSetCredentials
+            && self.EapPeerProcessRequestPacket == other.EapPeerProcessRequestPacket
+            && self.EapPeerGetResponsePacket == other.EapPeerGetResponsePacket
+            && self.EapPeerGetResult == other.EapPeerGetResult
+            && self.EapPeerGetUIContext == other.EapPeerGetUIContext
+            && self.EapPeerSetUIContext == other.EapPeerSetUIContext
+            && self.EapPeerGetResponseAttributes == other.EapPeerGetResponseAttributes
+            && self.EapPeerSetResponseAttributes == other.EapPeerSetResponseAttributes
+            && self.EapPeerEndSession == other.EapPeerEndSession
+            && self.EapPeerShutdown == other.EapPeerShutdown
     }
 }
 impl ::core::cmp::Eq for EAP_PEER_METHOD_ROUTINES {}
@@ -3059,7 +3062,7 @@ unsafe impl ::windows::core::Abi for EAP_TYPE {
 }
 impl ::core::cmp::PartialEq for EAP_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_TYPE>()) == 0 }
+        self.r#type == other.r#type && self.dwVendorId == other.dwVendorId && self.dwVendorType == other.dwVendorType
     }
 }
 impl ::core::cmp::Eq for EAP_TYPE {}
@@ -3084,12 +3087,6 @@ impl ::core::clone::Clone for EAP_UI_DATA_FORMAT {
 unsafe impl ::windows::core::Abi for EAP_UI_DATA_FORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EAP_UI_DATA_FORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EAP_UI_DATA_FORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EAP_UI_DATA_FORMAT {}
 impl ::core::default::Default for EAP_UI_DATA_FORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3117,7 +3114,7 @@ unsafe impl ::windows::core::Abi for EapCertificateCredential {
 }
 impl ::core::cmp::PartialEq for EapCertificateCredential {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapCertificateCredential>()) == 0 }
+        self.certHash == other.certHash && self.password == other.password
     }
 }
 impl ::core::cmp::Eq for EapCertificateCredential {}
@@ -3141,12 +3138,6 @@ impl ::core::clone::Clone for EapCredential {
 unsafe impl ::windows::core::Abi for EapCredential {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EapCredential {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapCredential>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EapCredential {}
 impl ::core::default::Default for EapCredential {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3168,12 +3159,6 @@ impl ::core::clone::Clone for EapCredentialTypeData {
 unsafe impl ::windows::core::Abi for EapCredentialTypeData {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EapCredentialTypeData {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapCredentialTypeData>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EapCredentialTypeData {}
 impl ::core::default::Default for EapCredentialTypeData {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3230,7 +3215,7 @@ unsafe impl ::windows::core::Abi for EapHostPeerMethodResult {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EapHostPeerMethodResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapHostPeerMethodResult>()) == 0 }
+        self.fIsSuccess == other.fIsSuccess && self.dwFailureReasonCode == other.dwFailureReasonCode && self.fSaveConnectionData == other.fSaveConnectionData && self.dwSizeofConnectionData == other.dwSizeofConnectionData && self.pConnectionData == other.pConnectionData && self.fSaveUserData == other.fSaveUserData && self.dwSizeofUserData == other.dwSizeofUserData && self.pUserData == other.pUserData && self.pAttribArray == other.pAttribArray && self.isolationState == other.isolationState && self.pEapMethodInfo == other.pEapMethodInfo && self.pEapError == other.pEapError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3265,7 +3250,7 @@ unsafe impl ::windows::core::Abi for EapPacket {
 }
 impl ::core::cmp::PartialEq for EapPacket {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapPacket>()) == 0 }
+        self.Code == other.Code && self.Id == other.Id && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for EapPacket {}
@@ -3302,7 +3287,7 @@ unsafe impl ::windows::core::Abi for EapPeerMethodOutput {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EapPeerMethodOutput {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapPeerMethodOutput>()) == 0 }
+        self.action == other.action && self.fAllowNotifications == other.fAllowNotifications
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3364,7 +3349,7 @@ unsafe impl ::windows::core::Abi for EapPeerMethodResult {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for EapPeerMethodResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapPeerMethodResult>()) == 0 }
+        self.fIsSuccess == other.fIsSuccess && self.dwFailureReasonCode == other.dwFailureReasonCode && self.fSaveConnectionData == other.fSaveConnectionData && self.dwSizeofConnectionData == other.dwSizeofConnectionData && self.pConnectionData == other.pConnectionData && self.fSaveUserData == other.fSaveUserData && self.dwSizeofUserData == other.dwSizeofUserData && self.pUserData == other.pUserData && self.pAttribArray == other.pAttribArray && self.pEapError == other.pEapError && self.pNgcKerbTicket == other.pNgcKerbTicket && self.fSaveToCredMan == other.fSaveToCredMan
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -3396,7 +3381,7 @@ unsafe impl ::windows::core::Abi for EapSimCredential {
 }
 impl ::core::cmp::PartialEq for EapSimCredential {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapSimCredential>()) == 0 }
+        self.iccID == other.iccID
     }
 }
 impl ::core::cmp::Eq for EapSimCredential {}
@@ -3427,7 +3412,7 @@ unsafe impl ::windows::core::Abi for EapUsernamePasswordCredential {
 }
 impl ::core::cmp::PartialEq for EapUsernamePasswordCredential {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EapUsernamePasswordCredential>()) == 0 }
+        self.username == other.username && self.password == other.password
     }
 }
 impl ::core::cmp::Eq for EapUsernamePasswordCredential {}
@@ -3477,7 +3462,7 @@ unsafe impl ::windows::core::Abi for LEGACY_IDENTITY_UI_PARAMS {
 }
 impl ::core::cmp::PartialEq for LEGACY_IDENTITY_UI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LEGACY_IDENTITY_UI_PARAMS>()) == 0 }
+        self.eapType == other.eapType && self.dwFlags == other.dwFlags && self.dwSizeofConnectionData == other.dwSizeofConnectionData && self.pConnectionData == other.pConnectionData && self.dwSizeofUserData == other.dwSizeofUserData && self.pUserData == other.pUserData && self.dwSizeofUserDataOut == other.dwSizeofUserDataOut && self.pUserDataOut == other.pUserDataOut && self.pwszIdentity == other.pwszIdentity && self.dwError == other.dwError
     }
 }
 impl ::core::cmp::Eq for LEGACY_IDENTITY_UI_PARAMS {}
@@ -3512,7 +3497,7 @@ unsafe impl ::windows::core::Abi for LEGACY_INTERACTIVE_UI_PARAMS {
 }
 impl ::core::cmp::PartialEq for LEGACY_INTERACTIVE_UI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LEGACY_INTERACTIVE_UI_PARAMS>()) == 0 }
+        self.eapType == other.eapType && self.dwSizeofContextData == other.dwSizeofContextData && self.pContextData == other.pContextData && self.dwSizeofInteractiveUIData == other.dwSizeofInteractiveUIData && self.pInteractiveUIData == other.pInteractiveUIData && self.dwError == other.dwError
     }
 }
 impl ::core::cmp::Eq for LEGACY_INTERACTIVE_UI_PARAMS {}
@@ -3550,7 +3535,7 @@ unsafe impl ::windows::core::Abi for NgcTicketContext {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for NgcTicketContext {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NgcTicketContext>()) == 0 }
+        self.wszTicket == other.wszTicket && self.hKey == other.hKey && self.hImpersonateToken == other.hImpersonateToken
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -3587,7 +3572,7 @@ unsafe impl ::windows::core::Abi for PPP_EAP_INFO {
 }
 impl ::core::cmp::PartialEq for PPP_EAP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_EAP_INFO>()) == 0 }
+        self.dwSizeInBytes == other.dwSizeInBytes && self.dwEapTypeId == other.dwEapTypeId && self.RasEapInitialize == other.RasEapInitialize && self.RasEapBegin == other.RasEapBegin && self.RasEapEnd == other.RasEapEnd && self.RasEapMakeMessage == other.RasEapMakeMessage
     }
 }
 impl ::core::cmp::Eq for PPP_EAP_INFO {}
@@ -3665,7 +3650,27 @@ unsafe impl ::windows::core::Abi for PPP_EAP_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PPP_EAP_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_EAP_INPUT>()) == 0 }
+        self.dwSizeInBytes == other.dwSizeInBytes
+            && self.fFlags == other.fFlags
+            && self.fAuthenticator == other.fAuthenticator
+            && self.pwszIdentity == other.pwszIdentity
+            && self.pwszPassword == other.pwszPassword
+            && self.bInitialId == other.bInitialId
+            && self.pUserAttributes == other.pUserAttributes
+            && self.fAuthenticationComplete == other.fAuthenticationComplete
+            && self.dwAuthResultCode == other.dwAuthResultCode
+            && self.hTokenImpersonateUser == other.hTokenImpersonateUser
+            && self.fSuccessPacketReceived == other.fSuccessPacketReceived
+            && self.fDataReceivedFromInteractiveUI == other.fDataReceivedFromInteractiveUI
+            && self.pDataFromInteractiveUI == other.pDataFromInteractiveUI
+            && self.dwSizeOfDataFromInteractiveUI == other.dwSizeOfDataFromInteractiveUI
+            && self.pConnectionData == other.pConnectionData
+            && self.dwSizeOfConnectionData == other.dwSizeOfConnectionData
+            && self.pUserData == other.pUserData
+            && self.dwSizeOfUserData == other.dwSizeOfUserData
+            && self.hReserved == other.hReserved
+            && self.guidConnectionId == other.guidConnectionId
+            && self.isVpn == other.isVpn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3733,7 +3738,7 @@ unsafe impl ::windows::core::Abi for PPP_EAP_OUTPUT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for PPP_EAP_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_EAP_OUTPUT>()) == 0 }
+        self.dwSizeInBytes == other.dwSizeInBytes && self.Action == other.Action && self.dwAuthResultCode == other.dwAuthResultCode && self.pUserAttributes == other.pUserAttributes && self.fInvokeInteractiveUI == other.fInvokeInteractiveUI && self.pUIContextData == other.pUIContextData && self.dwSizeOfUIContextData == other.dwSizeOfUIContextData && self.fSaveConnectionData == other.fSaveConnectionData && self.pConnectionData == other.pConnectionData && self.dwSizeOfConnectionData == other.dwSizeOfConnectionData && self.fSaveUserData == other.fSaveUserData && self.pUserData == other.pUserData && self.dwSizeOfUserData == other.dwSizeOfUserData && self.pNgcKerbTicket == other.pNgcKerbTicket && self.fSaveToCredMan == other.fSaveToCredMan
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -3768,7 +3773,7 @@ unsafe impl ::windows::core::Abi for PPP_EAP_PACKET {
 }
 impl ::core::cmp::PartialEq for PPP_EAP_PACKET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPP_EAP_PACKET>()) == 0 }
+        self.Code == other.Code && self.Id == other.Id && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for PPP_EAP_PACKET {}
@@ -3800,7 +3805,7 @@ unsafe impl ::windows::core::Abi for RAS_AUTH_ATTRIBUTE {
 }
 impl ::core::cmp::PartialEq for RAS_AUTH_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAS_AUTH_ATTRIBUTE>()) == 0 }
+        self.raaType == other.raaType && self.dwLength == other.dwLength && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for RAS_AUTH_ATTRIBUTE {}

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
@@ -171,7 +171,7 @@ unsafe impl ::windows::core::Abi for IsolatedAppLauncherTelemetryParameters {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IsolatedAppLauncherTelemetryParameters {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IsolatedAppLauncherTelemetryParameters>()) == 0 }
+        self.EnableForLaunch == other.EnableForLaunch && self.CorrelationGUID == other.CorrelationGUID
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/NetworkAccessProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/NetworkAccessProtection/mod.rs
@@ -267,7 +267,7 @@ unsafe impl ::windows::core::Abi for CorrelationId {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CorrelationId {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CorrelationId>()) == 0 }
+        self.connId == other.connId && self.timeStamp == other.timeStamp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -300,7 +300,7 @@ unsafe impl ::windows::core::Abi for CountedString {
 }
 impl ::core::cmp::PartialEq for CountedString {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CountedString>()) == 0 }
+        self.length == other.length && self.string == other.string
     }
 }
 impl ::core::cmp::Eq for CountedString {}
@@ -336,7 +336,7 @@ unsafe impl ::windows::core::Abi for FailureCategoryMapping {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FailureCategoryMapping {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FailureCategoryMapping>()) == 0 }
+        self.mappingCompliance == other.mappingCompliance
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -371,7 +371,7 @@ unsafe impl ::windows::core::Abi for FixupInfo {
 }
 impl ::core::cmp::PartialEq for FixupInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FixupInfo>()) == 0 }
+        self.state == other.state && self.percentage == other.percentage && self.resultCodes == other.resultCodes && self.fixupMsgId == other.fixupMsgId
     }
 }
 impl ::core::cmp::Eq for FixupInfo {}
@@ -401,7 +401,7 @@ unsafe impl ::windows::core::Abi for Ipv4Address {
 }
 impl ::core::cmp::PartialEq for Ipv4Address {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Ipv4Address>()) == 0 }
+        self.addr == other.addr
     }
 }
 impl ::core::cmp::Eq for Ipv4Address {}
@@ -431,7 +431,7 @@ unsafe impl ::windows::core::Abi for Ipv6Address {
 }
 impl ::core::cmp::PartialEq for Ipv6Address {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Ipv6Address>()) == 0 }
+        self.addr == other.addr
     }
 }
 impl ::core::cmp::Eq for Ipv6Address {}
@@ -469,7 +469,7 @@ unsafe impl ::windows::core::Abi for IsolationInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IsolationInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IsolationInfo>()) == 0 }
+        self.isolationState == other.isolationState && self.probEndTime == other.probEndTime && self.failureUrl == other.failureUrl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -510,7 +510,7 @@ unsafe impl ::windows::core::Abi for IsolationInfoEx {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IsolationInfoEx {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IsolationInfoEx>()) == 0 }
+        self.isolationState == other.isolationState && self.extendedIsolationState == other.extendedIsolationState && self.probEndTime == other.probEndTime && self.failureUrl == other.failureUrl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -556,7 +556,7 @@ unsafe impl ::windows::core::Abi for NapComponentRegistrationInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NapComponentRegistrationInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NapComponentRegistrationInfo>()) == 0 }
+        self.id == other.id && self.friendlyName == other.friendlyName && self.description == other.description && self.version == other.version && self.vendorName == other.vendorName && self.infoClsid == other.infoClsid && self.configClsid == other.configClsid && self.registrationDate == other.registrationDate && self.componentType == other.componentType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -589,7 +589,7 @@ unsafe impl ::windows::core::Abi for NetworkSoH {
 }
 impl ::core::cmp::PartialEq for NetworkSoH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NetworkSoH>()) == 0 }
+        self.size == other.size && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for NetworkSoH {}
@@ -620,7 +620,7 @@ unsafe impl ::windows::core::Abi for PrivateData {
 }
 impl ::core::cmp::PartialEq for PrivateData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrivateData>()) == 0 }
+        self.size == other.size && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for PrivateData {}
@@ -651,7 +651,7 @@ unsafe impl ::windows::core::Abi for ResultCodes {
 }
 impl ::core::cmp::PartialEq for ResultCodes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ResultCodes>()) == 0 }
+        self.count == other.count && self.results == other.results
     }
 }
 impl ::core::cmp::Eq for ResultCodes {}
@@ -682,7 +682,7 @@ unsafe impl ::windows::core::Abi for SoH {
 }
 impl ::core::cmp::PartialEq for SoH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SoH>()) == 0 }
+        self.count == other.count && self.attributes == other.attributes
     }
 }
 impl ::core::cmp::Eq for SoH {}
@@ -714,7 +714,7 @@ unsafe impl ::windows::core::Abi for SoHAttribute {
 }
 impl ::core::cmp::PartialEq for SoHAttribute {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SoHAttribute>()) == 0 }
+        self.r#type == other.r#type && self.size == other.size && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for SoHAttribute {}
@@ -747,7 +747,7 @@ unsafe impl ::windows::core::Abi for SystemHealthAgentState {
 }
 impl ::core::cmp::PartialEq for SystemHealthAgentState {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SystemHealthAgentState>()) == 0 }
+        self.id == other.id && self.shaResultCodes == other.shaResultCodes && self.failureCategory == other.failureCategory && self.fixupInfo == other.fixupInfo
     }
 }
 impl ::core::cmp::Eq for SystemHealthAgentState {}

--- a/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
@@ -847,7 +847,7 @@ unsafe impl ::windows::core::Abi for CAT_MEMBERINFO {
 }
 impl ::core::cmp::PartialEq for CAT_MEMBERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAT_MEMBERINFO>()) == 0 }
+        self.pwszSubjGuid == other.pwszSubjGuid && self.dwCertVersion == other.dwCertVersion
     }
 }
 impl ::core::cmp::Eq for CAT_MEMBERINFO {}
@@ -878,7 +878,7 @@ unsafe impl ::windows::core::Abi for CAT_MEMBERINFO2 {
 }
 impl ::core::cmp::PartialEq for CAT_MEMBERINFO2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAT_MEMBERINFO2>()) == 0 }
+        self.SubjectGuid == other.SubjectGuid && self.dwCertVersion == other.dwCertVersion
     }
 }
 impl ::core::cmp::Eq for CAT_MEMBERINFO2 {}
@@ -916,7 +916,7 @@ unsafe impl ::windows::core::Abi for CAT_NAMEVALUE {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for CAT_NAMEVALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAT_NAMEVALUE>()) == 0 }
+        self.pwszTag == other.pwszTag && self.fdwFlags == other.fdwFlags && self.Value == other.Value
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -958,7 +958,7 @@ unsafe impl ::windows::core::Abi for CONFIG_CI_PROV_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for CONFIG_CI_PROV_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFIG_CI_PROV_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwPolicies == other.dwPolicies && self.pPolicies == other.pPolicies && self.result == other.result && self.dwScenario == other.dwScenario
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -999,7 +999,7 @@ unsafe impl ::windows::core::Abi for CONFIG_CI_PROV_INFO_RESULT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONFIG_CI_PROV_INFO_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFIG_CI_PROV_INFO_RESULT>()) == 0 }
+        self.hr == other.hr && self.dwResult == other.dwResult && self.dwPolicyIndex == other.dwPolicyIndex && self.fIsExplicitDeny == other.fIsExplicitDeny
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1067,7 +1067,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_CERT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_CERT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_CERT>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pCert == other.pCert && self.fCommercial == other.fCommercial && self.fTrustedRoot == other.fTrustedRoot && self.fSelfSigned == other.fSelfSigned && self.fTestCert == other.fTestCert && self.dwRevokedReason == other.dwRevokedReason && self.dwConfidence == other.dwConfidence && self.dwError == other.dwError && self.pTrustListContext == other.pTrustListContext && self.fTrustListSignerCert == other.fTrustListSignerCert && self.pCtlContext == other.pCtlContext && self.dwCtlError == other.dwCtlError && self.fIsCyclic == other.fIsCyclic && self.pChainElement == other.pChainElement
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -1129,14 +1129,6 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_DATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for CRYPT_PROVIDER_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for CRYPT_PROVIDER_DATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for CRYPT_PROVIDER_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1160,14 +1152,6 @@ impl ::core::clone::Clone for CRYPT_PROVIDER_DATA_0 {
 unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_DATA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for CRYPT_PROVIDER_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_DATA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for CRYPT_PROVIDER_DATA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for CRYPT_PROVIDER_DATA_0 {
     fn default() -> Self {
@@ -1198,7 +1182,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_DEFUSAGE {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_DEFUSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_DEFUSAGE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.gActionID == other.gActionID && self.pDefPolicyCallbackData == other.pDefPolicyCallbackData && self.pDefSIPClientData == other.pDefSIPClientData
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_DEFUSAGE {}
@@ -1239,38 +1223,13 @@ impl ::core::clone::Clone for CRYPT_PROVIDER_FUNCTIONS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::fmt::Debug for CRYPT_PROVIDER_FUNCTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_PROVIDER_FUNCTIONS")
-            .field("cbStruct", &self.cbStruct)
-            .field("pfnAlloc", &self.pfnAlloc.map(|f| f as usize))
-            .field("pfnFree", &self.pfnFree.map(|f| f as usize))
-            .field("pfnAddStore2Chain", &self.pfnAddStore2Chain.map(|f| f as usize))
-            .field("pfnAddSgnr2Chain", &self.pfnAddSgnr2Chain.map(|f| f as usize))
-            .field("pfnAddCert2Chain", &self.pfnAddCert2Chain.map(|f| f as usize))
-            .field("pfnAddPrivData2Chain", &self.pfnAddPrivData2Chain.map(|f| f as usize))
-            .field("pfnInitialize", &self.pfnInitialize.map(|f| f as usize))
-            .field("pfnObjectTrust", &self.pfnObjectTrust.map(|f| f as usize))
-            .field("pfnSignatureTrust", &self.pfnSignatureTrust.map(|f| f as usize))
-            .field("pfnCertificateTrust", &self.pfnCertificateTrust.map(|f| f as usize))
-            .field("pfnFinalPolicy", &self.pfnFinalPolicy.map(|f| f as usize))
-            .field("pfnCertCheckPolicy", &self.pfnCertCheckPolicy.map(|f| f as usize))
-            .field("pfnTestFinalPolicy", &self.pfnTestFinalPolicy.map(|f| f as usize))
-            .field("psUIpfns", &self.psUIpfns)
-            .field("pfnCleanupPolicy", &self.pfnCleanupPolicy.map(|f| f as usize))
-            .finish()
+        f.debug_struct("CRYPT_PROVIDER_FUNCTIONS").field("cbStruct", &self.cbStruct).field("psUIpfns", &self.psUIpfns).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_FUNCTIONS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for CRYPT_PROVIDER_FUNCTIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_FUNCTIONS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for CRYPT_PROVIDER_FUNCTIONS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for CRYPT_PROVIDER_FUNCTIONS {
     fn default() -> Self {
@@ -1301,7 +1260,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_PRIVDATA {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_PRIVDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_PRIVDATA>()) == 0 }
+        self.cbStruct == other.cbStruct && self.gProviderID == other.gProviderID && self.cbProvData == other.cbProvData && self.pvProvData == other.pvProvData
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_PRIVDATA {}
@@ -1335,7 +1294,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_REGDEFUSAGE {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_REGDEFUSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_REGDEFUSAGE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pgActionID == other.pgActionID && self.pwszDllName == other.pwszDllName && self.pwszLoadCallbackDataFunctionName == other.pwszLoadCallbackDataFunctionName && self.pwszFreeCallbackDataFunctionName == other.pwszFreeCallbackDataFunctionName
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVIDER_REGDEFUSAGE {}
@@ -1380,7 +1339,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_SGNR {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_SGNR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_SGNR>()) == 0 }
+        self.cbStruct == other.cbStruct && self.sftVerifyAsOf == other.sftVerifyAsOf && self.csCertChain == other.csCertChain && self.pasCertChain == other.pasCertChain && self.dwSignerType == other.dwSignerType && self.psSigner == other.psSigner && self.dwError == other.dwError && self.csCounterSigners == other.csCounterSigners && self.pasCounterSigners == other.pasCounterSigners && self.pChainContext == other.pChainContext
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -1442,7 +1401,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVIDER_SIGSTATE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for CRYPT_PROVIDER_SIGSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVIDER_SIGSTATE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.rhSecondarySigs == other.rhSecondarySigs && self.hPrimarySig == other.hPrimarySig && self.fFirstAttemptMade == other.fFirstAttemptMade && self.fNoMoreSigs == other.fNoMoreSigs && self.cSecondarySigs == other.cSecondarySigs && self.dwCurrentIndex == other.dwCurrentIndex && self.fSupportMultiSig == other.fSupportMultiSig && self.dwCryptoPolicySupport == other.dwCryptoPolicySupport && self.iAttemptCount == other.iAttemptCount && self.fCheckedSealing == other.fCheckedSealing && self.pSealingSignature == other.pSealingSignature
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -1492,7 +1451,7 @@ unsafe impl ::windows::core::Abi for CRYPT_PROVUI_DATA {
 }
 impl ::core::cmp::PartialEq for CRYPT_PROVUI_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVUI_DATA>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwFinalError == other.dwFinalError && self.pYesButtonText == other.pYesButtonText && self.pNoButtonText == other.pNoButtonText && self.pMoreInfoButtonText == other.pMoreInfoButtonText && self.pAdvancedLinkText == other.pAdvancedLinkText && self.pCopyActionText == other.pCopyActionText && self.pCopyActionTextNoTS == other.pCopyActionTextNoTS && self.pCopyActionTextNotSigned == other.pCopyActionTextNotSigned
     }
 }
 impl ::core::cmp::Eq for CRYPT_PROVUI_DATA {}
@@ -1523,21 +1482,13 @@ impl ::core::clone::Clone for CRYPT_PROVUI_FUNCS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::fmt::Debug for CRYPT_PROVUI_FUNCS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CRYPT_PROVUI_FUNCS").field("cbStruct", &self.cbStruct).field("psUIData", &self.psUIData).field("pfnOnMoreInfoClick", &self.pfnOnMoreInfoClick.map(|f| f as usize)).field("pfnOnMoreInfoClickDefault", &self.pfnOnMoreInfoClickDefault.map(|f| f as usize)).field("pfnOnAdvancedClick", &self.pfnOnAdvancedClick.map(|f| f as usize)).field("pfnOnAdvancedClickDefault", &self.pfnOnAdvancedClickDefault.map(|f| f as usize)).finish()
+        f.debug_struct("CRYPT_PROVUI_FUNCS").field("cbStruct", &self.cbStruct).field("psUIData", &self.psUIData).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 unsafe impl ::windows::core::Abi for CRYPT_PROVUI_FUNCS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for CRYPT_PROVUI_FUNCS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_PROVUI_FUNCS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for CRYPT_PROVUI_FUNCS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for CRYPT_PROVUI_FUNCS {
     fn default() -> Self {
@@ -1583,7 +1534,7 @@ unsafe impl ::windows::core::Abi for CRYPT_REGISTER_ACTIONID {
 }
 impl ::core::cmp::PartialEq for CRYPT_REGISTER_ACTIONID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_REGISTER_ACTIONID>()) == 0 }
+        self.cbStruct == other.cbStruct && self.sInitProvider == other.sInitProvider && self.sObjectProvider == other.sObjectProvider && self.sSignatureProvider == other.sSignatureProvider && self.sCertificateProvider == other.sCertificateProvider && self.sCertificatePolicyProvider == other.sCertificatePolicyProvider && self.sFinalPolicyProvider == other.sFinalPolicyProvider && self.sTestPolicyProvider == other.sTestPolicyProvider && self.sCleanupProvider == other.sCleanupProvider
     }
 }
 impl ::core::cmp::Eq for CRYPT_REGISTER_ACTIONID {}
@@ -1615,7 +1566,7 @@ unsafe impl ::windows::core::Abi for CRYPT_TRUST_REG_ENTRY {
 }
 impl ::core::cmp::PartialEq for CRYPT_TRUST_REG_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CRYPT_TRUST_REG_ENTRY>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pwszDLLName == other.pwszDLLName && self.pwszFunctionName == other.pwszFunctionName
     }
 }
 impl ::core::cmp::Eq for CRYPT_TRUST_REG_ENTRY {}
@@ -1675,7 +1626,7 @@ unsafe impl ::windows::core::Abi for DRIVER_VER_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for DRIVER_VER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_VER_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.dwPlatform == other.dwPlatform && self.dwVersion == other.dwVersion && self.wszVersion == other.wszVersion && self.wszSignedBy == other.wszSignedBy && self.pcSignerCertContext == other.pcSignerCertContext && self.sOSVersionLow == other.sOSVersionLow && self.sOSVersionHigh == other.sOSVersionHigh && self.dwBuildNumberLow == other.dwBuildNumberLow && self.dwBuildNumberHigh == other.dwBuildNumberHigh
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -1708,7 +1659,7 @@ unsafe impl ::windows::core::Abi for DRIVER_VER_MAJORMINOR {
 }
 impl ::core::cmp::PartialEq for DRIVER_VER_MAJORMINOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVER_VER_MAJORMINOR>()) == 0 }
+        self.dwMajor == other.dwMajor && self.dwMinor == other.dwMinor
     }
 }
 impl ::core::cmp::Eq for DRIVER_VER_MAJORMINOR {}
@@ -1745,7 +1696,7 @@ unsafe impl ::windows::core::Abi for INTENT_TO_SEAL_ATTRIBUTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INTENT_TO_SEAL_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTENT_TO_SEAL_ATTRIBUTE>()) == 0 }
+        self.version == other.version && self.seal == other.seal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1789,7 +1740,7 @@ unsafe impl ::windows::core::Abi for PROVDATA_SIP {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::cmp::PartialEq for PROVDATA_SIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVDATA_SIP>()) == 0 }
+        self.cbStruct == other.cbStruct && self.gSubject == other.gSubject && self.pSip == other.pSip && self.pCATSip == other.pCATSip && self.psSipSubjectInfo == other.psSipSubjectInfo && self.psSipCATSubjectInfo == other.psSipCATSubjectInfo && self.psIndirectData == other.psIndirectData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
@@ -1830,7 +1781,7 @@ unsafe impl ::windows::core::Abi for SEALING_SIGNATURE_ATTRIBUTE {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SEALING_SIGNATURE_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEALING_SIGNATURE_ATTRIBUTE>()) == 0 }
+        self.version == other.version && self.signerIndex == other.signerIndex && self.signatureAlgorithm == other.signatureAlgorithm && self.encryptedDigest == other.encryptedDigest
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -1870,7 +1821,7 @@ unsafe impl ::windows::core::Abi for SEALING_TIMESTAMP_ATTRIBUTE {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SEALING_TIMESTAMP_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEALING_TIMESTAMP_ATTRIBUTE>()) == 0 }
+        self.version == other.version && self.signerIndex == other.signerIndex && self.sealTimeStampToken == other.sealTimeStampToken
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -1909,7 +1860,7 @@ unsafe impl ::windows::core::Abi for SPC_FINANCIAL_CRITERIA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SPC_FINANCIAL_CRITERIA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_FINANCIAL_CRITERIA>()) == 0 }
+        self.fFinancialInfoAvailable == other.fFinancialInfoAvailable && self.fMeetsCriteria == other.fMeetsCriteria
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1951,7 +1902,7 @@ unsafe impl ::windows::core::Abi for SPC_IMAGE {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_IMAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_IMAGE>()) == 0 }
+        self.pImageLink == other.pImageLink && self.Bitmap == other.Bitmap && self.Metafile == other.Metafile && self.EnhancedMetafile == other.EnhancedMetafile && self.GifFile == other.GifFile
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -1991,7 +1942,7 @@ unsafe impl ::windows::core::Abi for SPC_INDIRECT_DATA_CONTENT {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_INDIRECT_DATA_CONTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_INDIRECT_DATA_CONTENT>()) == 0 }
+        self.Data == other.Data && self.DigestAlgorithm == other.DigestAlgorithm && self.Digest == other.Digest
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2022,14 +1973,6 @@ unsafe impl ::windows::core::Abi for SPC_LINK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::PartialEq for SPC_LINK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_LINK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::Eq for SPC_LINK {}
-#[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::default::Default for SPC_LINK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2055,14 +1998,6 @@ impl ::core::clone::Clone for SPC_LINK_0 {
 unsafe impl ::windows::core::Abi for SPC_LINK_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::PartialEq for SPC_LINK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_LINK_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::Eq for SPC_LINK_0 {}
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::default::Default for SPC_LINK_0 {
     fn default() -> Self {
@@ -2097,7 +2032,7 @@ unsafe impl ::windows::core::Abi for SPC_PE_IMAGE_DATA {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_PE_IMAGE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_PE_IMAGE_DATA>()) == 0 }
+        self.Flags == other.Flags && self.pFile == other.pFile
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2136,7 +2071,7 @@ unsafe impl ::windows::core::Abi for SPC_SERIALIZED_OBJECT {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_SERIALIZED_OBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_SERIALIZED_OBJECT>()) == 0 }
+        self.ClassId == other.ClassId && self.SerializedData == other.SerializedData
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2174,7 +2109,7 @@ unsafe impl ::windows::core::Abi for SPC_SIGINFO {
 }
 impl ::core::cmp::PartialEq for SPC_SIGINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_SIGINFO>()) == 0 }
+        self.dwSipVersion == other.dwSipVersion && self.gSIPGuid == other.gSIPGuid && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3 && self.dwReserved4 == other.dwReserved4 && self.dwReserved5 == other.dwReserved5
     }
 }
 impl ::core::cmp::Eq for SPC_SIGINFO {}
@@ -2213,7 +2148,7 @@ unsafe impl ::windows::core::Abi for SPC_SP_AGENCY_INFO {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_SP_AGENCY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_SP_AGENCY_INFO>()) == 0 }
+        self.pPolicyInformation == other.pPolicyInformation && self.pwszPolicyDisplayText == other.pwszPolicyDisplayText && self.pLogoImage == other.pLogoImage && self.pLogoLink == other.pLogoLink
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2253,7 +2188,7 @@ unsafe impl ::windows::core::Abi for SPC_SP_OPUS_INFO {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for SPC_SP_OPUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_SP_OPUS_INFO>()) == 0 }
+        self.pwszProgramName == other.pwszProgramName && self.pMoreInfo == other.pMoreInfo && self.pPublisherInfo == other.pPublisherInfo
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2286,7 +2221,7 @@ unsafe impl ::windows::core::Abi for SPC_STATEMENT_TYPE {
 }
 impl ::core::cmp::PartialEq for SPC_STATEMENT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPC_STATEMENT_TYPE>()) == 0 }
+        self.cKeyPurposeId == other.cKeyPurposeId && self.rgpszKeyPurposeId == other.rgpszKeyPurposeId
     }
 }
 impl ::core::cmp::Eq for SPC_STATEMENT_TYPE {}
@@ -2322,7 +2257,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_BLOB_INFO {
 }
 impl ::core::cmp::PartialEq for WINTRUST_BLOB_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_BLOB_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.gSubject == other.gSubject && self.pcwszDisplayName == other.pcwszDisplayName && self.cbMemObject == other.cbMemObject && self.pbMemObject == other.pbMemObject && self.cbMemSignedMsg == other.cbMemSignedMsg && self.pbMemSignedMsg == other.pbMemSignedMsg
     }
 }
 impl ::core::cmp::Eq for WINTRUST_BLOB_INFO {}
@@ -2378,7 +2313,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_CATALOG_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for WINTRUST_CATALOG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_CATALOG_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwCatalogVersion == other.dwCatalogVersion && self.pcwszCatalogFilePath == other.pcwszCatalogFilePath && self.pcwszMemberTag == other.pcwszMemberTag && self.pcwszMemberFilePath == other.pcwszMemberFilePath && self.hMemberFile == other.hMemberFile && self.pbCalculatedFileHash == other.pbCalculatedFileHash && self.cbCalculatedFileHash == other.cbCalculatedFileHash && self.pcCatalogContext == other.pcCatalogContext && self.hCatAdmin == other.hCatAdmin
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -2422,7 +2357,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_CERT_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for WINTRUST_CERT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_CERT_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pcwszDisplayName == other.pcwszDisplayName && self.psCertContext == other.psCertContext && self.chStores == other.chStores && self.pahStores == other.pahStores && self.dwFlags == other.dwFlags && self.psftVerifyAsOf == other.psftVerifyAsOf
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -2464,14 +2399,6 @@ unsafe impl ::windows::core::Abi for WINTRUST_DATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WINTRUST_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WINTRUST_DATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WINTRUST_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2499,14 +2426,6 @@ impl ::core::clone::Clone for WINTRUST_DATA_0 {
 unsafe impl ::windows::core::Abi for WINTRUST_DATA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WINTRUST_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_DATA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WINTRUST_DATA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WINTRUST_DATA_0 {
     fn default() -> Self {
@@ -2543,7 +2462,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_FILE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINTRUST_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_FILE_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pcwszFilePath == other.pcwszFilePath && self.hFile == other.hFile && self.pgKnownSubject == other.pgKnownSubject
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2585,7 +2504,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_SGNR_INFO {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for WINTRUST_SGNR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_SGNR_INFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pcwszDisplayName == other.pcwszDisplayName && self.psSignerInfo == other.psSignerInfo && self.chStores == other.chStores && self.pahStores == other.pahStores
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2628,7 +2547,7 @@ unsafe impl ::windows::core::Abi for WINTRUST_SIGNATURE_SETTINGS {
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::cmp::PartialEq for WINTRUST_SIGNATURE_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINTRUST_SIGNATURE_SETTINGS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.dwIndex == other.dwIndex && self.dwFlags == other.dwFlags && self.cSecondarySigs == other.cSecondarySigs && self.dwVerifiedSigIndex == other.dwVerifiedSigIndex && self.pCryptoPolicy == other.pCryptoPolicy
     }
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2663,7 +2582,7 @@ unsafe impl ::windows::core::Abi for WIN_CERTIFICATE {
 }
 impl ::core::cmp::PartialEq for WIN_CERTIFICATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_CERTIFICATE>()) == 0 }
+        self.dwLength == other.dwLength && self.wRevision == other.wRevision && self.wCertificateType == other.wCertificateType && self.bCertificate == other.bCertificate
     }
 }
 impl ::core::cmp::Eq for WIN_CERTIFICATE {}
@@ -2700,7 +2619,7 @@ unsafe impl ::windows::core::Abi for WIN_SPUB_TRUSTED_PUBLISHER_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN_SPUB_TRUSTED_PUBLISHER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_SPUB_TRUSTED_PUBLISHER_DATA>()) == 0 }
+        self.hClientToken == other.hClientToken && self.lpCertificate == other.lpCertificate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2740,7 +2659,7 @@ unsafe impl ::windows::core::Abi for WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT>()) == 0 }
+        self.hClientToken == other.hClientToken && self.SubjectType == other.SubjectType && self.Subject == other.Subject
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2773,7 +2692,7 @@ unsafe impl ::windows::core::Abi for WIN_TRUST_ACTDATA_SUBJECT_ONLY {
 }
 impl ::core::cmp::PartialEq for WIN_TRUST_ACTDATA_SUBJECT_ONLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_TRUST_ACTDATA_SUBJECT_ONLY>()) == 0 }
+        self.SubjectType == other.SubjectType && self.Subject == other.Subject
     }
 }
 impl ::core::cmp::Eq for WIN_TRUST_ACTDATA_SUBJECT_ONLY {}
@@ -2810,7 +2729,7 @@ unsafe impl ::windows::core::Abi for WIN_TRUST_SUBJECT_FILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN_TRUST_SUBJECT_FILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_TRUST_SUBJECT_FILE>()) == 0 }
+        self.hFile == other.hFile && self.lpPath == other.lpPath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2850,7 +2769,7 @@ unsafe impl ::windows::core::Abi for WIN_TRUST_SUBJECT_FILE_AND_DISPLAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN_TRUST_SUBJECT_FILE_AND_DISPLAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN_TRUST_SUBJECT_FILE_AND_DISPLAY>()) == 0 }
+        self.hFile == other.hFile && self.lpPath == other.lpPath && self.lpDisplayName == other.lpDisplayName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2884,14 +2803,6 @@ unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_CREATE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {}
-#[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2916,14 +2827,6 @@ impl ::core::clone::Clone for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
 unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {}
 #[cfg(feature = "Win32_Security_Cryptography")]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
     fn default() -> Self {
@@ -2953,14 +2856,6 @@ unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_DATA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_DATA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2985,14 +2880,6 @@ impl ::core::clone::Clone for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
 unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_DATA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_DATA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
     fn default() -> Self {
@@ -3024,14 +2911,6 @@ unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3056,14 +2935,6 @@ impl ::core::clone::Clone for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
 unsafe impl ::windows::core::Abi for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::PartialEq for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
-impl ::core::cmp::Eq for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::default::Default for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/WinWlx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinWlx/mod.rs
@@ -176,7 +176,7 @@ unsafe impl ::windows::core::Abi for WLX_CLIENT_CREDENTIALS_INFO_V1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLX_CLIENT_CREDENTIALS_INFO_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_CLIENT_CREDENTIALS_INFO_V1_0>()) == 0 }
+        self.dwType == other.dwType && self.pszUserName == other.pszUserName && self.pszDomain == other.pszDomain && self.pszPassword == other.pszPassword && self.fPromptForPassword == other.fPromptForPassword
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -219,7 +219,7 @@ unsafe impl ::windows::core::Abi for WLX_CLIENT_CREDENTIALS_INFO_V2_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLX_CLIENT_CREDENTIALS_INFO_V2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_CLIENT_CREDENTIALS_INFO_V2_0>()) == 0 }
+        self.dwType == other.dwType && self.pszUserName == other.pszUserName && self.pszDomain == other.pszDomain && self.pszPassword == other.pszPassword && self.fPromptForPassword == other.fPromptForPassword && self.fDisconnectOnLogonFailure == other.fDisconnectOnLogonFailure
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -311,7 +311,33 @@ unsafe impl ::windows::core::Abi for WLX_CONSOLESWITCH_CREDENTIALS_INFO_V1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLX_CONSOLESWITCH_CREDENTIALS_INFO_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_CONSOLESWITCH_CREDENTIALS_INFO_V1_0>()) == 0 }
+        self.dwType == other.dwType
+            && self.UserToken == other.UserToken
+            && self.LogonId == other.LogonId
+            && self.Quotas == other.Quotas
+            && self.UserName == other.UserName
+            && self.Domain == other.Domain
+            && self.LogonTime == other.LogonTime
+            && self.SmartCardLogon == other.SmartCardLogon
+            && self.ProfileLength == other.ProfileLength
+            && self.MessageType == other.MessageType
+            && self.LogonCount == other.LogonCount
+            && self.BadPasswordCount == other.BadPasswordCount
+            && self.ProfileLogonTime == other.ProfileLogonTime
+            && self.LogoffTime == other.LogoffTime
+            && self.KickOffTime == other.KickOffTime
+            && self.PasswordLastSet == other.PasswordLastSet
+            && self.PasswordCanChange == other.PasswordCanChange
+            && self.PasswordMustChange == other.PasswordMustChange
+            && self.LogonScript == other.LogonScript
+            && self.HomeDirectory == other.HomeDirectory
+            && self.FullName == other.FullName
+            && self.ProfilePath == other.ProfilePath
+            && self.HomeDirectoryDrive == other.HomeDirectoryDrive
+            && self.LogonServer == other.LogonServer
+            && self.UserFlags == other.UserFlags
+            && self.PrivateDataLen == other.PrivateDataLen
+            && self.PrivateData == other.PrivateData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -352,7 +378,7 @@ unsafe impl ::windows::core::Abi for WLX_DESKTOP {
 #[cfg(feature = "Win32_System_StationsAndDesktops")]
 impl ::core::cmp::PartialEq for WLX_DESKTOP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DESKTOP>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.hDesktop == other.hDesktop && self.pszDesktopName == other.pszDesktopName
     }
 }
 #[cfg(feature = "Win32_System_StationsAndDesktops")]
@@ -392,35 +418,13 @@ impl ::core::clone::Clone for WLX_DISPATCH_VERSION_1_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for WLX_DISPATCH_VERSION_1_0 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_DISPATCH_VERSION_1_0")
-            .field("WlxUseCtrlAltDel", &self.WlxUseCtrlAltDel.map(|f| f as usize))
-            .field("WlxSetContextPointer", &self.WlxSetContextPointer.map(|f| f as usize))
-            .field("WlxSasNotify", &self.WlxSasNotify.map(|f| f as usize))
-            .field("WlxSetTimeout", &self.WlxSetTimeout.map(|f| f as usize))
-            .field("WlxAssignShellProtection", &self.WlxAssignShellProtection.map(|f| f as usize))
-            .field("WlxMessageBox", &self.WlxMessageBox.map(|f| f as usize))
-            .field("WlxDialogBox", &self.WlxDialogBox.map(|f| f as usize))
-            .field("WlxDialogBoxParam", &self.WlxDialogBoxParam.map(|f| f as usize))
-            .field("WlxDialogBoxIndirect", &self.WlxDialogBoxIndirect.map(|f| f as usize))
-            .field("WlxDialogBoxIndirectParam", &self.WlxDialogBoxIndirectParam.map(|f| f as usize))
-            .field("WlxSwitchDesktopToUser", &self.WlxSwitchDesktopToUser.map(|f| f as usize))
-            .field("WlxSwitchDesktopToWinlogon", &self.WlxSwitchDesktopToWinlogon.map(|f| f as usize))
-            .field("WlxChangePasswordNotify", &self.WlxChangePasswordNotify.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WLX_DISPATCH_VERSION_1_0").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for WLX_DISPATCH_VERSION_1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for WLX_DISPATCH_VERSION_1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DISPATCH_VERSION_1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for WLX_DISPATCH_VERSION_1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for WLX_DISPATCH_VERSION_1_0 {
     fn default() -> Self {
@@ -460,39 +464,13 @@ impl ::core::clone::Clone for WLX_DISPATCH_VERSION_1_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for WLX_DISPATCH_VERSION_1_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_DISPATCH_VERSION_1_1")
-            .field("WlxUseCtrlAltDel", &self.WlxUseCtrlAltDel.map(|f| f as usize))
-            .field("WlxSetContextPointer", &self.WlxSetContextPointer.map(|f| f as usize))
-            .field("WlxSasNotify", &self.WlxSasNotify.map(|f| f as usize))
-            .field("WlxSetTimeout", &self.WlxSetTimeout.map(|f| f as usize))
-            .field("WlxAssignShellProtection", &self.WlxAssignShellProtection.map(|f| f as usize))
-            .field("WlxMessageBox", &self.WlxMessageBox.map(|f| f as usize))
-            .field("WlxDialogBox", &self.WlxDialogBox.map(|f| f as usize))
-            .field("WlxDialogBoxParam", &self.WlxDialogBoxParam.map(|f| f as usize))
-            .field("WlxDialogBoxIndirect", &self.WlxDialogBoxIndirect.map(|f| f as usize))
-            .field("WlxDialogBoxIndirectParam", &self.WlxDialogBoxIndirectParam.map(|f| f as usize))
-            .field("WlxSwitchDesktopToUser", &self.WlxSwitchDesktopToUser.map(|f| f as usize))
-            .field("WlxSwitchDesktopToWinlogon", &self.WlxSwitchDesktopToWinlogon.map(|f| f as usize))
-            .field("WlxChangePasswordNotify", &self.WlxChangePasswordNotify.map(|f| f as usize))
-            .field("WlxGetSourceDesktop", &self.WlxGetSourceDesktop.map(|f| f as usize))
-            .field("WlxSetReturnDesktop", &self.WlxSetReturnDesktop.map(|f| f as usize))
-            .field("WlxCreateUserDesktop", &self.WlxCreateUserDesktop.map(|f| f as usize))
-            .field("WlxChangePasswordNotifyEx", &self.WlxChangePasswordNotifyEx.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WLX_DISPATCH_VERSION_1_1").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for WLX_DISPATCH_VERSION_1_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for WLX_DISPATCH_VERSION_1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DISPATCH_VERSION_1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for WLX_DISPATCH_VERSION_1_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for WLX_DISPATCH_VERSION_1_1 {
     fn default() -> Self {
@@ -533,40 +511,13 @@ impl ::core::clone::Clone for WLX_DISPATCH_VERSION_1_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for WLX_DISPATCH_VERSION_1_2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_DISPATCH_VERSION_1_2")
-            .field("WlxUseCtrlAltDel", &self.WlxUseCtrlAltDel.map(|f| f as usize))
-            .field("WlxSetContextPointer", &self.WlxSetContextPointer.map(|f| f as usize))
-            .field("WlxSasNotify", &self.WlxSasNotify.map(|f| f as usize))
-            .field("WlxSetTimeout", &self.WlxSetTimeout.map(|f| f as usize))
-            .field("WlxAssignShellProtection", &self.WlxAssignShellProtection.map(|f| f as usize))
-            .field("WlxMessageBox", &self.WlxMessageBox.map(|f| f as usize))
-            .field("WlxDialogBox", &self.WlxDialogBox.map(|f| f as usize))
-            .field("WlxDialogBoxParam", &self.WlxDialogBoxParam.map(|f| f as usize))
-            .field("WlxDialogBoxIndirect", &self.WlxDialogBoxIndirect.map(|f| f as usize))
-            .field("WlxDialogBoxIndirectParam", &self.WlxDialogBoxIndirectParam.map(|f| f as usize))
-            .field("WlxSwitchDesktopToUser", &self.WlxSwitchDesktopToUser.map(|f| f as usize))
-            .field("WlxSwitchDesktopToWinlogon", &self.WlxSwitchDesktopToWinlogon.map(|f| f as usize))
-            .field("WlxChangePasswordNotify", &self.WlxChangePasswordNotify.map(|f| f as usize))
-            .field("WlxGetSourceDesktop", &self.WlxGetSourceDesktop.map(|f| f as usize))
-            .field("WlxSetReturnDesktop", &self.WlxSetReturnDesktop.map(|f| f as usize))
-            .field("WlxCreateUserDesktop", &self.WlxCreateUserDesktop.map(|f| f as usize))
-            .field("WlxChangePasswordNotifyEx", &self.WlxChangePasswordNotifyEx.map(|f| f as usize))
-            .field("WlxCloseUserDesktop", &self.WlxCloseUserDesktop.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WLX_DISPATCH_VERSION_1_2").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for WLX_DISPATCH_VERSION_1_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for WLX_DISPATCH_VERSION_1_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DISPATCH_VERSION_1_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for WLX_DISPATCH_VERSION_1_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for WLX_DISPATCH_VERSION_1_2 {
     fn default() -> Self {
@@ -614,47 +565,13 @@ impl ::core::clone::Clone for WLX_DISPATCH_VERSION_1_3 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for WLX_DISPATCH_VERSION_1_3 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_DISPATCH_VERSION_1_3")
-            .field("WlxUseCtrlAltDel", &self.WlxUseCtrlAltDel.map(|f| f as usize))
-            .field("WlxSetContextPointer", &self.WlxSetContextPointer.map(|f| f as usize))
-            .field("WlxSasNotify", &self.WlxSasNotify.map(|f| f as usize))
-            .field("WlxSetTimeout", &self.WlxSetTimeout.map(|f| f as usize))
-            .field("WlxAssignShellProtection", &self.WlxAssignShellProtection.map(|f| f as usize))
-            .field("WlxMessageBox", &self.WlxMessageBox.map(|f| f as usize))
-            .field("WlxDialogBox", &self.WlxDialogBox.map(|f| f as usize))
-            .field("WlxDialogBoxParam", &self.WlxDialogBoxParam.map(|f| f as usize))
-            .field("WlxDialogBoxIndirect", &self.WlxDialogBoxIndirect.map(|f| f as usize))
-            .field("WlxDialogBoxIndirectParam", &self.WlxDialogBoxIndirectParam.map(|f| f as usize))
-            .field("WlxSwitchDesktopToUser", &self.WlxSwitchDesktopToUser.map(|f| f as usize))
-            .field("WlxSwitchDesktopToWinlogon", &self.WlxSwitchDesktopToWinlogon.map(|f| f as usize))
-            .field("WlxChangePasswordNotify", &self.WlxChangePasswordNotify.map(|f| f as usize))
-            .field("WlxGetSourceDesktop", &self.WlxGetSourceDesktop.map(|f| f as usize))
-            .field("WlxSetReturnDesktop", &self.WlxSetReturnDesktop.map(|f| f as usize))
-            .field("WlxCreateUserDesktop", &self.WlxCreateUserDesktop.map(|f| f as usize))
-            .field("WlxChangePasswordNotifyEx", &self.WlxChangePasswordNotifyEx.map(|f| f as usize))
-            .field("WlxCloseUserDesktop", &self.WlxCloseUserDesktop.map(|f| f as usize))
-            .field("WlxSetOption", &self.WlxSetOption.map(|f| f as usize))
-            .field("WlxGetOption", &self.WlxGetOption.map(|f| f as usize))
-            .field("WlxWin31Migrate", &self.WlxWin31Migrate.map(|f| f as usize))
-            .field("WlxQueryClientCredentials", &self.WlxQueryClientCredentials.map(|f| f as usize))
-            .field("WlxQueryInetConnectorCredentials", &self.WlxQueryInetConnectorCredentials.map(|f| f as usize))
-            .field("WlxDisconnect", &self.WlxDisconnect.map(|f| f as usize))
-            .field("WlxQueryTerminalServicesData", &self.WlxQueryTerminalServicesData.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WLX_DISPATCH_VERSION_1_3").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for WLX_DISPATCH_VERSION_1_3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for WLX_DISPATCH_VERSION_1_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DISPATCH_VERSION_1_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for WLX_DISPATCH_VERSION_1_3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for WLX_DISPATCH_VERSION_1_3 {
     fn default() -> Self {
@@ -704,49 +621,13 @@ impl ::core::clone::Clone for WLX_DISPATCH_VERSION_1_4 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for WLX_DISPATCH_VERSION_1_4 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_DISPATCH_VERSION_1_4")
-            .field("WlxUseCtrlAltDel", &self.WlxUseCtrlAltDel.map(|f| f as usize))
-            .field("WlxSetContextPointer", &self.WlxSetContextPointer.map(|f| f as usize))
-            .field("WlxSasNotify", &self.WlxSasNotify.map(|f| f as usize))
-            .field("WlxSetTimeout", &self.WlxSetTimeout.map(|f| f as usize))
-            .field("WlxAssignShellProtection", &self.WlxAssignShellProtection.map(|f| f as usize))
-            .field("WlxMessageBox", &self.WlxMessageBox.map(|f| f as usize))
-            .field("WlxDialogBox", &self.WlxDialogBox.map(|f| f as usize))
-            .field("WlxDialogBoxParam", &self.WlxDialogBoxParam.map(|f| f as usize))
-            .field("WlxDialogBoxIndirect", &self.WlxDialogBoxIndirect.map(|f| f as usize))
-            .field("WlxDialogBoxIndirectParam", &self.WlxDialogBoxIndirectParam.map(|f| f as usize))
-            .field("WlxSwitchDesktopToUser", &self.WlxSwitchDesktopToUser.map(|f| f as usize))
-            .field("WlxSwitchDesktopToWinlogon", &self.WlxSwitchDesktopToWinlogon.map(|f| f as usize))
-            .field("WlxChangePasswordNotify", &self.WlxChangePasswordNotify.map(|f| f as usize))
-            .field("WlxGetSourceDesktop", &self.WlxGetSourceDesktop.map(|f| f as usize))
-            .field("WlxSetReturnDesktop", &self.WlxSetReturnDesktop.map(|f| f as usize))
-            .field("WlxCreateUserDesktop", &self.WlxCreateUserDesktop.map(|f| f as usize))
-            .field("WlxChangePasswordNotifyEx", &self.WlxChangePasswordNotifyEx.map(|f| f as usize))
-            .field("WlxCloseUserDesktop", &self.WlxCloseUserDesktop.map(|f| f as usize))
-            .field("WlxSetOption", &self.WlxSetOption.map(|f| f as usize))
-            .field("WlxGetOption", &self.WlxGetOption.map(|f| f as usize))
-            .field("WlxWin31Migrate", &self.WlxWin31Migrate.map(|f| f as usize))
-            .field("WlxQueryClientCredentials", &self.WlxQueryClientCredentials.map(|f| f as usize))
-            .field("WlxQueryInetConnectorCredentials", &self.WlxQueryInetConnectorCredentials.map(|f| f as usize))
-            .field("WlxDisconnect", &self.WlxDisconnect.map(|f| f as usize))
-            .field("WlxQueryTerminalServicesData", &self.WlxQueryTerminalServicesData.map(|f| f as usize))
-            .field("WlxQueryConsoleSwitchCredentials", &self.WlxQueryConsoleSwitchCredentials.map(|f| f as usize))
-            .field("WlxQueryTsLogonCredentials", &self.WlxQueryTsLogonCredentials.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WLX_DISPATCH_VERSION_1_4").finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for WLX_DISPATCH_VERSION_1_4 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for WLX_DISPATCH_VERSION_1_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_DISPATCH_VERSION_1_4>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for WLX_DISPATCH_VERSION_1_4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for WLX_DISPATCH_VERSION_1_4 {
     fn default() -> Self {
@@ -777,7 +658,7 @@ unsafe impl ::windows::core::Abi for WLX_MPR_NOTIFY_INFO {
 }
 impl ::core::cmp::PartialEq for WLX_MPR_NOTIFY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_MPR_NOTIFY_INFO>()) == 0 }
+        self.pszUserName == other.pszUserName && self.pszDomain == other.pszDomain && self.pszPassword == other.pszPassword && self.pszOldPassword == other.pszOldPassword
     }
 }
 impl ::core::cmp::Eq for WLX_MPR_NOTIFY_INFO {}
@@ -810,21 +691,13 @@ impl ::core::clone::Clone for WLX_NOTIFICATION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops"))]
 impl ::core::fmt::Debug for WLX_NOTIFICATION_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WLX_NOTIFICATION_INFO").field("Size", &self.Size).field("Flags", &self.Flags).field("UserName", &self.UserName).field("Domain", &self.Domain).field("WindowStation", &self.WindowStation).field("hToken", &self.hToken).field("hDesktop", &self.hDesktop).field("pStatusCallback", &self.pStatusCallback.map(|f| f as usize)).finish()
+        f.debug_struct("WLX_NOTIFICATION_INFO").field("Size", &self.Size).field("Flags", &self.Flags).field("UserName", &self.UserName).field("Domain", &self.Domain).field("WindowStation", &self.WindowStation).field("hToken", &self.hToken).field("hDesktop", &self.hDesktop).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops"))]
 unsafe impl ::windows::core::Abi for WLX_NOTIFICATION_INFO {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops"))]
-impl ::core::cmp::PartialEq for WLX_NOTIFICATION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_NOTIFICATION_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops"))]
-impl ::core::cmp::Eq for WLX_NOTIFICATION_INFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_StationsAndDesktops"))]
 impl ::core::default::Default for WLX_NOTIFICATION_INFO {
     fn default() -> Self {
@@ -853,7 +726,7 @@ unsafe impl ::windows::core::Abi for WLX_PROFILE_V1_0 {
 }
 impl ::core::cmp::PartialEq for WLX_PROFILE_V1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_PROFILE_V1_0>()) == 0 }
+        self.dwType == other.dwType && self.pszProfile == other.pszProfile
     }
 }
 impl ::core::cmp::Eq for WLX_PROFILE_V1_0 {}
@@ -888,7 +761,7 @@ unsafe impl ::windows::core::Abi for WLX_PROFILE_V2_0 {
 }
 impl ::core::cmp::PartialEq for WLX_PROFILE_V2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_PROFILE_V2_0>()) == 0 }
+        self.dwType == other.dwType && self.pszProfile == other.pszProfile && self.pszPolicy == other.pszPolicy && self.pszNetworkDefaultUserProfile == other.pszNetworkDefaultUserProfile && self.pszServerName == other.pszServerName && self.pszEnvironment == other.pszEnvironment
     }
 }
 impl ::core::cmp::Eq for WLX_PROFILE_V2_0 {}
@@ -921,7 +794,7 @@ unsafe impl ::windows::core::Abi for WLX_SC_NOTIFICATION_INFO {
 }
 impl ::core::cmp::PartialEq for WLX_SC_NOTIFICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_SC_NOTIFICATION_INFO>()) == 0 }
+        self.pszCard == other.pszCard && self.pszReader == other.pszReader && self.pszContainer == other.pszContainer && self.pszCryptoProvider == other.pszCryptoProvider
     }
 }
 impl ::core::cmp::Eq for WLX_SC_NOTIFICATION_INFO {}
@@ -953,7 +826,7 @@ unsafe impl ::windows::core::Abi for WLX_TERMINAL_SERVICES_DATA {
 }
 impl ::core::cmp::PartialEq for WLX_TERMINAL_SERVICES_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLX_TERMINAL_SERVICES_DATA>()) == 0 }
+        self.ProfilePath == other.ProfilePath && self.HomeDir == other.HomeDir && self.HomeDirDrive == other.HomeDirDrive
     }
 }
 impl ::core::cmp::Eq for WLX_TERMINAL_SERVICES_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -2953,7 +2953,7 @@ unsafe impl ::windows::core::Abi for ACCESS_ALLOWED_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_ALLOWED_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_ALLOWED_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_ALLOWED_ACE {}
@@ -2985,7 +2985,7 @@ unsafe impl ::windows::core::Abi for ACCESS_ALLOWED_CALLBACK_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_ALLOWED_CALLBACK_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_ALLOWED_CALLBACK_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_ALLOWED_CALLBACK_ACE {}
@@ -3020,7 +3020,7 @@ unsafe impl ::windows::core::Abi for ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_ALLOWED_CALLBACK_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {}
@@ -3055,7 +3055,7 @@ unsafe impl ::windows::core::Abi for ACCESS_ALLOWED_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_ALLOWED_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_ALLOWED_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_ALLOWED_OBJECT_ACE {}
@@ -3087,7 +3087,7 @@ unsafe impl ::windows::core::Abi for ACCESS_DENIED_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_DENIED_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_DENIED_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_DENIED_ACE {}
@@ -3119,7 +3119,7 @@ unsafe impl ::windows::core::Abi for ACCESS_DENIED_CALLBACK_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_DENIED_CALLBACK_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_DENIED_CALLBACK_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_DENIED_CALLBACK_ACE {}
@@ -3154,7 +3154,7 @@ unsafe impl ::windows::core::Abi for ACCESS_DENIED_CALLBACK_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_DENIED_CALLBACK_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_DENIED_CALLBACK_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_DENIED_CALLBACK_OBJECT_ACE {}
@@ -3189,7 +3189,7 @@ unsafe impl ::windows::core::Abi for ACCESS_DENIED_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for ACCESS_DENIED_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_DENIED_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for ACCESS_DENIED_OBJECT_ACE {}
@@ -3219,7 +3219,7 @@ unsafe impl ::windows::core::Abi for ACCESS_REASONS {
 }
 impl ::core::cmp::PartialEq for ACCESS_REASONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESS_REASONS>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for ACCESS_REASONS {}
@@ -3251,7 +3251,7 @@ unsafe impl ::windows::core::Abi for ACE_HEADER {
 }
 impl ::core::cmp::PartialEq for ACE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACE_HEADER>()) == 0 }
+        self.AceType == other.AceType && self.AceFlags == other.AceFlags && self.AceSize == other.AceSize
     }
 }
 impl ::core::cmp::Eq for ACE_HEADER {}
@@ -3285,7 +3285,7 @@ unsafe impl ::windows::core::Abi for ACL {
 }
 impl ::core::cmp::PartialEq for ACL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACL>()) == 0 }
+        self.AclRevision == other.AclRevision && self.Sbz1 == other.Sbz1 && self.AclSize == other.AclSize && self.AceCount == other.AceCount && self.Sbz2 == other.Sbz2
     }
 }
 impl ::core::cmp::Eq for ACL {}
@@ -3315,7 +3315,7 @@ unsafe impl ::windows::core::Abi for ACL_REVISION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ACL_REVISION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACL_REVISION_INFORMATION>()) == 0 }
+        self.AclRevision == other.AclRevision
     }
 }
 impl ::core::cmp::Eq for ACL_REVISION_INFORMATION {}
@@ -3347,7 +3347,7 @@ unsafe impl ::windows::core::Abi for ACL_SIZE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ACL_SIZE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACL_SIZE_INFORMATION>()) == 0 }
+        self.AceCount == other.AceCount && self.AclBytesInUse == other.AclBytesInUse && self.AclBytesFree == other.AclBytesFree
     }
 }
 impl ::core::cmp::Eq for ACL_SIZE_INFORMATION {}
@@ -3373,12 +3373,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTES_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3398,12 +3392,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3431,7 +3419,7 @@ unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE {
 }
 impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE>()) == 0 }
+        self.Version == other.Version && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE {}
@@ -3462,7 +3450,7 @@ unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE
 }
 impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE>()) == 0 }
+        self.pValue == other.pValue && self.ValueLength == other.ValueLength
     }
 }
 impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {}
@@ -3490,12 +3478,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3519,12 +3501,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3549,12 +3525,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTE_V1 {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_V1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_V1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_V1 {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTE_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3578,12 +3548,6 @@ impl ::core::clone::Clone for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
 unsafe impl ::windows::core::Abi for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLAIM_SECURITY_ATTRIBUTE_V1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLAIM_SECURITY_ATTRIBUTE_V1_0 {}
 impl ::core::default::Default for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3613,7 +3577,7 @@ unsafe impl ::windows::core::Abi for GENERIC_MAPPING {
 }
 impl ::core::cmp::PartialEq for GENERIC_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GENERIC_MAPPING>()) == 0 }
+        self.GenericRead == other.GenericRead && self.GenericWrite == other.GenericWrite && self.GenericExecute == other.GenericExecute && self.GenericAll == other.GenericAll
     }
 }
 impl ::core::cmp::Eq for GENERIC_MAPPING {}
@@ -3833,14 +3797,6 @@ unsafe impl ::windows::core::Abi for LLFILETIME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LLFILETIME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LLFILETIME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LLFILETIME {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LLFILETIME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3865,14 +3821,6 @@ impl ::core::clone::Clone for LLFILETIME_0 {
 unsafe impl ::windows::core::Abi for LLFILETIME_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LLFILETIME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LLFILETIME_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LLFILETIME_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LLFILETIME_0 {
     fn default() -> Self {
@@ -3907,7 +3855,7 @@ unsafe impl ::windows::core::Abi for LUID_AND_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LUID_AND_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LUID_AND_ATTRIBUTES>()) == 0 }
+        self.Luid == other.Luid && self.Attributes == other.Attributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4005,7 +3953,7 @@ unsafe impl ::windows::core::Abi for OBJECT_TYPE_LIST {
 }
 impl ::core::cmp::PartialEq for OBJECT_TYPE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECT_TYPE_LIST>()) == 0 }
+        self.Level == other.Level && self.Sbz == other.Sbz && self.ObjectType == other.ObjectType
     }
 }
 impl ::core::cmp::Eq for OBJECT_TYPE_LIST {}
@@ -4043,7 +3991,7 @@ unsafe impl ::windows::core::Abi for PRIVILEGE_SET {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRIVILEGE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRIVILEGE_SET>()) == 0 }
+        self.PrivilegeCount == other.PrivilegeCount && self.Control == other.Control && self.Privilege == other.Privilege
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4112,7 +4060,7 @@ unsafe impl ::windows::core::Abi for QUOTA_LIMITS {
 }
 impl ::core::cmp::PartialEq for QUOTA_LIMITS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUOTA_LIMITS>()) == 0 }
+        self.PagedPoolLimit == other.PagedPoolLimit && self.NonPagedPoolLimit == other.NonPagedPoolLimit && self.MinimumWorkingSetSize == other.MinimumWorkingSetSize && self.MaximumWorkingSetSize == other.MaximumWorkingSetSize && self.PagefileLimit == other.PagefileLimit && self.TimeLimit == other.TimeLimit
     }
 }
 impl ::core::cmp::Eq for QUOTA_LIMITS {}
@@ -4214,7 +4162,7 @@ unsafe impl ::windows::core::Abi for SECURITY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_ATTRIBUTES>()) == 0 }
+        self.nLength == other.nLength && self.lpSecurityDescriptor == other.lpSecurityDescriptor && self.bInheritHandle == other.bInheritHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4255,7 +4203,7 @@ unsafe impl ::windows::core::Abi for SECURITY_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_CAPABILITIES>()) == 0 }
+        self.AppContainerSid == other.AppContainerSid && self.Capabilities == other.Capabilities && self.CapabilityCount == other.CapabilityCount && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4299,7 +4247,7 @@ unsafe impl ::windows::core::Abi for SECURITY_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_DESCRIPTOR>()) == 0 }
+        self.Revision == other.Revision && self.Sbz1 == other.Sbz1 && self.Control == other.Control && self.Owner == other.Owner && self.Group == other.Group && self.Sacl == other.Sacl && self.Dacl == other.Dacl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4340,7 +4288,7 @@ unsafe impl ::windows::core::Abi for SECURITY_QUALITY_OF_SERVICE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SECURITY_QUALITY_OF_SERVICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_QUALITY_OF_SERVICE>()) == 0 }
+        self.Length == other.Length && self.ImpersonationLevel == other.ImpersonationLevel && self.ContextTrackingMode == other.ContextTrackingMode && self.EffectiveOnly == other.EffectiveOnly
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4383,7 +4331,7 @@ unsafe impl ::windows::core::Abi for SE_ACCESS_REPLY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SE_ACCESS_REPLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ACCESS_REPLY>()) == 0 }
+        self.Size == other.Size && self.ResultListCount == other.ResultListCount && self.GrantedAccess == other.GrantedAccess && self.AccessStatus == other.AccessStatus && self.AccessReason == other.AccessReason && self.Privileges == other.Privileges
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4428,7 +4376,7 @@ unsafe impl ::windows::core::Abi for SE_ACCESS_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SE_ACCESS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_ACCESS_REQUEST>()) == 0 }
+        self.Size == other.Size && self.SeSecurityDescriptor == other.SeSecurityDescriptor && self.DesiredAccess == other.DesiredAccess && self.PreviouslyGrantedAccess == other.PreviouslyGrantedAccess && self.PrincipalSelfSid == other.PrincipalSelfSid && self.GenericMapping == other.GenericMapping && self.ObjectTypeListCount == other.ObjectTypeListCount && self.ObjectTypeList == other.ObjectTypeList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4469,7 +4417,7 @@ unsafe impl ::windows::core::Abi for SE_IMPERSONATION_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SE_IMPERSONATION_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_IMPERSONATION_STATE>()) == 0 }
+        self.Token == other.Token && self.CopyOnOpen == other.CopyOnOpen && self.EffectiveOnly == other.EffectiveOnly && self.Level == other.Level
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4503,7 +4451,7 @@ unsafe impl ::windows::core::Abi for SE_SECURITY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for SE_SECURITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_SECURITY_DESCRIPTOR>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.SecurityDescriptor == other.SecurityDescriptor
     }
 }
 impl ::core::cmp::Eq for SE_SECURITY_DESCRIPTOR {}
@@ -4527,12 +4475,6 @@ impl ::core::clone::Clone for SE_SID {
 unsafe impl ::windows::core::Abi for SE_SID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SE_SID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_SID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SE_SID {}
 impl ::core::default::Default for SE_SID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4562,7 +4504,7 @@ unsafe impl ::windows::core::Abi for SID {
 }
 impl ::core::cmp::PartialEq for SID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID>()) == 0 }
+        self.Revision == other.Revision && self.SubAuthorityCount == other.SubAuthorityCount && self.IdentifierAuthority == other.IdentifierAuthority && self.SubAuthority == other.SubAuthority
     }
 }
 impl ::core::cmp::Eq for SID {}
@@ -4599,7 +4541,7 @@ unsafe impl ::windows::core::Abi for SID_AND_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SID_AND_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID_AND_ATTRIBUTES>()) == 0 }
+        self.Sid == other.Sid && self.Attributes == other.Attributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4639,7 +4581,7 @@ unsafe impl ::windows::core::Abi for SID_AND_ATTRIBUTES_HASH {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SID_AND_ATTRIBUTES_HASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID_AND_ATTRIBUTES_HASH>()) == 0 }
+        self.SidCount == other.SidCount && self.SidAttr == other.SidAttr && self.Hash == other.Hash
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4671,7 +4613,7 @@ unsafe impl ::windows::core::Abi for SID_IDENTIFIER_AUTHORITY {
 }
 impl ::core::cmp::PartialEq for SID_IDENTIFIER_AUTHORITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SID_IDENTIFIER_AUTHORITY>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for SID_IDENTIFIER_AUTHORITY {}
@@ -4703,7 +4645,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_ACCESS_FILTER_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_ACCESS_FILTER_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_ACCESS_FILTER_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_ACCESS_FILTER_ACE {}
@@ -4735,7 +4677,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_ALARM_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_ALARM_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_ALARM_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_ALARM_ACE {}
@@ -4767,7 +4709,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_ALARM_CALLBACK_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_ALARM_CALLBACK_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_ALARM_CALLBACK_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_ALARM_CALLBACK_ACE {}
@@ -4802,7 +4744,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_ALARM_CALLBACK_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_ALARM_CALLBACK_OBJECT_ACE {}
@@ -4837,7 +4779,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_ALARM_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_ALARM_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_ALARM_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_ALARM_OBJECT_ACE {}
@@ -4869,7 +4811,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_AUDIT_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_AUDIT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_AUDIT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_AUDIT_ACE {}
@@ -4901,7 +4843,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_AUDIT_CALLBACK_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_AUDIT_CALLBACK_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_AUDIT_CALLBACK_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_AUDIT_CALLBACK_ACE {}
@@ -4936,7 +4878,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_AUDIT_CALLBACK_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {}
@@ -4971,7 +4913,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_AUDIT_OBJECT_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_AUDIT_OBJECT_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_AUDIT_OBJECT_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.Flags == other.Flags && self.ObjectType == other.ObjectType && self.InheritedObjectType == other.InheritedObjectType && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_AUDIT_OBJECT_ACE {}
@@ -5003,7 +4945,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_MANDATORY_LABEL_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_MANDATORY_LABEL_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_MANDATORY_LABEL_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_MANDATORY_LABEL_ACE {}
@@ -5035,7 +4977,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_PROCESS_TRUST_LABEL_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_PROCESS_TRUST_LABEL_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_PROCESS_TRUST_LABEL_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_PROCESS_TRUST_LABEL_ACE {}
@@ -5067,7 +5009,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_RESOURCE_ATTRIBUTE_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_RESOURCE_ATTRIBUTE_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_RESOURCE_ATTRIBUTE_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_RESOURCE_ATTRIBUTE_ACE {}
@@ -5099,7 +5041,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_SCOPED_POLICY_ID_ACE {
 }
 impl ::core::cmp::PartialEq for SYSTEM_SCOPED_POLICY_ID_ACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_SCOPED_POLICY_ID_ACE>()) == 0 }
+        self.Header == other.Header && self.Mask == other.Mask && self.SidStart == other.SidStart
     }
 }
 impl ::core::cmp::Eq for SYSTEM_SCOPED_POLICY_ID_ACE {}
@@ -5161,7 +5103,7 @@ unsafe impl ::windows::core::Abi for TOKEN_ACCESS_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_ACCESS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_ACCESS_INFORMATION>()) == 0 }
+        self.SidHash == other.SidHash && self.RestrictedSidHash == other.RestrictedSidHash && self.Privileges == other.Privileges && self.AuthenticationId == other.AuthenticationId && self.TokenType == other.TokenType && self.ImpersonationLevel == other.ImpersonationLevel && self.MandatoryPolicy == other.MandatoryPolicy && self.Flags == other.Flags && self.AppContainerNumber == other.AppContainerNumber && self.PackageSid == other.PackageSid && self.CapabilitiesHash == other.CapabilitiesHash && self.TrustLevelSid == other.TrustLevelSid && self.SecurityAttributes == other.SecurityAttributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5199,7 +5141,7 @@ unsafe impl ::windows::core::Abi for TOKEN_APPCONTAINER_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_APPCONTAINER_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_APPCONTAINER_INFORMATION>()) == 0 }
+        self.TokenAppContainer == other.TokenAppContainer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5231,7 +5173,7 @@ unsafe impl ::windows::core::Abi for TOKEN_AUDIT_POLICY {
 }
 impl ::core::cmp::PartialEq for TOKEN_AUDIT_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_AUDIT_POLICY>()) == 0 }
+        self.PerUserPolicy == other.PerUserPolicy
     }
 }
 impl ::core::cmp::Eq for TOKEN_AUDIT_POLICY {}
@@ -5270,7 +5212,7 @@ unsafe impl ::windows::core::Abi for TOKEN_CONTROL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_CONTROL>()) == 0 }
+        self.TokenId == other.TokenId && self.AuthenticationId == other.AuthenticationId && self.ModifiedId == other.ModifiedId && self.TokenSource == other.TokenSource
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5302,7 +5244,7 @@ unsafe impl ::windows::core::Abi for TOKEN_DEFAULT_DACL {
 }
 impl ::core::cmp::PartialEq for TOKEN_DEFAULT_DACL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_DEFAULT_DACL>()) == 0 }
+        self.DefaultDacl == other.DefaultDacl
     }
 }
 impl ::core::cmp::Eq for TOKEN_DEFAULT_DACL {}
@@ -5332,7 +5274,7 @@ unsafe impl ::windows::core::Abi for TOKEN_DEVICE_CLAIMS {
 }
 impl ::core::cmp::PartialEq for TOKEN_DEVICE_CLAIMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_DEVICE_CLAIMS>()) == 0 }
+        self.DeviceClaims == other.DeviceClaims
     }
 }
 impl ::core::cmp::Eq for TOKEN_DEVICE_CLAIMS {}
@@ -5362,7 +5304,7 @@ unsafe impl ::windows::core::Abi for TOKEN_ELEVATION {
 }
 impl ::core::cmp::PartialEq for TOKEN_ELEVATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_ELEVATION>()) == 0 }
+        self.TokenIsElevated == other.TokenIsElevated
     }
 }
 impl ::core::cmp::Eq for TOKEN_ELEVATION {}
@@ -5399,7 +5341,7 @@ unsafe impl ::windows::core::Abi for TOKEN_GROUPS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_GROUPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_GROUPS>()) == 0 }
+        self.GroupCount == other.GroupCount && self.Groups == other.Groups
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5457,7 +5399,7 @@ unsafe impl ::windows::core::Abi for TOKEN_GROUPS_AND_PRIVILEGES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_GROUPS_AND_PRIVILEGES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_GROUPS_AND_PRIVILEGES>()) == 0 }
+        self.SidCount == other.SidCount && self.SidLength == other.SidLength && self.Sids == other.Sids && self.RestrictedSidCount == other.RestrictedSidCount && self.RestrictedSidLength == other.RestrictedSidLength && self.RestrictedSids == other.RestrictedSids && self.PrivilegeCount == other.PrivilegeCount && self.PrivilegeLength == other.PrivilegeLength && self.Privileges == other.Privileges && self.AuthenticationId == other.AuthenticationId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5495,7 +5437,7 @@ unsafe impl ::windows::core::Abi for TOKEN_LINKED_TOKEN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_LINKED_TOKEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_LINKED_TOKEN>()) == 0 }
+        self.LinkedToken == other.LinkedToken
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5533,7 +5475,7 @@ unsafe impl ::windows::core::Abi for TOKEN_MANDATORY_LABEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_MANDATORY_LABEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_MANDATORY_LABEL>()) == 0 }
+        self.Label == other.Label
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5565,7 +5507,7 @@ unsafe impl ::windows::core::Abi for TOKEN_MANDATORY_POLICY {
 }
 impl ::core::cmp::PartialEq for TOKEN_MANDATORY_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_MANDATORY_POLICY>()) == 0 }
+        self.Policy == other.Policy
     }
 }
 impl ::core::cmp::Eq for TOKEN_MANDATORY_POLICY {}
@@ -5601,7 +5543,7 @@ unsafe impl ::windows::core::Abi for TOKEN_ORIGIN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_ORIGIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_ORIGIN>()) == 0 }
+        self.OriginatingLogonSession == other.OriginatingLogonSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5639,7 +5581,7 @@ unsafe impl ::windows::core::Abi for TOKEN_OWNER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_OWNER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_OWNER>()) == 0 }
+        self.Owner == other.Owner
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5677,7 +5619,7 @@ unsafe impl ::windows::core::Abi for TOKEN_PRIMARY_GROUP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_PRIMARY_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_PRIMARY_GROUP>()) == 0 }
+        self.PrimaryGroup == other.PrimaryGroup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5716,7 +5658,7 @@ unsafe impl ::windows::core::Abi for TOKEN_PRIVILEGES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_PRIVILEGES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_PRIVILEGES>()) == 0 }
+        self.PrivilegeCount == other.PrivilegeCount && self.Privileges == other.Privileges
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5755,7 +5697,7 @@ unsafe impl ::windows::core::Abi for TOKEN_SOURCE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_SOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_SOURCE>()) == 0 }
+        self.SourceName == other.SourceName && self.SourceIdentifier == other.SourceIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5802,7 +5744,7 @@ unsafe impl ::windows::core::Abi for TOKEN_STATISTICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_STATISTICS>()) == 0 }
+        self.TokenId == other.TokenId && self.AuthenticationId == other.AuthenticationId && self.ExpirationTime == other.ExpirationTime && self.TokenType == other.TokenType && self.ImpersonationLevel == other.ImpersonationLevel && self.DynamicCharged == other.DynamicCharged && self.DynamicAvailable == other.DynamicAvailable && self.GroupCount == other.GroupCount && self.PrivilegeCount == other.PrivilegeCount && self.ModifiedId == other.ModifiedId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5840,7 +5782,7 @@ unsafe impl ::windows::core::Abi for TOKEN_USER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_USER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_USER>()) == 0 }
+        self.User == other.User
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5872,7 +5814,7 @@ unsafe impl ::windows::core::Abi for TOKEN_USER_CLAIMS {
 }
 impl ::core::cmp::PartialEq for TOKEN_USER_CLAIMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_USER_CLAIMS>()) == 0 }
+        self.UserClaims == other.UserClaims
     }
 }
 impl ::core::cmp::Eq for TOKEN_USER_CLAIMS {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
@@ -383,7 +383,7 @@ unsafe impl ::windows::core::Abi for CCAB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CCAB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCAB>()) == 0 }
+        self.cb == other.cb && self.cbFolderThresh == other.cbFolderThresh && self.cbReserveCFHeader == other.cbReserveCFHeader && self.cbReserveCFFolder == other.cbReserveCFFolder && self.cbReserveCFData == other.cbReserveCFData && self.iCab == other.iCab && self.iDisk == other.iDisk && self.fFailOnIncompressible == other.fFailOnIncompressible && self.setID == other.setID && self.szDisk == other.szDisk && self.szCab == other.szCab && self.szCabPath == other.szCabPath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -423,7 +423,7 @@ unsafe impl ::windows::core::Abi for ERF {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ERF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERF>()) == 0 }
+        self.erfOper == other.erfOper && self.erfType == other.erfType && self.fError == other.fError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -468,7 +468,7 @@ unsafe impl ::windows::core::Abi for FDICABINETINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FDICABINETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDICABINETINFO>()) == 0 }
+        self.cbCabinet == other.cbCabinet && self.cFolders == other.cFolders && self.cFiles == other.cFiles && self.setID == other.setID && self.iCabinet == other.iCabinet && self.fReserve == other.fReserve && self.hasprev == other.hasprev && self.hasnext == other.hasnext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -500,14 +500,6 @@ unsafe impl ::windows::core::Abi for FDIDECRYPT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FDIDECRYPT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDIDECRYPT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FDIDECRYPT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FDIDECRYPT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -533,14 +525,6 @@ impl ::core::clone::Clone for FDIDECRYPT_0 {
 unsafe impl ::windows::core::Abi for FDIDECRYPT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FDIDECRYPT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDIDECRYPT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FDIDECRYPT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FDIDECRYPT_0 {
     fn default() -> Self {
@@ -577,7 +561,7 @@ unsafe impl ::windows::core::Abi for FDIDECRYPT_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FDIDECRYPT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDIDECRYPT_0_0>()) == 0 }
+        self.pHeaderReserve == other.pHeaderReserve && self.cbHeaderReserve == other.cbHeaderReserve && self.setID == other.setID && self.iCabinet == other.iCabinet
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -620,7 +604,7 @@ unsafe impl ::windows::core::Abi for FDIDECRYPT_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FDIDECRYPT_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDIDECRYPT_0_1>()) == 0 }
+        self.pDataReserve == other.pDataReserve && self.cbDataReserve == other.cbDataReserve && self.pbData == other.pbData && self.cbData == other.cbData && self.fSplit == other.fSplit && self.cbPartial == other.cbPartial
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -660,7 +644,7 @@ unsafe impl ::windows::core::Abi for FDIDECRYPT_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FDIDECRYPT_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDIDECRYPT_0_2>()) == 0 }
+        self.pFolderReserve == other.pFolderReserve && self.cbFolderReserve == other.cbFolderReserve && self.iFolder == other.iFolder
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -704,7 +688,7 @@ unsafe impl ::windows::core::Abi for FDINOTIFICATION {
 }
 impl ::core::cmp::PartialEq for FDINOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDINOTIFICATION>()) == 0 }
+        self.cb == other.cb && self.psz1 == other.psz1 && self.psz2 == other.psz2 && self.psz3 == other.psz3 && self.pv == other.pv && self.hf == other.hf && self.date == other.date && self.time == other.time && self.attribs == other.attribs && self.setID == other.setID && self.iCabinet == other.iCabinet && self.iFolder == other.iFolder && self.fdie == other.fdie
     }
 }
 impl ::core::cmp::Eq for FDINOTIFICATION {}
@@ -738,16 +722,6 @@ unsafe impl ::windows::core::Abi for FDISPILLFILE {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FDISPILLFILE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDISPILLFILE>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FDISPILLFILE {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FDISPILLFILE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -776,16 +750,6 @@ impl ::core::clone::Clone for FDISPILLFILE {
 unsafe impl ::windows::core::Abi for FDISPILLFILE {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FDISPILLFILE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FDISPILLFILE>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FDISPILLFILE {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FDISPILLFILE {

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -2967,7 +2967,25 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
 impl ::core::cmp::PartialEq for CF_CALLBACK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_INFO>()) == 0 }
+        self.StructSize == other.StructSize
+            && self.ConnectionKey == other.ConnectionKey
+            && self.CallbackContext == other.CallbackContext
+            && self.VolumeGuidName == other.VolumeGuidName
+            && self.VolumeDosName == other.VolumeDosName
+            && self.VolumeSerialNumber == other.VolumeSerialNumber
+            && self.SyncRootFileId == other.SyncRootFileId
+            && self.SyncRootIdentity == other.SyncRootIdentity
+            && self.SyncRootIdentityLength == other.SyncRootIdentityLength
+            && self.FileId == other.FileId
+            && self.FileSize == other.FileSize
+            && self.FileIdentity == other.FileIdentity
+            && self.FileIdentityLength == other.FileIdentityLength
+            && self.NormalizedPath == other.NormalizedPath
+            && self.TransferKey == other.TransferKey
+            && self.PriorityHint == other.PriorityHint
+            && self.CorrelationVector == other.CorrelationVector
+            && self.ProcessInfo == other.ProcessInfo
+            && self.RequestKey == other.RequestKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
@@ -2993,12 +3011,6 @@ impl ::core::clone::Clone for CF_CALLBACK_PARAMETERS {
 unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS {}
 impl ::core::default::Default for CF_CALLBACK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3029,12 +3041,6 @@ impl ::core::clone::Clone for CF_CALLBACK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0 {}
 impl ::core::default::Default for CF_CALLBACK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3055,12 +3061,6 @@ impl ::core::clone::Clone for CF_CALLBACK_PARAMETERS_0_0 {
 unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_0 {}
 impl ::core::default::Default for CF_CALLBACK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3080,12 +3080,6 @@ impl ::core::clone::Clone for CF_CALLBACK_PARAMETERS_0_0_0 {
 unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_0_0 {}
 impl ::core::default::Default for CF_CALLBACK_PARAMETERS_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3113,7 +3107,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_0_0_0 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_0_0_0>()) == 0 }
+        self.FileOffset == other.FileOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_0_0_0 {}
@@ -3143,7 +3137,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_1 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_1>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_1 {}
@@ -3174,7 +3168,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_2 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_2>()) == 0 }
+        self.Flags == other.Flags && self.Reason == other.Reason
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_2 {}
@@ -3205,7 +3199,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_3 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_3>()) == 0 }
+        self.Flags == other.Flags && self.Reason == other.Reason
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_3 {}
@@ -3235,7 +3229,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_4 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_4>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_4 {}
@@ -3265,7 +3259,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_5 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_5>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_5 {}
@@ -3301,7 +3295,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_6 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_6>()) == 0 }
+        self.Flags == other.Flags && self.RequiredFileOffset == other.RequiredFileOffset && self.RequiredLength == other.RequiredLength && self.OptionalFileOffset == other.OptionalFileOffset && self.OptionalLength == other.OptionalLength && self.LastDehydrationTime == other.LastDehydrationTime && self.LastDehydrationReason == other.LastDehydrationReason
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_6 {}
@@ -3332,7 +3326,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_7 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_7>()) == 0 }
+        self.Flags == other.Flags && self.Pattern == other.Pattern
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_7 {}
@@ -3362,7 +3356,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_8 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_8>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_8 {}
@@ -3393,7 +3387,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_9 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_9>()) == 0 }
+        self.Flags == other.Flags && self.SourcePath == other.SourcePath
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_9 {}
@@ -3424,7 +3418,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_10 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_10>()) == 0 }
+        self.Flags == other.Flags && self.TargetPath == other.TargetPath
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_10 {}
@@ -3456,7 +3450,7 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_PARAMETERS_0_11 {
 }
 impl ::core::cmp::PartialEq for CF_CALLBACK_PARAMETERS_0_11 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_PARAMETERS_0_11>()) == 0 }
+        self.Flags == other.Flags && self.RequiredFileOffset == other.RequiredFileOffset && self.RequiredLength == other.RequiredLength
     }
 }
 impl ::core::cmp::Eq for CF_CALLBACK_PARAMETERS_0_11 {}
@@ -3483,21 +3477,13 @@ impl ::core::clone::Clone for CF_CALLBACK_REGISTRATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
 impl ::core::fmt::Debug for CF_CALLBACK_REGISTRATION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CF_CALLBACK_REGISTRATION").field("Type", &self.Type).field("Callback", &self.Callback.map(|f| f as usize)).finish()
+        f.debug_struct("CF_CALLBACK_REGISTRATION").field("Type", &self.Type).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
 unsafe impl ::windows::core::Abi for CF_CALLBACK_REGISTRATION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
-impl ::core::cmp::PartialEq for CF_CALLBACK_REGISTRATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_CALLBACK_REGISTRATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
-impl ::core::cmp::Eq for CF_CALLBACK_REGISTRATION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
 impl ::core::default::Default for CF_CALLBACK_REGISTRATION {
     fn default() -> Self {
@@ -3558,7 +3544,7 @@ unsafe impl ::windows::core::Abi for CF_FILE_RANGE {
 }
 impl ::core::cmp::PartialEq for CF_FILE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_FILE_RANGE>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for CF_FILE_RANGE {}
@@ -3595,7 +3581,7 @@ unsafe impl ::windows::core::Abi for CF_FS_METADATA {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for CF_FS_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_FS_METADATA>()) == 0 }
+        self.BasicInfo == other.BasicInfo && self.FileSize == other.FileSize
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -3628,7 +3614,7 @@ unsafe impl ::windows::core::Abi for CF_HYDRATION_POLICY {
 }
 impl ::core::cmp::PartialEq for CF_HYDRATION_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_HYDRATION_POLICY>()) == 0 }
+        self.Primary == other.Primary && self.Modifier == other.Modifier
     }
 }
 impl ::core::cmp::Eq for CF_HYDRATION_POLICY {}
@@ -3658,7 +3644,7 @@ unsafe impl ::windows::core::Abi for CF_HYDRATION_POLICY_MODIFIER_USHORT {
 }
 impl ::core::cmp::PartialEq for CF_HYDRATION_POLICY_MODIFIER_USHORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_HYDRATION_POLICY_MODIFIER_USHORT>()) == 0 }
+        self.us == other.us
     }
 }
 impl ::core::cmp::Eq for CF_HYDRATION_POLICY_MODIFIER_USHORT {}
@@ -3688,7 +3674,7 @@ unsafe impl ::windows::core::Abi for CF_HYDRATION_POLICY_PRIMARY_USHORT {
 }
 impl ::core::cmp::PartialEq for CF_HYDRATION_POLICY_PRIMARY_USHORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_HYDRATION_POLICY_PRIMARY_USHORT>()) == 0 }
+        self.us == other.us
     }
 }
 impl ::core::cmp::Eq for CF_HYDRATION_POLICY_PRIMARY_USHORT {}
@@ -3730,7 +3716,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_INFO>()) == 0 }
+        self.StructSize == other.StructSize && self.Type == other.Type && self.ConnectionKey == other.ConnectionKey && self.TransferKey == other.TransferKey && self.CorrelationVector == other.CorrelationVector && self.SyncStatus == other.SyncStatus && self.RequestKey == other.RequestKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_CorrelationVector"))]
@@ -3760,14 +3746,6 @@ impl ::core::clone::Clone for CF_OPERATION_PARAMETERS {
 unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
-impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
-impl ::core::cmp::Eq for CF_OPERATION_PARAMETERS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::default::Default for CF_OPERATION_PARAMETERS {
     fn default() -> Self {
@@ -3799,14 +3777,6 @@ impl ::core::clone::Clone for CF_OPERATION_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
-impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
-impl ::core::cmp::Eq for CF_OPERATION_PARAMETERS_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::default::Default for CF_OPERATION_PARAMETERS_0 {
     fn default() -> Self {
@@ -3843,7 +3813,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_0>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -3884,7 +3854,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_1>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus && self.FileIdentity == other.FileIdentity && self.FileIdentityLength == other.FileIdentityLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -3923,7 +3893,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_2>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -3962,7 +3932,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_3 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_3>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -4003,7 +3973,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_4 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_4>()) == 0 }
+        self.Flags == other.Flags && self.FsMetadata == other.FsMetadata && self.FileIdentity == other.FileIdentity && self.FileIdentityLength == other.FileIdentityLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -4045,7 +4015,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_5 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_5>()) == 0 }
+        self.Flags == other.Flags && self.Buffer == other.Buffer && self.Offset == other.Offset && self.Length == other.Length && self.ReturnedLength == other.ReturnedLength
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -4087,7 +4057,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_6 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_6>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus && self.Buffer == other.Buffer && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -4130,7 +4100,7 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_PARAMETERS_0_7 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for CF_OPERATION_PARAMETERS_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_OPERATION_PARAMETERS_0_7>()) == 0 }
+        self.Flags == other.Flags && self.CompletionStatus == other.CompletionStatus && self.PlaceholderTotalCount == other.PlaceholderTotalCount && self.PlaceholderArray == other.PlaceholderArray && self.PlaceholderCount == other.PlaceholderCount && self.EntriesProcessed == other.EntriesProcessed
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -4167,7 +4137,7 @@ unsafe impl ::windows::core::Abi for CF_PLACEHOLDER_BASIC_INFO {
 }
 impl ::core::cmp::PartialEq for CF_PLACEHOLDER_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_PLACEHOLDER_BASIC_INFO>()) == 0 }
+        self.PinState == other.PinState && self.InSyncState == other.InSyncState && self.FileId == other.FileId && self.SyncRootFileId == other.SyncRootFileId && self.FileIdentityLength == other.FileIdentityLength && self.FileIdentity == other.FileIdentity
     }
 }
 impl ::core::cmp::Eq for CF_PLACEHOLDER_BASIC_INFO {}
@@ -4209,7 +4179,7 @@ unsafe impl ::windows::core::Abi for CF_PLACEHOLDER_CREATE_INFO {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for CF_PLACEHOLDER_CREATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_PLACEHOLDER_CREATE_INFO>()) == 0 }
+        self.RelativeFileName == other.RelativeFileName && self.FsMetadata == other.FsMetadata && self.FileIdentity == other.FileIdentity && self.FileIdentityLength == other.FileIdentityLength && self.Flags == other.Flags && self.Result == other.Result && self.CreateUsn == other.CreateUsn
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -4261,7 +4231,7 @@ unsafe impl ::windows::core::Abi for CF_PLACEHOLDER_STANDARD_INFO {
 }
 impl ::core::cmp::PartialEq for CF_PLACEHOLDER_STANDARD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_PLACEHOLDER_STANDARD_INFO>()) == 0 }
+        self.OnDiskDataSize == other.OnDiskDataSize && self.ValidatedDataSize == other.ValidatedDataSize && self.ModifiedDataSize == other.ModifiedDataSize && self.PropertiesSize == other.PropertiesSize && self.PinState == other.PinState && self.InSyncState == other.InSyncState && self.FileId == other.FileId && self.SyncRootFileId == other.SyncRootFileId && self.FileIdentityLength == other.FileIdentityLength && self.FileIdentity == other.FileIdentity
     }
 }
 impl ::core::cmp::Eq for CF_PLACEHOLDER_STANDARD_INFO {}
@@ -4293,7 +4263,7 @@ unsafe impl ::windows::core::Abi for CF_PLATFORM_INFO {
 }
 impl ::core::cmp::PartialEq for CF_PLATFORM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_PLATFORM_INFO>()) == 0 }
+        self.BuildNumber == other.BuildNumber && self.RevisionNumber == other.RevisionNumber && self.IntegrationNumber == other.IntegrationNumber
     }
 }
 impl ::core::cmp::Eq for CF_PLATFORM_INFO {}
@@ -4324,7 +4294,7 @@ unsafe impl ::windows::core::Abi for CF_POPULATION_POLICY {
 }
 impl ::core::cmp::PartialEq for CF_POPULATION_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_POPULATION_POLICY>()) == 0 }
+        self.Primary == other.Primary && self.Modifier == other.Modifier
     }
 }
 impl ::core::cmp::Eq for CF_POPULATION_POLICY {}
@@ -4354,7 +4324,7 @@ unsafe impl ::windows::core::Abi for CF_POPULATION_POLICY_MODIFIER_USHORT {
 }
 impl ::core::cmp::PartialEq for CF_POPULATION_POLICY_MODIFIER_USHORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_POPULATION_POLICY_MODIFIER_USHORT>()) == 0 }
+        self.us == other.us
     }
 }
 impl ::core::cmp::Eq for CF_POPULATION_POLICY_MODIFIER_USHORT {}
@@ -4384,7 +4354,7 @@ unsafe impl ::windows::core::Abi for CF_POPULATION_POLICY_PRIMARY_USHORT {
 }
 impl ::core::cmp::PartialEq for CF_POPULATION_POLICY_PRIMARY_USHORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_POPULATION_POLICY_PRIMARY_USHORT>()) == 0 }
+        self.us == other.us
     }
 }
 impl ::core::cmp::Eq for CF_POPULATION_POLICY_PRIMARY_USHORT {}
@@ -4420,7 +4390,7 @@ unsafe impl ::windows::core::Abi for CF_PROCESS_INFO {
 }
 impl ::core::cmp::PartialEq for CF_PROCESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_PROCESS_INFO>()) == 0 }
+        self.StructSize == other.StructSize && self.ProcessId == other.ProcessId && self.ImagePath == other.ImagePath && self.PackageName == other.PackageName && self.ApplicationId == other.ApplicationId && self.CommandLine == other.CommandLine && self.SessionId == other.SessionId
     }
 }
 impl ::core::cmp::Eq for CF_PROCESS_INFO {}
@@ -4455,7 +4425,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_POLICIES {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_POLICIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_POLICIES>()) == 0 }
+        self.StructSize == other.StructSize && self.Hydration == other.Hydration && self.Population == other.Population && self.InSync == other.InSync && self.HardLink == other.HardLink && self.PlaceholderManagement == other.PlaceholderManagement
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_POLICIES {}
@@ -4492,7 +4462,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_REGISTRATION {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_REGISTRATION>()) == 0 }
+        self.StructSize == other.StructSize && self.ProviderName == other.ProviderName && self.ProviderVersion == other.ProviderVersion && self.SyncRootIdentity == other.SyncRootIdentity && self.SyncRootIdentityLength == other.SyncRootIdentityLength && self.FileIdentity == other.FileIdentity && self.FileIdentityLength == other.FileIdentityLength && self.ProviderId == other.ProviderId
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_REGISTRATION {}
@@ -4522,7 +4492,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_ROOT_BASIC_INFO {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_ROOT_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_ROOT_BASIC_INFO>()) == 0 }
+        self.SyncRootFileId == other.SyncRootFileId
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_ROOT_BASIC_INFO {}
@@ -4554,7 +4524,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_ROOT_PROVIDER_INFO {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_ROOT_PROVIDER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_ROOT_PROVIDER_INFO>()) == 0 }
+        self.ProviderStatus == other.ProviderStatus && self.ProviderName == other.ProviderName && self.ProviderVersion == other.ProviderVersion
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_ROOT_PROVIDER_INFO {}
@@ -4604,7 +4574,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_ROOT_STANDARD_INFO {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_ROOT_STANDARD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_ROOT_STANDARD_INFO>()) == 0 }
+        self.SyncRootFileId == other.SyncRootFileId && self.HydrationPolicy == other.HydrationPolicy && self.PopulationPolicy == other.PopulationPolicy && self.InSyncPolicy == other.InSyncPolicy && self.HardLinkPolicy == other.HardLinkPolicy && self.ProviderStatus == other.ProviderStatus && self.ProviderName == other.ProviderName && self.ProviderVersion == other.ProviderVersion && self.SyncRootIdentityLength == other.SyncRootIdentityLength && self.SyncRootIdentity == other.SyncRootIdentity
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_ROOT_STANDARD_INFO {}
@@ -4639,7 +4609,7 @@ unsafe impl ::windows::core::Abi for CF_SYNC_STATUS {
 }
 impl ::core::cmp::PartialEq for CF_SYNC_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CF_SYNC_STATUS>()) == 0 }
+        self.StructSize == other.StructSize && self.Code == other.Code && self.DescriptionOffset == other.DescriptionOffset && self.DescriptionLength == other.DescriptionLength && self.DeviceIdOffset == other.DeviceIdOffset && self.DeviceIdLength == other.DeviceIdLength
     }
 }
 impl ::core::cmp::Eq for CF_SYNC_STATUS {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
@@ -212,18 +212,12 @@ impl ::core::clone::Clone for COMPRESS_ALLOCATION_ROUTINES {
 }
 impl ::core::fmt::Debug for COMPRESS_ALLOCATION_ROUTINES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("COMPRESS_ALLOCATION_ROUTINES").field("Allocate", &self.Allocate.map(|f| f as usize)).field("Free", &self.Free.map(|f| f as usize)).field("UserContext", &self.UserContext).finish()
+        f.debug_struct("COMPRESS_ALLOCATION_ROUTINES").field("UserContext", &self.UserContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for COMPRESS_ALLOCATION_ROUTINES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COMPRESS_ALLOCATION_ROUTINES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPRESS_ALLOCATION_ROUTINES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COMPRESS_ALLOCATION_ROUTINES {}
 impl ::core::default::Default for COMPRESS_ALLOCATION_ROUTINES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
@@ -638,7 +638,7 @@ unsafe impl ::windows::core::Abi for DDP_FILE_EXTENT {
 }
 impl ::core::cmp::PartialEq for DDP_FILE_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDP_FILE_EXTENT>()) == 0 }
+        self.Length == other.Length && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for DDP_FILE_EXTENT {}
@@ -671,7 +671,7 @@ unsafe impl ::windows::core::Abi for DEDUP_CHUNK_INFO_HASH32 {
 }
 impl ::core::cmp::PartialEq for DEDUP_CHUNK_INFO_HASH32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEDUP_CHUNK_INFO_HASH32>()) == 0 }
+        self.ChunkFlags == other.ChunkFlags && self.ChunkOffsetInStream == other.ChunkOffsetInStream && self.ChunkSize == other.ChunkSize && self.HashVal == other.HashVal
     }
 }
 impl ::core::cmp::Eq for DEDUP_CHUNK_INFO_HASH32 {}
@@ -703,7 +703,7 @@ unsafe impl ::windows::core::Abi for DEDUP_CONTAINER_EXTENT {
 }
 impl ::core::cmp::PartialEq for DEDUP_CONTAINER_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEDUP_CONTAINER_EXTENT>()) == 0 }
+        self.ContainerIndex == other.ContainerIndex && self.StartOffset == other.StartOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for DEDUP_CONTAINER_EXTENT {}
@@ -736,7 +736,7 @@ unsafe impl ::windows::core::Abi for DedupChunk {
 }
 impl ::core::cmp::PartialEq for DedupChunk {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DedupChunk>()) == 0 }
+        self.Hash == other.Hash && self.Flags == other.Flags && self.LogicalSize == other.LogicalSize && self.DataSize == other.DataSize
     }
 }
 impl ::core::cmp::Eq for DedupChunk {}
@@ -766,7 +766,7 @@ unsafe impl ::windows::core::Abi for DedupHash {
 }
 impl ::core::cmp::PartialEq for DedupHash {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DedupHash>()) == 0 }
+        self.Hash == other.Hash
     }
 }
 impl ::core::cmp::Eq for DedupHash {}
@@ -830,7 +830,7 @@ unsafe impl ::windows::core::Abi for DedupStreamEntry {
 }
 impl ::core::cmp::PartialEq for DedupStreamEntry {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DedupStreamEntry>()) == 0 }
+        self.Hash == other.Hash && self.LogicalSize == other.LogicalSize && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for DedupStreamEntry {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/DistributedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DistributedFileSystem/mod.rs
@@ -388,7 +388,7 @@ unsafe impl ::windows::core::Abi for DFS_GET_PKT_ENTRY_STATE_ARG {
 }
 impl ::core::cmp::PartialEq for DFS_GET_PKT_ENTRY_STATE_ARG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_GET_PKT_ENTRY_STATE_ARG>()) == 0 }
+        self.DfsEntryPathLen == other.DfsEntryPathLen && self.ServerNameLen == other.ServerNameLen && self.ShareNameLen == other.ShareNameLen && self.Level == other.Level && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for DFS_GET_PKT_ENTRY_STATE_ARG {}
@@ -418,7 +418,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_1 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_1>()) == 0 }
+        self.EntryPath == other.EntryPath
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_1 {}
@@ -448,7 +448,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_100 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_100 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_100>()) == 0 }
+        self.Comment == other.Comment
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_100 {}
@@ -478,7 +478,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_101 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_101 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_101>()) == 0 }
+        self.State == other.State
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_101 {}
@@ -508,7 +508,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_102 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_102 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_102>()) == 0 }
+        self.Timeout == other.Timeout
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_102 {}
@@ -539,7 +539,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_103 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_103 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_103>()) == 0 }
+        self.PropertyFlagMask == other.PropertyFlagMask && self.PropertyFlags == other.PropertyFlags
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_103 {}
@@ -569,7 +569,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_104 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_104 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_104>()) == 0 }
+        self.TargetPriority == other.TargetPriority
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_104 {}
@@ -603,7 +603,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_105 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_105 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_105>()) == 0 }
+        self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.PropertyFlagMask == other.PropertyFlagMask && self.PropertyFlags == other.PropertyFlags
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_105 {}
@@ -634,7 +634,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_106 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_106 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_106>()) == 0 }
+        self.State == other.State && self.TargetPriority == other.TargetPriority
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_106 {}
@@ -676,7 +676,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_107 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for DFS_INFO_107 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_107>()) == 0 }
+        self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.PropertyFlagMask == other.PropertyFlagMask && self.PropertyFlags == other.PropertyFlags && self.SdLengthReserved == other.SdLengthReserved && self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -715,7 +715,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_150 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for DFS_INFO_150 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_150>()) == 0 }
+        self.SdLengthReserved == other.SdLengthReserved && self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -753,7 +753,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_1_32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DFS_INFO_1_32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_1_32>()) == 0 }
+        self.EntryPath == other.EntryPath
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -788,7 +788,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_2 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_2>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.NumberOfStorages == other.NumberOfStorages
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_2 {}
@@ -818,7 +818,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_200 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_200 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_200>()) == 0 }
+        self.FtDfsName == other.FtDfsName
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_200 {}
@@ -857,7 +857,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_2_32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DFS_INFO_2_32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_2_32>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.NumberOfStorages == other.NumberOfStorages
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -893,7 +893,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_3 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_3>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_3 {}
@@ -924,7 +924,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_300 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_300 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_300>()) == 0 }
+        self.Flags == other.Flags && self.DfsName == other.DfsName
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_300 {}
@@ -964,7 +964,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_3_32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DFS_INFO_3_32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_3_32>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1002,7 +1002,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_4 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_4>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_4 {}
@@ -1044,7 +1044,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_4_32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DFS_INFO_4_32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_4_32>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1083,7 +1083,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_5 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_5>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.PropertyFlags == other.PropertyFlags && self.MetadataSize == other.MetadataSize && self.NumberOfStorages == other.NumberOfStorages
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_5 {}
@@ -1115,7 +1115,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_50 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_50 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_50>()) == 0 }
+        self.NamespaceMajorVersion == other.NamespaceMajorVersion && self.NamespaceMinorVersion == other.NamespaceMinorVersion && self.NamespaceCapabilities == other.NamespaceCapabilities
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_50 {}
@@ -1153,7 +1153,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_6 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_6>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.PropertyFlags == other.PropertyFlags && self.MetadataSize == other.MetadataSize && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_6 {}
@@ -1183,7 +1183,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_7 {
 }
 impl ::core::cmp::PartialEq for DFS_INFO_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_7>()) == 0 }
+        self.GenerationGuid == other.GenerationGuid
     }
 }
 impl ::core::cmp::Eq for DFS_INFO_7 {}
@@ -1228,7 +1228,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_8 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for DFS_INFO_8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_8>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.PropertyFlags == other.PropertyFlags && self.MetadataSize == other.MetadataSize && self.SdLengthReserved == other.SdLengthReserved && self.pSecurityDescriptor == other.pSecurityDescriptor && self.NumberOfStorages == other.NumberOfStorages
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -1276,7 +1276,7 @@ unsafe impl ::windows::core::Abi for DFS_INFO_9 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for DFS_INFO_9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_INFO_9>()) == 0 }
+        self.EntryPath == other.EntryPath && self.Comment == other.Comment && self.State == other.State && self.Timeout == other.Timeout && self.Guid == other.Guid && self.PropertyFlags == other.PropertyFlags && self.MetadataSize == other.MetadataSize && self.SdLengthReserved == other.SdLengthReserved && self.pSecurityDescriptor == other.pSecurityDescriptor && self.NumberOfStorages == other.NumberOfStorages && self.Storage == other.Storage
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -1309,7 +1309,7 @@ unsafe impl ::windows::core::Abi for DFS_SITELIST_INFO {
 }
 impl ::core::cmp::PartialEq for DFS_SITELIST_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_SITELIST_INFO>()) == 0 }
+        self.cSites == other.cSites && self.Site == other.Site
     }
 }
 impl ::core::cmp::Eq for DFS_SITELIST_INFO {}
@@ -1340,7 +1340,7 @@ unsafe impl ::windows::core::Abi for DFS_SITENAME_INFO {
 }
 impl ::core::cmp::PartialEq for DFS_SITENAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_SITENAME_INFO>()) == 0 }
+        self.SiteFlags == other.SiteFlags && self.SiteName == other.SiteName
     }
 }
 impl ::core::cmp::Eq for DFS_SITENAME_INFO {}
@@ -1372,7 +1372,7 @@ unsafe impl ::windows::core::Abi for DFS_STORAGE_INFO {
 }
 impl ::core::cmp::PartialEq for DFS_STORAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_STORAGE_INFO>()) == 0 }
+        self.State == other.State && self.ServerName == other.ServerName && self.ShareName == other.ShareName
     }
 }
 impl ::core::cmp::Eq for DFS_STORAGE_INFO {}
@@ -1410,7 +1410,7 @@ unsafe impl ::windows::core::Abi for DFS_STORAGE_INFO_0_32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DFS_STORAGE_INFO_0_32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_STORAGE_INFO_0_32>()) == 0 }
+        self.State == other.State && self.ServerName == other.ServerName && self.ShareName == other.ShareName
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1445,7 +1445,7 @@ unsafe impl ::windows::core::Abi for DFS_STORAGE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for DFS_STORAGE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_STORAGE_INFO_1>()) == 0 }
+        self.State == other.State && self.ServerName == other.ServerName && self.ShareName == other.ShareName && self.TargetPriority == other.TargetPriority
     }
 }
 impl ::core::cmp::Eq for DFS_STORAGE_INFO_1 {}
@@ -1480,7 +1480,7 @@ unsafe impl ::windows::core::Abi for DFS_SUPPORTED_NAMESPACE_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for DFS_SUPPORTED_NAMESPACE_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_SUPPORTED_NAMESPACE_VERSION_INFO>()) == 0 }
+        self.DomainDfsMajorVersion == other.DomainDfsMajorVersion && self.DomainDfsMinorVersion == other.DomainDfsMinorVersion && self.DomainDfsCapabilities == other.DomainDfsCapabilities && self.StandaloneDfsMajorVersion == other.StandaloneDfsMajorVersion && self.StandaloneDfsMinorVersion == other.StandaloneDfsMinorVersion && self.StandaloneDfsCapabilities == other.StandaloneDfsCapabilities
     }
 }
 impl ::core::cmp::Eq for DFS_SUPPORTED_NAMESPACE_VERSION_INFO {}
@@ -1512,7 +1512,7 @@ unsafe impl ::windows::core::Abi for DFS_TARGET_PRIORITY {
 }
 impl ::core::cmp::PartialEq for DFS_TARGET_PRIORITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DFS_TARGET_PRIORITY>()) == 0 }
+        self.TargetPriorityClass == other.TargetPriorityClass && self.TargetPriorityRank == other.TargetPriorityRank && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DFS_TARGET_PRIORITY {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
@@ -4234,7 +4234,7 @@ unsafe impl ::windows::core::Abi for ACT_AUTHORIZATION_STATE {
 }
 impl ::core::cmp::PartialEq for ACT_AUTHORIZATION_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACT_AUTHORIZATION_STATE>()) == 0 }
+        self.ulState == other.ulState
     }
 }
 impl ::core::cmp::Eq for ACT_AUTHORIZATION_STATE {}
@@ -4322,7 +4322,32 @@ unsafe impl ::windows::core::Abi for ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION 
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION>()) == 0 }
+        self.CurrentAdminFailures == other.CurrentAdminFailures
+            && self.CurrentUserFailures == other.CurrentUserFailures
+            && self.TotalUserAuthenticationCount == other.TotalUserAuthenticationCount
+            && self.TotalAdminAuthenticationCount == other.TotalAdminAuthenticationCount
+            && self.FipsCompliant == other.FipsCompliant
+            && self.SecurityIDAvailable == other.SecurityIDAvailable
+            && self.InitializeInProgress == other.InitializeInProgress
+            && self.ITMSArmed == other.ITMSArmed
+            && self.ITMSArmable == other.ITMSArmable
+            && self.UserCreated == other.UserCreated
+            && self.ResetOnPORDefault == other.ResetOnPORDefault
+            && self.ResetOnPORCurrent == other.ResetOnPORCurrent
+            && self.MaxAdminFailures == other.MaxAdminFailures
+            && self.MaxUserFailures == other.MaxUserFailures
+            && self.TimeToCompleteInitialization == other.TimeToCompleteInitialization
+            && self.TimeRemainingToCompleteInitialization == other.TimeRemainingToCompleteInitialization
+            && self.MinTimeToAuthenticate == other.MinTimeToAuthenticate
+            && self.MaxAdminPasswordSize == other.MaxAdminPasswordSize
+            && self.MinAdminPasswordSize == other.MinAdminPasswordSize
+            && self.MaxAdminHintSize == other.MaxAdminHintSize
+            && self.MaxUserPasswordSize == other.MaxUserPasswordSize
+            && self.MinUserPasswordSize == other.MinUserPasswordSize
+            && self.MaxUserHintSize == other.MaxUserHintSize
+            && self.MaxUserNameSize == other.MaxUserNameSize
+            && self.MaxSiloNameSize == other.MaxSiloNameSize
+            && self.MaxChallengeSize == other.MaxChallengeSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4360,7 +4385,7 @@ unsafe impl ::windows::core::Abi for SILO_INFO {
 }
 impl ::core::cmp::PartialEq for SILO_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SILO_INFO>()) == 0 }
+        self.ulSTID == other.ulSTID && self.SpecificationMajor == other.SpecificationMajor && self.SpecificationMinor == other.SpecificationMinor && self.ImplementationMajor == other.ImplementationMajor && self.ImplementationMinor == other.ImplementationMinor && self.r#type == other.r#type && self.capabilities == other.capabilities
     }
 }
 impl ::core::cmp::Eq for SILO_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -9456,7 +9456,7 @@ unsafe impl ::windows::core::Abi for BY_HANDLE_FILE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BY_HANDLE_FILE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BY_HANDLE_FILE_INFORMATION>()) == 0 }
+        self.dwFileAttributes == other.dwFileAttributes && self.ftCreationTime == other.ftCreationTime && self.ftLastAccessTime == other.ftLastAccessTime && self.ftLastWriteTime == other.ftLastWriteTime && self.dwVolumeSerialNumber == other.dwVolumeSerialNumber && self.nFileSizeHigh == other.nFileSizeHigh && self.nFileSizeLow == other.nFileSizeLow && self.nNumberOfLinks == other.nNumberOfLinks && self.nFileIndexHigh == other.nFileIndexHigh && self.nFileIndexLow == other.nFileIndexLow
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9489,7 +9489,7 @@ unsafe impl ::windows::core::Abi for CLFS_LOG_NAME_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CLFS_LOG_NAME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_LOG_NAME_INFORMATION>()) == 0 }
+        self.NameLengthInBytes == other.NameLengthInBytes && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for CLFS_LOG_NAME_INFORMATION {}
@@ -9521,7 +9521,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_NOTIFICATION>()) == 0 }
+        self.Notification == other.Notification && self.Lsn == other.Lsn && self.LogIsPinned == other.LogIsPinned
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_NOTIFICATION {}
@@ -9548,12 +9548,6 @@ impl ::core::clone::Clone for CLFS_MGMT_POLICY {
 unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLFS_MGMT_POLICY {}
 impl ::core::default::Default for CLFS_MGMT_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9582,12 +9576,6 @@ impl ::core::clone::Clone for CLFS_MGMT_POLICY_0 {
 unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0 {}
 impl ::core::default::Default for CLFS_MGMT_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9614,7 +9602,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_0 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_0>()) == 0 }
+        self.Enabled == other.Enabled
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_0 {}
@@ -9644,7 +9632,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_1 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_1>()) == 0 }
+        self.Percentage == other.Percentage
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_1 {}
@@ -9675,7 +9663,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_2 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_2>()) == 0 }
+        self.AbsoluteGrowthInContainers == other.AbsoluteGrowthInContainers && self.RelativeGrowthPercentage == other.RelativeGrowthPercentage
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_2 {}
@@ -9706,7 +9694,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_3 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_3>()) == 0 }
+        self.MinimumAvailablePercentage == other.MinimumAvailablePercentage && self.MinimumAvailableContainers == other.MinimumAvailableContainers
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_3 {}
@@ -9736,7 +9724,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_4 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_4>()) == 0 }
+        self.Containers == other.Containers
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_4 {}
@@ -9766,7 +9754,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_5 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_5>()) == 0 }
+        self.Containers == other.Containers
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_5 {}
@@ -9797,7 +9785,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_6 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_6>()) == 0 }
+        self.ExtensionLengthInBytes == other.ExtensionLengthInBytes && self.ExtensionString == other.ExtensionString
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_6 {}
@@ -9828,7 +9816,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_7 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_7>()) == 0 }
+        self.PrefixLengthInBytes == other.PrefixLengthInBytes && self.PrefixString == other.PrefixString
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_7 {}
@@ -9858,7 +9846,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_8 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_8>()) == 0 }
+        self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_8 {}
@@ -9888,7 +9876,7 @@ unsafe impl ::windows::core::Abi for CLFS_MGMT_POLICY_0_9 {
 }
 impl ::core::cmp::PartialEq for CLFS_MGMT_POLICY_0_9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_MGMT_POLICY_0_9>()) == 0 }
+        self.NextContainerSuffix == other.NextContainerSuffix
     }
 }
 impl ::core::cmp::Eq for CLFS_MGMT_POLICY_0_9 {}
@@ -9919,7 +9907,7 @@ unsafe impl ::windows::core::Abi for CLFS_NODE_ID {
 }
 impl ::core::cmp::PartialEq for CLFS_NODE_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_NODE_ID>()) == 0 }
+        self.cType == other.cType && self.cbNode == other.cbNode
     }
 }
 impl ::core::cmp::Eq for CLFS_NODE_ID {}
@@ -9951,7 +9939,7 @@ unsafe impl ::windows::core::Abi for CLFS_PHYSICAL_LSN_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CLFS_PHYSICAL_LSN_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_PHYSICAL_LSN_INFORMATION>()) == 0 }
+        self.StreamIdentifier == other.StreamIdentifier && self.VirtualLsn == other.VirtualLsn && self.PhysicalLsn == other.PhysicalLsn
     }
 }
 impl ::core::cmp::Eq for CLFS_PHYSICAL_LSN_INFORMATION {}
@@ -9981,7 +9969,7 @@ unsafe impl ::windows::core::Abi for CLFS_STREAM_ID_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CLFS_STREAM_ID_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLFS_STREAM_ID_INFORMATION>()) == 0 }
+        self.StreamIdentifier == other.StreamIdentifier
     }
 }
 impl ::core::cmp::Eq for CLFS_STREAM_ID_INFORMATION {}
@@ -10013,7 +10001,7 @@ unsafe impl ::windows::core::Abi for CLS_ARCHIVE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for CLS_ARCHIVE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_ARCHIVE_DESCRIPTOR>()) == 0 }
+        self.coffLow == other.coffLow && self.coffHigh == other.coffHigh && self.infoContainer == other.infoContainer
     }
 }
 impl ::core::cmp::Eq for CLS_ARCHIVE_DESCRIPTOR {}
@@ -10065,7 +10053,7 @@ unsafe impl ::windows::core::Abi for CLS_CONTAINER_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CLS_CONTAINER_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_CONTAINER_INFORMATION>()) == 0 }
+        self.FileAttributes == other.FileAttributes && self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ContainerSize == other.ContainerSize && self.FileNameActualLength == other.FileNameActualLength && self.FileNameLength == other.FileNameLength && self.FileName == other.FileName && self.State == other.State && self.PhysicalContainerId == other.PhysicalContainerId && self.LogicalContainerId == other.LogicalContainerId
     }
 }
 impl ::core::cmp::Eq for CLS_CONTAINER_INFORMATION {}
@@ -10129,7 +10117,7 @@ unsafe impl ::windows::core::Abi for CLS_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CLS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_INFORMATION>()) == 0 }
+        self.TotalAvailable == other.TotalAvailable && self.CurrentAvailable == other.CurrentAvailable && self.TotalReservation == other.TotalReservation && self.BaseFileSize == other.BaseFileSize && self.ContainerSize == other.ContainerSize && self.TotalContainers == other.TotalContainers && self.FreeContainers == other.FreeContainers && self.TotalClients == other.TotalClients && self.Attributes == other.Attributes && self.FlushThreshold == other.FlushThreshold && self.SectorSize == other.SectorSize && self.MinArchiveTailLsn == other.MinArchiveTailLsn && self.BaseLsn == other.BaseLsn && self.LastFlushedLsn == other.LastFlushedLsn && self.LastLsn == other.LastLsn && self.RestartLsn == other.RestartLsn && self.Identity == other.Identity
     }
 }
 impl ::core::cmp::Eq for CLS_INFORMATION {}
@@ -10163,7 +10151,7 @@ unsafe impl ::windows::core::Abi for CLS_IO_STATISTICS {
 }
 impl ::core::cmp::PartialEq for CLS_IO_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_IO_STATISTICS>()) == 0 }
+        self.hdrIoStats == other.hdrIoStats && self.cFlush == other.cFlush && self.cbFlush == other.cbFlush && self.cMetaFlush == other.cMetaFlush && self.cbMetaFlush == other.cbMetaFlush
     }
 }
 impl ::core::cmp::Eq for CLS_IO_STATISTICS {}
@@ -10197,7 +10185,7 @@ unsafe impl ::windows::core::Abi for CLS_IO_STATISTICS_HEADER {
 }
 impl ::core::cmp::PartialEq for CLS_IO_STATISTICS_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_IO_STATISTICS_HEADER>()) == 0 }
+        self.ubMajorVersion == other.ubMajorVersion && self.ubMinorVersion == other.ubMinorVersion && self.eStatsClass == other.eStatsClass && self.cbLength == other.cbLength && self.coffData == other.coffData
     }
 }
 impl ::core::cmp::Eq for CLS_IO_STATISTICS_HEADER {}
@@ -10227,7 +10215,7 @@ unsafe impl ::windows::core::Abi for CLS_LSN {
 }
 impl ::core::cmp::PartialEq for CLS_LSN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_LSN>()) == 0 }
+        self.Internal == other.Internal
     }
 }
 impl ::core::cmp::Eq for CLS_LSN {}
@@ -10269,7 +10257,7 @@ unsafe impl ::windows::core::Abi for CLS_SCAN_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLS_SCAN_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_SCAN_CONTEXT>()) == 0 }
+        self.cidNode == other.cidNode && self.hLog == other.hLog && self.cIndex == other.cIndex && self.cContainers == other.cContainers && self.cContainersReturned == other.cContainersReturned && self.eScanMode == other.eScanMode && self.pinfoContainer == other.pinfoContainer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10302,7 +10290,7 @@ unsafe impl ::windows::core::Abi for CLS_WRITE_ENTRY {
 }
 impl ::core::cmp::PartialEq for CLS_WRITE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLS_WRITE_ENTRY>()) == 0 }
+        self.Buffer == other.Buffer && self.ByteLength == other.ByteLength
     }
 }
 impl ::core::cmp::Eq for CLS_WRITE_ENTRY {}
@@ -10332,7 +10320,7 @@ unsafe impl ::windows::core::Abi for CONNECTION_INFO_0 {
 }
 impl ::core::cmp::PartialEq for CONNECTION_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTION_INFO_0>()) == 0 }
+        self.coni0_id == other.coni0_id
     }
 }
 impl ::core::cmp::Eq for CONNECTION_INFO_0 {}
@@ -10368,7 +10356,7 @@ unsafe impl ::windows::core::Abi for CONNECTION_INFO_1 {
 }
 impl ::core::cmp::PartialEq for CONNECTION_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONNECTION_INFO_1>()) == 0 }
+        self.coni1_id == other.coni1_id && self.coni1_type == other.coni1_type && self.coni1_num_opens == other.coni1_num_opens && self.coni1_num_users == other.coni1_num_users && self.coni1_time == other.coni1_time && self.coni1_username == other.coni1_username && self.coni1_netname == other.coni1_netname
     }
 }
 impl ::core::cmp::Eq for CONNECTION_INFO_1 {}
@@ -10398,21 +10386,13 @@ impl ::core::clone::Clone for COPYFILE2_EXTENDED_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for COPYFILE2_EXTENDED_PARAMETERS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("COPYFILE2_EXTENDED_PARAMETERS").field("dwSize", &self.dwSize).field("dwCopyFlags", &self.dwCopyFlags).field("pfCancel", &self.pfCancel).field("pProgressRoutine", &self.pProgressRoutine.map(|f| f as usize)).field("pvCallbackContext", &self.pvCallbackContext).finish()
+        f.debug_struct("COPYFILE2_EXTENDED_PARAMETERS").field("dwSize", &self.dwSize).field("dwCopyFlags", &self.dwCopyFlags).field("pfCancel", &self.pfCancel).field("pvCallbackContext", &self.pvCallbackContext).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for COPYFILE2_EXTENDED_PARAMETERS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COPYFILE2_EXTENDED_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_EXTENDED_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COPYFILE2_EXTENDED_PARAMETERS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COPYFILE2_EXTENDED_PARAMETERS {
     fn default() -> Self {
@@ -10444,21 +10424,13 @@ impl ::core::clone::Clone for COPYFILE2_EXTENDED_PARAMETERS_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for COPYFILE2_EXTENDED_PARAMETERS_V2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("COPYFILE2_EXTENDED_PARAMETERS_V2").field("dwSize", &self.dwSize).field("dwCopyFlags", &self.dwCopyFlags).field("pfCancel", &self.pfCancel).field("pProgressRoutine", &self.pProgressRoutine.map(|f| f as usize)).field("pvCallbackContext", &self.pvCallbackContext).field("dwCopyFlagsV2", &self.dwCopyFlagsV2).field("ioDesiredSize", &self.ioDesiredSize).field("ioDesiredRate", &self.ioDesiredRate).field("reserved", &self.reserved).finish()
+        f.debug_struct("COPYFILE2_EXTENDED_PARAMETERS_V2").field("dwSize", &self.dwSize).field("dwCopyFlags", &self.dwCopyFlags).field("pfCancel", &self.pfCancel).field("pvCallbackContext", &self.pvCallbackContext).field("dwCopyFlagsV2", &self.dwCopyFlagsV2).field("ioDesiredSize", &self.ioDesiredSize).field("ioDesiredRate", &self.ioDesiredRate).field("reserved", &self.reserved).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for COPYFILE2_EXTENDED_PARAMETERS_V2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COPYFILE2_EXTENDED_PARAMETERS_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_EXTENDED_PARAMETERS_V2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COPYFILE2_EXTENDED_PARAMETERS_V2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COPYFILE2_EXTENDED_PARAMETERS_V2 {
     fn default() -> Self {
@@ -10485,14 +10457,6 @@ impl ::core::clone::Clone for COPYFILE2_MESSAGE {
 unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COPYFILE2_MESSAGE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COPYFILE2_MESSAGE {
     fn default() -> Self {
@@ -10522,14 +10486,6 @@ impl ::core::clone::Clone for COPYFILE2_MESSAGE_0 {
 unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for COPYFILE2_MESSAGE_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for COPYFILE2_MESSAGE_0 {
     fn default() -> Self {
@@ -10583,7 +10539,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_0>()) == 0 }
+        self.dwStreamNumber == other.dwStreamNumber && self.dwFlags == other.dwFlags && self.hSourceFile == other.hSourceFile && self.hDestinationFile == other.hDestinationFile && self.uliChunkNumber == other.uliChunkNumber && self.uliChunkSize == other.uliChunkSize && self.uliStreamSize == other.uliStreamSize && self.uliStreamBytesTransferred == other.uliStreamBytesTransferred && self.uliTotalFileSize == other.uliTotalFileSize && self.uliTotalBytesTransferred == other.uliTotalBytesTransferred
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10628,7 +10584,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_1>()) == 0 }
+        self.dwStreamNumber == other.dwStreamNumber && self.dwReserved == other.dwReserved && self.hSourceFile == other.hSourceFile && self.hDestinationFile == other.hDestinationFile && self.uliChunkNumber == other.uliChunkNumber && self.uliChunkSize == other.uliChunkSize && self.uliStreamSize == other.uliStreamSize && self.uliTotalFileSize == other.uliTotalFileSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10674,7 +10630,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_2>()) == 0 }
+        self.CopyPhase == other.CopyPhase && self.dwStreamNumber == other.dwStreamNumber && self.hrFailure == other.hrFailure && self.dwReserved == other.dwReserved && self.uliChunkNumber == other.uliChunkNumber && self.uliStreamSize == other.uliStreamSize && self.uliStreamBytesTransferred == other.uliStreamBytesTransferred && self.uliTotalFileSize == other.uliTotalFileSize && self.uliTotalBytesTransferred == other.uliTotalBytesTransferred
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10712,7 +10668,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_3>()) == 0 }
+        self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10757,7 +10713,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_4>()) == 0 }
+        self.dwStreamNumber == other.dwStreamNumber && self.dwReserved == other.dwReserved && self.hSourceFile == other.hSourceFile && self.hDestinationFile == other.hDestinationFile && self.uliStreamSize == other.uliStreamSize && self.uliStreamBytesTransferred == other.uliStreamBytesTransferred && self.uliTotalFileSize == other.uliTotalFileSize && self.uliTotalBytesTransferred == other.uliTotalBytesTransferred
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10800,7 +10756,7 @@ unsafe impl ::windows::core::Abi for COPYFILE2_MESSAGE_0_5 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COPYFILE2_MESSAGE_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYFILE2_MESSAGE_0_5>()) == 0 }
+        self.dwStreamNumber == other.dwStreamNumber && self.dwReserved == other.dwReserved && self.hSourceFile == other.hSourceFile && self.hDestinationFile == other.hDestinationFile && self.uliStreamSize == other.uliStreamSize && self.uliTotalFileSize == other.uliTotalFileSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10843,7 +10799,7 @@ unsafe impl ::windows::core::Abi for CREATEFILE2_EXTENDED_PARAMETERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for CREATEFILE2_EXTENDED_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATEFILE2_EXTENDED_PARAMETERS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFileAttributes == other.dwFileAttributes && self.dwFileFlags == other.dwFileFlags && self.dwSecurityQosFlags == other.dwSecurityQosFlags && self.lpSecurityAttributes == other.lpSecurityAttributes && self.hTemplateFile == other.hTemplateFile
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -10877,7 +10833,7 @@ unsafe impl ::windows::core::Abi for DISKQUOTA_USER_INFORMATION {
 }
 impl ::core::cmp::PartialEq for DISKQUOTA_USER_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISKQUOTA_USER_INFORMATION>()) == 0 }
+        self.QuotaUsed == other.QuotaUsed && self.QuotaThreshold == other.QuotaThreshold && self.QuotaLimit == other.QuotaLimit
     }
 }
 impl ::core::cmp::Eq for DISKQUOTA_USER_INFORMATION {}
@@ -10933,7 +10889,19 @@ unsafe impl ::windows::core::Abi for DISK_SPACE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for DISK_SPACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_SPACE_INFORMATION>()) == 0 }
+        self.ActualTotalAllocationUnits == other.ActualTotalAllocationUnits
+            && self.ActualAvailableAllocationUnits == other.ActualAvailableAllocationUnits
+            && self.ActualPoolUnavailableAllocationUnits == other.ActualPoolUnavailableAllocationUnits
+            && self.CallerTotalAllocationUnits == other.CallerTotalAllocationUnits
+            && self.CallerAvailableAllocationUnits == other.CallerAvailableAllocationUnits
+            && self.CallerPoolUnavailableAllocationUnits == other.CallerPoolUnavailableAllocationUnits
+            && self.UsedAllocationUnits == other.UsedAllocationUnits
+            && self.TotalReservedAllocationUnits == other.TotalReservedAllocationUnits
+            && self.VolumeStorageReserveAllocationUnits == other.VolumeStorageReserveAllocationUnits
+            && self.AvailableCommittedAllocationUnits == other.AvailableCommittedAllocationUnits
+            && self.PoolAvailableAllocationUnits == other.PoolAvailableAllocationUnits
+            && self.SectorsPerAllocationUnit == other.SectorsPerAllocationUnit
+            && self.BytesPerSector == other.BytesPerSector
     }
 }
 impl ::core::cmp::Eq for DISK_SPACE_INFORMATION {}
@@ -10965,7 +10933,7 @@ unsafe impl ::windows::core::Abi for EFS_CERTIFICATE_BLOB {
 }
 impl ::core::cmp::PartialEq for EFS_CERTIFICATE_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_CERTIFICATE_BLOB>()) == 0 }
+        self.dwCertEncodingType == other.dwCertEncodingType && self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for EFS_CERTIFICATE_BLOB {}
@@ -10995,7 +10963,7 @@ unsafe impl ::windows::core::Abi for EFS_COMPATIBILITY_INFO {
 }
 impl ::core::cmp::PartialEq for EFS_COMPATIBILITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_COMPATIBILITY_INFO>()) == 0 }
+        self.EfsVersion == other.EfsVersion
     }
 }
 impl ::core::cmp::Eq for EFS_COMPATIBILITY_INFO {}
@@ -11027,7 +10995,7 @@ unsafe impl ::windows::core::Abi for EFS_DECRYPTION_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for EFS_DECRYPTION_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_DECRYPTION_STATUS_INFO>()) == 0 }
+        self.dwDecryptionError == other.dwDecryptionError && self.dwHashOffset == other.dwHashOffset && self.cbHash == other.cbHash
     }
 }
 impl ::core::cmp::Eq for EFS_DECRYPTION_STATUS_INFO {}
@@ -11064,7 +11032,7 @@ unsafe impl ::windows::core::Abi for EFS_ENCRYPTION_STATUS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EFS_ENCRYPTION_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_ENCRYPTION_STATUS_INFO>()) == 0 }
+        self.bHasCurrentKey == other.bHasCurrentKey && self.dwEncryptionError == other.dwEncryptionError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11097,7 +11065,7 @@ unsafe impl ::windows::core::Abi for EFS_HASH_BLOB {
 }
 impl ::core::cmp::PartialEq for EFS_HASH_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_HASH_BLOB>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for EFS_HASH_BLOB {}
@@ -11130,7 +11098,7 @@ unsafe impl ::windows::core::Abi for EFS_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for EFS_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_KEY_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.Entropy == other.Entropy && self.Algorithm == other.Algorithm && self.KeyLength == other.KeyLength
     }
 }
 impl ::core::cmp::Eq for EFS_KEY_INFO {}
@@ -11162,7 +11130,7 @@ unsafe impl ::windows::core::Abi for EFS_PIN_BLOB {
 }
 impl ::core::cmp::PartialEq for EFS_PIN_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_PIN_BLOB>()) == 0 }
+        self.cbPadding == other.cbPadding && self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for EFS_PIN_BLOB {}
@@ -11193,7 +11161,7 @@ unsafe impl ::windows::core::Abi for EFS_RPC_BLOB {
 }
 impl ::core::cmp::PartialEq for EFS_RPC_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_RPC_BLOB>()) == 0 }
+        self.cbData == other.cbData && self.pbData == other.pbData
     }
 }
 impl ::core::cmp::Eq for EFS_RPC_BLOB {}
@@ -11224,7 +11192,7 @@ unsafe impl ::windows::core::Abi for EFS_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for EFS_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EFS_VERSION_INFO>()) == 0 }
+        self.EfsVersion == other.EfsVersion && self.SubVersion == other.SubVersion
     }
 }
 impl ::core::cmp::Eq for EFS_VERSION_INFO {}
@@ -11263,7 +11231,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTED_FILE_METADATA_SIGNATURE {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTED_FILE_METADATA_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTED_FILE_METADATA_SIGNATURE>()) == 0 }
+        self.dwEfsAccessType == other.dwEfsAccessType && self.pCertificatesAdded == other.pCertificatesAdded && self.pEncryptionCertificate == other.pEncryptionCertificate && self.pEfsStreamSignature == other.pEfsStreamSignature
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11303,7 +11271,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_CERTIFICATE {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_CERTIFICATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_CERTIFICATE>()) == 0 }
+        self.cbTotalLength == other.cbTotalLength && self.pUserSid == other.pUserSid && self.pCertBlob == other.pCertBlob
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11344,7 +11312,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_CERTIFICATE_HASH {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_CERTIFICATE_HASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_CERTIFICATE_HASH>()) == 0 }
+        self.cbTotalLength == other.cbTotalLength && self.pUserSid == other.pUserSid && self.pHash == other.pHash && self.lpDisplayInformation == other.lpDisplayInformation
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11383,7 +11351,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_CERTIFICATE_HASH_LIST {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_CERTIFICATE_HASH_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_CERTIFICATE_HASH_LIST>()) == 0 }
+        self.nCert_Hash == other.nCert_Hash && self.pUsers == other.pUsers
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11422,7 +11390,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_CERTIFICATE_LIST {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_CERTIFICATE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_CERTIFICATE_LIST>()) == 0 }
+        self.nUsers == other.nUsers && self.pUsers == other.pUsers
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11462,7 +11430,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_PROTECTOR {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_PROTECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_PROTECTOR>()) == 0 }
+        self.cbTotalLength == other.cbTotalLength && self.pUserSid == other.pUserSid && self.lpProtectorDescriptor == other.lpProtectorDescriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11501,7 +11469,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_PROTECTOR_LIST {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for ENCRYPTION_PROTECTOR_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_PROTECTOR_LIST>()) == 0 }
+        self.nProtectors == other.nProtectors && self.pProtectors == other.pProtectors
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11538,21 +11506,13 @@ impl ::core::clone::Clone for FH_OVERLAPPED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for FH_OVERLAPPED {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("FH_OVERLAPPED").field("Internal", &self.Internal).field("InternalHigh", &self.InternalHigh).field("Offset", &self.Offset).field("OffsetHigh", &self.OffsetHigh).field("hEvent", &self.hEvent).field("pfnCompletion", &self.pfnCompletion.map(|f| f as usize)).field("Reserved1", &self.Reserved1).field("Reserved2", &self.Reserved2).field("Reserved3", &self.Reserved3).field("Reserved4", &self.Reserved4).finish()
+        f.debug_struct("FH_OVERLAPPED").field("Internal", &self.Internal).field("InternalHigh", &self.InternalHigh).field("Offset", &self.Offset).field("OffsetHigh", &self.OffsetHigh).field("hEvent", &self.hEvent).field("Reserved1", &self.Reserved1).field("Reserved2", &self.Reserved2).field("Reserved3", &self.Reserved3).field("Reserved4", &self.Reserved4).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for FH_OVERLAPPED {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FH_OVERLAPPED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FH_OVERLAPPED>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FH_OVERLAPPED {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FH_OVERLAPPED {
     fn default() -> Self {
@@ -11580,7 +11540,7 @@ unsafe impl ::windows::core::Abi for FILE_ALIGNMENT_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ALIGNMENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ALIGNMENT_INFO>()) == 0 }
+        self.AlignmentRequirement == other.AlignmentRequirement
     }
 }
 impl ::core::cmp::Eq for FILE_ALIGNMENT_INFO {}
@@ -11610,7 +11570,7 @@ unsafe impl ::windows::core::Abi for FILE_ALLOCATION_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ALLOCATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ALLOCATION_INFO>()) == 0 }
+        self.AllocationSize == other.AllocationSize
     }
 }
 impl ::core::cmp::Eq for FILE_ALLOCATION_INFO {}
@@ -11641,7 +11601,7 @@ unsafe impl ::windows::core::Abi for FILE_ATTRIBUTE_TAG_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ATTRIBUTE_TAG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>()) == 0 }
+        self.FileAttributes == other.FileAttributes && self.ReparseTag == other.ReparseTag
     }
 }
 impl ::core::cmp::Eq for FILE_ATTRIBUTE_TAG_INFO {}
@@ -11675,7 +11635,7 @@ unsafe impl ::windows::core::Abi for FILE_BASIC_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_BASIC_INFO>()) == 0 }
+        self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.FileAttributes == other.FileAttributes
     }
 }
 impl ::core::cmp::Eq for FILE_BASIC_INFO {}
@@ -11710,7 +11670,7 @@ unsafe impl ::windows::core::Abi for FILE_COMPRESSION_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_COMPRESSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_COMPRESSION_INFO>()) == 0 }
+        self.CompressedFileSize == other.CompressedFileSize && self.CompressionFormat == other.CompressionFormat && self.CompressionUnitShift == other.CompressionUnitShift && self.ChunkShift == other.ChunkShift && self.ClusterShift == other.ClusterShift && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FILE_COMPRESSION_INFO {}
@@ -11746,7 +11706,7 @@ unsafe impl ::windows::core::Abi for FILE_DISPOSITION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_DISPOSITION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_DISPOSITION_INFO>()) == 0 }
+        self.DeleteFile == other.DeleteFile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11778,7 +11738,7 @@ unsafe impl ::windows::core::Abi for FILE_END_OF_FILE_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_END_OF_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_END_OF_FILE_INFO>()) == 0 }
+        self.EndOfFile == other.EndOfFile
     }
 }
 impl ::core::cmp::Eq for FILE_END_OF_FILE_INFO {}
@@ -11809,7 +11769,7 @@ unsafe impl ::windows::core::Abi for FILE_EXTENT {
 }
 impl ::core::cmp::PartialEq for FILE_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_EXTENT>()) == 0 }
+        self.VolumeOffset == other.VolumeOffset && self.ExtentLength == other.ExtentLength
     }
 }
 impl ::core::cmp::Eq for FILE_EXTENT {}
@@ -11863,7 +11823,7 @@ unsafe impl ::windows::core::Abi for FILE_FULL_DIR_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_FULL_DIR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_FULL_DIR_INFO>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.FileIndex == other.FileIndex && self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.EndOfFile == other.EndOfFile && self.AllocationSize == other.AllocationSize && self.FileAttributes == other.FileAttributes && self.FileNameLength == other.FileNameLength && self.EaSize == other.EaSize && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_FULL_DIR_INFO {}
@@ -11893,7 +11853,7 @@ unsafe impl ::windows::core::Abi for FILE_ID_128 {
 }
 impl ::core::cmp::PartialEq for FILE_ID_128 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_128>()) == 0 }
+        self.Identifier == other.Identifier
     }
 }
 impl ::core::cmp::Eq for FILE_ID_128 {}
@@ -11953,7 +11913,7 @@ unsafe impl ::windows::core::Abi for FILE_ID_BOTH_DIR_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ID_BOTH_DIR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_BOTH_DIR_INFO>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.FileIndex == other.FileIndex && self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.EndOfFile == other.EndOfFile && self.AllocationSize == other.AllocationSize && self.FileAttributes == other.FileAttributes && self.FileNameLength == other.FileNameLength && self.EaSize == other.EaSize && self.ShortNameLength == other.ShortNameLength && self.ShortName == other.ShortName && self.FileId == other.FileId && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_ID_BOTH_DIR_INFO {}
@@ -11978,12 +11938,6 @@ impl ::core::clone::Clone for FILE_ID_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for FILE_ID_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_ID_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_ID_DESCRIPTOR {}
 impl ::core::default::Default for FILE_ID_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12005,12 +11959,6 @@ impl ::core::clone::Clone for FILE_ID_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for FILE_ID_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_ID_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_ID_DESCRIPTOR_0 {}
 impl ::core::default::Default for FILE_ID_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12065,7 +12013,7 @@ unsafe impl ::windows::core::Abi for FILE_ID_EXTD_DIR_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ID_EXTD_DIR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_EXTD_DIR_INFO>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.FileIndex == other.FileIndex && self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.EndOfFile == other.EndOfFile && self.AllocationSize == other.AllocationSize && self.FileAttributes == other.FileAttributes && self.FileNameLength == other.FileNameLength && self.EaSize == other.EaSize && self.ReparsePointTag == other.ReparsePointTag && self.FileId == other.FileId && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_ID_EXTD_DIR_INFO {}
@@ -12096,7 +12044,7 @@ unsafe impl ::windows::core::Abi for FILE_ID_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_ID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ID_INFO>()) == 0 }
+        self.VolumeSerialNumber == other.VolumeSerialNumber && self.FileId == other.FileId
     }
 }
 impl ::core::cmp::Eq for FILE_ID_INFO {}
@@ -12126,7 +12074,7 @@ unsafe impl ::windows::core::Abi for FILE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for FILE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_INFO_2>()) == 0 }
+        self.fi2_id == other.fi2_id
     }
 }
 impl ::core::cmp::Eq for FILE_INFO_2 {}
@@ -12160,7 +12108,7 @@ unsafe impl ::windows::core::Abi for FILE_INFO_3 {
 }
 impl ::core::cmp::PartialEq for FILE_INFO_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_INFO_3>()) == 0 }
+        self.fi3_id == other.fi3_id && self.fi3_permissions == other.fi3_permissions && self.fi3_num_locks == other.fi3_num_locks && self.fi3_pathname == other.fi3_pathname && self.fi3_username == other.fi3_username
     }
 }
 impl ::core::cmp::Eq for FILE_INFO_3 {}
@@ -12190,7 +12138,7 @@ unsafe impl ::windows::core::Abi for FILE_IO_PRIORITY_HINT_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_IO_PRIORITY_HINT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_IO_PRIORITY_HINT_INFO>()) == 0 }
+        self.PriorityHint == other.PriorityHint
     }
 }
 impl ::core::cmp::Eq for FILE_IO_PRIORITY_HINT_INFO {}
@@ -12221,7 +12169,7 @@ unsafe impl ::windows::core::Abi for FILE_NAME_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_NAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_NAME_INFO>()) == 0 }
+        self.FileNameLength == other.FileNameLength && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_NAME_INFO {}
@@ -12279,7 +12227,7 @@ unsafe impl ::windows::core::Abi for FILE_NOTIFY_EXTENDED_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILE_NOTIFY_EXTENDED_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_NOTIFY_EXTENDED_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.Action == other.Action && self.CreationTime == other.CreationTime && self.LastModificationTime == other.LastModificationTime && self.LastChangeTime == other.LastChangeTime && self.LastAccessTime == other.LastAccessTime && self.AllocatedLength == other.AllocatedLength && self.FileSize == other.FileSize && self.FileAttributes == other.FileAttributes && self.ReparsePointTag == other.ReparsePointTag && self.FileId == other.FileId && self.ParentFileId == other.ParentFileId && self.FileNameLength == other.FileNameLength && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_NOTIFY_EXTENDED_INFORMATION {}
@@ -12312,7 +12260,7 @@ unsafe impl ::windows::core::Abi for FILE_NOTIFY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILE_NOTIFY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_NOTIFY_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.Action == other.Action && self.FileNameLength == other.FileNameLength && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_NOTIFY_INFORMATION {}
@@ -12344,12 +12292,6 @@ impl ::core::clone::Clone for FILE_REMOTE_PROTOCOL_INFO {
 unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO {}
 impl ::core::default::Default for FILE_REMOTE_PROTOCOL_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12376,7 +12318,7 @@ unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO_0 {
 }
 impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO_0>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO_0 {}
@@ -12400,12 +12342,6 @@ impl ::core::clone::Clone for FILE_REMOTE_PROTOCOL_INFO_1 {
 unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO_1 {}
 impl ::core::default::Default for FILE_REMOTE_PROTOCOL_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12433,7 +12369,7 @@ unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO_1_0 {
 }
 impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO_1_0>()) == 0 }
+        self.Server == other.Server && self.Share == other.Share
     }
 }
 impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO_1_0 {}
@@ -12463,7 +12399,7 @@ unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO_1_0_0 {
 }
 impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO_1_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO_1_0_0>()) == 0 }
+        self.Capabilities == other.Capabilities
     }
 }
 impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO_1_0_0 {}
@@ -12494,7 +12430,7 @@ unsafe impl ::windows::core::Abi for FILE_REMOTE_PROTOCOL_INFO_1_0_1 {
 }
 impl ::core::cmp::PartialEq for FILE_REMOTE_PROTOCOL_INFO_1_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REMOTE_PROTOCOL_INFO_1_0_1>()) == 0 }
+        self.Capabilities == other.Capabilities && self.CachingFlags == other.CachingFlags
     }
 }
 impl ::core::cmp::Eq for FILE_REMOTE_PROTOCOL_INFO_1_0_1 {}
@@ -12525,14 +12461,6 @@ unsafe impl ::windows::core::Abi for FILE_RENAME_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILE_RENAME_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_RENAME_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILE_RENAME_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILE_RENAME_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12558,14 +12486,6 @@ unsafe impl ::windows::core::Abi for FILE_RENAME_INFO_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILE_RENAME_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_RENAME_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILE_RENAME_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILE_RENAME_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12586,12 +12506,6 @@ impl ::core::clone::Clone for FILE_SEGMENT_ELEMENT {
 unsafe impl ::windows::core::Abi for FILE_SEGMENT_ELEMENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_SEGMENT_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_SEGMENT_ELEMENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_SEGMENT_ELEMENT {}
 impl ::core::default::Default for FILE_SEGMENT_ELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12628,7 +12542,7 @@ unsafe impl ::windows::core::Abi for FILE_STANDARD_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_STANDARD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_STANDARD_INFO>()) == 0 }
+        self.AllocationSize == other.AllocationSize && self.EndOfFile == other.EndOfFile && self.NumberOfLinks == other.NumberOfLinks && self.DeletePending == other.DeletePending && self.Directory == other.Directory
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12674,7 +12588,7 @@ unsafe impl ::windows::core::Abi for FILE_STORAGE_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_STORAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_STORAGE_INFO>()) == 0 }
+        self.LogicalBytesPerSector == other.LogicalBytesPerSector && self.PhysicalBytesPerSectorForAtomicity == other.PhysicalBytesPerSectorForAtomicity && self.PhysicalBytesPerSectorForPerformance == other.PhysicalBytesPerSectorForPerformance && self.FileSystemEffectivePhysicalBytesPerSectorForAtomicity == other.FileSystemEffectivePhysicalBytesPerSectorForAtomicity && self.Flags == other.Flags && self.ByteOffsetForSectorAlignment == other.ByteOffsetForSectorAlignment && self.ByteOffsetForPartitionAlignment == other.ByteOffsetForPartitionAlignment
     }
 }
 impl ::core::cmp::Eq for FILE_STORAGE_INFO {}
@@ -12708,7 +12622,7 @@ unsafe impl ::windows::core::Abi for FILE_STREAM_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_STREAM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_STREAM_INFO>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.StreamNameLength == other.StreamNameLength && self.StreamSize == other.StreamSize && self.StreamAllocationSize == other.StreamAllocationSize && self.StreamName == other.StreamName
     }
 }
 impl ::core::cmp::Eq for FILE_STREAM_INFO {}
@@ -12748,7 +12662,7 @@ unsafe impl ::windows::core::Abi for FIO_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FIO_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIO_CONTEXT>()) == 0 }
+        self.m_dwTempHack == other.m_dwTempHack && self.m_dwSignature == other.m_dwSignature && self.m_hFile == other.m_hFile && self.m_dwLinesOffset == other.m_dwLinesOffset && self.m_dwHeaderLength == other.m_dwHeaderLength
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12972,7 +12886,7 @@ unsafe impl ::windows::core::Abi for HIORING__ {
 }
 impl ::core::cmp::PartialEq for HIORING__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIORING__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for HIORING__ {}
@@ -13003,7 +12917,7 @@ unsafe impl ::windows::core::Abi for IORING_BUFFER_INFO {
 }
 impl ::core::cmp::PartialEq for IORING_BUFFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_BUFFER_INFO>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for IORING_BUFFER_INFO {}
@@ -13027,12 +12941,6 @@ impl ::core::clone::Clone for IORING_BUFFER_REF {
 unsafe impl ::windows::core::Abi for IORING_BUFFER_REF {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IORING_BUFFER_REF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_BUFFER_REF>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IORING_BUFFER_REF {}
 impl ::core::default::Default for IORING_BUFFER_REF {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13053,12 +12961,6 @@ impl ::core::clone::Clone for IORING_BUFFER_REF_0 {
 unsafe impl ::windows::core::Abi for IORING_BUFFER_REF_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IORING_BUFFER_REF_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_BUFFER_REF_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IORING_BUFFER_REF_0 {}
 impl ::core::default::Default for IORING_BUFFER_REF_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13088,7 +12990,7 @@ unsafe impl ::windows::core::Abi for IORING_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for IORING_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_CAPABILITIES>()) == 0 }
+        self.MaxVersion == other.MaxVersion && self.MaxSubmissionQueueSize == other.MaxSubmissionQueueSize && self.MaxCompletionQueueSize == other.MaxCompletionQueueSize && self.FeatureFlags == other.FeatureFlags
     }
 }
 impl ::core::cmp::Eq for IORING_CAPABILITIES {}
@@ -13120,7 +13022,7 @@ unsafe impl ::windows::core::Abi for IORING_CQE {
 }
 impl ::core::cmp::PartialEq for IORING_CQE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_CQE>()) == 0 }
+        self.UserData == other.UserData && self.ResultCode == other.ResultCode && self.Information == other.Information
     }
 }
 impl ::core::cmp::Eq for IORING_CQE {}
@@ -13151,7 +13053,7 @@ unsafe impl ::windows::core::Abi for IORING_CREATE_FLAGS {
 }
 impl ::core::cmp::PartialEq for IORING_CREATE_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_CREATE_FLAGS>()) == 0 }
+        self.Required == other.Required && self.Advisory == other.Advisory
     }
 }
 impl ::core::cmp::Eq for IORING_CREATE_FLAGS {}
@@ -13180,14 +13082,6 @@ unsafe impl ::windows::core::Abi for IORING_HANDLE_REF {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IORING_HANDLE_REF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_HANDLE_REF>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IORING_HANDLE_REF {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IORING_HANDLE_REF {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13212,14 +13106,6 @@ impl ::core::clone::Clone for IORING_HANDLE_REF_0 {
 unsafe impl ::windows::core::Abi for IORING_HANDLE_REF_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IORING_HANDLE_REF_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_HANDLE_REF_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IORING_HANDLE_REF_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IORING_HANDLE_REF_0 {
     fn default() -> Self {
@@ -13250,7 +13136,7 @@ unsafe impl ::windows::core::Abi for IORING_INFO {
 }
 impl ::core::cmp::PartialEq for IORING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_INFO>()) == 0 }
+        self.IoRingVersion == other.IoRingVersion && self.Flags == other.Flags && self.SubmissionQueueSize == other.SubmissionQueueSize && self.CompletionQueueSize == other.CompletionQueueSize
     }
 }
 impl ::core::cmp::Eq for IORING_INFO {}
@@ -13281,7 +13167,7 @@ unsafe impl ::windows::core::Abi for IORING_REGISTERED_BUFFER {
 }
 impl ::core::cmp::PartialEq for IORING_REGISTERED_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IORING_REGISTERED_BUFFER>()) == 0 }
+        self.BufferIndex == other.BufferIndex && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for IORING_REGISTERED_BUFFER {}
@@ -13314,7 +13200,7 @@ unsafe impl ::windows::core::Abi for KCRM_MARSHAL_HEADER {
 }
 impl ::core::cmp::PartialEq for KCRM_MARSHAL_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KCRM_MARSHAL_HEADER>()) == 0 }
+        self.VersionMajor == other.VersionMajor && self.VersionMinor == other.VersionMinor && self.NumProtocols == other.NumProtocols && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for KCRM_MARSHAL_HEADER {}
@@ -13348,7 +13234,7 @@ unsafe impl ::windows::core::Abi for KCRM_PROTOCOL_BLOB {
 }
 impl ::core::cmp::PartialEq for KCRM_PROTOCOL_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KCRM_PROTOCOL_BLOB>()) == 0 }
+        self.ProtocolId == other.ProtocolId && self.StaticInfoLength == other.StaticInfoLength && self.TransactionIdInfoLength == other.TransactionIdInfoLength && self.Unused1 == other.Unused1 && self.Unused2 == other.Unused2
     }
 }
 impl ::core::cmp::Eq for KCRM_PROTOCOL_BLOB {}
@@ -13383,7 +13269,7 @@ unsafe impl ::windows::core::Abi for KCRM_TRANSACTION_BLOB {
 }
 impl ::core::cmp::PartialEq for KCRM_TRANSACTION_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KCRM_TRANSACTION_BLOB>()) == 0 }
+        self.UOW == other.UOW && self.TmIdentity == other.TmIdentity && self.IsolationLevel == other.IsolationLevel && self.IsolationFlags == other.IsolationFlags && self.Timeout == other.Timeout && self.Description == other.Description
     }
 }
 impl ::core::cmp::Eq for KCRM_TRANSACTION_BLOB {}
@@ -13412,21 +13298,13 @@ impl ::core::clone::Clone for LOG_MANAGEMENT_CALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for LOG_MANAGEMENT_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LOG_MANAGEMENT_CALLBACKS").field("CallbackContext", &self.CallbackContext).field("AdvanceTailCallback", &self.AdvanceTailCallback.map(|f| f as usize)).field("LogFullHandlerCallback", &self.LogFullHandlerCallback.map(|f| f as usize)).field("LogUnpinnedCallback", &self.LogUnpinnedCallback.map(|f| f as usize)).finish()
+        f.debug_struct("LOG_MANAGEMENT_CALLBACKS").field("CallbackContext", &self.CallbackContext).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for LOG_MANAGEMENT_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for LOG_MANAGEMENT_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOG_MANAGEMENT_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for LOG_MANAGEMENT_CALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for LOG_MANAGEMENT_CALLBACKS {
     fn default() -> Self {
@@ -13457,7 +13335,7 @@ unsafe impl ::windows::core::Abi for MediaLabelInfo {
 }
 impl ::core::cmp::PartialEq for MediaLabelInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MediaLabelInfo>()) == 0 }
+        self.LabelType == other.LabelType && self.LabelIDSize == other.LabelIDSize && self.LabelID == other.LabelID && self.LabelAppDescr == other.LabelAppDescr
     }
 }
 impl ::core::cmp::Eq for MediaLabelInfo {}
@@ -13487,7 +13365,7 @@ unsafe impl ::windows::core::Abi for NAME_CACHE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for NAME_CACHE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAME_CACHE_CONTEXT>()) == 0 }
+        self.m_dwSignature == other.m_dwSignature
     }
 }
 impl ::core::cmp::Eq for NAME_CACHE_CONTEXT {}
@@ -13519,7 +13397,7 @@ unsafe impl ::windows::core::Abi for NTMS_ALLOCATION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_ALLOCATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_ALLOCATION_INFORMATION>()) == 0 }
+        self.dwSize == other.dwSize && self.lpReserved == other.lpReserved && self.AllocatedFrom == other.AllocatedFrom
     }
 }
 impl ::core::cmp::Eq for NTMS_ALLOCATION_INFORMATION {}
@@ -13561,7 +13439,7 @@ unsafe impl ::windows::core::Abi for NTMS_ASYNC_IO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_ASYNC_IO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_ASYNC_IO>()) == 0 }
+        self.OperationId == other.OperationId && self.EventId == other.EventId && self.dwOperationType == other.dwOperationType && self.dwResult == other.dwResult && self.dwAsyncState == other.dwAsyncState && self.hEvent == other.hEvent && self.bOnStateChange == other.bOnStateChange
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13608,7 +13486,7 @@ unsafe impl ::windows::core::Abi for NTMS_CHANGERINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_CHANGERINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_CHANGERINFORMATIONA>()) == 0 }
+        self.Number == other.Number && self.ChangerType == other.ChangerType && self.szSerialNumber == other.szSerialNumber && self.szRevision == other.szRevision && self.szDeviceName == other.szDeviceName && self.ScsiPort == other.ScsiPort && self.ScsiBus == other.ScsiBus && self.ScsiTarget == other.ScsiTarget && self.ScsiLun == other.ScsiLun && self.Library == other.Library
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13649,7 +13527,7 @@ unsafe impl ::windows::core::Abi for NTMS_CHANGERINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_CHANGERINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_CHANGERINFORMATIONW>()) == 0 }
+        self.Number == other.Number && self.ChangerType == other.ChangerType && self.szSerialNumber == other.szSerialNumber && self.szRevision == other.szRevision && self.szDeviceName == other.szDeviceName && self.ScsiPort == other.ScsiPort && self.ScsiBus == other.ScsiBus && self.ScsiTarget == other.ScsiTarget && self.ScsiLun == other.ScsiLun && self.Library == other.Library
     }
 }
 impl ::core::cmp::Eq for NTMS_CHANGERINFORMATIONW {}
@@ -13687,7 +13565,7 @@ unsafe impl ::windows::core::Abi for NTMS_CHANGERTYPEINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_CHANGERTYPEINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_CHANGERTYPEINFORMATIONA>()) == 0 }
+        self.szVendor == other.szVendor && self.szProduct == other.szProduct && self.DeviceType == other.DeviceType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13721,7 +13599,7 @@ unsafe impl ::windows::core::Abi for NTMS_CHANGERTYPEINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_CHANGERTYPEINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_CHANGERTYPEINFORMATIONW>()) == 0 }
+        self.szVendor == other.szVendor && self.szProduct == other.szProduct && self.DeviceType == other.DeviceType
     }
 }
 impl ::core::cmp::Eq for NTMS_CHANGERTYPEINFORMATIONW {}
@@ -13755,7 +13633,7 @@ unsafe impl ::windows::core::Abi for NTMS_COMPUTERINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_COMPUTERINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_COMPUTERINFORMATION>()) == 0 }
+        self.dwLibRequestPurgeTime == other.dwLibRequestPurgeTime && self.dwOpRequestPurgeTime == other.dwOpRequestPurgeTime && self.dwLibRequestFlags == other.dwLibRequestFlags && self.dwOpRequestFlags == other.dwOpRequestFlags && self.dwMediaPoolPolicy == other.dwMediaPoolPolicy
     }
 }
 impl ::core::cmp::Eq for NTMS_COMPUTERINFORMATION {}
@@ -13823,7 +13701,7 @@ unsafe impl ::windows::core::Abi for NTMS_DRIVEINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_DRIVEINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_DRIVEINFORMATIONA>()) == 0 }
+        self.Number == other.Number && self.State == other.State && self.DriveType == other.DriveType && self.szDeviceName == other.szDeviceName && self.szSerialNumber == other.szSerialNumber && self.szRevision == other.szRevision && self.ScsiPort == other.ScsiPort && self.ScsiBus == other.ScsiBus && self.ScsiTarget == other.ScsiTarget && self.ScsiLun == other.ScsiLun && self.dwMountCount == other.dwMountCount && self.LastCleanedTs == other.LastCleanedTs && self.SavedPartitionId == other.SavedPartitionId && self.Library == other.Library && self.Reserved == other.Reserved && self.dwDeferDismountDelay == other.dwDeferDismountDelay
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13893,7 +13771,7 @@ unsafe impl ::windows::core::Abi for NTMS_DRIVEINFORMATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_DRIVEINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_DRIVEINFORMATIONW>()) == 0 }
+        self.Number == other.Number && self.State == other.State && self.DriveType == other.DriveType && self.szDeviceName == other.szDeviceName && self.szSerialNumber == other.szSerialNumber && self.szRevision == other.szRevision && self.ScsiPort == other.ScsiPort && self.ScsiBus == other.ScsiBus && self.ScsiTarget == other.ScsiTarget && self.ScsiLun == other.ScsiLun && self.dwMountCount == other.dwMountCount && self.LastCleanedTs == other.LastCleanedTs && self.SavedPartitionId == other.SavedPartitionId && self.Library == other.Library && self.Reserved == other.Reserved && self.dwDeferDismountDelay == other.dwDeferDismountDelay
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13934,7 +13812,7 @@ unsafe impl ::windows::core::Abi for NTMS_DRIVETYPEINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_DRIVETYPEINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_DRIVETYPEINFORMATIONA>()) == 0 }
+        self.szVendor == other.szVendor && self.szProduct == other.szProduct && self.NumberOfHeads == other.NumberOfHeads && self.DeviceType == other.DeviceType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13969,7 +13847,7 @@ unsafe impl ::windows::core::Abi for NTMS_DRIVETYPEINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_DRIVETYPEINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_DRIVETYPEINFORMATIONW>()) == 0 }
+        self.szVendor == other.szVendor && self.szProduct == other.szProduct && self.NumberOfHeads == other.NumberOfHeads && self.DeviceType == other.DeviceType
     }
 }
 impl ::core::cmp::Eq for NTMS_DRIVETYPEINFORMATIONW {}
@@ -14001,7 +13879,7 @@ unsafe impl ::windows::core::Abi for NTMS_FILESYSTEM_INFO {
 }
 impl ::core::cmp::PartialEq for NTMS_FILESYSTEM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_FILESYSTEM_INFO>()) == 0 }
+        self.FileSystemType == other.FileSystemType && self.VolumeName == other.VolumeName && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for NTMS_FILESYSTEM_INFO {}
@@ -14079,7 +13957,27 @@ unsafe impl ::windows::core::Abi for NTMS_I1_LIBRARYINFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_LIBRARYINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_LIBRARYINFORMATION>()) == 0 }
+        self.LibraryType == other.LibraryType
+            && self.CleanerSlot == other.CleanerSlot
+            && self.CleanerSlotDefault == other.CleanerSlotDefault
+            && self.LibrarySupportsDriveCleaning == other.LibrarySupportsDriveCleaning
+            && self.BarCodeReaderInstalled == other.BarCodeReaderInstalled
+            && self.InventoryMethod == other.InventoryMethod
+            && self.dwCleanerUsesRemaining == other.dwCleanerUsesRemaining
+            && self.FirstDriveNumber == other.FirstDriveNumber
+            && self.dwNumberOfDrives == other.dwNumberOfDrives
+            && self.FirstSlotNumber == other.FirstSlotNumber
+            && self.dwNumberOfSlots == other.dwNumberOfSlots
+            && self.FirstDoorNumber == other.FirstDoorNumber
+            && self.dwNumberOfDoors == other.dwNumberOfDoors
+            && self.FirstPortNumber == other.FirstPortNumber
+            && self.dwNumberOfPorts == other.dwNumberOfPorts
+            && self.FirstChangerNumber == other.FirstChangerNumber
+            && self.dwNumberOfChangers == other.dwNumberOfChangers
+            && self.dwNumberOfMedia == other.dwNumberOfMedia
+            && self.dwNumberOfMediaTypes == other.dwNumberOfMediaTypes
+            && self.dwNumberOfLibRequests == other.dwNumberOfLibRequests
+            && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14143,7 +14041,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_LIBREQUESTINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_LIBREQUESTINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_LIBREQUESTINFORMATIONA>()) == 0 }
+        self.OperationCode == other.OperationCode && self.OperationOption == other.OperationOption && self.State == other.State && self.PartitionId == other.PartitionId && self.DriveId == other.DriveId && self.PhysMediaId == other.PhysMediaId && self.Library == other.Library && self.SlotId == other.SlotId && self.TimeQueued == other.TimeQueued && self.TimeCompleted == other.TimeCompleted && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14207,7 +14105,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_LIBREQUESTINFORMATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_LIBREQUESTINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_LIBREQUESTINFORMATIONW>()) == 0 }
+        self.OperationCode == other.OperationCode && self.OperationOption == other.OperationOption && self.State == other.State && self.PartitionId == other.PartitionId && self.DriveId == other.DriveId && self.PhysMediaId == other.PhysMediaId && self.Library == other.Library && self.SlotId == other.SlotId && self.TimeQueued == other.TimeQueued && self.TimeCompleted == other.TimeCompleted && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14245,14 +14143,6 @@ impl ::core::clone::Clone for NTMS_I1_OBJECTINFORMATIONA {
 unsafe impl ::windows::core::Abi for NTMS_I1_OBJECTINFORMATIONA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_I1_OBJECTINFORMATIONA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OBJECTINFORMATIONA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_I1_OBJECTINFORMATIONA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_I1_OBJECTINFORMATIONA {
     fn default() -> Self {
@@ -14292,14 +14182,6 @@ unsafe impl ::windows::core::Abi for NTMS_I1_OBJECTINFORMATIONA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_I1_OBJECTINFORMATIONA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OBJECTINFORMATIONA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_I1_OBJECTINFORMATIONA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_I1_OBJECTINFORMATIONA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14332,14 +14214,6 @@ impl ::core::clone::Clone for NTMS_I1_OBJECTINFORMATIONW {
 unsafe impl ::windows::core::Abi for NTMS_I1_OBJECTINFORMATIONW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_I1_OBJECTINFORMATIONW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OBJECTINFORMATIONW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_I1_OBJECTINFORMATIONW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_I1_OBJECTINFORMATIONW {
     fn default() -> Self {
@@ -14378,14 +14252,6 @@ impl ::core::clone::Clone for NTMS_I1_OBJECTINFORMATIONW_0 {
 unsafe impl ::windows::core::Abi for NTMS_I1_OBJECTINFORMATIONW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_I1_OBJECTINFORMATIONW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OBJECTINFORMATIONW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_I1_OBJECTINFORMATIONW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_I1_OBJECTINFORMATIONW_0 {
     fn default() -> Self {
@@ -14429,7 +14295,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_OPREQUESTINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_OPREQUESTINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OPREQUESTINFORMATIONA>()) == 0 }
+        self.Request == other.Request && self.Submitted == other.Submitted && self.State == other.State && self.szMessage == other.szMessage && self.Arg1Type == other.Arg1Type && self.Arg1 == other.Arg1 && self.Arg2Type == other.Arg2Type && self.Arg2 == other.Arg2 && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14477,7 +14343,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_OPREQUESTINFORMATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_OPREQUESTINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_OPREQUESTINFORMATIONW>()) == 0 }
+        self.Request == other.Request && self.Submitted == other.Submitted && self.State == other.State && self.szMessage == other.szMessage && self.Arg1Type == other.Arg1Type && self.Arg1 == other.Arg1 && self.Arg2Type == other.Arg2Type && self.Arg2 == other.Arg2 && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14524,7 +14390,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_PARTITIONINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_PARTITIONINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_PARTITIONINFORMATIONA>()) == 0 }
+        self.PhysicalMedia == other.PhysicalMedia && self.LogicalMedia == other.LogicalMedia && self.State == other.State && self.Side == other.Side && self.dwOmidLabelIdLength == other.dwOmidLabelIdLength && self.OmidLabelId == other.OmidLabelId && self.szOmidLabelType == other.szOmidLabelType && self.szOmidLabelInfo == other.szOmidLabelInfo && self.dwMountCount == other.dwMountCount && self.dwAllocateCount == other.dwAllocateCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14565,7 +14431,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_PARTITIONINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_I1_PARTITIONINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_PARTITIONINFORMATIONW>()) == 0 }
+        self.PhysicalMedia == other.PhysicalMedia && self.LogicalMedia == other.LogicalMedia && self.State == other.State && self.Side == other.Side && self.dwOmidLabelIdLength == other.dwOmidLabelIdLength && self.OmidLabelId == other.OmidLabelId && self.szOmidLabelType == other.szOmidLabelType && self.szOmidLabelInfo == other.szOmidLabelInfo && self.dwMountCount == other.dwMountCount && self.dwAllocateCount == other.dwAllocateCount
     }
 }
 impl ::core::cmp::Eq for NTMS_I1_PARTITIONINFORMATIONW {}
@@ -14623,7 +14489,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_PMIDINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_I1_PMIDINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_PMIDINFORMATIONA>()) == 0 }
+        self.CurrentLibrary == other.CurrentLibrary && self.MediaPool == other.MediaPool && self.Location == other.Location && self.LocationType == other.LocationType && self.MediaType == other.MediaType && self.HomeSlot == other.HomeSlot && self.szBarCode == other.szBarCode && self.BarCodeState == other.BarCodeState && self.szSequenceNumber == other.szSequenceNumber && self.MediaState == other.MediaState && self.dwNumberOfPartitions == other.dwNumberOfPartitions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14677,7 +14543,7 @@ unsafe impl ::windows::core::Abi for NTMS_I1_PMIDINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_I1_PMIDINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_I1_PMIDINFORMATIONW>()) == 0 }
+        self.CurrentLibrary == other.CurrentLibrary && self.MediaPool == other.MediaPool && self.Location == other.Location && self.LocationType == other.LocationType && self.MediaType == other.MediaType && self.HomeSlot == other.HomeSlot && self.szBarCode == other.szBarCode && self.BarCodeState == other.BarCodeState && self.szSequenceNumber == other.szSequenceNumber && self.MediaState == other.MediaState && self.dwNumberOfPartitions == other.dwNumberOfPartitions
     }
 }
 impl ::core::cmp::Eq for NTMS_I1_PMIDINFORMATIONW {}
@@ -14710,7 +14576,7 @@ unsafe impl ::windows::core::Abi for NTMS_IEDOORINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_IEDOORINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_IEDOORINFORMATION>()) == 0 }
+        self.Number == other.Number && self.State == other.State && self.MaxOpenSecs == other.MaxOpenSecs && self.Library == other.Library
     }
 }
 impl ::core::cmp::Eq for NTMS_IEDOORINFORMATION {}
@@ -14744,7 +14610,7 @@ unsafe impl ::windows::core::Abi for NTMS_IEPORTINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_IEPORTINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_IEPORTINFORMATION>()) == 0 }
+        self.Number == other.Number && self.Content == other.Content && self.Position == other.Position && self.MaxExtendSecs == other.MaxExtendSecs && self.Library == other.Library
     }
 }
 impl ::core::cmp::Eq for NTMS_IEPORTINFORMATION {}
@@ -14826,7 +14692,29 @@ unsafe impl ::windows::core::Abi for NTMS_LIBRARYINFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_LIBRARYINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_LIBRARYINFORMATION>()) == 0 }
+        self.LibraryType == other.LibraryType
+            && self.CleanerSlot == other.CleanerSlot
+            && self.CleanerSlotDefault == other.CleanerSlotDefault
+            && self.LibrarySupportsDriveCleaning == other.LibrarySupportsDriveCleaning
+            && self.BarCodeReaderInstalled == other.BarCodeReaderInstalled
+            && self.InventoryMethod == other.InventoryMethod
+            && self.dwCleanerUsesRemaining == other.dwCleanerUsesRemaining
+            && self.FirstDriveNumber == other.FirstDriveNumber
+            && self.dwNumberOfDrives == other.dwNumberOfDrives
+            && self.FirstSlotNumber == other.FirstSlotNumber
+            && self.dwNumberOfSlots == other.dwNumberOfSlots
+            && self.FirstDoorNumber == other.FirstDoorNumber
+            && self.dwNumberOfDoors == other.dwNumberOfDoors
+            && self.FirstPortNumber == other.FirstPortNumber
+            && self.dwNumberOfPorts == other.dwNumberOfPorts
+            && self.FirstChangerNumber == other.FirstChangerNumber
+            && self.dwNumberOfChangers == other.dwNumberOfChangers
+            && self.dwNumberOfMedia == other.dwNumberOfMedia
+            && self.dwNumberOfMediaTypes == other.dwNumberOfMediaTypes
+            && self.dwNumberOfLibRequests == other.dwNumberOfLibRequests
+            && self.Reserved == other.Reserved
+            && self.AutoRecovery == other.AutoRecovery
+            && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14896,7 +14784,7 @@ unsafe impl ::windows::core::Abi for NTMS_LIBREQUESTINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_LIBREQUESTINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_LIBREQUESTINFORMATIONA>()) == 0 }
+        self.OperationCode == other.OperationCode && self.OperationOption == other.OperationOption && self.State == other.State && self.PartitionId == other.PartitionId && self.DriveId == other.DriveId && self.PhysMediaId == other.PhysMediaId && self.Library == other.Library && self.SlotId == other.SlotId && self.TimeQueued == other.TimeQueued && self.TimeCompleted == other.TimeCompleted && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer && self.dwErrorCode == other.dwErrorCode && self.WorkItemId == other.WorkItemId && self.dwPriority == other.dwPriority
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14966,7 +14854,7 @@ unsafe impl ::windows::core::Abi for NTMS_LIBREQUESTINFORMATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_LIBREQUESTINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_LIBREQUESTINFORMATIONW>()) == 0 }
+        self.OperationCode == other.OperationCode && self.OperationOption == other.OperationOption && self.State == other.State && self.PartitionId == other.PartitionId && self.DriveId == other.DriveId && self.PhysMediaId == other.PhysMediaId && self.Library == other.Library && self.SlotId == other.SlotId && self.TimeQueued == other.TimeQueued && self.TimeCompleted == other.TimeCompleted && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer && self.dwErrorCode == other.dwErrorCode && self.WorkItemId == other.WorkItemId && self.dwPriority == other.dwPriority
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14999,7 +14887,7 @@ unsafe impl ::windows::core::Abi for NTMS_LMIDINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_LMIDINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_LMIDINFORMATION>()) == 0 }
+        self.MediaPool == other.MediaPool && self.dwNumberOfPartitions == other.dwNumberOfPartitions
     }
 }
 impl ::core::cmp::Eq for NTMS_LMIDINFORMATION {}
@@ -15047,7 +14935,7 @@ unsafe impl ::windows::core::Abi for NTMS_MEDIAPOOLINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_MEDIAPOOLINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_MEDIAPOOLINFORMATION>()) == 0 }
+        self.PoolType == other.PoolType && self.MediaType == other.MediaType && self.Parent == other.Parent && self.AllocationPolicy == other.AllocationPolicy && self.DeallocationPolicy == other.DeallocationPolicy && self.dwMaxAllocates == other.dwMaxAllocates && self.dwNumberOfPhysicalMedia == other.dwNumberOfPhysicalMedia && self.dwNumberOfLogicalMedia == other.dwNumberOfLogicalMedia && self.dwNumberOfMediaPools == other.dwNumberOfMediaPools
     }
 }
 impl ::core::cmp::Eq for NTMS_MEDIAPOOLINFORMATION {}
@@ -15080,7 +14968,7 @@ unsafe impl ::windows::core::Abi for NTMS_MEDIATYPEINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_MEDIATYPEINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_MEDIATYPEINFORMATION>()) == 0 }
+        self.MediaType == other.MediaType && self.NumberOfSides == other.NumberOfSides && self.ReadWriteCharacteristics == other.ReadWriteCharacteristics && self.DeviceType == other.DeviceType
     }
 }
 impl ::core::cmp::Eq for NTMS_MEDIATYPEINFORMATION {}
@@ -15111,7 +14999,7 @@ unsafe impl ::windows::core::Abi for NTMS_MOUNT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_MOUNT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_MOUNT_INFORMATION>()) == 0 }
+        self.dwSize == other.dwSize && self.lpReserved == other.lpReserved
     }
 }
 impl ::core::cmp::Eq for NTMS_MOUNT_INFORMATION {}
@@ -15142,7 +15030,7 @@ unsafe impl ::windows::core::Abi for NTMS_NOTIFICATIONINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_NOTIFICATIONINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_NOTIFICATIONINFORMATION>()) == 0 }
+        self.dwOperation == other.dwOperation && self.ObjectId == other.ObjectId
     }
 }
 impl ::core::cmp::Eq for NTMS_NOTIFICATIONINFORMATION {}
@@ -15178,14 +15066,6 @@ impl ::core::clone::Clone for NTMS_OBJECTINFORMATIONA {
 unsafe impl ::windows::core::Abi for NTMS_OBJECTINFORMATIONA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_OBJECTINFORMATIONA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OBJECTINFORMATIONA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_OBJECTINFORMATIONA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_OBJECTINFORMATIONA {
     fn default() -> Self {
@@ -15226,14 +15106,6 @@ unsafe impl ::windows::core::Abi for NTMS_OBJECTINFORMATIONA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_OBJECTINFORMATIONA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OBJECTINFORMATIONA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_OBJECTINFORMATIONA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_OBJECTINFORMATIONA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15266,14 +15138,6 @@ impl ::core::clone::Clone for NTMS_OBJECTINFORMATIONW {
 unsafe impl ::windows::core::Abi for NTMS_OBJECTINFORMATIONW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_OBJECTINFORMATIONW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OBJECTINFORMATIONW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_OBJECTINFORMATIONW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_OBJECTINFORMATIONW {
     fn default() -> Self {
@@ -15313,14 +15177,6 @@ impl ::core::clone::Clone for NTMS_OBJECTINFORMATIONW_0 {
 unsafe impl ::windows::core::Abi for NTMS_OBJECTINFORMATIONW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NTMS_OBJECTINFORMATIONW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OBJECTINFORMATIONW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NTMS_OBJECTINFORMATIONW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NTMS_OBJECTINFORMATIONW_0 {
     fn default() -> Self {
@@ -15364,7 +15220,7 @@ unsafe impl ::windows::core::Abi for NTMS_OPREQUESTINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_OPREQUESTINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OPREQUESTINFORMATIONA>()) == 0 }
+        self.Request == other.Request && self.Submitted == other.Submitted && self.State == other.State && self.szMessage == other.szMessage && self.Arg1Type == other.Arg1Type && self.Arg1 == other.Arg1 && self.Arg2Type == other.Arg2Type && self.Arg2 == other.Arg2 && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15412,7 +15268,7 @@ unsafe impl ::windows::core::Abi for NTMS_OPREQUESTINFORMATIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_OPREQUESTINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_OPREQUESTINFORMATIONW>()) == 0 }
+        self.Request == other.Request && self.Submitted == other.Submitted && self.State == other.State && self.szMessage == other.szMessage && self.Arg1Type == other.Arg1Type && self.Arg1 == other.Arg1 && self.Arg2Type == other.Arg2Type && self.Arg2 == other.Arg2 && self.szApplication == other.szApplication && self.szUser == other.szUser && self.szComputer == other.szComputer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15472,7 +15328,7 @@ unsafe impl ::windows::core::Abi for NTMS_PARTITIONINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_PARTITIONINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_PARTITIONINFORMATIONA>()) == 0 }
+        self.PhysicalMedia == other.PhysicalMedia && self.LogicalMedia == other.LogicalMedia && self.State == other.State && self.Side == other.Side && self.dwOmidLabelIdLength == other.dwOmidLabelIdLength && self.OmidLabelId == other.OmidLabelId && self.szOmidLabelType == other.szOmidLabelType && self.szOmidLabelInfo == other.szOmidLabelInfo && self.dwMountCount == other.dwMountCount && self.dwAllocateCount == other.dwAllocateCount && self.Capacity == other.Capacity
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15526,7 +15382,7 @@ unsafe impl ::windows::core::Abi for NTMS_PARTITIONINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_PARTITIONINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_PARTITIONINFORMATIONW>()) == 0 }
+        self.PhysicalMedia == other.PhysicalMedia && self.LogicalMedia == other.LogicalMedia && self.State == other.State && self.Side == other.Side && self.dwOmidLabelIdLength == other.dwOmidLabelIdLength && self.OmidLabelId == other.OmidLabelId && self.szOmidLabelType == other.szOmidLabelType && self.szOmidLabelInfo == other.szOmidLabelInfo && self.dwMountCount == other.dwMountCount && self.dwAllocateCount == other.dwAllocateCount && self.Capacity == other.Capacity
     }
 }
 impl ::core::cmp::Eq for NTMS_PARTITIONINFORMATIONW {}
@@ -15590,7 +15446,7 @@ unsafe impl ::windows::core::Abi for NTMS_PMIDINFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NTMS_PMIDINFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_PMIDINFORMATIONA>()) == 0 }
+        self.CurrentLibrary == other.CurrentLibrary && self.MediaPool == other.MediaPool && self.Location == other.Location && self.LocationType == other.LocationType && self.MediaType == other.MediaType && self.HomeSlot == other.HomeSlot && self.szBarCode == other.szBarCode && self.BarCodeState == other.BarCodeState && self.szSequenceNumber == other.szSequenceNumber && self.MediaState == other.MediaState && self.dwNumberOfPartitions == other.dwNumberOfPartitions && self.dwMediaTypeCode == other.dwMediaTypeCode && self.dwDensityCode == other.dwDensityCode && self.MountedPartition == other.MountedPartition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15650,7 +15506,7 @@ unsafe impl ::windows::core::Abi for NTMS_PMIDINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for NTMS_PMIDINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_PMIDINFORMATIONW>()) == 0 }
+        self.CurrentLibrary == other.CurrentLibrary && self.MediaPool == other.MediaPool && self.Location == other.Location && self.LocationType == other.LocationType && self.MediaType == other.MediaType && self.HomeSlot == other.HomeSlot && self.szBarCode == other.szBarCode && self.BarCodeState == other.BarCodeState && self.szSequenceNumber == other.szSequenceNumber && self.MediaState == other.MediaState && self.dwNumberOfPartitions == other.dwNumberOfPartitions && self.dwMediaTypeCode == other.dwMediaTypeCode && self.dwDensityCode == other.dwDensityCode && self.MountedPartition == other.MountedPartition
     }
 }
 impl ::core::cmp::Eq for NTMS_PMIDINFORMATIONW {}
@@ -15682,7 +15538,7 @@ unsafe impl ::windows::core::Abi for NTMS_STORAGESLOTINFORMATION {
 }
 impl ::core::cmp::PartialEq for NTMS_STORAGESLOTINFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTMS_STORAGESLOTINFORMATION>()) == 0 }
+        self.Number == other.Number && self.State == other.State && self.Library == other.Library
     }
 }
 impl ::core::cmp::Eq for NTMS_STORAGESLOTINFORMATION {}
@@ -15723,7 +15579,7 @@ unsafe impl ::windows::core::Abi for OFSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OFSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFSTRUCT>()) == 0 }
+        self.cBytes == other.cBytes && self.fFixedDisk == other.fFixedDisk && self.nErrCode == other.nErrCode && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.szPathName == other.szPathName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15759,7 +15615,7 @@ unsafe impl ::windows::core::Abi for REPARSE_GUID_DATA_BUFFER {
 }
 impl ::core::cmp::PartialEq for REPARSE_GUID_DATA_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPARSE_GUID_DATA_BUFFER>()) == 0 }
+        self.ReparseTag == other.ReparseTag && self.ReparseDataLength == other.ReparseDataLength && self.Reserved == other.Reserved && self.ReparseGuid == other.ReparseGuid && self.GenericReparseBuffer == other.GenericReparseBuffer
     }
 }
 impl ::core::cmp::Eq for REPARSE_GUID_DATA_BUFFER {}
@@ -15789,7 +15645,7 @@ unsafe impl ::windows::core::Abi for REPARSE_GUID_DATA_BUFFER_0 {
 }
 impl ::core::cmp::PartialEq for REPARSE_GUID_DATA_BUFFER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPARSE_GUID_DATA_BUFFER_0>()) == 0 }
+        self.DataBuffer == other.DataBuffer
     }
 }
 impl ::core::cmp::Eq for REPARSE_GUID_DATA_BUFFER_0 {}
@@ -15828,7 +15684,7 @@ unsafe impl ::windows::core::Abi for SERVER_ALIAS_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVER_ALIAS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_ALIAS_INFO_0>()) == 0 }
+        self.srvai0_alias == other.srvai0_alias && self.srvai0_target == other.srvai0_target && self.srvai0_default == other.srvai0_default && self.srvai0_reserved == other.srvai0_reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15884,7 +15740,7 @@ unsafe impl ::windows::core::Abi for SERVER_CERTIFICATE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SERVER_CERTIFICATE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVER_CERTIFICATE_INFO_0>()) == 0 }
+        self.srvci0_name == other.srvci0_name && self.srvci0_subject == other.srvci0_subject && self.srvci0_issuer == other.srvci0_issuer && self.srvci0_thumbprint == other.srvci0_thumbprint && self.srvci0_friendlyname == other.srvci0_friendlyname && self.srvci0_notbefore == other.srvci0_notbefore && self.srvci0_notafter == other.srvci0_notafter && self.srvci0_storelocation == other.srvci0_storelocation && self.srvci0_storename == other.srvci0_storename && self.srvci0_renewalchain == other.srvci0_renewalchain && self.srvci0_type == other.srvci0_type && self.srvci0_flags == other.srvci0_flags
     }
 }
 impl ::core::cmp::Eq for SERVER_CERTIFICATE_INFO_0 {}
@@ -15914,7 +15770,7 @@ unsafe impl ::windows::core::Abi for SESSION_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SESSION_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_INFO_0>()) == 0 }
+        self.sesi0_cname == other.sesi0_cname
     }
 }
 impl ::core::cmp::Eq for SESSION_INFO_0 {}
@@ -15949,7 +15805,7 @@ unsafe impl ::windows::core::Abi for SESSION_INFO_1 {
 }
 impl ::core::cmp::PartialEq for SESSION_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_INFO_1>()) == 0 }
+        self.sesi1_cname == other.sesi1_cname && self.sesi1_username == other.sesi1_username && self.sesi1_num_opens == other.sesi1_num_opens && self.sesi1_time == other.sesi1_time && self.sesi1_idle_time == other.sesi1_idle_time && self.sesi1_user_flags == other.sesi1_user_flags
     }
 }
 impl ::core::cmp::Eq for SESSION_INFO_1 {}
@@ -15982,7 +15838,7 @@ unsafe impl ::windows::core::Abi for SESSION_INFO_10 {
 }
 impl ::core::cmp::PartialEq for SESSION_INFO_10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_INFO_10>()) == 0 }
+        self.sesi10_cname == other.sesi10_cname && self.sesi10_username == other.sesi10_username && self.sesi10_time == other.sesi10_time && self.sesi10_idle_time == other.sesi10_idle_time
     }
 }
 impl ::core::cmp::Eq for SESSION_INFO_10 {}
@@ -16018,7 +15874,7 @@ unsafe impl ::windows::core::Abi for SESSION_INFO_2 {
 }
 impl ::core::cmp::PartialEq for SESSION_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_INFO_2>()) == 0 }
+        self.sesi2_cname == other.sesi2_cname && self.sesi2_username == other.sesi2_username && self.sesi2_num_opens == other.sesi2_num_opens && self.sesi2_time == other.sesi2_time && self.sesi2_idle_time == other.sesi2_idle_time && self.sesi2_user_flags == other.sesi2_user_flags && self.sesi2_cltype_name == other.sesi2_cltype_name
     }
 }
 impl ::core::cmp::Eq for SESSION_INFO_2 {}
@@ -16055,7 +15911,7 @@ unsafe impl ::windows::core::Abi for SESSION_INFO_502 {
 }
 impl ::core::cmp::PartialEq for SESSION_INFO_502 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SESSION_INFO_502>()) == 0 }
+        self.sesi502_cname == other.sesi502_cname && self.sesi502_username == other.sesi502_username && self.sesi502_num_opens == other.sesi502_num_opens && self.sesi502_time == other.sesi502_time && self.sesi502_idle_time == other.sesi502_idle_time && self.sesi502_user_flags == other.sesi502_user_flags && self.sesi502_cltype_name == other.sesi502_cltype_name && self.sesi502_transport == other.sesi502_transport
     }
 }
 impl ::core::cmp::Eq for SESSION_INFO_502 {}
@@ -16085,7 +15941,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_0>()) == 0 }
+        self.shi0_netname == other.shi0_netname
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_0 {}
@@ -16117,7 +15973,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1>()) == 0 }
+        self.shi1_netname == other.shi1_netname && self.shi1_type == other.shi1_type && self.shi1_remark == other.shi1_remark
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_1 {}
@@ -16147,7 +16003,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1004 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_1004 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1004>()) == 0 }
+        self.shi1004_remark == other.shi1004_remark
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_1004 {}
@@ -16177,7 +16033,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1005 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_1005 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1005>()) == 0 }
+        self.shi1005_flags == other.shi1005_flags
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_1005 {}
@@ -16207,7 +16063,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1006 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_1006 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1006>()) == 0 }
+        self.shi1006_max_uses == other.shi1006_max_uses
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_1006 {}
@@ -16244,7 +16100,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1501 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for SHARE_INFO_1501 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1501>()) == 0 }
+        self.shi1501_reserved == other.shi1501_reserved && self.shi1501_security_descriptor == other.shi1501_security_descriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -16276,7 +16132,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_1503 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_1503 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_1503>()) == 0 }
+        self.shi1503_sharefilter == other.shi1503_sharefilter
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_1503 {}
@@ -16313,7 +16169,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_2 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_2>()) == 0 }
+        self.shi2_netname == other.shi2_netname && self.shi2_type == other.shi2_type && self.shi2_remark == other.shi2_remark && self.shi2_permissions == other.shi2_permissions && self.shi2_max_uses == other.shi2_max_uses && self.shi2_current_uses == other.shi2_current_uses && self.shi2_path == other.shi2_path && self.shi2_passwd == other.shi2_passwd
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_2 {}
@@ -16346,7 +16202,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_501 {
 }
 impl ::core::cmp::PartialEq for SHARE_INFO_501 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_501>()) == 0 }
+        self.shi501_netname == other.shi501_netname && self.shi501_type == other.shi501_type && self.shi501_remark == other.shi501_remark && self.shi501_flags == other.shi501_flags
     }
 }
 impl ::core::cmp::Eq for SHARE_INFO_501 {}
@@ -16402,7 +16258,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_502 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for SHARE_INFO_502 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_502>()) == 0 }
+        self.shi502_netname == other.shi502_netname && self.shi502_type == other.shi502_type && self.shi502_remark == other.shi502_remark && self.shi502_permissions == other.shi502_permissions && self.shi502_max_uses == other.shi502_max_uses && self.shi502_current_uses == other.shi502_current_uses && self.shi502_path == other.shi502_path && self.shi502_passwd == other.shi502_passwd && self.shi502_reserved == other.shi502_reserved && self.shi502_security_descriptor == other.shi502_security_descriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -16462,7 +16318,7 @@ unsafe impl ::windows::core::Abi for SHARE_INFO_503 {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for SHARE_INFO_503 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARE_INFO_503>()) == 0 }
+        self.shi503_netname == other.shi503_netname && self.shi503_type == other.shi503_type && self.shi503_remark == other.shi503_remark && self.shi503_permissions == other.shi503_permissions && self.shi503_max_uses == other.shi503_max_uses && self.shi503_current_uses == other.shi503_current_uses && self.shi503_path == other.shi503_path && self.shi503_passwd == other.shi503_passwd && self.shi503_servername == other.shi503_servername && self.shi503_reserved == other.shi503_reserved && self.shi503_security_descriptor == other.shi503_security_descriptor
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -16528,7 +16384,23 @@ unsafe impl ::windows::core::Abi for STAT_SERVER_0 {
 }
 impl ::core::cmp::PartialEq for STAT_SERVER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STAT_SERVER_0>()) == 0 }
+        self.sts0_start == other.sts0_start
+            && self.sts0_fopens == other.sts0_fopens
+            && self.sts0_devopens == other.sts0_devopens
+            && self.sts0_jobsqueued == other.sts0_jobsqueued
+            && self.sts0_sopens == other.sts0_sopens
+            && self.sts0_stimedout == other.sts0_stimedout
+            && self.sts0_serrorout == other.sts0_serrorout
+            && self.sts0_pwerrors == other.sts0_pwerrors
+            && self.sts0_permerrors == other.sts0_permerrors
+            && self.sts0_syserrors == other.sts0_syserrors
+            && self.sts0_bytessent_low == other.sts0_bytessent_low
+            && self.sts0_bytessent_high == other.sts0_bytessent_high
+            && self.sts0_bytesrcvd_low == other.sts0_bytesrcvd_low
+            && self.sts0_bytesrcvd_high == other.sts0_bytesrcvd_high
+            && self.sts0_avresponse == other.sts0_avresponse
+            && self.sts0_reqbufneed == other.sts0_reqbufneed
+            && self.sts0_bigbufneed == other.sts0_bigbufneed
     }
 }
 impl ::core::cmp::Eq for STAT_SERVER_0 {}
@@ -16638,7 +16510,46 @@ unsafe impl ::windows::core::Abi for STAT_WORKSTATION_0 {
 }
 impl ::core::cmp::PartialEq for STAT_WORKSTATION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STAT_WORKSTATION_0>()) == 0 }
+        self.StatisticsStartTime == other.StatisticsStartTime
+            && self.BytesReceived == other.BytesReceived
+            && self.SmbsReceived == other.SmbsReceived
+            && self.PagingReadBytesRequested == other.PagingReadBytesRequested
+            && self.NonPagingReadBytesRequested == other.NonPagingReadBytesRequested
+            && self.CacheReadBytesRequested == other.CacheReadBytesRequested
+            && self.NetworkReadBytesRequested == other.NetworkReadBytesRequested
+            && self.BytesTransmitted == other.BytesTransmitted
+            && self.SmbsTransmitted == other.SmbsTransmitted
+            && self.PagingWriteBytesRequested == other.PagingWriteBytesRequested
+            && self.NonPagingWriteBytesRequested == other.NonPagingWriteBytesRequested
+            && self.CacheWriteBytesRequested == other.CacheWriteBytesRequested
+            && self.NetworkWriteBytesRequested == other.NetworkWriteBytesRequested
+            && self.InitiallyFailedOperations == other.InitiallyFailedOperations
+            && self.FailedCompletionOperations == other.FailedCompletionOperations
+            && self.ReadOperations == other.ReadOperations
+            && self.RandomReadOperations == other.RandomReadOperations
+            && self.ReadSmbs == other.ReadSmbs
+            && self.LargeReadSmbs == other.LargeReadSmbs
+            && self.SmallReadSmbs == other.SmallReadSmbs
+            && self.WriteOperations == other.WriteOperations
+            && self.RandomWriteOperations == other.RandomWriteOperations
+            && self.WriteSmbs == other.WriteSmbs
+            && self.LargeWriteSmbs == other.LargeWriteSmbs
+            && self.SmallWriteSmbs == other.SmallWriteSmbs
+            && self.RawReadsDenied == other.RawReadsDenied
+            && self.RawWritesDenied == other.RawWritesDenied
+            && self.NetworkErrors == other.NetworkErrors
+            && self.Sessions == other.Sessions
+            && self.FailedSessions == other.FailedSessions
+            && self.Reconnects == other.Reconnects
+            && self.CoreConnects == other.CoreConnects
+            && self.Lanman20Connects == other.Lanman20Connects
+            && self.Lanman21Connects == other.Lanman21Connects
+            && self.LanmanNtConnects == other.LanmanNtConnects
+            && self.ServerDisconnects == other.ServerDisconnects
+            && self.HungSessions == other.HungSessions
+            && self.UseCount == other.UseCount
+            && self.FailedUseCount == other.FailedUseCount
+            && self.CurrentCommands == other.CurrentCommands
     }
 }
 impl ::core::cmp::Eq for STAT_WORKSTATION_0 {}
@@ -16675,7 +16586,7 @@ unsafe impl ::windows::core::Abi for TAPE_ERASE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_ERASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_ERASE>()) == 0 }
+        self.Type == other.Type && self.Immediate == other.Immediate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16709,7 +16620,7 @@ unsafe impl ::windows::core::Abi for TAPE_GET_POSITION {
 }
 impl ::core::cmp::PartialEq for TAPE_GET_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_GET_POSITION>()) == 0 }
+        self.Type == other.Type && self.Partition == other.Partition && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for TAPE_GET_POSITION {}
@@ -16746,7 +16657,7 @@ unsafe impl ::windows::core::Abi for TAPE_PREPARE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_PREPARE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_PREPARE>()) == 0 }
+        self.Operation == other.Operation && self.Immediate == other.Immediate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16787,7 +16698,7 @@ unsafe impl ::windows::core::Abi for TAPE_SET_POSITION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_SET_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_SET_POSITION>()) == 0 }
+        self.Method == other.Method && self.Partition == other.Partition && self.Offset == other.Offset && self.Immediate == other.Immediate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16827,7 +16738,7 @@ unsafe impl ::windows::core::Abi for TAPE_WRITE_MARKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_WRITE_MARKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_WRITE_MARKS>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.Immediate == other.Immediate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16862,7 +16773,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION>()) == 0 }
+        self.TransactionKey == other.TransactionKey && self.TransactionNotification == other.TransactionNotification && self.TmVirtualClock == other.TmVirtualClock && self.ArgumentLength == other.ArgumentLength
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION {}
@@ -16893,7 +16804,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT>()) == 0 }
+        self.MarshalCookie == other.MarshalCookie && self.UOW == other.UOW
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {}
@@ -16926,7 +16837,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT>()) == 0 }
+        self.PropagationCookie == other.PropagationCookie && self.UOW == other.UOW && self.TmIdentity == other.TmIdentity && self.BufferLength == other.BufferLength
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT {}
@@ -16957,7 +16868,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT 
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT>()) == 0 }
+        self.EnlistmentId == other.EnlistmentId && self.UOW == other.UOW
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT {}
@@ -16987,7 +16898,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT>()) == 0 }
+        self.SavepointId == other.SavepointId
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT {}
@@ -17018,7 +16929,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT
 }
 impl ::core::cmp::PartialEq for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT>()) == 0 }
+        self.TmIdentity == other.TmIdentity && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {}
@@ -17041,12 +16952,6 @@ impl ::core::clone::Clone for TXF_ID {
 unsafe impl ::windows::core::Abi for TXF_ID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_ID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_ID {}
 impl ::core::default::Default for TXF_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17067,12 +16972,6 @@ impl ::core::clone::Clone for TXF_ID_0 {
 unsafe impl ::windows::core::Abi for TXF_ID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_ID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_ID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_ID_0 {}
 impl ::core::default::Default for TXF_ID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17098,12 +16997,6 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_AFFECTED_FILE {
 unsafe impl ::windows::core::Abi for TXF_LOG_RECORD_AFFECTED_FILE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_LOG_RECORD_AFFECTED_FILE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_LOG_RECORD_AFFECTED_FILE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_LOG_RECORD_AFFECTED_FILE {}
 impl ::core::default::Default for TXF_LOG_RECORD_AFFECTED_FILE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17125,12 +17018,6 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_BASE {
 unsafe impl ::windows::core::Abi for TXF_LOG_RECORD_BASE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_LOG_RECORD_BASE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_LOG_RECORD_BASE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_LOG_RECORD_BASE {}
 impl ::core::default::Default for TXF_LOG_RECORD_BASE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17158,12 +17045,6 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_TRUNCATE {
 unsafe impl ::windows::core::Abi for TXF_LOG_RECORD_TRUNCATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_LOG_RECORD_TRUNCATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_LOG_RECORD_TRUNCATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_LOG_RECORD_TRUNCATE {}
 impl ::core::default::Default for TXF_LOG_RECORD_TRUNCATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17193,12 +17074,6 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_WRITE {
 unsafe impl ::windows::core::Abi for TXF_LOG_RECORD_WRITE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXF_LOG_RECORD_WRITE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXF_LOG_RECORD_WRITE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXF_LOG_RECORD_WRITE {}
 impl ::core::default::Default for TXF_LOG_RECORD_WRITE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17240,7 +17115,7 @@ unsafe impl ::windows::core::Abi for VOLUME_ALLOCATE_BC_STREAM_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VOLUME_ALLOCATE_BC_STREAM_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_ALLOCATE_BC_STREAM_INPUT>()) == 0 }
+        self.Version == other.Version && self.RequestsPerPeriod == other.RequestsPerPeriod && self.Period == other.Period && self.RetryFailures == other.RetryFailures && self.Discardable == other.Discardable && self.Reserved1 == other.Reserved1 && self.LowestByteOffset == other.LowestByteOffset && self.HighestByteOffset == other.HighestByteOffset && self.AccessType == other.AccessType && self.AccessMode == other.AccessMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17273,7 +17148,7 @@ unsafe impl ::windows::core::Abi for VOLUME_ALLOCATE_BC_STREAM_OUTPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_ALLOCATE_BC_STREAM_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_ALLOCATE_BC_STREAM_OUTPUT>()) == 0 }
+        self.RequestSize == other.RequestSize && self.NumOutStandingRequests == other.NumOutStandingRequests
     }
 }
 impl ::core::cmp::Eq for VOLUME_ALLOCATE_BC_STREAM_OUTPUT {}
@@ -17305,7 +17180,7 @@ unsafe impl ::windows::core::Abi for VOLUME_ALLOCATION_HINT_INPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_ALLOCATION_HINT_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_ALLOCATION_HINT_INPUT>()) == 0 }
+        self.ClusterSize == other.ClusterSize && self.NumberOfClusters == other.NumberOfClusters && self.StartingClusterNumber == other.StartingClusterNumber
     }
 }
 impl ::core::cmp::Eq for VOLUME_ALLOCATION_HINT_INPUT {}
@@ -17335,7 +17210,7 @@ unsafe impl ::windows::core::Abi for VOLUME_ALLOCATION_HINT_OUTPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_ALLOCATION_HINT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_ALLOCATION_HINT_OUTPUT>()) == 0 }
+        self.Bitmap == other.Bitmap
     }
 }
 impl ::core::cmp::Eq for VOLUME_ALLOCATION_HINT_OUTPUT {}
@@ -17367,7 +17242,7 @@ unsafe impl ::windows::core::Abi for VOLUME_CRITICAL_IO {
 }
 impl ::core::cmp::PartialEq for VOLUME_CRITICAL_IO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_CRITICAL_IO>()) == 0 }
+        self.AccessType == other.AccessType && self.ExtentsCount == other.ExtentsCount && self.Extents == other.Extents
     }
 }
 impl ::core::cmp::Eq for VOLUME_CRITICAL_IO {}
@@ -17398,7 +17273,7 @@ unsafe impl ::windows::core::Abi for VOLUME_FAILOVER_SET {
 }
 impl ::core::cmp::PartialEq for VOLUME_FAILOVER_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_FAILOVER_SET>()) == 0 }
+        self.NumberOfDisks == other.NumberOfDisks && self.DiskNumbers == other.DiskNumbers
     }
 }
 impl ::core::cmp::Eq for VOLUME_FAILOVER_SET {}
@@ -17433,7 +17308,7 @@ unsafe impl ::windows::core::Abi for VOLUME_GET_BC_PROPERTIES_INPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_GET_BC_PROPERTIES_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_GET_BC_PROPERTIES_INPUT>()) == 0 }
+        self.Version == other.Version && self.Reserved1 == other.Reserved1 && self.LowestByteOffset == other.LowestByteOffset && self.HighestByteOffset == other.HighestByteOffset && self.AccessType == other.AccessType && self.AccessMode == other.AccessMode
     }
 }
 impl ::core::cmp::Eq for VOLUME_GET_BC_PROPERTIES_INPUT {}
@@ -17468,7 +17343,7 @@ unsafe impl ::windows::core::Abi for VOLUME_GET_BC_PROPERTIES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_GET_BC_PROPERTIES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_GET_BC_PROPERTIES_OUTPUT>()) == 0 }
+        self.MaximumRequestsPerPeriod == other.MaximumRequestsPerPeriod && self.MinimumPeriod == other.MinimumPeriod && self.MaximumRequestSize == other.MaximumRequestSize && self.EstimatedTimePerRequest == other.EstimatedTimePerRequest && self.NumOutStandingRequests == other.NumOutStandingRequests && self.RequestSize == other.RequestSize
     }
 }
 impl ::core::cmp::Eq for VOLUME_GET_BC_PROPERTIES_OUTPUT {}
@@ -17498,7 +17373,7 @@ unsafe impl ::windows::core::Abi for VOLUME_LOGICAL_OFFSET {
 }
 impl ::core::cmp::PartialEq for VOLUME_LOGICAL_OFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_LOGICAL_OFFSET>()) == 0 }
+        self.LogicalOffset == other.LogicalOffset
     }
 }
 impl ::core::cmp::Eq for VOLUME_LOGICAL_OFFSET {}
@@ -17529,7 +17404,7 @@ unsafe impl ::windows::core::Abi for VOLUME_NUMBER {
 }
 impl ::core::cmp::PartialEq for VOLUME_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_NUMBER>()) == 0 }
+        self.VolumeNumber == other.VolumeNumber && self.VolumeManagerName == other.VolumeManagerName
     }
 }
 impl ::core::cmp::Eq for VOLUME_NUMBER {}
@@ -17560,7 +17435,7 @@ unsafe impl ::windows::core::Abi for VOLUME_PHYSICAL_OFFSET {
 }
 impl ::core::cmp::PartialEq for VOLUME_PHYSICAL_OFFSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_PHYSICAL_OFFSET>()) == 0 }
+        self.DiskNumber == other.DiskNumber && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for VOLUME_PHYSICAL_OFFSET {}
@@ -17591,7 +17466,7 @@ unsafe impl ::windows::core::Abi for VOLUME_PHYSICAL_OFFSETS {
 }
 impl ::core::cmp::PartialEq for VOLUME_PHYSICAL_OFFSETS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_PHYSICAL_OFFSETS>()) == 0 }
+        self.NumberOfPhysicalOffsets == other.NumberOfPhysicalOffsets && self.PhysicalOffset == other.PhysicalOffset
     }
 }
 impl ::core::cmp::Eq for VOLUME_PHYSICAL_OFFSETS {}
@@ -17623,7 +17498,7 @@ unsafe impl ::windows::core::Abi for VOLUME_READ_PLEX_INPUT {
 }
 impl ::core::cmp::PartialEq for VOLUME_READ_PLEX_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_READ_PLEX_INPUT>()) == 0 }
+        self.ByteOffset == other.ByteOffset && self.Length == other.Length && self.PlexNumber == other.PlexNumber
     }
 }
 impl ::core::cmp::Eq for VOLUME_READ_PLEX_INPUT {}
@@ -17663,7 +17538,7 @@ unsafe impl ::windows::core::Abi for VOLUME_SET_GPT_ATTRIBUTES_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VOLUME_SET_GPT_ATTRIBUTES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_SET_GPT_ATTRIBUTES_INFORMATION>()) == 0 }
+        self.GptAttributes == other.GptAttributes && self.RevertOnClose == other.RevertOnClose && self.ApplyToAllConnectedVolumes == other.ApplyToAllConnectedVolumes && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17695,7 +17570,7 @@ unsafe impl ::windows::core::Abi for VOLUME_SHRINK_INFO {
 }
 impl ::core::cmp::PartialEq for VOLUME_SHRINK_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_SHRINK_INFO>()) == 0 }
+        self.VolumeSize == other.VolumeSize
     }
 }
 impl ::core::cmp::Eq for VOLUME_SHRINK_INFO {}
@@ -17751,7 +17626,7 @@ unsafe impl ::windows::core::Abi for VS_FIXEDFILEINFO {
 }
 impl ::core::cmp::PartialEq for VS_FIXEDFILEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VS_FIXEDFILEINFO>()) == 0 }
+        self.dwSignature == other.dwSignature && self.dwStrucVersion == other.dwStrucVersion && self.dwFileVersionMS == other.dwFileVersionMS && self.dwFileVersionLS == other.dwFileVersionLS && self.dwProductVersionMS == other.dwProductVersionMS && self.dwProductVersionLS == other.dwProductVersionLS && self.dwFileFlagsMask == other.dwFileFlagsMask && self.dwFileFlags == other.dwFileFlags && self.dwFileOS == other.dwFileOS && self.dwFileType == other.dwFileType && self.dwFileSubtype == other.dwFileSubtype && self.dwFileDateMS == other.dwFileDateMS && self.dwFileDateLS == other.dwFileDateLS
     }
 }
 impl ::core::cmp::Eq for VS_FIXEDFILEINFO {}
@@ -17787,7 +17662,7 @@ unsafe impl ::windows::core::Abi for WIM_ENTRY_INFO {
 }
 impl ::core::cmp::PartialEq for WIM_ENTRY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_ENTRY_INFO>()) == 0 }
+        self.WimEntryInfoSize == other.WimEntryInfoSize && self.WimType == other.WimType && self.DataSourceId == other.DataSourceId && self.WimGuid == other.WimGuid && self.WimPath == other.WimPath && self.WimIndex == other.WimIndex && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WIM_ENTRY_INFO {}
@@ -17819,7 +17694,7 @@ unsafe impl ::windows::core::Abi for WIM_EXTERNAL_FILE_INFO {
 }
 impl ::core::cmp::PartialEq for WIM_EXTERNAL_FILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_EXTERNAL_FILE_INFO>()) == 0 }
+        self.DataSourceId == other.DataSourceId && self.ResourceHash == other.ResourceHash && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WIM_EXTERNAL_FILE_INFO {}
@@ -17860,7 +17735,7 @@ unsafe impl ::windows::core::Abi for WIN32_FILE_ATTRIBUTE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN32_FILE_ATTRIBUTE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_FILE_ATTRIBUTE_DATA>()) == 0 }
+        self.dwFileAttributes == other.dwFileAttributes && self.ftCreationTime == other.ftCreationTime && self.ftLastAccessTime == other.ftLastAccessTime && self.ftLastWriteTime == other.ftLastWriteTime && self.nFileSizeHigh == other.nFileSizeHigh && self.nFileSizeLow == other.nFileSizeLow
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17918,7 +17793,7 @@ unsafe impl ::windows::core::Abi for WIN32_FIND_DATAA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN32_FIND_DATAA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_FIND_DATAA>()) == 0 }
+        self.dwFileAttributes == other.dwFileAttributes && self.ftCreationTime == other.ftCreationTime && self.ftLastAccessTime == other.ftLastAccessTime && self.ftLastWriteTime == other.ftLastWriteTime && self.nFileSizeHigh == other.nFileSizeHigh && self.nFileSizeLow == other.nFileSizeLow && self.dwReserved0 == other.dwReserved0 && self.dwReserved1 == other.dwReserved1 && self.cFileName == other.cFileName && self.cAlternateFileName == other.cAlternateFileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17976,7 +17851,7 @@ unsafe impl ::windows::core::Abi for WIN32_FIND_DATAW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WIN32_FIND_DATAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_FIND_DATAW>()) == 0 }
+        self.dwFileAttributes == other.dwFileAttributes && self.ftCreationTime == other.ftCreationTime && self.ftLastAccessTime == other.ftLastAccessTime && self.ftLastWriteTime == other.ftLastWriteTime && self.nFileSizeHigh == other.nFileSizeHigh && self.nFileSizeLow == other.nFileSizeLow && self.dwReserved0 == other.dwReserved0 && self.dwReserved1 == other.dwReserved1 && self.cFileName == other.cFileName && self.cAlternateFileName == other.cAlternateFileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18009,7 +17884,7 @@ unsafe impl ::windows::core::Abi for WIN32_FIND_STREAM_DATA {
 }
 impl ::core::cmp::PartialEq for WIN32_FIND_STREAM_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_FIND_STREAM_DATA>()) == 0 }
+        self.StreamSize == other.StreamSize && self.cStreamName == other.cStreamName
     }
 }
 impl ::core::cmp::Eq for WIN32_FIND_STREAM_DATA {}
@@ -18043,7 +17918,7 @@ unsafe impl ::windows::core::Abi for WIN32_STREAM_ID {
 }
 impl ::core::cmp::PartialEq for WIN32_STREAM_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_STREAM_ID>()) == 0 }
+        self.dwStreamId == other.dwStreamId && self.dwStreamAttributes == other.dwStreamAttributes && self.Size == other.Size && self.dwStreamNameSize == other.dwStreamNameSize && self.cStreamName == other.cStreamName
     }
 }
 impl ::core::cmp::Eq for WIN32_STREAM_ID {}
@@ -18073,7 +17948,7 @@ unsafe impl ::windows::core::Abi for WOF_FILE_COMPRESSION_INFO_V0 {
 }
 impl ::core::cmp::PartialEq for WOF_FILE_COMPRESSION_INFO_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOF_FILE_COMPRESSION_INFO_V0>()) == 0 }
+        self.Algorithm == other.Algorithm
     }
 }
 impl ::core::cmp::Eq for WOF_FILE_COMPRESSION_INFO_V0 {}
@@ -18104,7 +17979,7 @@ unsafe impl ::windows::core::Abi for WOF_FILE_COMPRESSION_INFO_V1 {
 }
 impl ::core::cmp::PartialEq for WOF_FILE_COMPRESSION_INFO_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOF_FILE_COMPRESSION_INFO_V1>()) == 0 }
+        self.Algorithm == other.Algorithm && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WOF_FILE_COMPRESSION_INFO_V1 {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -8506,7 +8506,7 @@ unsafe impl ::windows::core::Abi for IMMP_MPV_STORE_DRIVER_HANDLE {
 }
 impl ::core::cmp::PartialEq for IMMP_MPV_STORE_DRIVER_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMMP_MPV_STORE_DRIVER_HANDLE>()) == 0 }
+        self.guidSignature == other.guidSignature
     }
 }
 impl ::core::cmp::Eq for IMMP_MPV_STORE_DRIVER_HANDLE {}
@@ -8537,7 +8537,7 @@ unsafe impl ::windows::core::Abi for SPropAttrArray {
 }
 impl ::core::cmp::PartialEq for SPropAttrArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropAttrArray>()) == 0 }
+        self.cValues == other.cValues && self.aPropAttr == other.aPropAttr
     }
 }
 impl ::core::cmp::Eq for SPropAttrArray {}
@@ -8571,7 +8571,7 @@ unsafe impl ::windows::core::Abi for tagIMMPID_GUIDLIST_ITEM {
 }
 impl ::core::cmp::PartialEq for tagIMMPID_GUIDLIST_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<tagIMMPID_GUIDLIST_ITEM>()) == 0 }
+        self.pguid == other.pguid && self.dwStart == other.dwStart && self.dwLast == other.dwLast
     }
 }
 impl ::core::cmp::Eq for tagIMMPID_GUIDLIST_ITEM {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
@@ -688,7 +688,7 @@ unsafe impl ::windows::core::Abi for CI_STATE {
 }
 impl ::core::cmp::PartialEq for CI_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CI_STATE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.cWordList == other.cWordList && self.cPersistentIndex == other.cPersistentIndex && self.cQueries == other.cQueries && self.cDocuments == other.cDocuments && self.cFreshTest == other.cFreshTest && self.dwMergeProgress == other.dwMergeProgress && self.eState == other.eState && self.cFilteredDocuments == other.cFilteredDocuments && self.cTotalDocuments == other.cTotalDocuments && self.cPendingScans == other.cPendingScans && self.dwIndexSize == other.dwIndexSize && self.cUniqueKeys == other.cUniqueKeys && self.cSecQDocuments == other.cSecQDocuments && self.dwPropCacheSize == other.dwPropCacheSize
     }
 }
 impl ::core::cmp::Eq for CI_STATE {}
@@ -718,14 +718,6 @@ unsafe impl ::windows::core::Abi for DBID {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBID {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -751,14 +743,6 @@ unsafe impl ::windows::core::Abi for DBID_0 {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBID_0 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -783,14 +767,6 @@ impl ::core::clone::Clone for DBID_1 {
 unsafe impl ::windows::core::Abi for DBID_1 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBID_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID_1>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBID_1 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBID_1 {
     fn default() -> Self {
@@ -818,14 +794,6 @@ unsafe impl ::windows::core::Abi for DBID {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBID {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -851,14 +819,6 @@ unsafe impl ::windows::core::Abi for DBID_0 {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBID_0 {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -883,14 +843,6 @@ impl ::core::clone::Clone for DBID_1 {
 unsafe impl ::windows::core::Abi for DBID_1 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBID_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBID_1>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBID_1 {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBID_1 {
     fn default() -> Self {
@@ -920,7 +872,7 @@ unsafe impl ::windows::core::Abi for FILTERREGION {
 }
 impl ::core::cmp::PartialEq for FILTERREGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTERREGION>()) == 0 }
+        self.idChunk == other.idChunk && self.cwcStart == other.cwcStart && self.cwcExtent == other.cwcExtent
     }
 }
 impl ::core::cmp::Eq for FILTERREGION {}
@@ -948,14 +900,6 @@ impl ::core::clone::Clone for FULLPROPSPEC {
 unsafe impl ::windows::core::Abi for FULLPROPSPEC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::PartialEq for FULLPROPSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FULLPROPSPEC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::Eq for FULLPROPSPEC {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::default::Default for FULLPROPSPEC {
     fn default() -> Self {
@@ -987,14 +931,6 @@ impl ::core::clone::Clone for STAT_CHUNK {
 unsafe impl ::windows::core::Abi for STAT_CHUNK {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::PartialEq for STAT_CHUNK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STAT_CHUNK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::cmp::Eq for STAT_CHUNK {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::default::Default for STAT_CHUNK {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
@@ -628,12 +628,6 @@ impl ::core::clone::Clone for FILTER_AGGREGATE_BASIC_INFORMATION {
 unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_BASIC_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILTER_AGGREGATE_BASIC_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_BASIC_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILTER_AGGREGATE_BASIC_INFORMATION {}
 impl ::core::default::Default for FILTER_AGGREGATE_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -654,12 +648,6 @@ impl ::core::clone::Clone for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_BASIC_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILTER_AGGREGATE_BASIC_INFORMATION_0 {}
 impl ::core::default::Default for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -687,7 +675,7 @@ unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
 }
 impl ::core::cmp::PartialEq for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_BASIC_INFORMATION_0_0>()) == 0 }
+        self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset
     }
 }
 impl ::core::cmp::Eq for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {}
@@ -722,7 +710,7 @@ unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
 }
 impl ::core::cmp::PartialEq for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_BASIC_INFORMATION_0_1>()) == 0 }
+        self.FrameID == other.FrameID && self.NumberOfInstances == other.NumberOfInstances && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset && self.FilterAltitudeLength == other.FilterAltitudeLength && self.FilterAltitudeBufferOffset == other.FilterAltitudeBufferOffset
     }
 }
 impl ::core::cmp::Eq for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {}
@@ -747,12 +735,6 @@ impl ::core::clone::Clone for FILTER_AGGREGATE_STANDARD_INFORMATION {
 unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_STANDARD_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILTER_AGGREGATE_STANDARD_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_STANDARD_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILTER_AGGREGATE_STANDARD_INFORMATION {}
 impl ::core::default::Default for FILTER_AGGREGATE_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -773,12 +755,6 @@ impl ::core::clone::Clone for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_STANDARD_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {}
 impl ::core::default::Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -809,7 +785,7 @@ unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
 }
 impl ::core::cmp::PartialEq for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_STANDARD_INFORMATION_0_0>()) == 0 }
+        self.Flags == other.Flags && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset && self.FilterAltitudeLength == other.FilterAltitudeLength && self.FilterAltitudeBufferOffset == other.FilterAltitudeBufferOffset
     }
 }
 impl ::core::cmp::Eq for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {}
@@ -845,7 +821,7 @@ unsafe impl ::windows::core::Abi for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
 }
 impl ::core::cmp::PartialEq for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_AGGREGATE_STANDARD_INFORMATION_0_1>()) == 0 }
+        self.Flags == other.Flags && self.FrameID == other.FrameID && self.NumberOfInstances == other.NumberOfInstances && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset && self.FilterAltitudeLength == other.FilterAltitudeLength && self.FilterAltitudeBufferOffset == other.FilterAltitudeBufferOffset
     }
 }
 impl ::core::cmp::Eq for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {}
@@ -879,7 +855,7 @@ unsafe impl ::windows::core::Abi for FILTER_FULL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILTER_FULL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_FULL_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.FrameID == other.FrameID && self.NumberOfInstances == other.NumberOfInstances && self.FilterNameLength == other.FilterNameLength && self.FilterNameBuffer == other.FilterNameBuffer
     }
 }
 impl ::core::cmp::Eq for FILTER_FULL_INFORMATION {}
@@ -910,7 +886,7 @@ unsafe impl ::windows::core::Abi for FILTER_MESSAGE_HEADER {
 }
 impl ::core::cmp::PartialEq for FILTER_MESSAGE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_MESSAGE_HEADER>()) == 0 }
+        self.ReplyLength == other.ReplyLength && self.MessageId == other.MessageId
     }
 }
 impl ::core::cmp::Eq for FILTER_MESSAGE_HEADER {}
@@ -947,7 +923,7 @@ unsafe impl ::windows::core::Abi for FILTER_REPLY_HEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILTER_REPLY_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_REPLY_HEADER>()) == 0 }
+        self.Status == other.Status && self.MessageId == other.MessageId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -980,7 +956,7 @@ unsafe impl ::windows::core::Abi for FILTER_VOLUME_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILTER_VOLUME_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_VOLUME_BASIC_INFORMATION>()) == 0 }
+        self.FilterVolumeNameLength == other.FilterVolumeNameLength && self.FilterVolumeName == other.FilterVolumeName
     }
 }
 impl ::core::cmp::Eq for FILTER_VOLUME_BASIC_INFORMATION {}
@@ -1015,7 +991,7 @@ unsafe impl ::windows::core::Abi for FILTER_VOLUME_STANDARD_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILTER_VOLUME_STANDARD_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTER_VOLUME_STANDARD_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.Flags == other.Flags && self.FrameID == other.FrameID && self.FileSystemType == other.FileSystemType && self.FilterVolumeNameLength == other.FilterVolumeNameLength && self.FilterVolumeName == other.FilterVolumeName
     }
 }
 impl ::core::cmp::Eq for FILTER_VOLUME_STANDARD_INFORMATION {}
@@ -1232,12 +1208,6 @@ impl ::core::clone::Clone for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
 unsafe impl ::windows::core::Abi for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_AGGREGATE_STANDARD_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INSTANCE_AGGREGATE_STANDARD_INFORMATION {}
 impl ::core::default::Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1258,12 +1228,6 @@ impl ::core::clone::Clone for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_AGGREGATE_STANDARD_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {}
 impl ::core::default::Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1297,7 +1261,7 @@ unsafe impl ::windows::core::Abi for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0
 }
 impl ::core::cmp::PartialEq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0>()) == 0 }
+        self.Flags == other.Flags && self.AltitudeLength == other.AltitudeLength && self.AltitudeBufferOffset == other.AltitudeBufferOffset && self.VolumeNameLength == other.VolumeNameLength && self.VolumeNameBufferOffset == other.VolumeNameBufferOffset && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset && self.SupportedFeatures == other.SupportedFeatures
     }
 }
 impl ::core::cmp::Eq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {}
@@ -1351,7 +1315,7 @@ unsafe impl ::windows::core::Abi for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1
 }
 impl ::core::cmp::PartialEq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1>()) == 0 }
+        self.Flags == other.Flags && self.FrameID == other.FrameID && self.VolumeFileSystemType == other.VolumeFileSystemType && self.InstanceNameLength == other.InstanceNameLength && self.InstanceNameBufferOffset == other.InstanceNameBufferOffset && self.AltitudeLength == other.AltitudeLength && self.AltitudeBufferOffset == other.AltitudeBufferOffset && self.VolumeNameLength == other.VolumeNameLength && self.VolumeNameBufferOffset == other.VolumeNameBufferOffset && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset && self.SupportedFeatures == other.SupportedFeatures
     }
 }
 impl ::core::cmp::Eq for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {}
@@ -1383,7 +1347,7 @@ unsafe impl ::windows::core::Abi for INSTANCE_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for INSTANCE_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_BASIC_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.InstanceNameLength == other.InstanceNameLength && self.InstanceNameBufferOffset == other.InstanceNameBufferOffset
     }
 }
 impl ::core::cmp::Eq for INSTANCE_BASIC_INFORMATION {}
@@ -1431,7 +1395,7 @@ unsafe impl ::windows::core::Abi for INSTANCE_FULL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for INSTANCE_FULL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_FULL_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.InstanceNameLength == other.InstanceNameLength && self.InstanceNameBufferOffset == other.InstanceNameBufferOffset && self.AltitudeLength == other.AltitudeLength && self.AltitudeBufferOffset == other.AltitudeBufferOffset && self.VolumeNameLength == other.VolumeNameLength && self.VolumeNameBufferOffset == other.VolumeNameBufferOffset && self.FilterNameLength == other.FilterNameLength && self.FilterNameBufferOffset == other.FilterNameBufferOffset
     }
 }
 impl ::core::cmp::Eq for INSTANCE_FULL_INFORMATION {}
@@ -1465,7 +1429,7 @@ unsafe impl ::windows::core::Abi for INSTANCE_PARTIAL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for INSTANCE_PARTIAL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTANCE_PARTIAL_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.InstanceNameLength == other.InstanceNameLength && self.InstanceNameBufferOffset == other.InstanceNameBufferOffset && self.AltitudeLength == other.AltitudeLength && self.AltitudeBufferOffset == other.AltitudeBufferOffset
     }
 }
 impl ::core::cmp::Eq for INSTANCE_PARTIAL_INFORMATION {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -1351,7 +1351,7 @@ unsafe impl ::windows::core::Abi for ATA_PASS_THROUGH_DIRECT {
 }
 impl ::core::cmp::PartialEq for ATA_PASS_THROUGH_DIRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATA_PASS_THROUGH_DIRECT>()) == 0 }
+        self.Length == other.Length && self.AtaFlags == other.AtaFlags && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.ReservedAsUchar == other.ReservedAsUchar && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.ReservedAsUlong == other.ReservedAsUlong && self.DataBuffer == other.DataBuffer && self.PreviousTaskFile == other.PreviousTaskFile && self.CurrentTaskFile == other.CurrentTaskFile
     }
 }
 impl ::core::cmp::Eq for ATA_PASS_THROUGH_DIRECT {}
@@ -1411,7 +1411,7 @@ unsafe impl ::windows::core::Abi for ATA_PASS_THROUGH_DIRECT32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for ATA_PASS_THROUGH_DIRECT32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATA_PASS_THROUGH_DIRECT32>()) == 0 }
+        self.Length == other.Length && self.AtaFlags == other.AtaFlags && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.ReservedAsUchar == other.ReservedAsUchar && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.ReservedAsUlong == other.ReservedAsUlong && self.DataBuffer == other.DataBuffer && self.PreviousTaskFile == other.PreviousTaskFile && self.CurrentTaskFile == other.CurrentTaskFile
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1467,7 +1467,7 @@ unsafe impl ::windows::core::Abi for ATA_PASS_THROUGH_EX {
 }
 impl ::core::cmp::PartialEq for ATA_PASS_THROUGH_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATA_PASS_THROUGH_EX>()) == 0 }
+        self.Length == other.Length && self.AtaFlags == other.AtaFlags && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.ReservedAsUchar == other.ReservedAsUchar && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.ReservedAsUlong == other.ReservedAsUlong && self.DataBufferOffset == other.DataBufferOffset && self.PreviousTaskFile == other.PreviousTaskFile && self.CurrentTaskFile == other.CurrentTaskFile
     }
 }
 impl ::core::cmp::Eq for ATA_PASS_THROUGH_EX {}
@@ -1527,7 +1527,7 @@ unsafe impl ::windows::core::Abi for ATA_PASS_THROUGH_EX32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for ATA_PASS_THROUGH_EX32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATA_PASS_THROUGH_EX32>()) == 0 }
+        self.Length == other.Length && self.AtaFlags == other.AtaFlags && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.ReservedAsUchar == other.ReservedAsUchar && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.ReservedAsUlong == other.ReservedAsUlong && self.DataBufferOffset == other.DataBufferOffset && self.PreviousTaskFile == other.PreviousTaskFile && self.CurrentTaskFile == other.CurrentTaskFile
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1565,7 +1565,7 @@ unsafe impl ::windows::core::Abi for DSM_NOTIFICATION_REQUEST_BLOCK {
 }
 impl ::core::cmp::PartialEq for DSM_NOTIFICATION_REQUEST_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSM_NOTIFICATION_REQUEST_BLOCK>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.NotifyFlags == other.NotifyFlags && self.DataSetProfile == other.DataSetProfile && self.Reserved == other.Reserved && self.DataSetRangesCount == other.DataSetRangesCount && self.DataSetRanges == other.DataSetRanges
     }
 }
 impl ::core::cmp::Eq for DSM_NOTIFICATION_REQUEST_BLOCK {}
@@ -1597,7 +1597,7 @@ unsafe impl ::windows::core::Abi for DUMP_DRIVER {
 }
 impl ::core::cmp::PartialEq for DUMP_DRIVER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_DRIVER>()) == 0 }
+        self.DumpDriverList == other.DumpDriverList && self.DriverName == other.DriverName && self.BaseName == other.BaseName
     }
 }
 impl ::core::cmp::Eq for DUMP_DRIVER {}
@@ -1630,7 +1630,7 @@ unsafe impl ::windows::core::Abi for DUMP_DRIVER_EX {
 }
 impl ::core::cmp::PartialEq for DUMP_DRIVER_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_DRIVER_EX>()) == 0 }
+        self.DumpDriverList == other.DumpDriverList && self.DriverName == other.DriverName && self.BaseName == other.BaseName && self.DriverFullPath == other.DriverFullPath
     }
 }
 impl ::core::cmp::Eq for DUMP_DRIVER_EX {}
@@ -1686,7 +1686,7 @@ unsafe impl ::windows::core::Abi for DUMP_POINTERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DUMP_POINTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_POINTERS>()) == 0 }
+        self.AdapterObject == other.AdapterObject && self.MappedRegisterBase == other.MappedRegisterBase && self.DumpData == other.DumpData && self.CommonBufferVa == other.CommonBufferVa && self.CommonBufferPa == other.CommonBufferPa && self.CommonBufferSize == other.CommonBufferSize && self.AllocateCommonBuffers == other.AllocateCommonBuffers && self.UseDiskDump == other.UseDiskDump && self.Spare1 == other.Spare1 && self.DeviceObject == other.DeviceObject
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1744,7 +1744,6 @@ impl ::core::fmt::Debug for DUMP_POINTERS_EX {
             .field("AdapterObject", &self.AdapterObject)
             .field("MappedRegisterBase", &self.MappedRegisterBase)
             .field("DeviceReady", &self.DeviceReady)
-            .field("DumpDevicePowerOn", &self.DumpDevicePowerOn.map(|f| f as usize))
             .field("DumpDevicePowerOnContext", &self.DumpDevicePowerOnContext)
             .finish()
     }
@@ -1753,14 +1752,6 @@ impl ::core::fmt::Debug for DUMP_POINTERS_EX {
 unsafe impl ::windows::core::Abi for DUMP_POINTERS_EX {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DUMP_POINTERS_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_POINTERS_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DUMP_POINTERS_EX {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DUMP_POINTERS_EX {
     fn default() -> Self {
@@ -1789,7 +1780,7 @@ unsafe impl ::windows::core::Abi for DUMP_POINTERS_VERSION {
 }
 impl ::core::cmp::PartialEq for DUMP_POINTERS_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_POINTERS_VERSION>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for DUMP_POINTERS_VERSION {}
@@ -1824,7 +1815,7 @@ unsafe impl ::windows::core::Abi for FIRMWARE_REQUEST_BLOCK {
 }
 impl ::core::cmp::PartialEq for FIRMWARE_REQUEST_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIRMWARE_REQUEST_BLOCK>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Function == other.Function && self.Flags == other.Flags && self.DataBufferOffset == other.DataBufferOffset && self.DataBufferLength == other.DataBufferLength
     }
 }
 impl ::core::cmp::Eq for FIRMWARE_REQUEST_BLOCK {}
@@ -1860,7 +1851,7 @@ unsafe impl ::windows::core::Abi for HYBRID_DEMOTE_BY_SIZE {
 }
 impl ::core::cmp::PartialEq for HYBRID_DEMOTE_BY_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_DEMOTE_BY_SIZE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SourcePriority == other.SourcePriority && self.TargetPriority == other.TargetPriority && self.Reserved0 == other.Reserved0 && self.Reserved1 == other.Reserved1 && self.LbaCount == other.LbaCount
     }
 }
 impl ::core::cmp::Eq for HYBRID_DEMOTE_BY_SIZE {}
@@ -1893,7 +1884,7 @@ unsafe impl ::windows::core::Abi for HYBRID_DIRTY_THRESHOLDS {
 }
 impl ::core::cmp::PartialEq for HYBRID_DIRTY_THRESHOLDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_DIRTY_THRESHOLDS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DirtyLowThreshold == other.DirtyLowThreshold && self.DirtyHighThreshold == other.DirtyHighThreshold
     }
 }
 impl ::core::cmp::Eq for HYBRID_DIRTY_THRESHOLDS {}
@@ -1938,7 +1929,7 @@ unsafe impl ::windows::core::Abi for HYBRID_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HYBRID_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_INFORMATION>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.HybridSupported == other.HybridSupported && self.Status == other.Status && self.CacheTypeEffective == other.CacheTypeEffective && self.CacheTypeDefault == other.CacheTypeDefault && self.FractionBase == other.FractionBase && self.CacheSize == other.CacheSize && self.Attributes == other.Attributes && self.Priorities == other.Priorities
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1976,7 +1967,7 @@ unsafe impl ::windows::core::Abi for HYBRID_INFORMATION_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HYBRID_INFORMATION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_INFORMATION_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2021,7 +2012,7 @@ unsafe impl ::windows::core::Abi for HYBRID_INFORMATION_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HYBRID_INFORMATION_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_INFORMATION_1>()) == 0 }
+        self.PriorityLevelCount == other.PriorityLevelCount && self.MaxPriorityBehavior == other.MaxPriorityBehavior && self.OptimalWriteGranularity == other.OptimalWriteGranularity && self.Reserved == other.Reserved && self.DirtyThresholdLow == other.DirtyThresholdLow && self.DirtyThresholdHigh == other.DirtyThresholdHigh && self.SupportedCommands == other.SupportedCommands && self.Priority == other.Priority
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2062,7 +2053,7 @@ unsafe impl ::windows::core::Abi for HYBRID_INFORMATION_1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HYBRID_INFORMATION_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_INFORMATION_1_0>()) == 0 }
+        self._bitfield == other._bitfield && self.MaxEvictCommands == other.MaxEvictCommands && self.MaxLbaRangeCountForEvict == other.MaxLbaRangeCountForEvict && self.MaxLbaRangeCountForChangeLba == other.MaxLbaRangeCountForChangeLba
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2099,7 +2090,7 @@ unsafe impl ::windows::core::Abi for HYBRID_REQUEST_BLOCK {
 }
 impl ::core::cmp::PartialEq for HYBRID_REQUEST_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYBRID_REQUEST_BLOCK>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Function == other.Function && self.Flags == other.Flags && self.DataBufferOffset == other.DataBufferOffset && self.DataBufferLength == other.DataBufferLength
     }
 }
 impl ::core::cmp::Eq for HYBRID_REQUEST_BLOCK {}
@@ -2134,7 +2125,7 @@ unsafe impl ::windows::core::Abi for IDE_IO_CONTROL {
 }
 impl ::core::cmp::PartialEq for IDE_IO_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IDE_IO_CONTROL>()) == 0 }
+        self.HeaderLength == other.HeaderLength && self.Signature == other.Signature && self.Timeout == other.Timeout && self.ControlCode == other.ControlCode && self.ReturnStatus == other.ReturnStatus && self.DataLength == other.DataLength
     }
 }
 impl ::core::cmp::Eq for IDE_IO_CONTROL {}
@@ -2158,12 +2149,6 @@ impl ::core::clone::Clone for IKE_AUTHENTICATION_INFORMATION {
 unsafe impl ::windows::core::Abi for IKE_AUTHENTICATION_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKE_AUTHENTICATION_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKE_AUTHENTICATION_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKE_AUTHENTICATION_INFORMATION {}
 impl ::core::default::Default for IKE_AUTHENTICATION_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2183,12 +2168,6 @@ impl ::core::clone::Clone for IKE_AUTHENTICATION_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for IKE_AUTHENTICATION_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IKE_AUTHENTICATION_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKE_AUTHENTICATION_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IKE_AUTHENTICATION_INFORMATION_0 {}
 impl ::core::default::Default for IKE_AUTHENTICATION_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2220,7 +2199,7 @@ unsafe impl ::windows::core::Abi for IKE_AUTHENTICATION_PRESHARED_KEY {
 }
 impl ::core::cmp::PartialEq for IKE_AUTHENTICATION_PRESHARED_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IKE_AUTHENTICATION_PRESHARED_KEY>()) == 0 }
+        self.SecurityFlags == other.SecurityFlags && self.IdType == other.IdType && self.IdLengthInBytes == other.IdLengthInBytes && self.Id == other.Id && self.KeyLengthInBytes == other.KeyLengthInBytes && self.Key == other.Key
     }
 }
 impl ::core::cmp::Eq for IKE_AUTHENTICATION_PRESHARED_KEY {}
@@ -2263,7 +2242,7 @@ unsafe impl ::windows::core::Abi for IO_SCSI_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IO_SCSI_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_SCSI_CAPABILITIES>()) == 0 }
+        self.Length == other.Length && self.MaximumTransferLength == other.MaximumTransferLength && self.MaximumPhysicalPages == other.MaximumPhysicalPages && self.SupportedAsynchronousEvents == other.SupportedAsynchronousEvents && self.AlignmentMask == other.AlignmentMask && self.TaggedQueuing == other.TaggedQueuing && self.AdapterScansDown == other.AdapterScansDown && self.AdapterUsesPio == other.AdapterUsesPio
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2300,7 +2279,7 @@ unsafe impl ::windows::core::Abi for ISCSI_CONNECTION_INFOA {
 }
 impl ::core::cmp::PartialEq for ISCSI_CONNECTION_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_CONNECTION_INFOA>()) == 0 }
+        self.ConnectionId == other.ConnectionId && self.InitiatorAddress == other.InitiatorAddress && self.TargetAddress == other.TargetAddress && self.InitiatorSocket == other.InitiatorSocket && self.TargetSocket == other.TargetSocket && self.CID == other.CID
     }
 }
 impl ::core::cmp::Eq for ISCSI_CONNECTION_INFOA {}
@@ -2335,7 +2314,7 @@ unsafe impl ::windows::core::Abi for ISCSI_CONNECTION_INFOW {
 }
 impl ::core::cmp::PartialEq for ISCSI_CONNECTION_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_CONNECTION_INFOW>()) == 0 }
+        self.ConnectionId == other.ConnectionId && self.InitiatorAddress == other.InitiatorAddress && self.TargetAddress == other.TargetAddress && self.InitiatorSocket == other.InitiatorSocket && self.TargetSocket == other.TargetSocket && self.CID == other.CID
     }
 }
 impl ::core::cmp::Eq for ISCSI_CONNECTION_INFOW {}
@@ -2373,7 +2352,7 @@ unsafe impl ::windows::core::Abi for ISCSI_CONNECTION_INFO_EX {
 }
 impl ::core::cmp::PartialEq for ISCSI_CONNECTION_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_CONNECTION_INFO_EX>()) == 0 }
+        self.ConnectionId == other.ConnectionId && self.State == other.State && self.Protocol == other.Protocol && self.HeaderDigest == other.HeaderDigest && self.DataDigest == other.DataDigest && self.MaxRecvDataSegmentLength == other.MaxRecvDataSegmentLength && self.AuthType == other.AuthType && self.EstimatedThroughput == other.EstimatedThroughput && self.MaxDatagramSize == other.MaxDatagramSize
     }
 }
 impl ::core::cmp::Eq for ISCSI_CONNECTION_INFO_EX {}
@@ -2416,7 +2395,7 @@ unsafe impl ::windows::core::Abi for ISCSI_DEVICE_ON_SESSIONA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ioctl"))]
 impl ::core::cmp::PartialEq for ISCSI_DEVICE_ON_SESSIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_DEVICE_ON_SESSIONA>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.TargetName == other.TargetName && self.ScsiAddress == other.ScsiAddress && self.DeviceInterfaceType == other.DeviceInterfaceType && self.DeviceInterfaceName == other.DeviceInterfaceName && self.LegacyName == other.LegacyName && self.StorageDeviceNumber == other.StorageDeviceNumber && self.DeviceInstance == other.DeviceInstance
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ioctl"))]
@@ -2461,7 +2440,7 @@ unsafe impl ::windows::core::Abi for ISCSI_DEVICE_ON_SESSIONW {
 #[cfg(feature = "Win32_System_Ioctl")]
 impl ::core::cmp::PartialEq for ISCSI_DEVICE_ON_SESSIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_DEVICE_ON_SESSIONW>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.TargetName == other.TargetName && self.ScsiAddress == other.ScsiAddress && self.DeviceInterfaceType == other.DeviceInterfaceType && self.DeviceInterfaceName == other.DeviceInterfaceName && self.LegacyName == other.LegacyName && self.StorageDeviceNumber == other.StorageDeviceNumber && self.DeviceInstance == other.DeviceInstance
     }
 }
 #[cfg(feature = "Win32_System_Ioctl")]
@@ -2519,7 +2498,7 @@ unsafe impl ::windows::core::Abi for ISCSI_LOGIN_OPTIONS {
 }
 impl ::core::cmp::PartialEq for ISCSI_LOGIN_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_LOGIN_OPTIONS>()) == 0 }
+        self.Version == other.Version && self.InformationSpecified == other.InformationSpecified && self.LoginFlags == other.LoginFlags && self.AuthType == other.AuthType && self.HeaderDigest == other.HeaderDigest && self.DataDigest == other.DataDigest && self.MaximumConnections == other.MaximumConnections && self.DefaultTime2Wait == other.DefaultTime2Wait && self.DefaultTime2Retain == other.DefaultTime2Retain && self.UsernameLength == other.UsernameLength && self.PasswordLength == other.PasswordLength && self.Username == other.Username && self.Password == other.Password
     }
 }
 impl ::core::cmp::Eq for ISCSI_LOGIN_OPTIONS {}
@@ -2556,7 +2535,7 @@ unsafe impl ::windows::core::Abi for ISCSI_SESSION_INFOA {
 }
 impl ::core::cmp::PartialEq for ISCSI_SESSION_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_SESSION_INFOA>()) == 0 }
+        self.SessionId == other.SessionId && self.InitiatorName == other.InitiatorName && self.TargetNodeName == other.TargetNodeName && self.TargetName == other.TargetName && self.ISID == other.ISID && self.TSID == other.TSID && self.ConnectionCount == other.ConnectionCount && self.Connections == other.Connections
     }
 }
 impl ::core::cmp::Eq for ISCSI_SESSION_INFOA {}
@@ -2593,7 +2572,7 @@ unsafe impl ::windows::core::Abi for ISCSI_SESSION_INFOW {
 }
 impl ::core::cmp::PartialEq for ISCSI_SESSION_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_SESSION_INFOW>()) == 0 }
+        self.SessionId == other.SessionId && self.InitiatorName == other.InitiatorName && self.TargetNodeName == other.TargetNodeName && self.TargetName == other.TargetName && self.ISID == other.ISID && self.TSID == other.TSID && self.ConnectionCount == other.ConnectionCount && self.Connections == other.Connections
     }
 }
 impl ::core::cmp::Eq for ISCSI_SESSION_INFOW {}
@@ -2655,7 +2634,7 @@ unsafe impl ::windows::core::Abi for ISCSI_SESSION_INFO_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_SESSION_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_SESSION_INFO_EX>()) == 0 }
+        self.SessionId == other.SessionId && self.InitialR2t == other.InitialR2t && self.ImmediateData == other.ImmediateData && self.Type == other.Type && self.DataSequenceInOrder == other.DataSequenceInOrder && self.DataPduInOrder == other.DataPduInOrder && self.ErrorRecoveryLevel == other.ErrorRecoveryLevel && self.MaxOutstandingR2t == other.MaxOutstandingR2t && self.FirstBurstLength == other.FirstBurstLength && self.MaxBurstLength == other.MaxBurstLength && self.MaximumConnections == other.MaximumConnections && self.ConnectionCount == other.ConnectionCount && self.Connections == other.Connections
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2700,7 +2679,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_MAPPINGA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_TARGET_MAPPINGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_MAPPINGA>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.TargetName == other.TargetName && self.OSDeviceName == other.OSDeviceName && self.SessionId == other.SessionId && self.OSBusNumber == other.OSBusNumber && self.OSTargetNumber == other.OSTargetNumber && self.LUNCount == other.LUNCount && self.LUNList == other.LUNList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2739,7 +2718,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_MAPPINGW {
 }
 impl ::core::cmp::PartialEq for ISCSI_TARGET_MAPPINGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_MAPPINGW>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.TargetName == other.TargetName && self.OSDeviceName == other.OSDeviceName && self.SessionId == other.SessionId && self.OSBusNumber == other.OSBusNumber && self.OSTargetNumber == other.OSTargetNumber && self.LUNCount == other.LUNCount && self.LUNList == other.LUNList
     }
 }
 impl ::core::cmp::Eq for ISCSI_TARGET_MAPPINGW {}
@@ -2777,7 +2756,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTALA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTALA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTALA>()) == 0 }
+        self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2811,7 +2790,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTALW {
 }
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTALW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTALW>()) == 0 }
+        self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket
     }
 }
 impl ::core::cmp::Eq for ISCSI_TARGET_PORTALW {}
@@ -2848,7 +2827,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_GROUPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_GROUPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_GROUPA>()) == 0 }
+        self.Count == other.Count && self.Portals == other.Portals
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2881,7 +2860,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_GROUPW {
 }
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_GROUPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_GROUPW>()) == 0 }
+        self.Count == other.Count && self.Portals == other.Portals
     }
 }
 impl ::core::cmp::Eq for ISCSI_TARGET_PORTAL_GROUPW {}
@@ -2921,7 +2900,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_INFOA>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.InitiatorPortNumber == other.InitiatorPortNumber && self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2957,7 +2936,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_INFOW {
 }
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_INFOW>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.InitiatorPortNumber == other.InitiatorPortNumber && self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket
     }
 }
 impl ::core::cmp::Eq for ISCSI_TARGET_PORTAL_INFOW {}
@@ -2999,7 +2978,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_INFO_EXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_INFO_EXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_INFO_EXA>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.InitiatorPortNumber == other.InitiatorPortNumber && self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket && self.SecurityFlags == other.SecurityFlags && self.LoginOptions == other.LoginOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3037,7 +3016,7 @@ unsafe impl ::windows::core::Abi for ISCSI_TARGET_PORTAL_INFO_EXW {
 }
 impl ::core::cmp::PartialEq for ISCSI_TARGET_PORTAL_INFO_EXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_TARGET_PORTAL_INFO_EXW>()) == 0 }
+        self.InitiatorName == other.InitiatorName && self.InitiatorPortNumber == other.InitiatorPortNumber && self.SymbolicName == other.SymbolicName && self.Address == other.Address && self.Socket == other.Socket && self.SecurityFlags == other.SecurityFlags && self.LoginOptions == other.LoginOptions
     }
 }
 impl ::core::cmp::Eq for ISCSI_TARGET_PORTAL_INFO_EXW {}
@@ -3068,7 +3047,7 @@ unsafe impl ::windows::core::Abi for ISCSI_UNIQUE_SESSION_ID {
 }
 impl ::core::cmp::PartialEq for ISCSI_UNIQUE_SESSION_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_UNIQUE_SESSION_ID>()) == 0 }
+        self.AdapterUnique == other.AdapterUnique && self.AdapterSpecific == other.AdapterSpecific
     }
 }
 impl ::core::cmp::Eq for ISCSI_UNIQUE_SESSION_ID {}
@@ -3100,7 +3079,7 @@ unsafe impl ::windows::core::Abi for ISCSI_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for ISCSI_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ISCSI_VERSION_INFO>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.BuildNumber == other.BuildNumber
     }
 }
 impl ::core::cmp::Eq for ISCSI_VERSION_INFO {}
@@ -3135,7 +3114,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH {
 }
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH>()) == 0 }
+        self.PassThrough == other.PassThrough && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 impl ::core::cmp::Eq for MPIO_PASS_THROUGH_PATH {}
@@ -3176,7 +3155,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH32>()) == 0 }
+        self.PassThrough == other.PassThrough && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3219,7 +3198,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH32_EX {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH32_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH32_EX>()) == 0 }
+        self.PassThroughOffset == other.PassThroughOffset && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3256,7 +3235,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH_DIRECT {
 }
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH_DIRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH_DIRECT>()) == 0 }
+        self.PassThrough == other.PassThrough && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 impl ::core::cmp::Eq for MPIO_PASS_THROUGH_PATH_DIRECT {}
@@ -3297,7 +3276,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH_DIRECT32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH_DIRECT32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH_DIRECT32>()) == 0 }
+        self.PassThrough == other.PassThrough && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3340,7 +3319,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH_DIRECT32_EX {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH_DIRECT32_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH_DIRECT32_EX>()) == 0 }
+        self.PassThroughOffset == other.PassThroughOffset && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3377,7 +3356,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH_DIRECT_EX {
 }
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH_DIRECT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH_DIRECT_EX>()) == 0 }
+        self.PassThroughOffset == other.PassThroughOffset && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 impl ::core::cmp::Eq for MPIO_PASS_THROUGH_PATH_DIRECT_EX {}
@@ -3412,7 +3391,7 @@ unsafe impl ::windows::core::Abi for MPIO_PASS_THROUGH_PATH_EX {
 }
 impl ::core::cmp::PartialEq for MPIO_PASS_THROUGH_PATH_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MPIO_PASS_THROUGH_PATH_EX>()) == 0 }
+        self.PassThroughOffset == other.PassThroughOffset && self.Version == other.Version && self.Length == other.Length && self.Flags == other.Flags && self.PortNumber == other.PortNumber && self.MpioPathId == other.MpioPathId
     }
 }
 impl ::core::cmp::Eq for MPIO_PASS_THROUGH_PATH_EX {}
@@ -3443,7 +3422,7 @@ unsafe impl ::windows::core::Abi for MP_DEVICE_DATA_SET_RANGE {
 }
 impl ::core::cmp::PartialEq for MP_DEVICE_DATA_SET_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MP_DEVICE_DATA_SET_RANGE>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for MP_DEVICE_DATA_SET_RANGE {}
@@ -3475,7 +3454,7 @@ unsafe impl ::windows::core::Abi for NTSCSI_UNICODE_STRING {
 }
 impl ::core::cmp::PartialEq for NTSCSI_UNICODE_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTSCSI_UNICODE_STRING>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for NTSCSI_UNICODE_STRING {}
@@ -3531,7 +3510,7 @@ unsafe impl ::windows::core::Abi for NVCACHE_HINT_PAYLOAD {
 }
 impl ::core::cmp::PartialEq for NVCACHE_HINT_PAYLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NVCACHE_HINT_PAYLOAD>()) == 0 }
+        self.Command == other.Command && self.Feature7_0 == other.Feature7_0 && self.Feature15_8 == other.Feature15_8 && self.Count15_8 == other.Count15_8 && self.LBA7_0 == other.LBA7_0 && self.LBA15_8 == other.LBA15_8 && self.LBA23_16 == other.LBA23_16 && self.LBA31_24 == other.LBA31_24 && self.LBA39_32 == other.LBA39_32 && self.LBA47_40 == other.LBA47_40 && self.Auxiliary7_0 == other.Auxiliary7_0 && self.Auxiliary23_16 == other.Auxiliary23_16 && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NVCACHE_HINT_PAYLOAD {}
@@ -3575,7 +3554,7 @@ unsafe impl ::windows::core::Abi for NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NVCACHE_PRIORITY_LEVEL_DESCRIPTOR>()) == 0 }
+        self.PriorityLevel == other.PriorityLevel && self.Reserved0 == other.Reserved0 && self.ConsumedNVMSizeFraction == other.ConsumedNVMSizeFraction && self.ConsumedMappingResourcesFraction == other.ConsumedMappingResourcesFraction && self.ConsumedNVMSizeForDirtyDataFraction == other.ConsumedNVMSizeForDirtyDataFraction && self.ConsumedMappingResourcesForDirtyDataFraction == other.ConsumedMappingResourcesForDirtyDataFraction && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {}
@@ -3613,7 +3592,7 @@ unsafe impl ::windows::core::Abi for NVCACHE_REQUEST_BLOCK {
 }
 impl ::core::cmp::PartialEq for NVCACHE_REQUEST_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NVCACHE_REQUEST_BLOCK>()) == 0 }
+        self.NRBSize == other.NRBSize && self.Function == other.Function && self.NRBFlags == other.NRBFlags && self.NRBStatus == other.NRBStatus && self.Count == other.Count && self.LBA == other.LBA && self.DataBufSize == other.DataBufSize && self.NVCacheStatus == other.NVCacheStatus && self.NVCacheSubStatus == other.NVCacheSubStatus
     }
 }
 impl ::core::cmp::Eq for NVCACHE_REQUEST_BLOCK {}
@@ -3663,7 +3642,7 @@ unsafe impl ::windows::core::Abi for NV_FEATURE_PARAMETER {
 }
 impl ::core::cmp::PartialEq for NV_FEATURE_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NV_FEATURE_PARAMETER>()) == 0 }
+        self.NVPowerModeEnabled == other.NVPowerModeEnabled && self.NVParameterReserv1 == other.NVParameterReserv1 && self.NVCmdEnabled == other.NVCmdEnabled && self.NVParameterReserv2 == other.NVParameterReserv2 && self.NVPowerModeVer == other.NVPowerModeVer && self.NVCmdVer == other.NVCmdVer && self.NVSize == other.NVSize && self.NVReadSpeed == other.NVReadSpeed && self.NVWrtSpeed == other.NVWrtSpeed && self.DeviceSpinUpTime == other.DeviceSpinUpTime
     }
 }
 impl ::core::cmp::Eq for NV_FEATURE_PARAMETER {}
@@ -3691,12 +3670,6 @@ impl ::core::clone::Clone for NV_SEP_CACHE_PARAMETER {
 unsafe impl ::windows::core::Abi for NV_SEP_CACHE_PARAMETER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NV_SEP_CACHE_PARAMETER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NV_SEP_CACHE_PARAMETER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NV_SEP_CACHE_PARAMETER {}
 impl ::core::default::Default for NV_SEP_CACHE_PARAMETER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3717,12 +3690,6 @@ impl ::core::clone::Clone for NV_SEP_CACHE_PARAMETER_0 {
 unsafe impl ::windows::core::Abi for NV_SEP_CACHE_PARAMETER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NV_SEP_CACHE_PARAMETER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NV_SEP_CACHE_PARAMETER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NV_SEP_CACHE_PARAMETER_0 {}
 impl ::core::default::Default for NV_SEP_CACHE_PARAMETER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3749,7 +3716,7 @@ unsafe impl ::windows::core::Abi for NV_SEP_CACHE_PARAMETER_0_0 {
 }
 impl ::core::cmp::PartialEq for NV_SEP_CACHE_PARAMETER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NV_SEP_CACHE_PARAMETER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NV_SEP_CACHE_PARAMETER_0_0 {}
@@ -3792,7 +3759,7 @@ unsafe impl ::windows::core::Abi for PERSISTENT_ISCSI_LOGIN_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERSISTENT_ISCSI_LOGIN_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_ISCSI_LOGIN_INFOA>()) == 0 }
+        self.TargetName == other.TargetName && self.IsInformationalSession == other.IsInformationalSession && self.InitiatorInstance == other.InitiatorInstance && self.InitiatorPortNumber == other.InitiatorPortNumber && self.TargetPortal == other.TargetPortal && self.SecurityFlags == other.SecurityFlags && self.Mappings == other.Mappings && self.LoginOptions == other.LoginOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3837,7 +3804,7 @@ unsafe impl ::windows::core::Abi for PERSISTENT_ISCSI_LOGIN_INFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERSISTENT_ISCSI_LOGIN_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_ISCSI_LOGIN_INFOW>()) == 0 }
+        self.TargetName == other.TargetName && self.IsInformationalSession == other.IsInformationalSession && self.InitiatorInstance == other.InitiatorInstance && self.InitiatorPortNumber == other.InitiatorPortNumber && self.TargetPortal == other.TargetPortal && self.SecurityFlags == other.SecurityFlags && self.Mappings == other.Mappings && self.LoginOptions == other.LoginOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3870,7 +3837,7 @@ unsafe impl ::windows::core::Abi for SCSI_ADAPTER_BUS_INFO {
 }
 impl ::core::cmp::PartialEq for SCSI_ADAPTER_BUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_ADAPTER_BUS_INFO>()) == 0 }
+        self.NumberOfBuses == other.NumberOfBuses && self.BusData == other.BusData
     }
 }
 impl ::core::cmp::Eq for SCSI_ADAPTER_BUS_INFO {}
@@ -3904,7 +3871,7 @@ unsafe impl ::windows::core::Abi for SCSI_ADDRESS {
 }
 impl ::core::cmp::PartialEq for SCSI_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_ADDRESS>()) == 0 }
+        self.Length == other.Length && self.PortNumber == other.PortNumber && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun
     }
 }
 impl ::core::cmp::Eq for SCSI_ADDRESS {}
@@ -3936,7 +3903,7 @@ unsafe impl ::windows::core::Abi for SCSI_BUS_DATA {
 }
 impl ::core::cmp::PartialEq for SCSI_BUS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_BUS_DATA>()) == 0 }
+        self.NumberOfLogicalUnits == other.NumberOfLogicalUnits && self.InitiatorBusId == other.InitiatorBusId && self.InquiryDataOffset == other.InquiryDataOffset
     }
 }
 impl ::core::cmp::Eq for SCSI_BUS_DATA {}
@@ -3978,7 +3945,7 @@ unsafe impl ::windows::core::Abi for SCSI_INQUIRY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCSI_INQUIRY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_INQUIRY_DATA>()) == 0 }
+        self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.DeviceClaimed == other.DeviceClaimed && self.InquiryDataLength == other.InquiryDataLength && self.NextInquiryDataOffset == other.NextInquiryDataOffset && self.InquiryData == other.InquiryData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4011,7 +3978,7 @@ unsafe impl ::windows::core::Abi for SCSI_LUN_LIST {
 }
 impl ::core::cmp::PartialEq for SCSI_LUN_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_LUN_LIST>()) == 0 }
+        self.OSLUN == other.OSLUN && self.TargetLUN == other.TargetLUN
     }
 }
 impl ::core::cmp::Eq for SCSI_LUN_LIST {}
@@ -4067,7 +4034,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH {
 }
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH>()) == 0 }
+        self.Length == other.Length && self.ScsiStatus == other.ScsiStatus && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.CdbLength == other.CdbLength && self.SenseInfoLength == other.SenseInfoLength && self.DataIn == other.DataIn && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.DataBufferOffset == other.DataBufferOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.Cdb == other.Cdb
     }
 }
 impl ::core::cmp::Eq for SCSI_PASS_THROUGH {}
@@ -4129,7 +4096,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH32>()) == 0 }
+        self.Length == other.Length && self.ScsiStatus == other.ScsiStatus && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.CdbLength == other.CdbLength && self.SenseInfoLength == other.SenseInfoLength && self.DataIn == other.DataIn && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.DataBufferOffset == other.DataBufferOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.Cdb == other.Cdb
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -4199,7 +4166,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH32_EX {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH32_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH32_EX>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.CdbLength == other.CdbLength && self.StorAddressLength == other.StorAddressLength && self.ScsiStatus == other.ScsiStatus && self.SenseInfoLength == other.SenseInfoLength && self.DataDirection == other.DataDirection && self.Reserved == other.Reserved && self.TimeOutValue == other.TimeOutValue && self.StorAddressOffset == other.StorAddressOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.DataOutTransferLength == other.DataOutTransferLength && self.DataInTransferLength == other.DataInTransferLength && self.DataOutBufferOffset == other.DataOutBufferOffset && self.DataInBufferOffset == other.DataInBufferOffset && self.Cdb == other.Cdb
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -4257,7 +4224,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH_DIRECT {
 }
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH_DIRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH_DIRECT>()) == 0 }
+        self.Length == other.Length && self.ScsiStatus == other.ScsiStatus && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.CdbLength == other.CdbLength && self.SenseInfoLength == other.SenseInfoLength && self.DataIn == other.DataIn && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.DataBuffer == other.DataBuffer && self.SenseInfoOffset == other.SenseInfoOffset && self.Cdb == other.Cdb
     }
 }
 impl ::core::cmp::Eq for SCSI_PASS_THROUGH_DIRECT {}
@@ -4319,7 +4286,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH_DIRECT32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH_DIRECT32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH_DIRECT32>()) == 0 }
+        self.Length == other.Length && self.ScsiStatus == other.ScsiStatus && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun && self.CdbLength == other.CdbLength && self.SenseInfoLength == other.SenseInfoLength && self.DataIn == other.DataIn && self.DataTransferLength == other.DataTransferLength && self.TimeOutValue == other.TimeOutValue && self.DataBuffer == other.DataBuffer && self.SenseInfoOffset == other.SenseInfoOffset && self.Cdb == other.Cdb
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -4389,7 +4356,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH_DIRECT32_EX {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH_DIRECT32_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH_DIRECT32_EX>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.CdbLength == other.CdbLength && self.StorAddressLength == other.StorAddressLength && self.ScsiStatus == other.ScsiStatus && self.SenseInfoLength == other.SenseInfoLength && self.DataDirection == other.DataDirection && self.Reserved == other.Reserved && self.TimeOutValue == other.TimeOutValue && self.StorAddressOffset == other.StorAddressOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.DataOutTransferLength == other.DataOutTransferLength && self.DataInTransferLength == other.DataInTransferLength && self.DataOutBuffer == other.DataOutBuffer && self.DataInBuffer == other.DataInBuffer && self.Cdb == other.Cdb
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -4453,7 +4420,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH_DIRECT_EX {
 }
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH_DIRECT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH_DIRECT_EX>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.CdbLength == other.CdbLength && self.StorAddressLength == other.StorAddressLength && self.ScsiStatus == other.ScsiStatus && self.SenseInfoLength == other.SenseInfoLength && self.DataDirection == other.DataDirection && self.Reserved == other.Reserved && self.TimeOutValue == other.TimeOutValue && self.StorAddressOffset == other.StorAddressOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.DataOutTransferLength == other.DataOutTransferLength && self.DataInTransferLength == other.DataInTransferLength && self.DataOutBuffer == other.DataOutBuffer && self.DataInBuffer == other.DataInBuffer && self.Cdb == other.Cdb
     }
 }
 impl ::core::cmp::Eq for SCSI_PASS_THROUGH_DIRECT_EX {}
@@ -4515,7 +4482,7 @@ unsafe impl ::windows::core::Abi for SCSI_PASS_THROUGH_EX {
 }
 impl ::core::cmp::PartialEq for SCSI_PASS_THROUGH_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCSI_PASS_THROUGH_EX>()) == 0 }
+        self.Version == other.Version && self.Length == other.Length && self.CdbLength == other.CdbLength && self.StorAddressLength == other.StorAddressLength && self.ScsiStatus == other.ScsiStatus && self.SenseInfoLength == other.SenseInfoLength && self.DataDirection == other.DataDirection && self.Reserved == other.Reserved && self.TimeOutValue == other.TimeOutValue && self.StorAddressOffset == other.StorAddressOffset && self.SenseInfoOffset == other.SenseInfoOffset && self.DataOutTransferLength == other.DataOutTransferLength && self.DataInTransferLength == other.DataInTransferLength && self.DataOutBufferOffset == other.DataOutBufferOffset && self.DataInBufferOffset == other.DataInBufferOffset && self.Cdb == other.Cdb
     }
 }
 impl ::core::cmp::Eq for SCSI_PASS_THROUGH_EX {}
@@ -4550,7 +4517,7 @@ unsafe impl ::windows::core::Abi for SRB_IO_CONTROL {
 }
 impl ::core::cmp::PartialEq for SRB_IO_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRB_IO_CONTROL>()) == 0 }
+        self.HeaderLength == other.HeaderLength && self.Signature == other.Signature && self.Timeout == other.Timeout && self.ControlCode == other.ControlCode && self.ReturnCode == other.ReturnCode && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for SRB_IO_CONTROL {}
@@ -4587,7 +4554,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DIAGNOSTIC_MP_REQUEST {
 }
 impl ::core::cmp::PartialEq for STORAGE_DIAGNOSTIC_MP_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DIAGNOSTIC_MP_REQUEST>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.TargetType == other.TargetType && self.Level == other.Level && self.ProviderId == other.ProviderId && self.BufferSize == other.BufferSize && self.Reserved == other.Reserved && self.DataBuffer == other.DataBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_DIAGNOSTIC_MP_REQUEST {}
@@ -4619,7 +4586,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ENDURANCE_DATA_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_ENDURANCE_DATA_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ENDURANCE_DATA_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.EnduranceInfo == other.EnduranceInfo
     }
 }
 impl ::core::cmp::Eq for STORAGE_ENDURANCE_DATA_DESCRIPTOR {}
@@ -4654,7 +4621,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ENDURANCE_INFO {
 }
 impl ::core::cmp::PartialEq for STORAGE_ENDURANCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ENDURANCE_INFO>()) == 0 }
+        self.ValidFields == other.ValidFields && self.GroupId == other.GroupId && self.Flags == other.Flags && self.LifePercentage == other.LifePercentage && self.BytesReadCount == other.BytesReadCount && self.ByteWriteCount == other.ByteWriteCount
     }
 }
 impl ::core::cmp::Eq for STORAGE_ENDURANCE_INFO {}
@@ -4684,7 +4651,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ENDURANCE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_ENDURANCE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ENDURANCE_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for STORAGE_ENDURANCE_INFO_0 {}
@@ -4717,7 +4684,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_ACTIVATE {
 }
 impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_ACTIVATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_ACTIVATE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SlotToActivate == other.SlotToActivate && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for STORAGE_FIRMWARE_ACTIVATE {}
@@ -4751,7 +4718,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_DOWNLOAD {
 }
 impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_DOWNLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_DOWNLOAD>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Offset == other.Offset && self.BufferSize == other.BufferSize && self.ImageBuffer == other.ImageBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_FIRMWARE_DOWNLOAD {}
@@ -4788,7 +4755,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_DOWNLOAD_V2 {
 }
 impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_DOWNLOAD_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_DOWNLOAD_V2>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Offset == other.Offset && self.BufferSize == other.BufferSize && self.Slot == other.Slot && self.Reserved == other.Reserved && self.ImageSize == other.ImageSize && self.ImageBuffer == other.ImageBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_FIRMWARE_DOWNLOAD_V2 {}
@@ -4822,14 +4789,6 @@ impl ::core::clone::Clone for STORAGE_FIRMWARE_INFO {
 unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_FIRMWARE_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_FIRMWARE_INFO {
     fn default() -> Self {
@@ -4885,7 +4844,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_INFO_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_INFO_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_INFO_V2>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.UpgradeSupport == other.UpgradeSupport && self.SlotCount == other.SlotCount && self.ActiveSlot == other.ActiveSlot && self.PendingActivateSlot == other.PendingActivateSlot && self.FirmwareShared == other.FirmwareShared && self.Reserved == other.Reserved && self.ImagePayloadAlignment == other.ImagePayloadAlignment && self.ImagePayloadMaxSize == other.ImagePayloadMaxSize && self.Slot == other.Slot
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4918,14 +4877,6 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_SLOT_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_SLOT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_SLOT_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_FIRMWARE_SLOT_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_FIRMWARE_SLOT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4950,14 +4901,6 @@ impl ::core::clone::Clone for STORAGE_FIRMWARE_SLOT_INFO_0 {
 unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_SLOT_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_SLOT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_SLOT_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_FIRMWARE_SLOT_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_FIRMWARE_SLOT_INFO_0 {
     fn default() -> Self {
@@ -4994,7 +4937,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FIRMWARE_SLOT_INFO_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_FIRMWARE_SLOT_INFO_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FIRMWARE_SLOT_INFO_V2>()) == 0 }
+        self.SlotNumber == other.SlotNumber && self.ReadOnly == other.ReadOnly && self.Reserved == other.Reserved && self.Revision == other.Revision
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
@@ -4308,14 +4308,6 @@ unsafe impl ::windows::core::Abi for JET_BKINFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_BKINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_BKINFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_BKINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4340,14 +4332,6 @@ impl ::core::clone::Clone for JET_BKINFO_0 {
 unsafe impl ::windows::core::Abi for JET_BKINFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_BKINFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKINFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_BKINFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_BKINFO_0 {
     fn default() -> Self {
@@ -4380,14 +4364,6 @@ unsafe impl ::windows::core::Abi for JET_BKLOGTIME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_BKLOGTIME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKLOGTIME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_BKLOGTIME {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_BKLOGTIME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4412,14 +4388,6 @@ impl ::core::clone::Clone for JET_BKLOGTIME_0 {
 unsafe impl ::windows::core::Abi for JET_BKLOGTIME_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_BKLOGTIME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKLOGTIME_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_BKLOGTIME_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_BKLOGTIME_0 {
     fn default() -> Self {
@@ -4453,7 +4421,7 @@ unsafe impl ::windows::core::Abi for JET_BKLOGTIME_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_BKLOGTIME_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKLOGTIME_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4483,14 +4451,6 @@ impl ::core::clone::Clone for JET_BKLOGTIME_1 {
 unsafe impl ::windows::core::Abi for JET_BKLOGTIME_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_BKLOGTIME_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKLOGTIME_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_BKLOGTIME_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_BKLOGTIME_1 {
     fn default() -> Self {
@@ -4524,7 +4484,7 @@ unsafe impl ::windows::core::Abi for JET_BKLOGTIME_1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_BKLOGTIME_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_BKLOGTIME_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4572,7 +4532,7 @@ unsafe impl ::windows::core::Abi for JET_COLUMNBASE_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_COLUMNBASE_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNBASE_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.columnid == other.columnid && self.coltyp == other.coltyp && self.wCountry == other.wCountry && self.langid == other.langid && self.cp == other.cp && self.wFiller == other.wFiller && self.cbMax == other.cbMax && self.grbit == other.grbit && self.szBaseTableName == other.szBaseTableName && self.szBaseColumnName == other.szBaseColumnName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4614,7 +4574,7 @@ unsafe impl ::windows::core::Abi for JET_COLUMNBASE_W {
 }
 impl ::core::cmp::PartialEq for JET_COLUMNBASE_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNBASE_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.columnid == other.columnid && self.coltyp == other.coltyp && self.wCountry == other.wCountry && self.langid == other.langid && self.cp == other.cp && self.wFiller == other.wFiller && self.cbMax == other.cbMax && self.grbit == other.grbit && self.szBaseTableName == other.szBaseTableName && self.szBaseColumnName == other.szBaseColumnName
     }
 }
 impl ::core::cmp::Eq for JET_COLUMNBASE_W {}
@@ -4653,7 +4613,7 @@ unsafe impl ::windows::core::Abi for JET_COLUMNCREATE_A {
 }
 impl ::core::cmp::PartialEq for JET_COLUMNCREATE_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNCREATE_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szColumnName == other.szColumnName && self.coltyp == other.coltyp && self.cbMax == other.cbMax && self.grbit == other.grbit && self.pvDefault == other.pvDefault && self.cbDefault == other.cbDefault && self.cp == other.cp && self.columnid == other.columnid && self.err == other.err
     }
 }
 impl ::core::cmp::Eq for JET_COLUMNCREATE_A {}
@@ -4692,7 +4652,7 @@ unsafe impl ::windows::core::Abi for JET_COLUMNCREATE_W {
 }
 impl ::core::cmp::PartialEq for JET_COLUMNCREATE_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNCREATE_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szColumnName == other.szColumnName && self.coltyp == other.coltyp && self.cbMax == other.cbMax && self.grbit == other.grbit && self.pvDefault == other.pvDefault && self.cbDefault == other.cbDefault && self.cp == other.cp && self.columnid == other.columnid && self.err == other.err
     }
 }
 impl ::core::cmp::Eq for JET_COLUMNCREATE_W {}
@@ -4730,7 +4690,7 @@ unsafe impl ::windows::core::Abi for JET_COLUMNDEF {
 }
 impl ::core::cmp::PartialEq for JET_COLUMNDEF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNDEF>()) == 0 }
+        self.cbStruct == other.cbStruct && self.columnid == other.columnid && self.coltyp == other.coltyp && self.wCountry == other.wCountry && self.langid == other.langid && self.cp == other.cp && self.wCollate == other.wCollate && self.cbMax == other.cbMax && self.grbit == other.grbit
     }
 }
 impl ::core::cmp::Eq for JET_COLUMNDEF {}
@@ -4800,7 +4760,23 @@ unsafe impl ::windows::core::Abi for JET_COLUMNLIST {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_COLUMNLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COLUMNLIST>()) == 0 }
+        self.cbStruct == other.cbStruct
+            && self.tableid == other.tableid
+            && self.cRecord == other.cRecord
+            && self.columnidPresentationOrder == other.columnidPresentationOrder
+            && self.columnidcolumnname == other.columnidcolumnname
+            && self.columnidcolumnid == other.columnidcolumnid
+            && self.columnidcoltyp == other.columnidcoltyp
+            && self.columnidCountry == other.columnidCountry
+            && self.columnidLangid == other.columnidLangid
+            && self.columnidCp == other.columnidCp
+            && self.columnidCollate == other.columnidCollate
+            && self.columnidcbMax == other.columnidcbMax
+            && self.columnidgrbit == other.columnidgrbit
+            && self.columnidDefault == other.columnidDefault
+            && self.columnidBaseTableName == other.columnidBaseTableName
+            && self.columnidBaseColumnName == other.columnidBaseColumnName
+            && self.columnidDefinitionName == other.columnidDefinitionName
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -4837,16 +4813,6 @@ unsafe impl ::windows::core::Abi for JET_COMMIT_ID {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_COMMIT_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COMMIT_ID>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_COMMIT_ID {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_COMMIT_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4878,16 +4844,6 @@ unsafe impl ::windows::core::Abi for JET_COMMIT_ID {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_COMMIT_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_COMMIT_ID>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_COMMIT_ID {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_COMMIT_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4916,7 +4872,7 @@ unsafe impl ::windows::core::Abi for JET_CONDITIONALCOLUMN_A {
 }
 impl ::core::cmp::PartialEq for JET_CONDITIONALCOLUMN_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONDITIONALCOLUMN_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szColumnName == other.szColumnName && self.grbit == other.grbit
     }
 }
 impl ::core::cmp::Eq for JET_CONDITIONALCOLUMN_A {}
@@ -4948,7 +4904,7 @@ unsafe impl ::windows::core::Abi for JET_CONDITIONALCOLUMN_W {
 }
 impl ::core::cmp::PartialEq for JET_CONDITIONALCOLUMN_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONDITIONALCOLUMN_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szColumnName == other.szColumnName && self.grbit == other.grbit
     }
 }
 impl ::core::cmp::Eq for JET_CONDITIONALCOLUMN_W {}
@@ -4972,12 +4928,6 @@ impl ::core::clone::Clone for JET_CONVERT_A {
 unsafe impl ::windows::core::Abi for JET_CONVERT_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_CONVERT_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_CONVERT_A {}
 impl ::core::default::Default for JET_CONVERT_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4998,12 +4948,6 @@ impl ::core::clone::Clone for JET_CONVERT_A_0 {
 unsafe impl ::windows::core::Abi for JET_CONVERT_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_CONVERT_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_CONVERT_A_0 {}
 impl ::core::default::Default for JET_CONVERT_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5030,7 +4974,7 @@ unsafe impl ::windows::core::Abi for JET_CONVERT_A_0_0 {
 }
 impl ::core::cmp::PartialEq for JET_CONVERT_A_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_A_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for JET_CONVERT_A_0_0 {}
@@ -5054,12 +4998,6 @@ impl ::core::clone::Clone for JET_CONVERT_W {
 unsafe impl ::windows::core::Abi for JET_CONVERT_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_CONVERT_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_CONVERT_W {}
 impl ::core::default::Default for JET_CONVERT_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5080,12 +5018,6 @@ impl ::core::clone::Clone for JET_CONVERT_W_0 {
 unsafe impl ::windows::core::Abi for JET_CONVERT_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_CONVERT_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_CONVERT_W_0 {}
 impl ::core::default::Default for JET_CONVERT_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5112,7 +5044,7 @@ unsafe impl ::windows::core::Abi for JET_CONVERT_W_0_0 {
 }
 impl ::core::cmp::PartialEq for JET_CONVERT_W_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_CONVERT_W_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for JET_CONVERT_W_0_0 {}
@@ -5159,14 +5091,6 @@ impl ::core::clone::Clone for JET_DBINFOMISC {
 unsafe impl ::windows::core::Abi for JET_DBINFOMISC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_DBINFOMISC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOMISC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_DBINFOMISC {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_DBINFOMISC {
     fn default() -> Self {
@@ -5227,14 +5151,6 @@ unsafe impl ::windows::core::Abi for JET_DBINFOMISC2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_DBINFOMISC2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOMISC2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_DBINFOMISC2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_DBINFOMISC2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5294,14 +5210,6 @@ impl ::core::clone::Clone for JET_DBINFOMISC3 {
 unsafe impl ::windows::core::Abi for JET_DBINFOMISC3 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_DBINFOMISC3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOMISC3>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_DBINFOMISC3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_DBINFOMISC3 {
     fn default() -> Self {
@@ -5365,14 +5273,6 @@ unsafe impl ::windows::core::Abi for JET_DBINFOMISC4 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_DBINFOMISC4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOMISC4>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_DBINFOMISC4 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_DBINFOMISC4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5398,12 +5298,6 @@ impl ::core::clone::Clone for JET_DBINFOUPGRADE {
 unsafe impl ::windows::core::Abi for JET_DBINFOUPGRADE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_DBINFOUPGRADE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOUPGRADE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_DBINFOUPGRADE {}
 impl ::core::default::Default for JET_DBINFOUPGRADE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5424,12 +5318,6 @@ impl ::core::clone::Clone for JET_DBINFOUPGRADE_0 {
 unsafe impl ::windows::core::Abi for JET_DBINFOUPGRADE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_DBINFOUPGRADE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOUPGRADE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_DBINFOUPGRADE_0 {}
 impl ::core::default::Default for JET_DBINFOUPGRADE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5456,7 +5344,7 @@ unsafe impl ::windows::core::Abi for JET_DBINFOUPGRADE_0_0 {
 }
 impl ::core::cmp::PartialEq for JET_DBINFOUPGRADE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_DBINFOUPGRADE_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for JET_DBINFOUPGRADE_0_0 {}
@@ -5481,12 +5369,6 @@ impl ::core::clone::Clone for JET_ENUMCOLUMN {
 unsafe impl ::windows::core::Abi for JET_ENUMCOLUMN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_ENUMCOLUMN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_ENUMCOLUMN {}
 impl ::core::default::Default for JET_ENUMCOLUMN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5507,12 +5389,6 @@ impl ::core::clone::Clone for JET_ENUMCOLUMN_0 {
 unsafe impl ::windows::core::Abi for JET_ENUMCOLUMN_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_ENUMCOLUMN_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMN_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_ENUMCOLUMN_0 {}
 impl ::core::default::Default for JET_ENUMCOLUMN_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5540,7 +5416,7 @@ unsafe impl ::windows::core::Abi for JET_ENUMCOLUMN_0_0 {
 }
 impl ::core::cmp::PartialEq for JET_ENUMCOLUMN_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMN_0_0>()) == 0 }
+        self.cEnumColumnValue == other.cEnumColumnValue && self.rgEnumColumnValue == other.rgEnumColumnValue
     }
 }
 impl ::core::cmp::Eq for JET_ENUMCOLUMN_0_0 {}
@@ -5571,7 +5447,7 @@ unsafe impl ::windows::core::Abi for JET_ENUMCOLUMN_0_1 {
 }
 impl ::core::cmp::PartialEq for JET_ENUMCOLUMN_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMN_0_1>()) == 0 }
+        self.cbData == other.cbData && self.pvData == other.pvData
     }
 }
 impl ::core::cmp::Eq for JET_ENUMCOLUMN_0_1 {}
@@ -5603,7 +5479,7 @@ unsafe impl ::windows::core::Abi for JET_ENUMCOLUMNID {
 }
 impl ::core::cmp::PartialEq for JET_ENUMCOLUMNID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMNID>()) == 0 }
+        self.columnid == other.columnid && self.ctagSequence == other.ctagSequence && self.rgtagSequence == other.rgtagSequence
     }
 }
 impl ::core::cmp::Eq for JET_ENUMCOLUMNID {}
@@ -5636,7 +5512,7 @@ unsafe impl ::windows::core::Abi for JET_ENUMCOLUMNVALUE {
 }
 impl ::core::cmp::PartialEq for JET_ENUMCOLUMNVALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ENUMCOLUMNVALUE>()) == 0 }
+        self.itagSequence == other.itagSequence && self.err == other.err && self.cbData == other.cbData && self.pvData == other.pvData
     }
 }
 impl ::core::cmp::Eq for JET_ENUMCOLUMNVALUE {}
@@ -5671,7 +5547,7 @@ unsafe impl ::windows::core::Abi for JET_ERRINFOBASIC_W {
 }
 impl ::core::cmp::PartialEq for JET_ERRINFOBASIC_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_ERRINFOBASIC_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.errValue == other.errValue && self.errcatMostSpecific == other.errcatMostSpecific && self.rgCategoricalHierarchy == other.rgCategoricalHierarchy && self.lSourceLine == other.lSourceLine && self.rgszSourceFile == other.rgszSourceFile
     }
 }
 impl ::core::cmp::Eq for JET_ERRINFOBASIC_W {}
@@ -5706,12 +5582,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_A {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_A {}
 impl ::core::default::Default for JET_INDEXCREATE2_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5732,12 +5602,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_A_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_A_0 {}
 impl ::core::default::Default for JET_INDEXCREATE2_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5758,12 +5622,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_A_1 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_A_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_A_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_A_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_A_1 {}
 impl ::core::default::Default for JET_INDEXCREATE2_A_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5795,12 +5653,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_W {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_W {}
 impl ::core::default::Default for JET_INDEXCREATE2_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5821,12 +5673,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_W_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_W_0 {}
 impl ::core::default::Default for JET_INDEXCREATE2_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5847,12 +5693,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE2_W_1 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE2_W_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE2_W_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE2_W_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE2_W_1 {}
 impl ::core::default::Default for JET_INDEXCREATE2_W_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5884,12 +5724,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE3_A {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE3_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE3_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE3_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE3_A {}
 impl ::core::default::Default for JET_INDEXCREATE3_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5910,12 +5744,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE3_A_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE3_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE3_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE3_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE3_A_0 {}
 impl ::core::default::Default for JET_INDEXCREATE3_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5947,12 +5775,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE3_W {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE3_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE3_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE3_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE3_W {}
 impl ::core::default::Default for JET_INDEXCREATE3_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5973,12 +5795,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE3_W_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE3_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE3_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE3_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE3_W_0 {}
 impl ::core::default::Default for JET_INDEXCREATE3_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6009,12 +5825,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_A {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_A {}
 impl ::core::default::Default for JET_INDEXCREATE_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6035,12 +5845,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_A_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_A_0 {}
 impl ::core::default::Default for JET_INDEXCREATE_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6061,12 +5865,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_A_1 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_A_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_A_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_A_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_A_1 {}
 impl ::core::default::Default for JET_INDEXCREATE_A_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6097,12 +5895,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_W {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_W {}
 impl ::core::default::Default for JET_INDEXCREATE_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6123,12 +5915,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_W_0 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_W_0 {}
 impl ::core::default::Default for JET_INDEXCREATE_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6149,12 +5935,6 @@ impl ::core::clone::Clone for JET_INDEXCREATE_W_1 {
 unsafe impl ::windows::core::Abi for JET_INDEXCREATE_W_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_INDEXCREATE_W_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXCREATE_W_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_INDEXCREATE_W_1 {}
 impl ::core::default::Default for JET_INDEXCREATE_W_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6188,7 +5968,7 @@ unsafe impl ::windows::core::Abi for JET_INDEXID {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for JET_INDEXID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXID>()) == 0 }
+        self.cbStruct == other.cbStruct && self.rgbIndexId == other.rgbIndexId
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -6227,7 +6007,7 @@ unsafe impl ::windows::core::Abi for JET_INDEXID {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for JET_INDEXID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXID>()) == 0 }
+        self.cbStruct == other.cbStruct && self.rgbIndexId == other.rgbIndexId
     }
 }
 #[cfg(target_arch = "x86")]
@@ -6303,7 +6083,25 @@ unsafe impl ::windows::core::Abi for JET_INDEXLIST {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_INDEXLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXLIST>()) == 0 }
+        self.cbStruct == other.cbStruct
+            && self.tableid == other.tableid
+            && self.cRecord == other.cRecord
+            && self.columnidindexname == other.columnidindexname
+            && self.columnidgrbitIndex == other.columnidgrbitIndex
+            && self.columnidcKey == other.columnidcKey
+            && self.columnidcEntry == other.columnidcEntry
+            && self.columnidcPage == other.columnidcPage
+            && self.columnidcColumn == other.columnidcColumn
+            && self.columnidiColumn == other.columnidiColumn
+            && self.columnidcolumnid == other.columnidcolumnid
+            && self.columnidcoltyp == other.columnidcoltyp
+            && self.columnidCountry == other.columnidCountry
+            && self.columnidLangid == other.columnidLangid
+            && self.columnidCp == other.columnidCp
+            && self.columnidCollate == other.columnidCollate
+            && self.columnidgrbitColumn == other.columnidgrbitColumn
+            && self.columnidcolumnname == other.columnidcolumnname
+            && self.columnidLCMapFlags == other.columnidLCMapFlags
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -6343,7 +6141,7 @@ unsafe impl ::windows::core::Abi for JET_INDEXRANGE {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_INDEXRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEXRANGE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.tableid == other.tableid && self.grbit == other.grbit
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -6379,7 +6177,7 @@ unsafe impl ::windows::core::Abi for JET_INDEX_COLUMN {
 }
 impl ::core::cmp::PartialEq for JET_INDEX_COLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEX_COLUMN>()) == 0 }
+        self.columnid == other.columnid && self.relop == other.relop && self.pv == other.pv && self.cb == other.cb && self.grbit == other.grbit
     }
 }
 impl ::core::cmp::Eq for JET_INDEX_COLUMN {}
@@ -6412,7 +6210,7 @@ unsafe impl ::windows::core::Abi for JET_INDEX_RANGE {
 }
 impl ::core::cmp::PartialEq for JET_INDEX_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INDEX_RANGE>()) == 0 }
+        self.rgStartColumns == other.rgStartColumns && self.cStartColumns == other.cStartColumns && self.rgEndColumns == other.rgEndColumns && self.cEndColumns == other.cEndColumns
     }
 }
 impl ::core::cmp::Eq for JET_INDEX_RANGE {}
@@ -6453,7 +6251,7 @@ unsafe impl ::windows::core::Abi for JET_INSTANCE_INFO_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_INSTANCE_INFO_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INSTANCE_INFO_A>()) == 0 }
+        self.hInstanceId == other.hInstanceId && self.szInstanceName == other.szInstanceName && self.cDatabases == other.cDatabases && self.szDatabaseFileName == other.szDatabaseFileName && self.szDatabaseDisplayName == other.szDatabaseDisplayName && self.szDatabaseSLVFileName_Obsolete == other.szDatabaseSLVFileName_Obsolete
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -6496,7 +6294,7 @@ unsafe impl ::windows::core::Abi for JET_INSTANCE_INFO_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_INSTANCE_INFO_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_INSTANCE_INFO_W>()) == 0 }
+        self.hInstanceId == other.hInstanceId && self.szInstanceName == other.szInstanceName && self.cDatabases == other.cDatabases && self.szDatabaseFileName == other.szDatabaseFileName && self.szDatabaseDisplayName == other.szDatabaseDisplayName && self.szDatabaseSLVFileName_Obsolete == other.szDatabaseSLVFileName_Obsolete
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -6523,12 +6321,6 @@ impl ::core::clone::Clone for JET_LGPOS {
 unsafe impl ::windows::core::Abi for JET_LGPOS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JET_LGPOS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LGPOS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JET_LGPOS {}
 impl ::core::default::Default for JET_LGPOS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6564,7 +6356,7 @@ unsafe impl ::windows::core::Abi for JET_LOGINFO_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_LOGINFO_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGINFO_A>()) == 0 }
+        self.cbSize == other.cbSize && self.ulGenLow == other.ulGenLow && self.ulGenHigh == other.ulGenHigh && self.szBaseName == other.szBaseName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6599,7 +6391,7 @@ unsafe impl ::windows::core::Abi for JET_LOGINFO_W {
 }
 impl ::core::cmp::PartialEq for JET_LOGINFO_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGINFO_W>()) == 0 }
+        self.cbSize == other.cbSize && self.ulGenLow == other.ulGenLow && self.ulGenHigh == other.ulGenHigh && self.szBaseName == other.szBaseName
     }
 }
 impl ::core::cmp::Eq for JET_LOGINFO_W {}
@@ -6634,14 +6426,6 @@ unsafe impl ::windows::core::Abi for JET_LOGTIME {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_LOGTIME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGTIME>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_LOGTIME {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_LOGTIME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6666,14 +6450,6 @@ impl ::core::clone::Clone for JET_LOGTIME_0 {
 unsafe impl ::windows::core::Abi for JET_LOGTIME_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_LOGTIME_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGTIME_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_LOGTIME_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_LOGTIME_0 {
     fn default() -> Self {
@@ -6707,7 +6483,7 @@ unsafe impl ::windows::core::Abi for JET_LOGTIME_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_LOGTIME_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGTIME_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6737,14 +6513,6 @@ impl ::core::clone::Clone for JET_LOGTIME_1 {
 unsafe impl ::windows::core::Abi for JET_LOGTIME_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_LOGTIME_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGTIME_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_LOGTIME_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_LOGTIME_1 {
     fn default() -> Self {
@@ -6778,7 +6546,7 @@ unsafe impl ::windows::core::Abi for JET_LOGTIME_1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JET_LOGTIME_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_LOGTIME_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6847,14 +6615,6 @@ unsafe impl ::windows::core::Abi for JET_OBJECTINFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for JET_OBJECTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OBJECTINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for JET_OBJECTINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for JET_OBJECTINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6885,14 +6645,6 @@ impl ::core::clone::Clone for JET_OBJECTINFO {
 unsafe impl ::windows::core::Abi for JET_OBJECTINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for JET_OBJECTINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OBJECTINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for JET_OBJECTINFO {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for JET_OBJECTINFO {
     fn default() -> Self {
@@ -6950,7 +6702,7 @@ unsafe impl ::windows::core::Abi for JET_OBJECTLIST {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_OBJECTLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OBJECTLIST>()) == 0 }
+        self.cbStruct == other.cbStruct && self.tableid == other.tableid && self.cRecord == other.cRecord && self.columnidcontainername == other.columnidcontainername && self.columnidobjectname == other.columnidobjectname && self.columnidobjtyp == other.columnidobjtyp && self.columniddtCreate == other.columniddtCreate && self.columniddtUpdate == other.columniddtUpdate && self.columnidgrbit == other.columnidgrbit && self.columnidflags == other.columnidflags && self.columnidcRecord == other.columnidcRecord && self.columnidcPage == other.columnidcPage
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -6996,7 +6748,7 @@ unsafe impl ::windows::core::Abi for JET_OPENTEMPORARYTABLE {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_OPENTEMPORARYTABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OPENTEMPORARYTABLE>()) == 0 }
+        self.cbStruct == other.cbStruct && self.prgcolumndef == other.prgcolumndef && self.ccolumn == other.ccolumn && self.pidxunicode == other.pidxunicode && self.grbit == other.grbit && self.prgcolumnid == other.prgcolumnid && self.cbKeyMost == other.cbKeyMost && self.cbVarSegMac == other.cbVarSegMac && self.tableid == other.tableid
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -7042,7 +6794,7 @@ unsafe impl ::windows::core::Abi for JET_OPENTEMPORARYTABLE2 {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_OPENTEMPORARYTABLE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OPENTEMPORARYTABLE2>()) == 0 }
+        self.cbStruct == other.cbStruct && self.prgcolumndef == other.prgcolumndef && self.ccolumn == other.ccolumn && self.pidxunicode == other.pidxunicode && self.grbit == other.grbit && self.prgcolumnid == other.prgcolumnid && self.cbKeyMost == other.cbKeyMost && self.cbVarSegMac == other.cbVarSegMac && self.tableid == other.tableid
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -7078,7 +6830,7 @@ unsafe impl ::windows::core::Abi for JET_OPERATIONCONTEXT {
 }
 impl ::core::cmp::PartialEq for JET_OPERATIONCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_OPERATIONCONTEXT>()) == 0 }
+        self.ulUserID == other.ulUserID && self.nOperationID == other.nOperationID && self.nOperationType == other.nOperationType && self.nClientType == other.nClientType && self.fFlags == other.fFlags
     }
 }
 impl ::core::cmp::Eq for JET_OPERATIONCONTEXT {}
@@ -7148,16 +6900,6 @@ unsafe impl ::windows::core::Abi for JET_RBSINFOMISC {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_RBSINFOMISC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RBSINFOMISC>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_RBSINFOMISC {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_RBSINFOMISC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7190,16 +6932,6 @@ impl ::core::clone::Clone for JET_RBSINFOMISC {
 unsafe impl ::windows::core::Abi for JET_RBSINFOMISC {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_RBSINFOMISC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RBSINFOMISC>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_RBSINFOMISC {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_RBSINFOMISC {
@@ -7237,16 +6969,6 @@ unsafe impl ::windows::core::Abi for JET_RBSREVERTINFOMISC {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_RBSREVERTINFOMISC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RBSREVERTINFOMISC>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_RBSREVERTINFOMISC {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_RBSREVERTINFOMISC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7280,16 +7002,6 @@ impl ::core::clone::Clone for JET_RBSREVERTINFOMISC {
 unsafe impl ::windows::core::Abi for JET_RBSREVERTINFOMISC {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_RBSREVERTINFOMISC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RBSREVERTINFOMISC>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_RBSREVERTINFOMISC {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_RBSREVERTINFOMISC {
@@ -7327,7 +7039,7 @@ unsafe impl ::windows::core::Abi for JET_RECORDLIST {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_RECORDLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECORDLIST>()) == 0 }
+        self.cbStruct == other.cbStruct && self.tableid == other.tableid && self.cRecord == other.cRecord && self.columnidBookmark == other.columnidBookmark
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -7362,7 +7074,7 @@ unsafe impl ::windows::core::Abi for JET_RECPOS {
 }
 impl ::core::cmp::PartialEq for JET_RECPOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECPOS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.centriesLT == other.centriesLT && self.centriesInRange == other.centriesInRange && self.centriesTotal == other.centriesTotal
     }
 }
 impl ::core::cmp::Eq for JET_RECPOS {}
@@ -7397,14 +7109,6 @@ unsafe impl ::windows::core::Abi for JET_RECSIZE {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for JET_RECSIZE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECSIZE>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for JET_RECSIZE {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for JET_RECSIZE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7436,14 +7140,6 @@ unsafe impl ::windows::core::Abi for JET_RECSIZE {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for JET_RECSIZE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECSIZE>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for JET_RECSIZE {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for JET_RECSIZE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7477,14 +7173,6 @@ impl ::core::clone::Clone for JET_RECSIZE2 {
 unsafe impl ::windows::core::Abi for JET_RECSIZE2 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for JET_RECSIZE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECSIZE2>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for JET_RECSIZE2 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for JET_RECSIZE2 {
     fn default() -> Self {
@@ -7520,14 +7208,6 @@ unsafe impl ::windows::core::Abi for JET_RECSIZE2 {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for JET_RECSIZE2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RECSIZE2>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for JET_RECSIZE2 {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for JET_RECSIZE2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7557,7 +7237,7 @@ unsafe impl ::windows::core::Abi for JET_RETINFO {
 }
 impl ::core::cmp::PartialEq for JET_RETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RETINFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.ibLongValue == other.ibLongValue && self.itagSequence == other.itagSequence && self.columnidNextTagged == other.columnidNextTagged
     }
 }
 impl ::core::cmp::Eq for JET_RETINFO {}
@@ -7595,7 +7275,7 @@ unsafe impl ::windows::core::Abi for JET_RETRIEVECOLUMN {
 }
 impl ::core::cmp::PartialEq for JET_RETRIEVECOLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RETRIEVECOLUMN>()) == 0 }
+        self.columnid == other.columnid && self.pvData == other.pvData && self.cbData == other.cbData && self.cbActual == other.cbActual && self.grbit == other.grbit && self.ibLongValue == other.ibLongValue && self.itagSequence == other.itagSequence && self.columnidNextTagged == other.columnidNextTagged && self.err == other.err
     }
 }
 impl ::core::cmp::Eq for JET_RETRIEVECOLUMN {}
@@ -7628,14 +7308,6 @@ unsafe impl ::windows::core::Abi for JET_RSTINFO_A {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
-impl ::core::cmp::PartialEq for JET_RSTINFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RSTINFO_A>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
-impl ::core::cmp::Eq for JET_RSTINFO_A {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
 impl ::core::default::Default for JET_RSTINFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7665,14 +7337,6 @@ unsafe impl ::windows::core::Abi for JET_RSTINFO_W {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
-impl ::core::cmp::PartialEq for JET_RSTINFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RSTINFO_W>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
-impl ::core::cmp::Eq for JET_RSTINFO_W {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_StructuredStorage"))]
 impl ::core::default::Default for JET_RSTINFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7700,7 +7364,7 @@ unsafe impl ::windows::core::Abi for JET_RSTMAP_A {
 }
 impl ::core::cmp::PartialEq for JET_RSTMAP_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RSTMAP_A>()) == 0 }
+        self.szDatabaseName == other.szDatabaseName && self.szNewDatabaseName == other.szNewDatabaseName
     }
 }
 impl ::core::cmp::Eq for JET_RSTMAP_A {}
@@ -7731,7 +7395,7 @@ unsafe impl ::windows::core::Abi for JET_RSTMAP_W {
 }
 impl ::core::cmp::PartialEq for JET_RSTMAP_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_RSTMAP_W>()) == 0 }
+        self.szDatabaseName == other.szDatabaseName && self.szNewDatabaseName == other.szNewDatabaseName
     }
 }
 impl ::core::cmp::Eq for JET_RSTMAP_W {}
@@ -7767,7 +7431,7 @@ unsafe impl ::windows::core::Abi for JET_SETCOLUMN {
 }
 impl ::core::cmp::PartialEq for JET_SETCOLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SETCOLUMN>()) == 0 }
+        self.columnid == other.columnid && self.pvData == other.pvData && self.cbData == other.cbData && self.grbit == other.grbit && self.ibLongValue == other.ibLongValue && self.itagSequence == other.itagSequence && self.err == other.err
     }
 }
 impl ::core::cmp::Eq for JET_SETCOLUMN {}
@@ -7799,7 +7463,7 @@ unsafe impl ::windows::core::Abi for JET_SETINFO {
 }
 impl ::core::cmp::PartialEq for JET_SETINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SETINFO>()) == 0 }
+        self.cbStruct == other.cbStruct && self.ibLongValue == other.ibLongValue && self.itagSequence == other.itagSequence
     }
 }
 impl ::core::cmp::Eq for JET_SETINFO {}
@@ -7838,7 +7502,7 @@ unsafe impl ::windows::core::Abi for JET_SETSYSPARAM_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_SETSYSPARAM_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SETSYSPARAM_A>()) == 0 }
+        self.paramid == other.paramid && self.lParam == other.lParam && self.sz == other.sz && self.err == other.err
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -7879,7 +7543,7 @@ unsafe impl ::windows::core::Abi for JET_SETSYSPARAM_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_SETSYSPARAM_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SETSYSPARAM_W>()) == 0 }
+        self.paramid == other.paramid && self.lParam == other.lParam && self.sz == other.sz && self.err == other.err
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -7911,14 +7575,6 @@ unsafe impl ::windows::core::Abi for JET_SIGNATURE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for JET_SIGNATURE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SIGNATURE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for JET_SIGNATURE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for JET_SIGNATURE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7947,7 +7603,7 @@ unsafe impl ::windows::core::Abi for JET_SNPROG {
 }
 impl ::core::cmp::PartialEq for JET_SNPROG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SNPROG>()) == 0 }
+        self.cbStruct == other.cbStruct && self.cunitDone == other.cunitDone && self.cunitTotal == other.cunitTotal
     }
 }
 impl ::core::cmp::Eq for JET_SNPROG {}
@@ -7984,7 +7640,7 @@ unsafe impl ::windows::core::Abi for JET_SPACEHINTS {
 }
 impl ::core::cmp::PartialEq for JET_SPACEHINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_SPACEHINTS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.ulInitialDensity == other.ulInitialDensity && self.cbInitial == other.cbInitial && self.grbit == other.grbit && self.ulMaintDensity == other.ulMaintDensity && self.ulGrowth == other.ulGrowth && self.cbMinExtent == other.cbMinExtent && self.cbMaxExtent == other.cbMaxExtent
     }
 }
 impl ::core::cmp::Eq for JET_SPACEHINTS {}
@@ -8048,7 +7704,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE2_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE2_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE2_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8114,7 +7770,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE2_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE2_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE2_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8186,7 +7842,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE3_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE3_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE3_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.pSeqSpacehints == other.pSeqSpacehints && self.pLVSpacehints == other.pLVSpacehints && self.cbSeparateLV == other.cbSeparateLV && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8258,7 +7914,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE3_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE3_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE3_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.pSeqSpacehints == other.pSeqSpacehints && self.pLVSpacehints == other.pLVSpacehints && self.cbSeparateLV == other.cbSeparateLV && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8330,7 +7986,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE4_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE4_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE4_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.pSeqSpacehints == other.pSeqSpacehints && self.pLVSpacehints == other.pLVSpacehints && self.cbSeparateLV == other.cbSeparateLV && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8402,7 +8058,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE4_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE4_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE4_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.szCallback == other.szCallback && self.cbtyp == other.cbtyp && self.grbit == other.grbit && self.pSeqSpacehints == other.pSeqSpacehints && self.pLVSpacehints == other.pLVSpacehints && self.cbSeparateLV == other.cbSeparateLV && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8464,7 +8120,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE_A {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE_A>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.grbit == other.grbit && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8526,7 +8182,7 @@ unsafe impl ::windows::core::Abi for JET_TABLECREATE_W {
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 impl ::core::cmp::PartialEq for JET_TABLECREATE_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TABLECREATE_W>()) == 0 }
+        self.cbStruct == other.cbStruct && self.szTableName == other.szTableName && self.szTemplateTableName == other.szTemplateTableName && self.ulPages == other.ulPages && self.ulDensity == other.ulDensity && self.rgcolumncreate == other.rgcolumncreate && self.cColumns == other.cColumns && self.rgindexcreate == other.rgindexcreate && self.cIndexes == other.cIndexes && self.grbit == other.grbit && self.tableid == other.tableid && self.cCreated == other.cCreated
     }
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -8565,7 +8221,7 @@ unsafe impl ::windows::core::Abi for JET_THREADSTATS {
 }
 impl ::core::cmp::PartialEq for JET_THREADSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_THREADSTATS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.cPageReferenced == other.cPageReferenced && self.cPageRead == other.cPageRead && self.cPagePreread == other.cPagePreread && self.cPageDirtied == other.cPageDirtied && self.cPageRedirtied == other.cPageRedirtied && self.cLogRecord == other.cLogRecord && self.cbLogRecord == other.cbLogRecord
     }
 }
 impl ::core::cmp::Eq for JET_THREADSTATS {}
@@ -8602,14 +8258,6 @@ unsafe impl ::windows::core::Abi for JET_THREADSTATS2 {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for JET_THREADSTATS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_THREADSTATS2>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for JET_THREADSTATS2 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for JET_THREADSTATS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8643,14 +8291,6 @@ unsafe impl ::windows::core::Abi for JET_THREADSTATS2 {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for JET_THREADSTATS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_THREADSTATS2>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for JET_THREADSTATS2 {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for JET_THREADSTATS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8681,7 +8321,7 @@ unsafe impl ::windows::core::Abi for JET_TUPLELIMITS {
 }
 impl ::core::cmp::PartialEq for JET_TUPLELIMITS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_TUPLELIMITS>()) == 0 }
+        self.chLengthMin == other.chLengthMin && self.chLengthMax == other.chLengthMax && self.chToIndexMax == other.chToIndexMax && self.cchIncrement == other.cchIncrement && self.ichStart == other.ichStart
     }
 }
 impl ::core::cmp::Eq for JET_TUPLELIMITS {}
@@ -8712,7 +8352,7 @@ unsafe impl ::windows::core::Abi for JET_UNICODEINDEX {
 }
 impl ::core::cmp::PartialEq for JET_UNICODEINDEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_UNICODEINDEX>()) == 0 }
+        self.lcid == other.lcid && self.dwMapFlags == other.dwMapFlags
     }
 }
 impl ::core::cmp::Eq for JET_UNICODEINDEX {}
@@ -8743,7 +8383,7 @@ unsafe impl ::windows::core::Abi for JET_UNICODEINDEX2 {
 }
 impl ::core::cmp::PartialEq for JET_UNICODEINDEX2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_UNICODEINDEX2>()) == 0 }
+        self.szLocaleName == other.szLocaleName && self.dwMapFlags == other.dwMapFlags
     }
 }
 impl ::core::cmp::Eq for JET_UNICODEINDEX2 {}
@@ -8776,7 +8416,7 @@ unsafe impl ::windows::core::Abi for JET_USERDEFINEDDEFAULT_A {
 }
 impl ::core::cmp::PartialEq for JET_USERDEFINEDDEFAULT_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_USERDEFINEDDEFAULT_A>()) == 0 }
+        self.szCallback == other.szCallback && self.pbUserData == other.pbUserData && self.cbUserData == other.cbUserData && self.szDependantColumns == other.szDependantColumns
     }
 }
 impl ::core::cmp::Eq for JET_USERDEFINEDDEFAULT_A {}
@@ -8809,7 +8449,7 @@ unsafe impl ::windows::core::Abi for JET_USERDEFINEDDEFAULT_W {
 }
 impl ::core::cmp::PartialEq for JET_USERDEFINEDDEFAULT_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JET_USERDEFINEDDEFAULT_W>()) == 0 }
+        self.szCallback == other.szCallback && self.pbUserData == other.pbUserData && self.cbUserData == other.cbUserData && self.szDependantColumns == other.szDependantColumns
     }
 }
 impl ::core::cmp::Eq for JET_USERDEFINEDDEFAULT_W {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
@@ -141,7 +141,7 @@ unsafe impl ::windows::core::Abi for OPERATION_END_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for OPERATION_END_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPERATION_END_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.OperationId == other.OperationId && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for OPERATION_END_PARAMETERS {}
@@ -173,7 +173,7 @@ unsafe impl ::windows::core::Abi for OPERATION_START_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for OPERATION_START_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPERATION_START_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.OperationId == other.OperationId && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for OPERATION_START_PARAMETERS {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -6199,7 +6199,7 @@ unsafe impl ::windows::core::Abi for APPX_ENCRYPTED_EXEMPTIONS {
 }
 impl ::core::cmp::PartialEq for APPX_ENCRYPTED_EXEMPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPX_ENCRYPTED_EXEMPTIONS>()) == 0 }
+        self.count == other.count && self.plainTextFiles == other.plainTextFiles
     }
 }
 impl ::core::cmp::Eq for APPX_ENCRYPTED_EXEMPTIONS {}
@@ -6320,7 +6320,7 @@ unsafe impl ::windows::core::Abi for APPX_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for APPX_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPX_KEY_INFO>()) == 0 }
+        self.keyLength == other.keyLength && self.keyIdLength == other.keyIdLength && self.key == other.key && self.keyId == other.keyId
     }
 }
 impl ::core::cmp::Eq for APPX_KEY_INFO {}
@@ -6426,7 +6426,7 @@ unsafe impl ::windows::core::Abi for PACKAGEDEPENDENCY_CONTEXT__ {
 }
 impl ::core::cmp::PartialEq for PACKAGEDEPENDENCY_CONTEXT__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGEDEPENDENCY_CONTEXT__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for PACKAGEDEPENDENCY_CONTEXT__ {}
@@ -6455,12 +6455,6 @@ impl ::core::clone::Clone for PACKAGE_ID {
 unsafe impl ::windows::core::Abi for PACKAGE_ID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PACKAGE_ID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_ID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PACKAGE_ID {}
 impl ::core::default::Default for PACKAGE_ID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6485,12 +6479,6 @@ impl ::core::clone::Clone for PACKAGE_INFO {
 unsafe impl ::windows::core::Abi for PACKAGE_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PACKAGE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PACKAGE_INFO {}
 impl ::core::default::Default for PACKAGE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6510,12 +6498,6 @@ impl ::core::clone::Clone for PACKAGE_VERSION {
 unsafe impl ::windows::core::Abi for PACKAGE_VERSION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PACKAGE_VERSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_VERSION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PACKAGE_VERSION {}
 impl ::core::default::Default for PACKAGE_VERSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6536,12 +6518,6 @@ impl ::core::clone::Clone for PACKAGE_VERSION_0 {
 unsafe impl ::windows::core::Abi for PACKAGE_VERSION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PACKAGE_VERSION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_VERSION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PACKAGE_VERSION_0 {}
 impl ::core::default::Default for PACKAGE_VERSION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6571,7 +6547,7 @@ unsafe impl ::windows::core::Abi for PACKAGE_VERSION_0_0 {
 }
 impl ::core::cmp::PartialEq for PACKAGE_VERSION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_VERSION_0_0>()) == 0 }
+        self.Revision == other.Revision && self.Build == other.Build && self.Minor == other.Minor && self.Major == other.Major
     }
 }
 impl ::core::cmp::Eq for PACKAGE_VERSION_0_0 {}
@@ -6601,7 +6577,7 @@ unsafe impl ::windows::core::Abi for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE__ {
 }
 impl ::core::cmp::PartialEq for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE__ {}
@@ -6631,7 +6607,7 @@ unsafe impl ::windows::core::Abi for _PACKAGE_INFO_REFERENCE {
 }
 impl ::core::cmp::PartialEq for _PACKAGE_INFO_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_PACKAGE_INFO_REFERENCE>()) == 0 }
+        self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for _PACKAGE_INFO_REFERENCE {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -689,30 +689,13 @@ impl ::core::clone::Clone for PRJ_CALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PRJ_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PRJ_CALLBACKS")
-            .field("StartDirectoryEnumerationCallback", &self.StartDirectoryEnumerationCallback.map(|f| f as usize))
-            .field("EndDirectoryEnumerationCallback", &self.EndDirectoryEnumerationCallback.map(|f| f as usize))
-            .field("GetDirectoryEnumerationCallback", &self.GetDirectoryEnumerationCallback.map(|f| f as usize))
-            .field("GetPlaceholderInfoCallback", &self.GetPlaceholderInfoCallback.map(|f| f as usize))
-            .field("GetFileDataCallback", &self.GetFileDataCallback.map(|f| f as usize))
-            .field("QueryFileNameCallback", &self.QueryFileNameCallback.map(|f| f as usize))
-            .field("NotificationCallback", &self.NotificationCallback.map(|f| f as usize))
-            .field("CancelCommandCallback", &self.CancelCommandCallback.map(|f| f as usize))
-            .finish()
+        f.debug_struct("PRJ_CALLBACKS").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PRJ_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PRJ_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PRJ_CALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PRJ_CALLBACKS {
     fn default() -> Self {
@@ -762,7 +745,7 @@ unsafe impl ::windows::core::Abi for PRJ_CALLBACK_DATA {
 }
 impl ::core::cmp::PartialEq for PRJ_CALLBACK_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_CALLBACK_DATA>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.NamespaceVirtualizationContext == other.NamespaceVirtualizationContext && self.CommandId == other.CommandId && self.FileId == other.FileId && self.DataStreamId == other.DataStreamId && self.FilePathName == other.FilePathName && self.VersionInfo == other.VersionInfo && self.TriggeringProcessId == other.TriggeringProcessId && self.TriggeringProcessImageFileName == other.TriggeringProcessImageFileName && self.InstanceContext == other.InstanceContext
     }
 }
 impl ::core::cmp::Eq for PRJ_CALLBACK_DATA {}
@@ -786,12 +769,6 @@ impl ::core::clone::Clone for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
 unsafe impl ::windows::core::Abi for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {}
 impl ::core::default::Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -812,12 +789,6 @@ impl ::core::clone::Clone for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {}
 impl ::core::default::Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -844,7 +815,7 @@ unsafe impl ::windows::core::Abi for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_
 }
 impl ::core::cmp::PartialEq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0>()) == 0 }
+        self.DirEntryBufferHandle == other.DirEntryBufferHandle
     }
 }
 impl ::core::cmp::Eq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {}
@@ -874,7 +845,7 @@ unsafe impl ::windows::core::Abi for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_
 }
 impl ::core::cmp::PartialEq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1>()) == 0 }
+        self.NotificationMask == other.NotificationMask
     }
 }
 impl ::core::cmp::Eq for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {}
@@ -931,12 +902,6 @@ impl ::core::clone::Clone for PRJ_EXTENDED_INFO {
 unsafe impl ::windows::core::Abi for PRJ_EXTENDED_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRJ_EXTENDED_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_EXTENDED_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRJ_EXTENDED_INFO {}
 impl ::core::default::Default for PRJ_EXTENDED_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -956,12 +921,6 @@ impl ::core::clone::Clone for PRJ_EXTENDED_INFO_0 {
 unsafe impl ::windows::core::Abi for PRJ_EXTENDED_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PRJ_EXTENDED_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_EXTENDED_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PRJ_EXTENDED_INFO_0 {}
 impl ::core::default::Default for PRJ_EXTENDED_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -988,7 +947,7 @@ unsafe impl ::windows::core::Abi for PRJ_EXTENDED_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for PRJ_EXTENDED_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_EXTENDED_INFO_0_0>()) == 0 }
+        self.TargetName == other.TargetName
     }
 }
 impl ::core::cmp::Eq for PRJ_EXTENDED_INFO_0_0 {}
@@ -1030,7 +989,7 @@ unsafe impl ::windows::core::Abi for PRJ_FILE_BASIC_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_FILE_BASIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_FILE_BASIC_INFO>()) == 0 }
+        self.IsDirectory == other.IsDirectory && self.FileSize == other.FileSize && self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.FileAttributes == other.FileAttributes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1095,7 +1054,7 @@ unsafe impl ::windows::core::Abi for PRJ_NOTIFICATION_MAPPING {
 }
 impl ::core::cmp::PartialEq for PRJ_NOTIFICATION_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_NOTIFICATION_MAPPING>()) == 0 }
+        self.NotificationBitMask == other.NotificationBitMask && self.NotificationRoot == other.NotificationRoot
     }
 }
 impl ::core::cmp::Eq for PRJ_NOTIFICATION_MAPPING {}
@@ -1124,14 +1083,6 @@ impl ::core::clone::Clone for PRJ_NOTIFICATION_PARAMETERS {
 unsafe impl ::windows::core::Abi for PRJ_NOTIFICATION_PARAMETERS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PRJ_NOTIFICATION_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_NOTIFICATION_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PRJ_NOTIFICATION_PARAMETERS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PRJ_NOTIFICATION_PARAMETERS {
     fn default() -> Self {
@@ -1165,7 +1116,7 @@ unsafe impl ::windows::core::Abi for PRJ_NOTIFICATION_PARAMETERS_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_NOTIFICATION_PARAMETERS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_NOTIFICATION_PARAMETERS_0>()) == 0 }
+        self.IsFileModified == other.IsFileModified
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1203,7 +1154,7 @@ unsafe impl ::windows::core::Abi for PRJ_NOTIFICATION_PARAMETERS_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_NOTIFICATION_PARAMETERS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_NOTIFICATION_PARAMETERS_1>()) == 0 }
+        self.NotificationMask == other.NotificationMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1241,7 +1192,7 @@ unsafe impl ::windows::core::Abi for PRJ_NOTIFICATION_PARAMETERS_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_NOTIFICATION_PARAMETERS_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_NOTIFICATION_PARAMETERS_2>()) == 0 }
+        self.NotificationMask == other.NotificationMask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1284,7 +1235,7 @@ unsafe impl ::windows::core::Abi for PRJ_PLACEHOLDER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_PLACEHOLDER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_PLACEHOLDER_INFO>()) == 0 }
+        self.FileBasicInfo == other.FileBasicInfo && self.EaInformation == other.EaInformation && self.SecurityInformation == other.SecurityInformation && self.StreamsInformation == other.StreamsInformation && self.VersionInfo == other.VersionInfo && self.VariableData == other.VariableData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1323,7 +1274,7 @@ unsafe impl ::windows::core::Abi for PRJ_PLACEHOLDER_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_PLACEHOLDER_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_PLACEHOLDER_INFO_0>()) == 0 }
+        self.EaBufferSize == other.EaBufferSize && self.OffsetToFirstEa == other.OffsetToFirstEa
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1362,7 +1313,7 @@ unsafe impl ::windows::core::Abi for PRJ_PLACEHOLDER_INFO_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_PLACEHOLDER_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_PLACEHOLDER_INFO_1>()) == 0 }
+        self.SecurityBufferSize == other.SecurityBufferSize && self.OffsetToSecurityDescriptor == other.OffsetToSecurityDescriptor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1401,7 +1352,7 @@ unsafe impl ::windows::core::Abi for PRJ_PLACEHOLDER_INFO_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRJ_PLACEHOLDER_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_PLACEHOLDER_INFO_2>()) == 0 }
+        self.StreamsInfoBufferSize == other.StreamsInfoBufferSize && self.OffsetToFirstStreamInfo == other.OffsetToFirstStreamInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1434,7 +1385,7 @@ unsafe impl ::windows::core::Abi for PRJ_PLACEHOLDER_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for PRJ_PLACEHOLDER_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_PLACEHOLDER_VERSION_INFO>()) == 0 }
+        self.ProviderID == other.ProviderID && self.ContentID == other.ContentID
     }
 }
 impl ::core::cmp::Eq for PRJ_PLACEHOLDER_VERSION_INFO {}
@@ -1468,7 +1419,7 @@ unsafe impl ::windows::core::Abi for PRJ_STARTVIRTUALIZING_OPTIONS {
 }
 impl ::core::cmp::PartialEq for PRJ_STARTVIRTUALIZING_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_STARTVIRTUALIZING_OPTIONS>()) == 0 }
+        self.Flags == other.Flags && self.PoolThreadCount == other.PoolThreadCount && self.ConcurrentThreadCount == other.ConcurrentThreadCount && self.NotificationMappings == other.NotificationMappings && self.NotificationMappingsCount == other.NotificationMappingsCount
     }
 }
 impl ::core::cmp::Eq for PRJ_STARTVIRTUALIZING_OPTIONS {}
@@ -1499,7 +1450,7 @@ unsafe impl ::windows::core::Abi for PRJ_VIRTUALIZATION_INSTANCE_INFO {
 }
 impl ::core::cmp::PartialEq for PRJ_VIRTUALIZATION_INSTANCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRJ_VIRTUALIZATION_INSTANCE_INFO>()) == 0 }
+        self.InstanceID == other.InstanceID && self.WriteAlignment == other.WriteAlignment
     }
 }
 impl ::core::cmp::Eq for PRJ_VIRTUALIZATION_INSTANCE_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -1996,12 +1996,6 @@ impl ::core::clone::Clone for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
 unsafe impl ::windows::core::Abi for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLY_SNAPSHOT_VHDSET_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for APPLY_SNAPSHOT_VHDSET_PARAMETERS {}
 impl ::core::default::Default for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2021,12 +2015,6 @@ impl ::core::clone::Clone for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLY_SNAPSHOT_VHDSET_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {}
 impl ::core::default::Default for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2054,7 +2042,7 @@ unsafe impl ::windows::core::Abi for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0>()) == 0 }
+        self.SnapshotId == other.SnapshotId && self.LeafSnapshotId == other.LeafSnapshotId
     }
 }
 impl ::core::cmp::Eq for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0 {}
@@ -2078,12 +2066,6 @@ impl ::core::clone::Clone for ATTACH_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for ATTACH_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ATTACH_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTACH_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ATTACH_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for ATTACH_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2104,12 +2086,6 @@ impl ::core::clone::Clone for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTACH_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2136,7 +2112,7 @@ unsafe impl ::windows::core::Abi for ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTACH_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -2167,7 +2143,7 @@ unsafe impl ::windows::core::Abi for ATTACH_VIRTUAL_DISK_PARAMETERS_0_1 {
 }
 impl ::core::cmp::PartialEq for ATTACH_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ATTACH_VIRTUAL_DISK_PARAMETERS_0_1>()) == 0 }
+        self.RestrictedOffset == other.RestrictedOffset && self.RestrictedLength == other.RestrictedLength
     }
 }
 impl ::core::cmp::Eq for ATTACH_VIRTUAL_DISK_PARAMETERS_0_1 {}
@@ -2191,12 +2167,6 @@ impl ::core::clone::Clone for COMPACT_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for COMPACT_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COMPACT_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPACT_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COMPACT_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for COMPACT_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2216,12 +2186,6 @@ impl ::core::clone::Clone for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPACT_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2248,7 +2212,7 @@ unsafe impl ::windows::core::Abi for COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPACT_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -2272,12 +2236,6 @@ impl ::core::clone::Clone for CREATE_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for CREATE_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2300,12 +2258,6 @@ impl ::core::clone::Clone for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2337,7 +2289,7 @@ unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.UniqueId == other.UniqueId && self.MaximumSize == other.MaximumSize && self.BlockSizeInBytes == other.BlockSizeInBytes && self.SectorSizeInBytes == other.SectorSizeInBytes && self.ParentPath == other.ParentPath && self.SourcePath == other.SourcePath
     }
 }
 impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -2389,7 +2341,7 @@ unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS_0_1 {
 }
 impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS_0_1>()) == 0 }
+        self.UniqueId == other.UniqueId && self.MaximumSize == other.MaximumSize && self.BlockSizeInBytes == other.BlockSizeInBytes && self.SectorSizeInBytes == other.SectorSizeInBytes && self.PhysicalSectorSizeInBytes == other.PhysicalSectorSizeInBytes && self.ParentPath == other.ParentPath && self.SourcePath == other.SourcePath && self.OpenFlags == other.OpenFlags && self.ParentVirtualStorageType == other.ParentVirtualStorageType && self.SourceVirtualStorageType == other.SourceVirtualStorageType && self.ResiliencyGuid == other.ResiliencyGuid
     }
 }
 impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS_0_1 {}
@@ -2445,7 +2397,7 @@ unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS_0_2 {
 }
 impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS_0_2>()) == 0 }
+        self.UniqueId == other.UniqueId && self.MaximumSize == other.MaximumSize && self.BlockSizeInBytes == other.BlockSizeInBytes && self.SectorSizeInBytes == other.SectorSizeInBytes && self.PhysicalSectorSizeInBytes == other.PhysicalSectorSizeInBytes && self.ParentPath == other.ParentPath && self.SourcePath == other.SourcePath && self.OpenFlags == other.OpenFlags && self.ParentVirtualStorageType == other.ParentVirtualStorageType && self.SourceVirtualStorageType == other.SourceVirtualStorageType && self.ResiliencyGuid == other.ResiliencyGuid && self.SourceLimitPath == other.SourceLimitPath && self.BackingStorageType == other.BackingStorageType
     }
 }
 impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS_0_2 {}
@@ -2505,7 +2457,7 @@ unsafe impl ::windows::core::Abi for CREATE_VIRTUAL_DISK_PARAMETERS_0_3 {
 }
 impl ::core::cmp::PartialEq for CREATE_VIRTUAL_DISK_PARAMETERS_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_VIRTUAL_DISK_PARAMETERS_0_3>()) == 0 }
+        self.UniqueId == other.UniqueId && self.MaximumSize == other.MaximumSize && self.BlockSizeInBytes == other.BlockSizeInBytes && self.SectorSizeInBytes == other.SectorSizeInBytes && self.PhysicalSectorSizeInBytes == other.PhysicalSectorSizeInBytes && self.ParentPath == other.ParentPath && self.SourcePath == other.SourcePath && self.OpenFlags == other.OpenFlags && self.ParentVirtualStorageType == other.ParentVirtualStorageType && self.SourceVirtualStorageType == other.SourceVirtualStorageType && self.ResiliencyGuid == other.ResiliencyGuid && self.SourceLimitPath == other.SourceLimitPath && self.BackingStorageType == other.BackingStorageType && self.PmemAddressAbstractionType == other.PmemAddressAbstractionType && self.DataAlignment == other.DataAlignment
     }
 }
 impl ::core::cmp::Eq for CREATE_VIRTUAL_DISK_PARAMETERS_0_3 {}
@@ -2529,12 +2481,6 @@ impl ::core::clone::Clone for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
 unsafe impl ::windows::core::Abi for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETE_SNAPSHOT_VHDSET_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DELETE_SNAPSHOT_VHDSET_PARAMETERS {}
 impl ::core::default::Default for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2554,12 +2500,6 @@ impl ::core::clone::Clone for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETE_SNAPSHOT_VHDSET_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {}
 impl ::core::default::Default for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2586,7 +2526,7 @@ unsafe impl ::windows::core::Abi for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0>()) == 0 }
+        self.SnapshotId == other.SnapshotId
     }
 }
 impl ::core::cmp::Eq for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {}
@@ -2610,12 +2550,6 @@ impl ::core::clone::Clone for EXPAND_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for EXPAND_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EXPAND_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXPAND_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EXPAND_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for EXPAND_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2635,12 +2569,6 @@ impl ::core::clone::Clone for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXPAND_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2667,7 +2595,7 @@ unsafe impl ::windows::core::Abi for EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXPAND_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.NewSize == other.NewSize
     }
 }
 impl ::core::cmp::Eq for EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -2691,12 +2619,6 @@ impl ::core::clone::Clone for FORK_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for FORK_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FORK_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORK_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FORK_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for FORK_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2716,12 +2638,6 @@ impl ::core::clone::Clone for FORK_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for FORK_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FORK_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORK_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FORK_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for FORK_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2748,7 +2664,7 @@ unsafe impl ::windows::core::Abi for FORK_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for FORK_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORK_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.ForkedVirtualDiskPath == other.ForkedVirtualDiskPath
     }
 }
 impl ::core::cmp::Eq for FORK_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -2776,14 +2692,6 @@ impl ::core::clone::Clone for GET_VIRTUAL_DISK_INFO {
 unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GET_VIRTUAL_DISK_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GET_VIRTUAL_DISK_INFO {
     fn default() -> Self {
@@ -2823,14 +2731,6 @@ unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GET_VIRTUAL_DISK_INFO_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GET_VIRTUAL_DISK_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2865,7 +2765,7 @@ unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO_0_0>()) == 0 }
+        self.Enabled == other.Enabled && self.NewerChanges == other.NewerChanges && self.MostRecentId == other.MostRecentId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2904,7 +2804,7 @@ unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO_0_1>()) == 0 }
+        self.ParentResolved == other.ParentResolved && self.ParentLocationBuffer == other.ParentLocationBuffer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2944,7 +2844,7 @@ unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO_0_2>()) == 0 }
+        self.LogicalSectorSize == other.LogicalSectorSize && self.PhysicalSectorSize == other.PhysicalSectorSize && self.IsRemote == other.IsRemote
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2985,7 +2885,7 @@ unsafe impl ::windows::core::Abi for GET_VIRTUAL_DISK_INFO_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GET_VIRTUAL_DISK_INFO_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_VIRTUAL_DISK_INFO_0_3>()) == 0 }
+        self.VirtualSize == other.VirtualSize && self.PhysicalSize == other.PhysicalSize && self.BlockSize == other.BlockSize && self.SectorSize == other.SectorSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3011,12 +2911,6 @@ impl ::core::clone::Clone for MERGE_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for MERGE_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MERGE_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MERGE_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MERGE_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for MERGE_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3037,12 +2931,6 @@ impl ::core::clone::Clone for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MERGE_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MERGE_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3069,7 +2957,7 @@ unsafe impl ::windows::core::Abi for MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MERGE_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.MergeDepth == other.MergeDepth
     }
 }
 impl ::core::cmp::Eq for MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -3100,7 +2988,7 @@ unsafe impl ::windows::core::Abi for MERGE_VIRTUAL_DISK_PARAMETERS_0_1 {
 }
 impl ::core::cmp::PartialEq for MERGE_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MERGE_VIRTUAL_DISK_PARAMETERS_0_1>()) == 0 }
+        self.MergeSourceDepth == other.MergeSourceDepth && self.MergeTargetDepth == other.MergeTargetDepth
     }
 }
 impl ::core::cmp::Eq for MERGE_VIRTUAL_DISK_PARAMETERS_0_1 {}
@@ -3124,12 +3012,6 @@ impl ::core::clone::Clone for MIRROR_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for MIRROR_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIRROR_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIRROR_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIRROR_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for MIRROR_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3149,12 +3031,6 @@ impl ::core::clone::Clone for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIRROR_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3181,7 +3057,7 @@ unsafe impl ::windows::core::Abi for MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIRROR_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.MirrorVirtualDiskPath == other.MirrorVirtualDiskPath
     }
 }
 impl ::core::cmp::Eq for MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -3205,12 +3081,6 @@ impl ::core::clone::Clone for MODIFY_VHDSET_PARAMETERS {
 unsafe impl ::windows::core::Abi for MODIFY_VHDSET_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MODIFY_VHDSET_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODIFY_VHDSET_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MODIFY_VHDSET_PARAMETERS {}
 impl ::core::default::Default for MODIFY_VHDSET_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3232,12 +3102,6 @@ impl ::core::clone::Clone for MODIFY_VHDSET_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for MODIFY_VHDSET_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MODIFY_VHDSET_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODIFY_VHDSET_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MODIFY_VHDSET_PARAMETERS_0 {}
 impl ::core::default::Default for MODIFY_VHDSET_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3265,7 +3129,7 @@ unsafe impl ::windows::core::Abi for MODIFY_VHDSET_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for MODIFY_VHDSET_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODIFY_VHDSET_PARAMETERS_0_0>()) == 0 }
+        self.SnapshotId == other.SnapshotId && self.SnapshotFilePath == other.SnapshotFilePath
     }
 }
 impl ::core::cmp::Eq for MODIFY_VHDSET_PARAMETERS_0_0 {}
@@ -3294,14 +3158,6 @@ unsafe impl ::windows::core::Abi for OPEN_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_VIRTUAL_DISK_PARAMETERS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3327,14 +3183,6 @@ impl ::core::clone::Clone for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_VIRTUAL_DISK_PARAMETERS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
@@ -3368,7 +3216,7 @@ unsafe impl ::windows::core::Abi for OPEN_VIRTUAL_DISK_PARAMETERS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPEN_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.RWDepth == other.RWDepth
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3408,7 +3256,7 @@ unsafe impl ::windows::core::Abi for OPEN_VIRTUAL_DISK_PARAMETERS_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPEN_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_VIRTUAL_DISK_PARAMETERS_0_1>()) == 0 }
+        self.GetInfoOnly == other.GetInfoOnly && self.ReadOnly == other.ReadOnly && self.ResiliencyGuid == other.ResiliencyGuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3449,7 +3297,7 @@ unsafe impl ::windows::core::Abi for OPEN_VIRTUAL_DISK_PARAMETERS_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OPEN_VIRTUAL_DISK_PARAMETERS_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_VIRTUAL_DISK_PARAMETERS_0_2>()) == 0 }
+        self.GetInfoOnly == other.GetInfoOnly && self.ReadOnly == other.ReadOnly && self.ResiliencyGuid == other.ResiliencyGuid && self.SnapshotId == other.SnapshotId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3483,7 +3331,7 @@ unsafe impl ::windows::core::Abi for QUERY_CHANGES_VIRTUAL_DISK_RANGE {
 }
 impl ::core::cmp::PartialEq for QUERY_CHANGES_VIRTUAL_DISK_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_CHANGES_VIRTUAL_DISK_RANGE>()) == 0 }
+        self.ByteOffset == other.ByteOffset && self.ByteLength == other.ByteLength && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for QUERY_CHANGES_VIRTUAL_DISK_RANGE {}
@@ -3512,14 +3360,6 @@ unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3543,14 +3383,6 @@ impl ::core::clone::Clone for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
@@ -3592,7 +3424,7 @@ unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.RSVDHandle == other.RSVDHandle && self.DataIn == other.DataIn && self.CdbLength == other.CdbLength && self.SenseInfoLength == other.SenseInfoLength && self.SrbFlags == other.SrbFlags && self.DataTransferLength == other.DataTransferLength && self.DataBuffer == other.DataBuffer && self.SenseInfo == other.SenseInfo && self.Cdb == other.Cdb
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3618,12 +3450,6 @@ impl ::core::clone::Clone for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
 unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_RESPONSE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAW_SCSI_VIRTUAL_DISK_RESPONSE {}
 impl ::core::default::Default for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3643,12 +3469,6 @@ impl ::core::clone::Clone for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
 unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_RESPONSE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {}
 impl ::core::default::Default for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3677,7 +3497,7 @@ unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0 {
 }
 impl ::core::cmp::PartialEq for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0>()) == 0 }
+        self.ScsiStatus == other.ScsiStatus && self.SenseInfoLength == other.SenseInfoLength && self.DataTransferLength == other.DataTransferLength
     }
 }
 impl ::core::cmp::Eq for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0 {}
@@ -3701,12 +3521,6 @@ impl ::core::clone::Clone for RESIZE_VIRTUAL_DISK_PARAMETERS {
 unsafe impl ::windows::core::Abi for RESIZE_VIRTUAL_DISK_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RESIZE_VIRTUAL_DISK_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESIZE_VIRTUAL_DISK_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RESIZE_VIRTUAL_DISK_PARAMETERS {}
 impl ::core::default::Default for RESIZE_VIRTUAL_DISK_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3726,12 +3540,6 @@ impl ::core::clone::Clone for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESIZE_VIRTUAL_DISK_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {}
 impl ::core::default::Default for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3758,7 +3566,7 @@ unsafe impl ::windows::core::Abi for RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESIZE_VIRTUAL_DISK_PARAMETERS_0_0>()) == 0 }
+        self.NewSize == other.NewSize
     }
 }
 impl ::core::cmp::Eq for RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {}
@@ -3786,14 +3594,6 @@ impl ::core::clone::Clone for SET_VIRTUAL_DISK_INFO {
 unsafe impl ::windows::core::Abi for SET_VIRTUAL_DISK_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SET_VIRTUAL_DISK_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_VIRTUAL_DISK_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SET_VIRTUAL_DISK_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SET_VIRTUAL_DISK_INFO {
     fn default() -> Self {
@@ -3824,14 +3624,6 @@ impl ::core::clone::Clone for SET_VIRTUAL_DISK_INFO_0 {
 unsafe impl ::windows::core::Abi for SET_VIRTUAL_DISK_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SET_VIRTUAL_DISK_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_VIRTUAL_DISK_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SET_VIRTUAL_DISK_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SET_VIRTUAL_DISK_INFO_0 {
     fn default() -> Self {
@@ -3866,7 +3658,7 @@ unsafe impl ::windows::core::Abi for SET_VIRTUAL_DISK_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SET_VIRTUAL_DISK_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_VIRTUAL_DISK_INFO_0_0>()) == 0 }
+        self.LinkageId == other.LinkageId && self.ParentFilePath == other.ParentFilePath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3905,7 +3697,7 @@ unsafe impl ::windows::core::Abi for SET_VIRTUAL_DISK_INFO_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SET_VIRTUAL_DISK_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_VIRTUAL_DISK_INFO_0_1>()) == 0 }
+        self.ChildDepth == other.ChildDepth && self.ParentFilePath == other.ParentFilePath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3932,12 +3724,6 @@ impl ::core::clone::Clone for STORAGE_DEPENDENCY_INFO {
 unsafe impl ::windows::core::Abi for STORAGE_DEPENDENCY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_DEPENDENCY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEPENDENCY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_DEPENDENCY_INFO {}
 impl ::core::default::Default for STORAGE_DEPENDENCY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3958,12 +3744,6 @@ impl ::core::clone::Clone for STORAGE_DEPENDENCY_INFO_0 {
 unsafe impl ::windows::core::Abi for STORAGE_DEPENDENCY_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_DEPENDENCY_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEPENDENCY_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_DEPENDENCY_INFO_0 {}
 impl ::core::default::Default for STORAGE_DEPENDENCY_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3992,7 +3772,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEPENDENCY_INFO_TYPE_1 {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEPENDENCY_INFO_TYPE_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEPENDENCY_INFO_TYPE_1>()) == 0 }
+        self.DependencyTypeFlags == other.DependencyTypeFlags && self.ProviderSpecificFlags == other.ProviderSpecificFlags && self.VirtualStorageType == other.VirtualStorageType
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEPENDENCY_INFO_TYPE_1 {}
@@ -4038,7 +3818,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEPENDENCY_INFO_TYPE_2 {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEPENDENCY_INFO_TYPE_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEPENDENCY_INFO_TYPE_2>()) == 0 }
+        self.DependencyTypeFlags == other.DependencyTypeFlags && self.ProviderSpecificFlags == other.ProviderSpecificFlags && self.VirtualStorageType == other.VirtualStorageType && self.AncestorLevel == other.AncestorLevel && self.DependencyDeviceName == other.DependencyDeviceName && self.HostVolumeName == other.HostVolumeName && self.DependentVolumeName == other.DependentVolumeName && self.DependentVolumeRelativePath == other.DependentVolumeRelativePath
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEPENDENCY_INFO_TYPE_2 {}
@@ -4062,12 +3842,6 @@ impl ::core::clone::Clone for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
 unsafe impl ::windows::core::Abi for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAKE_SNAPSHOT_VHDSET_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TAKE_SNAPSHOT_VHDSET_PARAMETERS {}
 impl ::core::default::Default for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4087,12 +3861,6 @@ impl ::core::clone::Clone for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAKE_SNAPSHOT_VHDSET_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {}
 impl ::core::default::Default for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4119,7 +3887,7 @@ unsafe impl ::windows::core::Abi for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0>()) == 0 }
+        self.SnapshotId == other.SnapshotId
     }
 }
 impl ::core::cmp::Eq for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {}
@@ -4151,7 +3919,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_DISK_PROGRESS {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_DISK_PROGRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_DISK_PROGRESS>()) == 0 }
+        self.OperationStatus == other.OperationStatus && self.CurrentValue == other.CurrentValue && self.CompletionValue == other.CompletionValue
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_DISK_PROGRESS {}
@@ -4182,7 +3950,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_STORAGE_TYPE {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_STORAGE_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_STORAGE_TYPE>()) == 0 }
+        self.DeviceId == other.DeviceId && self.VendorId == other.VendorId
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_STORAGE_TYPE {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -4948,12 +4948,6 @@ impl ::core::clone::Clone for VDS_ASYNC_OUTPUT {
 unsafe impl ::windows::core::Abi for VDS_ASYNC_OUTPUT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for VDS_ASYNC_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        self.r#type == other.r#type && self.Anonymous == other.Anonymous
-    }
-}
-impl ::core::cmp::Eq for VDS_ASYNC_OUTPUT {}
 impl ::core::default::Default for VDS_ASYNC_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4979,12 +4973,6 @@ impl ::core::clone::Clone for VDS_ASYNC_OUTPUT_0 {
 unsafe impl ::windows::core::Abi for VDS_ASYNC_OUTPUT_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for VDS_ASYNC_OUTPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ASYNC_OUTPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_ASYNC_OUTPUT_0 {}
 impl ::core::default::Default for VDS_ASYNC_OUTPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5070,7 +5058,7 @@ unsafe impl ::windows::core::Abi for VDS_ASYNC_OUTPUT_0_2 {
 }
 impl ::core::cmp::PartialEq for VDS_ASYNC_OUTPUT_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ASYNC_OUTPUT_0_2>()) == 0 }
+        self.ullOffset == other.ullOffset && self.volumeId == other.volumeId
     }
 }
 impl ::core::cmp::Eq for VDS_ASYNC_OUTPUT_0_2 {}
@@ -5216,7 +5204,7 @@ unsafe impl ::windows::core::Abi for VDS_ASYNC_OUTPUT_0_7 {
 }
 impl ::core::cmp::PartialEq for VDS_ASYNC_OUTPUT_0_7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ASYNC_OUTPUT_0_7>()) == 0 }
+        self.ullReclaimedBytes == other.ullReclaimedBytes
     }
 }
 impl ::core::cmp::Eq for VDS_ASYNC_OUTPUT_0_7 {}
@@ -5247,7 +5235,7 @@ unsafe impl ::windows::core::Abi for VDS_CONTROLLER_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_CONTROLLER_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_CONTROLLER_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.controllerId == other.controllerId
     }
 }
 impl ::core::cmp::Eq for VDS_CONTROLLER_NOTIFICATION {}
@@ -5282,7 +5270,7 @@ unsafe impl ::windows::core::Abi for VDS_CONTROLLER_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_CONTROLLER_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_CONTROLLER_PROP>()) == 0 }
+        self.id == other.id && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.status == other.status && self.health == other.health && self.sNumberOfPorts == other.sNumberOfPorts
     }
 }
 impl ::core::cmp::Eq for VDS_CONTROLLER_PROP {}
@@ -5313,7 +5301,7 @@ unsafe impl ::windows::core::Abi for VDS_DISK_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_DISK_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DISK_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.diskId == other.diskId
     }
 }
 impl ::core::cmp::Eq for VDS_DISK_NOTIFICATION {}
@@ -5352,7 +5340,7 @@ unsafe impl ::windows::core::Abi for VDS_DRIVE_EXTENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_DRIVE_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DRIVE_EXTENT>()) == 0 }
+        self.id == other.id && self.LunId == other.LunId && self.ullSize == other.ullSize && self.bUsed == other.bUsed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5386,7 +5374,7 @@ unsafe impl ::windows::core::Abi for VDS_DRIVE_LETTER_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_DRIVE_LETTER_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DRIVE_LETTER_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.wcLetter == other.wcLetter && self.volumeId == other.volumeId
     }
 }
 impl ::core::cmp::Eq for VDS_DRIVE_LETTER_NOTIFICATION {}
@@ -5417,7 +5405,7 @@ unsafe impl ::windows::core::Abi for VDS_DRIVE_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_DRIVE_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DRIVE_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.driveId == other.driveId
     }
 }
 impl ::core::cmp::Eq for VDS_DRIVE_NOTIFICATION {}
@@ -5455,7 +5443,7 @@ unsafe impl ::windows::core::Abi for VDS_DRIVE_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_DRIVE_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DRIVE_PROP>()) == 0 }
+        self.id == other.id && self.ullSize == other.ullSize && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.ulFlags == other.ulFlags && self.status == other.status && self.health == other.health && self.sInternalBusNumber == other.sInternalBusNumber && self.sSlotNumber == other.sSlotNumber
     }
 }
 impl ::core::cmp::Eq for VDS_DRIVE_PROP {}
@@ -5509,7 +5497,7 @@ unsafe impl ::windows::core::Abi for VDS_DRIVE_PROP2 {
 }
 impl ::core::cmp::PartialEq for VDS_DRIVE_PROP2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_DRIVE_PROP2>()) == 0 }
+        self.id == other.id && self.ullSize == other.ullSize && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.ulFlags == other.ulFlags && self.status == other.status && self.health == other.health && self.sInternalBusNumber == other.sInternalBusNumber && self.sSlotNumber == other.sSlotNumber && self.ulEnclosureNumber == other.ulEnclosureNumber && self.busType == other.busType && self.ulSpindleSpeed == other.ulSpindleSpeed
     }
 }
 impl ::core::cmp::Eq for VDS_DRIVE_PROP2 {}
@@ -5541,7 +5529,7 @@ unsafe impl ::windows::core::Abi for VDS_FILE_SYSTEM_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_FILE_SYSTEM_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_FILE_SYSTEM_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.volumeId == other.volumeId && self.dwPercentCompleted == other.dwPercentCompleted
     }
 }
 impl ::core::cmp::Eq for VDS_FILE_SYSTEM_NOTIFICATION {}
@@ -5577,7 +5565,7 @@ unsafe impl ::windows::core::Abi for VDS_HBAPORT_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_HBAPORT_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_HBAPORT_PROP>()) == 0 }
+        self.id == other.id && self.wwnNode == other.wwnNode && self.wwnPort == other.wwnPort && self.r#type == other.r#type && self.status == other.status && self.ulPortSpeed == other.ulPortSpeed && self.ulSupportedPortSpeed == other.ulSupportedPortSpeed
     }
 }
 impl ::core::cmp::Eq for VDS_HBAPORT_PROP {}
@@ -5649,7 +5637,24 @@ unsafe impl ::windows::core::Abi for VDS_HINTS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_HINTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_HINTS>()) == 0 }
+        self.ullHintMask == other.ullHintMask
+            && self.ullExpectedMaximumSize == other.ullExpectedMaximumSize
+            && self.ulOptimalReadSize == other.ulOptimalReadSize
+            && self.ulOptimalReadAlignment == other.ulOptimalReadAlignment
+            && self.ulOptimalWriteSize == other.ulOptimalWriteSize
+            && self.ulOptimalWriteAlignment == other.ulOptimalWriteAlignment
+            && self.ulMaximumDriveCount == other.ulMaximumDriveCount
+            && self.ulStripeSize == other.ulStripeSize
+            && self.bFastCrashRecoveryRequired == other.bFastCrashRecoveryRequired
+            && self.bMostlyReads == other.bMostlyReads
+            && self.bOptimizeForSequentialReads == other.bOptimizeForSequentialReads
+            && self.bOptimizeForSequentialWrites == other.bOptimizeForSequentialWrites
+            && self.bRemapEnabled == other.bRemapEnabled
+            && self.bReadBackVerifyEnabled == other.bReadBackVerifyEnabled
+            && self.bWriteThroughCachingEnabled == other.bWriteThroughCachingEnabled
+            && self.bHardwareChecksumEnabled == other.bHardwareChecksumEnabled
+            && self.bIsYankable == other.bIsYankable
+            && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5749,7 +5754,37 @@ unsafe impl ::windows::core::Abi for VDS_HINTS2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_HINTS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_HINTS2>()) == 0 }
+        self.ullHintMask == other.ullHintMask
+            && self.ullExpectedMaximumSize == other.ullExpectedMaximumSize
+            && self.ulOptimalReadSize == other.ulOptimalReadSize
+            && self.ulOptimalReadAlignment == other.ulOptimalReadAlignment
+            && self.ulOptimalWriteSize == other.ulOptimalWriteSize
+            && self.ulOptimalWriteAlignment == other.ulOptimalWriteAlignment
+            && self.ulMaximumDriveCount == other.ulMaximumDriveCount
+            && self.ulStripeSize == other.ulStripeSize
+            && self.ulReserved1 == other.ulReserved1
+            && self.ulReserved2 == other.ulReserved2
+            && self.ulReserved3 == other.ulReserved3
+            && self.bFastCrashRecoveryRequired == other.bFastCrashRecoveryRequired
+            && self.bMostlyReads == other.bMostlyReads
+            && self.bOptimizeForSequentialReads == other.bOptimizeForSequentialReads
+            && self.bOptimizeForSequentialWrites == other.bOptimizeForSequentialWrites
+            && self.bRemapEnabled == other.bRemapEnabled
+            && self.bReadBackVerifyEnabled == other.bReadBackVerifyEnabled
+            && self.bWriteThroughCachingEnabled == other.bWriteThroughCachingEnabled
+            && self.bHardwareChecksumEnabled == other.bHardwareChecksumEnabled
+            && self.bIsYankable == other.bIsYankable
+            && self.bAllocateHotSpare == other.bAllocateHotSpare
+            && self.bUseMirroredCache == other.bUseMirroredCache
+            && self.bReadCachingEnabled == other.bReadCachingEnabled
+            && self.bWriteCachingEnabled == other.bWriteCachingEnabled
+            && self.bMediaScanEnabled == other.bMediaScanEnabled
+            && self.bConsistencyCheckEnabled == other.bConsistencyCheckEnabled
+            && self.BusType == other.BusType
+            && self.bReserved1 == other.bReserved1
+            && self.bReserved2 == other.bReserved2
+            && self.bReserved3 == other.bReserved3
+            && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5785,7 +5820,7 @@ unsafe impl ::windows::core::Abi for VDS_INTERCONNECT {
 }
 impl ::core::cmp::PartialEq for VDS_INTERCONNECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_INTERCONNECT>()) == 0 }
+        self.m_addressType == other.m_addressType && self.m_cbPort == other.m_cbPort && self.m_pbPort == other.m_pbPort && self.m_cbAddress == other.m_cbAddress && self.m_pbAddress == other.m_pbAddress
     }
 }
 impl ::core::cmp::Eq for VDS_INTERCONNECT {}
@@ -5821,7 +5856,7 @@ unsafe impl ::windows::core::Abi for VDS_IPADDRESS {
 }
 impl ::core::cmp::PartialEq for VDS_IPADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_IPADDRESS>()) == 0 }
+        self.r#type == other.r#type && self.ipv4Address == other.ipv4Address && self.ipv6Address == other.ipv6Address && self.ulIpv6FlowInfo == other.ulIpv6FlowInfo && self.ulIpv6ScopeId == other.ulIpv6ScopeId && self.wszTextAddress == other.wszTextAddress && self.ulPort == other.ulPort
     }
 }
 impl ::core::cmp::Eq for VDS_IPADDRESS {}
@@ -5852,7 +5887,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_INITIATOR_ADAPTER_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_INITIATOR_ADAPTER_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_INITIATOR_ADAPTER_PROP>()) == 0 }
+        self.id == other.id && self.pwszName == other.pwszName
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_INITIATOR_ADAPTER_PROP {}
@@ -5884,7 +5919,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_INITIATOR_PORTAL_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_INITIATOR_PORTAL_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_INITIATOR_PORTAL_PROP>()) == 0 }
+        self.id == other.id && self.address == other.address && self.ulPortIndex == other.ulPortIndex
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_INITIATOR_PORTAL_PROP {}
@@ -5915,7 +5950,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_IPSEC_KEY {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_IPSEC_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_IPSEC_KEY>()) == 0 }
+        self.pKey == other.pKey && self.ulKeySize == other.ulKeySize
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_IPSEC_KEY {}
@@ -5946,7 +5981,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_PORTALGROUP_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_PORTALGROUP_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_PORTALGROUP_PROP>()) == 0 }
+        self.id == other.id && self.tag == other.tag
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_PORTALGROUP_PROP {}
@@ -5978,7 +6013,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_PORTAL_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_PORTAL_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_PORTAL_PROP>()) == 0 }
+        self.id == other.id && self.address == other.address && self.status == other.status
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_PORTAL_PROP {}
@@ -6009,7 +6044,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_SHARED_SECRET {
 }
 impl ::core::cmp::PartialEq for VDS_ISCSI_SHARED_SECRET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_SHARED_SECRET>()) == 0 }
+        self.pSharedSecret == other.pSharedSecret && self.ulSharedSecretSize == other.ulSharedSecretSize
     }
 }
 impl ::core::cmp::Eq for VDS_ISCSI_SHARED_SECRET {}
@@ -6048,7 +6083,7 @@ unsafe impl ::windows::core::Abi for VDS_ISCSI_TARGET_PROP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_ISCSI_TARGET_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_ISCSI_TARGET_PROP>()) == 0 }
+        self.id == other.id && self.pwszIscsiName == other.pwszIscsiName && self.pwszFriendlyName == other.pwszFriendlyName && self.bChapEnabled == other.bChapEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6112,7 +6147,7 @@ unsafe impl ::windows::core::Abi for VDS_LUN_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_LUN_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_LUN_INFORMATION>()) == 0 }
+        self.m_version == other.m_version && self.m_DeviceType == other.m_DeviceType && self.m_DeviceTypeModifier == other.m_DeviceTypeModifier && self.m_bCommandQueueing == other.m_bCommandQueueing && self.m_BusType == other.m_BusType && self.m_szVendorId == other.m_szVendorId && self.m_szProductId == other.m_szProductId && self.m_szProductRevision == other.m_szProductRevision && self.m_szSerialNumber == other.m_szSerialNumber && self.m_diskSignature == other.m_diskSignature && self.m_deviceIdDescriptor == other.m_deviceIdDescriptor && self.m_cInterconnects == other.m_cInterconnects && self.m_rgInterconnects == other.m_rgInterconnects
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6145,7 +6180,7 @@ unsafe impl ::windows::core::Abi for VDS_LUN_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_LUN_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_LUN_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.LunId == other.LunId
     }
 }
 impl ::core::cmp::Eq for VDS_LUN_NOTIFICATION {}
@@ -6183,7 +6218,7 @@ unsafe impl ::windows::core::Abi for VDS_LUN_PLEX_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_LUN_PLEX_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_LUN_PLEX_PROP>()) == 0 }
+        self.id == other.id && self.ullSize == other.ullSize && self.r#type == other.r#type && self.status == other.status && self.health == other.health && self.TransitionState == other.TransitionState && self.ulFlags == other.ulFlags && self.ulStripeSize == other.ulStripeSize && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 impl ::core::cmp::Eq for VDS_LUN_PLEX_PROP {}
@@ -6223,7 +6258,7 @@ unsafe impl ::windows::core::Abi for VDS_LUN_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_LUN_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_LUN_PROP>()) == 0 }
+        self.id == other.id && self.ullSize == other.ullSize && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.pwszUnmaskingList == other.pwszUnmaskingList && self.ulFlags == other.ulFlags && self.r#type == other.r#type && self.status == other.status && self.health == other.health && self.TransitionState == other.TransitionState && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 impl ::core::cmp::Eq for VDS_LUN_PROP {}
@@ -6254,7 +6289,7 @@ unsafe impl ::windows::core::Abi for VDS_MOUNT_POINT_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_MOUNT_POINT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_MOUNT_POINT_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.volumeId == other.volumeId
     }
 }
 impl ::core::cmp::Eq for VDS_MOUNT_POINT_NOTIFICATION {}
@@ -6278,12 +6313,6 @@ impl ::core::clone::Clone for VDS_NOTIFICATION {
 unsafe impl ::windows::core::Abi for VDS_NOTIFICATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_NOTIFICATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_NOTIFICATION {}
 impl ::core::default::Default for VDS_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6318,12 +6347,6 @@ impl ::core::clone::Clone for VDS_NOTIFICATION_0 {
 unsafe impl ::windows::core::Abi for VDS_NOTIFICATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_NOTIFICATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_NOTIFICATION_0 {}
 impl ::core::default::Default for VDS_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6351,7 +6374,7 @@ unsafe impl ::windows::core::Abi for VDS_PACK_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_PACK_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PACK_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.packId == other.packId
     }
 }
 impl ::core::cmp::Eq for VDS_PACK_NOTIFICATION {}
@@ -6383,7 +6406,7 @@ unsafe impl ::windows::core::Abi for VDS_PARTITION_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_PARTITION_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PARTITION_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.diskId == other.diskId && self.ullOffset == other.ullOffset
     }
 }
 impl ::core::cmp::Eq for VDS_PARTITION_NOTIFICATION {}
@@ -6414,7 +6437,7 @@ unsafe impl ::windows::core::Abi for VDS_PATH_ID {
 }
 impl ::core::cmp::PartialEq for VDS_PATH_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_ID>()) == 0 }
+        self.ullSourceId == other.ullSourceId && self.ullPathId == other.ullPathId
     }
 }
 impl ::core::cmp::Eq for VDS_PATH_ID {}
@@ -6442,12 +6465,6 @@ impl ::core::clone::Clone for VDS_PATH_INFO {
 unsafe impl ::windows::core::Abi for VDS_PATH_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_PATH_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_PATH_INFO {}
 impl ::core::default::Default for VDS_PATH_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6468,12 +6485,6 @@ impl ::core::clone::Clone for VDS_PATH_INFO_0 {
 unsafe impl ::windows::core::Abi for VDS_PATH_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_PATH_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_PATH_INFO_0 {}
 impl ::core::default::Default for VDS_PATH_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6494,12 +6505,6 @@ impl ::core::clone::Clone for VDS_PATH_INFO_1 {
 unsafe impl ::windows::core::Abi for VDS_PATH_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_PATH_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_PATH_INFO_1 {}
 impl ::core::default::Default for VDS_PATH_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6520,12 +6525,6 @@ impl ::core::clone::Clone for VDS_PATH_INFO_2 {
 unsafe impl ::windows::core::Abi for VDS_PATH_INFO_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VDS_PATH_INFO_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_INFO_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VDS_PATH_INFO_2 {}
 impl ::core::default::Default for VDS_PATH_INFO_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6560,7 +6559,7 @@ unsafe impl ::windows::core::Abi for VDS_PATH_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_PATH_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PATH_POLICY>()) == 0 }
+        self.pathId == other.pathId && self.bPrimaryPath == other.bPrimaryPath && self.ulWeight == other.ulWeight
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6674,7 +6673,44 @@ unsafe impl ::windows::core::Abi for VDS_POOL_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_POOL_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_POOL_ATTRIBUTES>()) == 0 }
+        self.ullAttributeMask == other.ullAttributeMask
+            && self.raidType == other.raidType
+            && self.busType == other.busType
+            && self.pwszIntendedUsage == other.pwszIntendedUsage
+            && self.bSpinDown == other.bSpinDown
+            && self.bIsThinProvisioned == other.bIsThinProvisioned
+            && self.ullProvisionedSpace == other.ullProvisionedSpace
+            && self.bNoSinglePointOfFailure == other.bNoSinglePointOfFailure
+            && self.ulDataRedundancyMax == other.ulDataRedundancyMax
+            && self.ulDataRedundancyMin == other.ulDataRedundancyMin
+            && self.ulDataRedundancyDefault == other.ulDataRedundancyDefault
+            && self.ulPackageRedundancyMax == other.ulPackageRedundancyMax
+            && self.ulPackageRedundancyMin == other.ulPackageRedundancyMin
+            && self.ulPackageRedundancyDefault == other.ulPackageRedundancyDefault
+            && self.ulStripeSize == other.ulStripeSize
+            && self.ulStripeSizeMax == other.ulStripeSizeMax
+            && self.ulStripeSizeMin == other.ulStripeSizeMin
+            && self.ulDefaultStripeSize == other.ulDefaultStripeSize
+            && self.ulNumberOfColumns == other.ulNumberOfColumns
+            && self.ulNumberOfColumnsMax == other.ulNumberOfColumnsMax
+            && self.ulNumberOfColumnsMin == other.ulNumberOfColumnsMin
+            && self.ulDefaultNumberofColumns == other.ulDefaultNumberofColumns
+            && self.ulDataAvailabilityHint == other.ulDataAvailabilityHint
+            && self.ulAccessRandomnessHint == other.ulAccessRandomnessHint
+            && self.ulAccessDirectionHint == other.ulAccessDirectionHint
+            && self.ulAccessSizeHint == other.ulAccessSizeHint
+            && self.ulAccessLatencyHint == other.ulAccessLatencyHint
+            && self.ulAccessBandwidthWeightHint == other.ulAccessBandwidthWeightHint
+            && self.ulStorageCostHint == other.ulStorageCostHint
+            && self.ulStorageEfficiencyHint == other.ulStorageEfficiencyHint
+            && self.ulNumOfCustomAttributes == other.ulNumOfCustomAttributes
+            && self.pPoolCustomAttributes == other.pPoolCustomAttributes
+            && self.bReserved1 == other.bReserved1
+            && self.bReserved2 == other.bReserved2
+            && self.ulReserved1 == other.ulReserved1
+            && self.ulReserved2 == other.ulReserved2
+            && self.ullReserved1 == other.ullReserved1
+            && self.ullReserved2 == other.ullReserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6707,7 +6743,7 @@ unsafe impl ::windows::core::Abi for VDS_POOL_CUSTOM_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for VDS_POOL_CUSTOM_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_POOL_CUSTOM_ATTRIBUTES>()) == 0 }
+        self.pwszName == other.pwszName && self.pwszValue == other.pwszValue
     }
 }
 impl ::core::cmp::Eq for VDS_POOL_CUSTOM_ATTRIBUTES {}
@@ -6738,7 +6774,7 @@ unsafe impl ::windows::core::Abi for VDS_PORTAL_GROUP_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_PORTAL_GROUP_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PORTAL_GROUP_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.portalGroupId == other.portalGroupId
     }
 }
 impl ::core::cmp::Eq for VDS_PORTAL_GROUP_NOTIFICATION {}
@@ -6769,7 +6805,7 @@ unsafe impl ::windows::core::Abi for VDS_PORTAL_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_PORTAL_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PORTAL_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.portalId == other.portalId
     }
 }
 impl ::core::cmp::Eq for VDS_PORTAL_NOTIFICATION {}
@@ -6800,7 +6836,7 @@ unsafe impl ::windows::core::Abi for VDS_PORT_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_PORT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PORT_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.portId == other.portId
     }
 }
 impl ::core::cmp::Eq for VDS_PORT_NOTIFICATION {}
@@ -6833,7 +6869,7 @@ unsafe impl ::windows::core::Abi for VDS_PORT_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_PORT_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PORT_PROP>()) == 0 }
+        self.id == other.id && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.status == other.status
     }
 }
 impl ::core::cmp::Eq for VDS_PORT_PROP {}
@@ -6870,7 +6906,7 @@ unsafe impl ::windows::core::Abi for VDS_PROVIDER_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_PROVIDER_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_PROVIDER_PROP>()) == 0 }
+        self.id == other.id && self.pwszName == other.pwszName && self.guidVersionId == other.guidVersionId && self.pwszVersion == other.pwszVersion && self.r#type == other.r#type && self.ulFlags == other.ulFlags && self.ulStripeSizeFlags == other.ulStripeSizeFlags && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 impl ::core::cmp::Eq for VDS_PROVIDER_PROP {}
@@ -6901,7 +6937,7 @@ unsafe impl ::windows::core::Abi for VDS_SERVICE_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_SERVICE_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_SERVICE_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.action == other.action
     }
 }
 impl ::core::cmp::Eq for VDS_SERVICE_NOTIFICATION {}
@@ -6933,7 +6969,7 @@ unsafe impl ::windows::core::Abi for VDS_STORAGE_DEVICE_ID_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for VDS_STORAGE_DEVICE_ID_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_STORAGE_DEVICE_ID_DESCRIPTOR>()) == 0 }
+        self.m_version == other.m_version && self.m_cIdentifiers == other.m_cIdentifiers && self.m_rgIdentifiers == other.m_rgIdentifiers
     }
 }
 impl ::core::cmp::Eq for VDS_STORAGE_DEVICE_ID_DESCRIPTOR {}
@@ -6966,7 +7002,7 @@ unsafe impl ::windows::core::Abi for VDS_STORAGE_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for VDS_STORAGE_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_STORAGE_IDENTIFIER>()) == 0 }
+        self.m_CodeSet == other.m_CodeSet && self.m_Type == other.m_Type && self.m_cbIdentifier == other.m_cbIdentifier && self.m_rgbIdentifier == other.m_rgbIdentifier
     }
 }
 impl ::core::cmp::Eq for VDS_STORAGE_IDENTIFIER {}
@@ -7004,7 +7040,7 @@ unsafe impl ::windows::core::Abi for VDS_STORAGE_POOL_DRIVE_EXTENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDS_STORAGE_POOL_DRIVE_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_STORAGE_POOL_DRIVE_EXTENT>()) == 0 }
+        self.id == other.id && self.ullSize == other.ullSize && self.bUsed == other.bUsed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7044,7 +7080,7 @@ unsafe impl ::windows::core::Abi for VDS_STORAGE_POOL_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_STORAGE_POOL_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_STORAGE_POOL_PROP>()) == 0 }
+        self.id == other.id && self.status == other.status && self.health == other.health && self.r#type == other.r#type && self.pwszName == other.pwszName && self.pwszDescription == other.pwszDescription && self.ullTotalConsumedSpace == other.ullTotalConsumedSpace && self.ullTotalManagedSpace == other.ullTotalManagedSpace && self.ullRemainingFreeSpace == other.ullRemainingFreeSpace
     }
 }
 impl ::core::cmp::Eq for VDS_STORAGE_POOL_PROP {}
@@ -7075,7 +7111,7 @@ unsafe impl ::windows::core::Abi for VDS_SUB_SYSTEM_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_SUB_SYSTEM_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_SUB_SYSTEM_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.subSystemId == other.subSystemId
     }
 }
 impl ::core::cmp::Eq for VDS_SUB_SYSTEM_NOTIFICATION {}
@@ -7127,7 +7163,7 @@ unsafe impl ::windows::core::Abi for VDS_SUB_SYSTEM_PROP {
 }
 impl ::core::cmp::PartialEq for VDS_SUB_SYSTEM_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_SUB_SYSTEM_PROP>()) == 0 }
+        self.id == other.id && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.ulFlags == other.ulFlags && self.ulStripeSizeFlags == other.ulStripeSizeFlags && self.status == other.status && self.health == other.health && self.sNumberOfInternalBuses == other.sNumberOfInternalBuses && self.sMaxNumberOfSlotsEachBus == other.sMaxNumberOfSlotsEachBus && self.sMaxNumberOfControllers == other.sMaxNumberOfControllers && self.sRebuildPriority == other.sRebuildPriority
     }
 }
 impl ::core::cmp::Eq for VDS_SUB_SYSTEM_PROP {}
@@ -7183,7 +7219,7 @@ unsafe impl ::windows::core::Abi for VDS_SUB_SYSTEM_PROP2 {
 }
 impl ::core::cmp::PartialEq for VDS_SUB_SYSTEM_PROP2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_SUB_SYSTEM_PROP2>()) == 0 }
+        self.id == other.id && self.pwszFriendlyName == other.pwszFriendlyName && self.pwszIdentification == other.pwszIdentification && self.ulFlags == other.ulFlags && self.ulStripeSizeFlags == other.ulStripeSizeFlags && self.ulSupportedRaidTypeFlags == other.ulSupportedRaidTypeFlags && self.status == other.status && self.health == other.health && self.sNumberOfInternalBuses == other.sNumberOfInternalBuses && self.sMaxNumberOfSlotsEachBus == other.sMaxNumberOfSlotsEachBus && self.sMaxNumberOfControllers == other.sMaxNumberOfControllers && self.sRebuildPriority == other.sRebuildPriority && self.ulNumberOfEnclosures == other.ulNumberOfEnclosures
     }
 }
 impl ::core::cmp::Eq for VDS_SUB_SYSTEM_PROP2 {}
@@ -7214,7 +7250,7 @@ unsafe impl ::windows::core::Abi for VDS_TARGET_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_TARGET_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_TARGET_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.targetId == other.targetId
     }
 }
 impl ::core::cmp::Eq for VDS_TARGET_NOTIFICATION {}
@@ -7247,7 +7283,7 @@ unsafe impl ::windows::core::Abi for VDS_VOLUME_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for VDS_VOLUME_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_VOLUME_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.volumeId == other.volumeId && self.plexId == other.plexId && self.ulPercentCompleted == other.ulPercentCompleted
     }
 }
 impl ::core::cmp::Eq for VDS_VOLUME_NOTIFICATION {}
@@ -7277,7 +7313,7 @@ unsafe impl ::windows::core::Abi for VDS_WWN {
 }
 impl ::core::cmp::PartialEq for VDS_WWN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDS_WWN>()) == 0 }
+        self.rguchWwn == other.rguchWwn
     }
 }
 impl ::core::cmp::Eq for VDS_WWN {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -3675,7 +3675,7 @@ unsafe impl ::windows::core::Abi for VSS_DIFF_AREA_PROP {
 }
 impl ::core::cmp::PartialEq for VSS_DIFF_AREA_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_DIFF_AREA_PROP>()) == 0 }
+        self.m_pwszVolumeName == other.m_pwszVolumeName && self.m_pwszDiffAreaVolumeName == other.m_pwszDiffAreaVolumeName && self.m_llMaximumDiffSpace == other.m_llMaximumDiffSpace && self.m_llAllocatedDiffSpace == other.m_llAllocatedDiffSpace && self.m_llUsedDiffSpace == other.m_llUsedDiffSpace
     }
 }
 impl ::core::cmp::Eq for VSS_DIFF_AREA_PROP {}
@@ -3708,7 +3708,7 @@ unsafe impl ::windows::core::Abi for VSS_DIFF_VOLUME_PROP {
 }
 impl ::core::cmp::PartialEq for VSS_DIFF_VOLUME_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_DIFF_VOLUME_PROP>()) == 0 }
+        self.m_pwszVolumeName == other.m_pwszVolumeName && self.m_pwszVolumeDisplayName == other.m_pwszVolumeDisplayName && self.m_llVolumeFreeSpace == other.m_llVolumeFreeSpace && self.m_llVolumeTotalSpace == other.m_llVolumeTotalSpace
     }
 }
 impl ::core::cmp::Eq for VSS_DIFF_VOLUME_PROP {}
@@ -3732,12 +3732,6 @@ impl ::core::clone::Clone for VSS_MGMT_OBJECT_PROP {
 unsafe impl ::windows::core::Abi for VSS_MGMT_OBJECT_PROP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VSS_MGMT_OBJECT_PROP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_MGMT_OBJECT_PROP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VSS_MGMT_OBJECT_PROP {}
 impl ::core::default::Default for VSS_MGMT_OBJECT_PROP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3759,12 +3753,6 @@ impl ::core::clone::Clone for VSS_MGMT_OBJECT_UNION {
 unsafe impl ::windows::core::Abi for VSS_MGMT_OBJECT_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VSS_MGMT_OBJECT_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_MGMT_OBJECT_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VSS_MGMT_OBJECT_UNION {}
 impl ::core::default::Default for VSS_MGMT_OBJECT_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3785,12 +3773,6 @@ impl ::core::clone::Clone for VSS_OBJECT_PROP {
 unsafe impl ::windows::core::Abi for VSS_OBJECT_PROP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VSS_OBJECT_PROP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_OBJECT_PROP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VSS_OBJECT_PROP {}
 impl ::core::default::Default for VSS_OBJECT_PROP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3811,12 +3793,6 @@ impl ::core::clone::Clone for VSS_OBJECT_UNION {
 unsafe impl ::windows::core::Abi for VSS_OBJECT_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VSS_OBJECT_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_OBJECT_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VSS_OBJECT_UNION {}
 impl ::core::default::Default for VSS_OBJECT_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3848,7 +3824,7 @@ unsafe impl ::windows::core::Abi for VSS_PROVIDER_PROP {
 }
 impl ::core::cmp::PartialEq for VSS_PROVIDER_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_PROVIDER_PROP>()) == 0 }
+        self.m_ProviderId == other.m_ProviderId && self.m_pwszProviderName == other.m_pwszProviderName && self.m_eProviderType == other.m_eProviderType && self.m_pwszProviderVersion == other.m_pwszProviderVersion && self.m_ProviderVersionId == other.m_ProviderVersionId && self.m_ClassId == other.m_ClassId
     }
 }
 impl ::core::cmp::Eq for VSS_PROVIDER_PROP {}
@@ -3904,7 +3880,7 @@ unsafe impl ::windows::core::Abi for VSS_SNAPSHOT_PROP {
 }
 impl ::core::cmp::PartialEq for VSS_SNAPSHOT_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_SNAPSHOT_PROP>()) == 0 }
+        self.m_SnapshotId == other.m_SnapshotId && self.m_SnapshotSetId == other.m_SnapshotSetId && self.m_lSnapshotsCount == other.m_lSnapshotsCount && self.m_pwszSnapshotDeviceObject == other.m_pwszSnapshotDeviceObject && self.m_pwszOriginalVolumeName == other.m_pwszOriginalVolumeName && self.m_pwszOriginatingMachine == other.m_pwszOriginatingMachine && self.m_pwszServiceMachine == other.m_pwszServiceMachine && self.m_pwszExposedName == other.m_pwszExposedName && self.m_pwszExposedPath == other.m_pwszExposedPath && self.m_ProviderId == other.m_ProviderId && self.m_lSnapshotAttributes == other.m_lSnapshotAttributes && self.m_tsCreationTimestamp == other.m_tsCreationTimestamp && self.m_eStatus == other.m_eStatus
     }
 }
 impl ::core::cmp::Eq for VSS_SNAPSHOT_PROP {}
@@ -3935,7 +3911,7 @@ unsafe impl ::windows::core::Abi for VSS_VOLUME_PROP {
 }
 impl ::core::cmp::PartialEq for VSS_VOLUME_PROP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_VOLUME_PROP>()) == 0 }
+        self.m_pwszVolumeName == other.m_pwszVolumeName && self.m_pwszVolumeDisplayName == other.m_pwszVolumeDisplayName
     }
 }
 impl ::core::cmp::Eq for VSS_VOLUME_PROP {}
@@ -3976,7 +3952,7 @@ unsafe impl ::windows::core::Abi for VSS_VOLUME_PROTECTION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VSS_VOLUME_PROTECTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSS_VOLUME_PROTECTION_INFO>()) == 0 }
+        self.m_protectionLevel == other.m_protectionLevel && self.m_volumeIsOfflineForProtection == other.m_volumeIsOfflineForProtection && self.m_protectionFault == other.m_protectionFault && self.m_failureStatus == other.m_failureStatus && self.m_volumeHasUnusedDiffArea == other.m_volumeHasUnusedDiffArea && self.m_reserved == other.m_reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
@@ -363,7 +363,7 @@ unsafe impl ::windows::core::Abi for PrintDocumentPackageStatus {
 }
 impl ::core::cmp::PartialEq for PrintDocumentPackageStatus {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrintDocumentPackageStatus>()) == 0 }
+        self.JobId == other.JobId && self.CurrentDocument == other.CurrentDocument && self.CurrentPage == other.CurrentPage && self.CurrentPageTotal == other.CurrentPageTotal && self.Completion == other.Completion && self.PackageStatus == other.PackageStatus
     }
 }
 impl ::core::cmp::Eq for PrintDocumentPackageStatus {}
@@ -398,7 +398,7 @@ unsafe impl ::windows::core::Abi for XPS_JOB_STATUS {
 }
 impl ::core::cmp::PartialEq for XPS_JOB_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_JOB_STATUS>()) == 0 }
+        self.jobId == other.jobId && self.currentDocument == other.currentDocument && self.currentPage == other.currentPage && self.currentPageTotal == other.currentPageTotal && self.completion == other.completion && self.jobStatus == other.jobStatus
     }
 }
 impl ::core::cmp::Eq for XPS_JOB_STATUS {}

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -8640,7 +8640,7 @@ unsafe impl ::windows::core::Abi for DOCINFOA {
 }
 impl ::core::cmp::PartialEq for DOCINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.lpszDocName == other.lpszDocName && self.lpszOutput == other.lpszOutput && self.lpszDatatype == other.lpszDatatype && self.fwType == other.fwType
     }
 }
 impl ::core::cmp::Eq for DOCINFOA {}
@@ -8674,7 +8674,7 @@ unsafe impl ::windows::core::Abi for DOCINFOW {
 }
 impl ::core::cmp::PartialEq for DOCINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOCINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.lpszDocName == other.lpszDocName && self.lpszOutput == other.lpszOutput && self.lpszDatatype == other.lpszDatatype && self.fwType == other.fwType
     }
 }
 impl ::core::cmp::Eq for DOCINFOW {}
@@ -8713,7 +8713,7 @@ unsafe impl ::windows::core::Abi for DRAWPATRECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRAWPATRECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAWPATRECT>()) == 0 }
+        self.ptPosition == other.ptPosition && self.ptSize == other.ptSize && self.wStyle == other.wStyle && self.wPattern == other.wPattern
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8781,7 +8781,7 @@ unsafe impl ::windows::core::Abi for PSFEATURE_CUSTPAPER {
 }
 impl ::core::cmp::PartialEq for PSFEATURE_CUSTPAPER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSFEATURE_CUSTPAPER>()) == 0 }
+        self.lOrientation == other.lOrientation && self.lWidth == other.lWidth && self.lHeight == other.lHeight && self.lWidthOffset == other.lWidthOffset && self.lHeightOffset == other.lHeightOffset
     }
 }
 impl ::core::cmp::Eq for PSFEATURE_CUSTPAPER {}
@@ -8818,7 +8818,7 @@ unsafe impl ::windows::core::Abi for PSFEATURE_OUTPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSFEATURE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSFEATURE_OUTPUT>()) == 0 }
+        self.bPageIndependent == other.bPageIndependent && self.bSetPageDevice == other.bSetPageDevice
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8852,7 +8852,7 @@ unsafe impl ::windows::core::Abi for PSINJECTDATA {
 }
 impl ::core::cmp::PartialEq for PSINJECTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSINJECTDATA>()) == 0 }
+        self.DataBytes == other.DataBytes && self.InjectionPoint == other.InjectionPoint && self.PageNumber == other.PageNumber
     }
 }
 impl ::core::cmp::Eq for PSINJECTDATA {}
@@ -8876,12 +8876,6 @@ impl ::core::clone::Clone for XPS_COLOR {
 unsafe impl ::windows::core::Abi for XPS_COLOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XPS_COLOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_COLOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XPS_COLOR {}
 impl ::core::default::Default for XPS_COLOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8903,12 +8897,6 @@ impl ::core::clone::Clone for XPS_COLOR_0 {
 unsafe impl ::windows::core::Abi for XPS_COLOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XPS_COLOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_COLOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XPS_COLOR_0 {}
 impl ::core::default::Default for XPS_COLOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8936,7 +8924,7 @@ unsafe impl ::windows::core::Abi for XPS_COLOR_0_0 {
 }
 impl ::core::cmp::PartialEq for XPS_COLOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_COLOR_0_0>()) == 0 }
+        self.channelCount == other.channelCount && self.channels == other.channels
     }
 }
 impl ::core::cmp::Eq for XPS_COLOR_0_0 {}
@@ -8969,7 +8957,7 @@ unsafe impl ::windows::core::Abi for XPS_COLOR_0_1 {
 }
 impl ::core::cmp::PartialEq for XPS_COLOR_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_COLOR_0_1>()) == 0 }
+        self.alpha == other.alpha && self.red == other.red && self.green == other.green && self.blue == other.blue
     }
 }
 impl ::core::cmp::Eq for XPS_COLOR_0_1 {}
@@ -9002,7 +8990,7 @@ unsafe impl ::windows::core::Abi for XPS_COLOR_0_2 {
 }
 impl ::core::cmp::PartialEq for XPS_COLOR_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_COLOR_0_2>()) == 0 }
+        self.alpha == other.alpha && self.red == other.red && self.green == other.green && self.blue == other.blue
     }
 }
 impl ::core::cmp::Eq for XPS_COLOR_0_2 {}
@@ -9033,7 +9021,7 @@ unsafe impl ::windows::core::Abi for XPS_DASH {
 }
 impl ::core::cmp::PartialEq for XPS_DASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_DASH>()) == 0 }
+        self.length == other.length && self.gap == other.gap
     }
 }
 impl ::core::cmp::Eq for XPS_DASH {}
@@ -9066,7 +9054,7 @@ unsafe impl ::windows::core::Abi for XPS_GLYPH_INDEX {
 }
 impl ::core::cmp::PartialEq for XPS_GLYPH_INDEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_GLYPH_INDEX>()) == 0 }
+        self.index == other.index && self.advanceWidth == other.advanceWidth && self.horizontalOffset == other.horizontalOffset && self.verticalOffset == other.verticalOffset
     }
 }
 impl ::core::cmp::Eq for XPS_GLYPH_INDEX {}
@@ -9099,7 +9087,7 @@ unsafe impl ::windows::core::Abi for XPS_GLYPH_MAPPING {
 }
 impl ::core::cmp::PartialEq for XPS_GLYPH_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_GLYPH_MAPPING>()) == 0 }
+        self.unicodeStringStart == other.unicodeStringStart && self.unicodeStringLength == other.unicodeStringLength && self.glyphIndicesStart == other.glyphIndicesStart && self.glyphIndicesLength == other.glyphIndicesLength
     }
 }
 impl ::core::cmp::Eq for XPS_GLYPH_MAPPING {}
@@ -9134,7 +9122,7 @@ unsafe impl ::windows::core::Abi for XPS_MATRIX {
 }
 impl ::core::cmp::PartialEq for XPS_MATRIX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_MATRIX>()) == 0 }
+        self.m11 == other.m11 && self.m12 == other.m12 && self.m21 == other.m21 && self.m22 == other.m22 && self.m31 == other.m31 && self.m32 == other.m32
     }
 }
 impl ::core::cmp::Eq for XPS_MATRIX {}
@@ -9165,7 +9153,7 @@ unsafe impl ::windows::core::Abi for XPS_POINT {
 }
 impl ::core::cmp::PartialEq for XPS_POINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_POINT>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for XPS_POINT {}
@@ -9198,7 +9186,7 @@ unsafe impl ::windows::core::Abi for XPS_RECT {
 }
 impl ::core::cmp::PartialEq for XPS_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_RECT>()) == 0 }
+        self.x == other.x && self.y == other.y && self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for XPS_RECT {}
@@ -9229,7 +9217,7 @@ unsafe impl ::windows::core::Abi for XPS_SIZE {
 }
 impl ::core::cmp::PartialEq for XPS_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPS_SIZE>()) == 0 }
+        self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for XPS_SIZE {}

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -3192,7 +3192,7 @@ unsafe impl ::windows::core::Abi for ADRENTRY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for ADRENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADRENTRY>()) == 0 }
+        self.ulReserved1 == other.ulReserved1 && self.cValues == other.cValues && self.rgPropVals == other.rgPropVals
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -3231,7 +3231,7 @@ unsafe impl ::windows::core::Abi for ADRLIST {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for ADRLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADRLIST>()) == 0 }
+        self.cEntries == other.cEntries && self.aEntries == other.aEntries
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -3283,8 +3283,6 @@ impl ::core::fmt::Debug for ADRPARM {
             .field("lpReserved", &self.lpReserved)
             .field("ulHelpContext", &self.ulHelpContext)
             .field("lpszHelpFileName", &self.lpszHelpFileName)
-            .field("lpfnABSDI", &self.lpfnABSDI.map(|f| f as usize))
-            .field("lpfnDismiss", &self.lpfnDismiss.map(|f| f as usize))
             .field("lpvDismissContext", &self.lpvDismissContext)
             .field("lpszCaption", &self.lpszCaption)
             .field("lpszNewEntryTitle", &self.lpszNewEntryTitle)
@@ -3302,14 +3300,6 @@ impl ::core::fmt::Debug for ADRPARM {
 unsafe impl ::windows::core::Abi for ADRPARM {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for ADRPARM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADRPARM>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for ADRPARM {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for ADRPARM {
     fn default() -> Self {
@@ -3339,7 +3329,7 @@ unsafe impl ::windows::core::Abi for DTBLBUTTON {
 }
 impl ::core::cmp::PartialEq for DTBLBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLBUTTON>()) == 0 }
+        self.ulbLpszLabel == other.ulbLpszLabel && self.ulFlags == other.ulFlags && self.ulPRControl == other.ulPRControl
     }
 }
 impl ::core::cmp::Eq for DTBLBUTTON {}
@@ -3371,7 +3361,7 @@ unsafe impl ::windows::core::Abi for DTBLCHECKBOX {
 }
 impl ::core::cmp::PartialEq for DTBLCHECKBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLCHECKBOX>()) == 0 }
+        self.ulbLpszLabel == other.ulbLpszLabel && self.ulFlags == other.ulFlags && self.ulPRPropertyName == other.ulPRPropertyName
     }
 }
 impl ::core::cmp::Eq for DTBLCHECKBOX {}
@@ -3405,7 +3395,7 @@ unsafe impl ::windows::core::Abi for DTBLCOMBOBOX {
 }
 impl ::core::cmp::PartialEq for DTBLCOMBOBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLCOMBOBOX>()) == 0 }
+        self.ulbLpszCharsAllowed == other.ulbLpszCharsAllowed && self.ulFlags == other.ulFlags && self.ulNumCharsAllowed == other.ulNumCharsAllowed && self.ulPRPropertyName == other.ulPRPropertyName && self.ulPRTableName == other.ulPRTableName
     }
 }
 impl ::core::cmp::Eq for DTBLCOMBOBOX {}
@@ -3438,7 +3428,7 @@ unsafe impl ::windows::core::Abi for DTBLDDLBX {
 }
 impl ::core::cmp::PartialEq for DTBLDDLBX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLDDLBX>()) == 0 }
+        self.ulFlags == other.ulFlags && self.ulPRDisplayProperty == other.ulPRDisplayProperty && self.ulPRSetProperty == other.ulPRSetProperty && self.ulPRTableName == other.ulPRTableName
     }
 }
 impl ::core::cmp::Eq for DTBLDDLBX {}
@@ -3471,7 +3461,7 @@ unsafe impl ::windows::core::Abi for DTBLEDIT {
 }
 impl ::core::cmp::PartialEq for DTBLEDIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLEDIT>()) == 0 }
+        self.ulbLpszCharsAllowed == other.ulbLpszCharsAllowed && self.ulFlags == other.ulFlags && self.ulNumCharsAllowed == other.ulNumCharsAllowed && self.ulPropTag == other.ulPropTag
     }
 }
 impl ::core::cmp::Eq for DTBLEDIT {}
@@ -3502,7 +3492,7 @@ unsafe impl ::windows::core::Abi for DTBLGROUPBOX {
 }
 impl ::core::cmp::PartialEq for DTBLGROUPBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLGROUPBOX>()) == 0 }
+        self.ulbLpszLabel == other.ulbLpszLabel && self.ulFlags == other.ulFlags
     }
 }
 impl ::core::cmp::Eq for DTBLGROUPBOX {}
@@ -3533,7 +3523,7 @@ unsafe impl ::windows::core::Abi for DTBLLABEL {
 }
 impl ::core::cmp::PartialEq for DTBLLABEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLLABEL>()) == 0 }
+        self.ulbLpszLabelName == other.ulbLpszLabelName && self.ulFlags == other.ulFlags
     }
 }
 impl ::core::cmp::Eq for DTBLLABEL {}
@@ -3565,7 +3555,7 @@ unsafe impl ::windows::core::Abi for DTBLLBX {
 }
 impl ::core::cmp::PartialEq for DTBLLBX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLLBX>()) == 0 }
+        self.ulFlags == other.ulFlags && self.ulPRSetProperty == other.ulPRSetProperty && self.ulPRTableName == other.ulPRTableName
     }
 }
 impl ::core::cmp::Eq for DTBLLBX {}
@@ -3596,7 +3586,7 @@ unsafe impl ::windows::core::Abi for DTBLMVDDLBX {
 }
 impl ::core::cmp::PartialEq for DTBLMVDDLBX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLMVDDLBX>()) == 0 }
+        self.ulFlags == other.ulFlags && self.ulMVPropTag == other.ulMVPropTag
     }
 }
 impl ::core::cmp::Eq for DTBLMVDDLBX {}
@@ -3627,7 +3617,7 @@ unsafe impl ::windows::core::Abi for DTBLMVLISTBOX {
 }
 impl ::core::cmp::PartialEq for DTBLMVLISTBOX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLMVLISTBOX>()) == 0 }
+        self.ulFlags == other.ulFlags && self.ulMVPropTag == other.ulMVPropTag
     }
 }
 impl ::core::cmp::Eq for DTBLMVLISTBOX {}
@@ -3660,7 +3650,7 @@ unsafe impl ::windows::core::Abi for DTBLPAGE {
 }
 impl ::core::cmp::PartialEq for DTBLPAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLPAGE>()) == 0 }
+        self.ulbLpszLabel == other.ulbLpszLabel && self.ulFlags == other.ulFlags && self.ulbLpszComponent == other.ulbLpszComponent && self.ulContext == other.ulContext
     }
 }
 impl ::core::cmp::Eq for DTBLPAGE {}
@@ -3694,7 +3684,7 @@ unsafe impl ::windows::core::Abi for DTBLRADIOBUTTON {
 }
 impl ::core::cmp::PartialEq for DTBLRADIOBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBLRADIOBUTTON>()) == 0 }
+        self.ulbLpszLabel == other.ulbLpszLabel && self.ulFlags == other.ulFlags && self.ulcButtons == other.ulcButtons && self.ulPropTag == other.ulPropTag && self.lReturnValue == other.lReturnValue
     }
 }
 impl ::core::cmp::Eq for DTBLRADIOBUTTON {}
@@ -3723,12 +3713,6 @@ impl ::core::clone::Clone for DTCTL {
 unsafe impl ::windows::core::Abi for DTCTL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DTCTL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTCTL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DTCTL {}
 impl ::core::default::Default for DTCTL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3760,12 +3744,6 @@ impl ::core::clone::Clone for DTCTL_0 {
 unsafe impl ::windows::core::Abi for DTCTL_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DTCTL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTCTL_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DTCTL_0 {}
 impl ::core::default::Default for DTCTL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3788,12 +3766,6 @@ impl ::core::clone::Clone for DTPAGE {
 unsafe impl ::windows::core::Abi for DTPAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DTPAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTPAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DTPAGE {}
 impl ::core::default::Default for DTPAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3814,12 +3786,6 @@ impl ::core::clone::Clone for DTPAGE_0 {
 unsafe impl ::windows::core::Abi for DTPAGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DTPAGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTPAGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DTPAGE_0 {}
 impl ::core::default::Default for DTPAGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3847,7 +3813,7 @@ unsafe impl ::windows::core::Abi for ENTRYID {
 }
 impl ::core::cmp::PartialEq for ENTRYID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENTRYID>()) == 0 }
+        self.abFlags == other.abFlags && self.ab == other.ab
     }
 }
 impl ::core::cmp::Eq for ENTRYID {}
@@ -3881,7 +3847,7 @@ unsafe impl ::windows::core::Abi for ERROR_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for ERROR_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERROR_NOTIFICATION>()) == 0 }
+        self.cbEntryID == other.cbEntryID && self.lpEntryID == other.lpEntryID && self.scode == other.scode && self.ulFlags == other.ulFlags && self.lpMAPIError == other.lpMAPIError
     }
 }
 impl ::core::cmp::Eq for ERROR_NOTIFICATION {}
@@ -3913,7 +3879,7 @@ unsafe impl ::windows::core::Abi for EXTENDED_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for EXTENDED_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTENDED_NOTIFICATION>()) == 0 }
+        self.ulEvent == other.ulEvent && self.cb == other.cb && self.pbEventParameters == other.pbEventParameters
     }
 }
 impl ::core::cmp::Eq for EXTENDED_NOTIFICATION {}
@@ -3944,7 +3910,7 @@ unsafe impl ::windows::core::Abi for FLATENTRY {
 }
 impl ::core::cmp::PartialEq for FLATENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLATENTRY>()) == 0 }
+        self.cb == other.cb && self.abEntry == other.abEntry
     }
 }
 impl ::core::cmp::Eq for FLATENTRY {}
@@ -3976,7 +3942,7 @@ unsafe impl ::windows::core::Abi for FLATENTRYLIST {
 }
 impl ::core::cmp::PartialEq for FLATENTRYLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLATENTRYLIST>()) == 0 }
+        self.cEntries == other.cEntries && self.cbEntries == other.cbEntries && self.abEntries == other.abEntries
     }
 }
 impl ::core::cmp::Eq for FLATENTRYLIST {}
@@ -4008,7 +3974,7 @@ unsafe impl ::windows::core::Abi for FLATMTSIDLIST {
 }
 impl ::core::cmp::PartialEq for FLATMTSIDLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLATMTSIDLIST>()) == 0 }
+        self.cMTSIDs == other.cMTSIDs && self.cbMTSIDs == other.cbMTSIDs && self.abMTSIDs == other.abMTSIDs
     }
 }
 impl ::core::cmp::Eq for FLATMTSIDLIST {}
@@ -4039,7 +4005,7 @@ unsafe impl ::windows::core::Abi for FlagList {
 }
 impl ::core::cmp::PartialEq for FlagList {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FlagList>()) == 0 }
+        self.cFlags == other.cFlags && self.ulFlag == other.ulFlag
     }
 }
 impl ::core::cmp::Eq for FlagList {}
@@ -4073,7 +4039,7 @@ unsafe impl ::windows::core::Abi for MAPIERROR {
 }
 impl ::core::cmp::PartialEq for MAPIERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPIERROR>()) == 0 }
+        self.ulVersion == other.ulVersion && self.lpszError == other.lpszError && self.lpszComponent == other.lpszComponent && self.ulLowLevelError == other.ulLowLevelError && self.ulContext == other.ulContext
     }
 }
 impl ::core::cmp::Eq for MAPIERROR {}
@@ -4098,12 +4064,6 @@ impl ::core::clone::Clone for MAPINAMEID {
 unsafe impl ::windows::core::Abi for MAPINAMEID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MAPINAMEID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPINAMEID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MAPINAMEID {}
 impl ::core::default::Default for MAPINAMEID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4124,12 +4084,6 @@ impl ::core::clone::Clone for MAPINAMEID_0 {
 unsafe impl ::windows::core::Abi for MAPINAMEID_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MAPINAMEID_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPINAMEID_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MAPINAMEID_0 {}
 impl ::core::default::Default for MAPINAMEID_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4156,7 +4110,7 @@ unsafe impl ::windows::core::Abi for MAPIUID {
 }
 impl ::core::cmp::PartialEq for MAPIUID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAPIUID>()) == 0 }
+        self.ab == other.ab
     }
 }
 impl ::core::cmp::Eq for MAPIUID {}
@@ -4187,7 +4141,7 @@ unsafe impl ::windows::core::Abi for MTSID {
 }
 impl ::core::cmp::PartialEq for MTSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MTSID>()) == 0 }
+        self.cb == other.cb && self.ab == other.ab
     }
 }
 impl ::core::cmp::Eq for MTSID {}
@@ -4223,7 +4177,7 @@ unsafe impl ::windows::core::Abi for NEWMAIL_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for NEWMAIL_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWMAIL_NOTIFICATION>()) == 0 }
+        self.cbEntryID == other.cbEntryID && self.lpEntryID == other.lpEntryID && self.cbParentID == other.cbParentID && self.lpParentID == other.lpParentID && self.ulFlags == other.ulFlags && self.lpszMessageClass == other.lpszMessageClass && self.ulMessageFlags == other.ulMessageFlags
     }
 }
 impl ::core::cmp::Eq for NEWMAIL_NOTIFICATION {}
@@ -4252,14 +4206,6 @@ impl ::core::clone::Clone for NOTIFICATION {
 unsafe impl ::windows::core::Abi for NOTIFICATION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFICATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for NOTIFICATION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for NOTIFICATION {
     fn default() -> Self {
@@ -4290,14 +4236,6 @@ unsafe impl ::windows::core::Abi for NOTIFICATION_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFICATION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for NOTIFICATION_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4325,7 +4263,7 @@ unsafe impl ::windows::core::Abi for NOTIFKEY {
 }
 impl ::core::cmp::PartialEq for NOTIFKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFKEY>()) == 0 }
+        self.cb == other.cb && self.ab == other.ab
     }
 }
 impl ::core::cmp::Eq for NOTIFKEY {}
@@ -4364,7 +4302,7 @@ unsafe impl ::windows::core::Abi for OBJECT_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for OBJECT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECT_NOTIFICATION>()) == 0 }
+        self.cbEntryID == other.cbEntryID && self.lpEntryID == other.lpEntryID && self.ulObjType == other.ulObjType && self.cbParentID == other.cbParentID && self.lpParentID == other.lpParentID && self.cbOldID == other.cbOldID && self.lpOldID == other.lpOldID && self.cbOldParentID == other.cbOldParentID && self.lpOldParentID == other.lpOldParentID && self.lpPropTagArray == other.lpPropTagArray
     }
 }
 impl ::core::cmp::Eq for OBJECT_NOTIFICATION {}
@@ -4401,7 +4339,7 @@ unsafe impl ::windows::core::Abi for SAndRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SAndRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAndRestriction>()) == 0 }
+        self.cRes == other.cRes && self.lpRes == other.lpRes
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4434,7 +4372,7 @@ unsafe impl ::windows::core::Abi for SAppTimeArray {
 }
 impl ::core::cmp::PartialEq for SAppTimeArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAppTimeArray>()) == 0 }
+        self.cValues == other.cValues && self.lpat == other.lpat
     }
 }
 impl ::core::cmp::Eq for SAppTimeArray {}
@@ -4465,7 +4403,7 @@ unsafe impl ::windows::core::Abi for SBinary {
 }
 impl ::core::cmp::PartialEq for SBinary {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SBinary>()) == 0 }
+        self.cb == other.cb && self.lpb == other.lpb
     }
 }
 impl ::core::cmp::Eq for SBinary {}
@@ -4496,7 +4434,7 @@ unsafe impl ::windows::core::Abi for SBinaryArray {
 }
 impl ::core::cmp::PartialEq for SBinaryArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SBinaryArray>()) == 0 }
+        self.cValues == other.cValues && self.lpbin == other.lpbin
     }
 }
 impl ::core::cmp::Eq for SBinaryArray {}
@@ -4528,7 +4466,7 @@ unsafe impl ::windows::core::Abi for SBitMaskRestriction {
 }
 impl ::core::cmp::PartialEq for SBitMaskRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SBitMaskRestriction>()) == 0 }
+        self.relBMR == other.relBMR && self.ulPropTag == other.ulPropTag && self.ulMask == other.ulMask
     }
 }
 impl ::core::cmp::Eq for SBitMaskRestriction {}
@@ -4566,7 +4504,7 @@ unsafe impl ::windows::core::Abi for SCommentRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SCommentRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCommentRestriction>()) == 0 }
+        self.cValues == other.cValues && self.lpRes == other.lpRes && self.lpProp == other.lpProp
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4600,7 +4538,7 @@ unsafe impl ::windows::core::Abi for SComparePropsRestriction {
 }
 impl ::core::cmp::PartialEq for SComparePropsRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SComparePropsRestriction>()) == 0 }
+        self.relop == other.relop && self.ulPropTag1 == other.ulPropTag1 && self.ulPropTag2 == other.ulPropTag2
     }
 }
 impl ::core::cmp::Eq for SComparePropsRestriction {}
@@ -4638,7 +4576,7 @@ unsafe impl ::windows::core::Abi for SContentRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SContentRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SContentRestriction>()) == 0 }
+        self.ulFuzzyLevel == other.ulFuzzyLevel && self.ulPropTag == other.ulPropTag && self.lpProp == other.lpProp
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4677,7 +4615,7 @@ unsafe impl ::windows::core::Abi for SCurrencyArray {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SCurrencyArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCurrencyArray>()) == 0 }
+        self.cValues == other.cValues && self.lpcur == other.lpcur
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -4716,7 +4654,7 @@ unsafe impl ::windows::core::Abi for SDateTimeArray {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SDateTimeArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDateTimeArray>()) == 0 }
+        self.cValues == other.cValues && self.lpft == other.lpft
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4749,7 +4687,7 @@ unsafe impl ::windows::core::Abi for SDoubleArray {
 }
 impl ::core::cmp::PartialEq for SDoubleArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SDoubleArray>()) == 0 }
+        self.cValues == other.cValues && self.lpdbl == other.lpdbl
     }
 }
 impl ::core::cmp::Eq for SDoubleArray {}
@@ -4781,7 +4719,7 @@ unsafe impl ::windows::core::Abi for SExistRestriction {
 }
 impl ::core::cmp::PartialEq for SExistRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SExistRestriction>()) == 0 }
+        self.ulReserved1 == other.ulReserved1 && self.ulPropTag == other.ulPropTag && self.ulReserved2 == other.ulReserved2
     }
 }
 impl ::core::cmp::Eq for SExistRestriction {}
@@ -4812,7 +4750,7 @@ unsafe impl ::windows::core::Abi for SGuidArray {
 }
 impl ::core::cmp::PartialEq for SGuidArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SGuidArray>()) == 0 }
+        self.cValues == other.cValues && self.lpguid == other.lpguid
     }
 }
 impl ::core::cmp::Eq for SGuidArray {}
@@ -4843,7 +4781,7 @@ unsafe impl ::windows::core::Abi for SLPSTRArray {
 }
 impl ::core::cmp::PartialEq for SLPSTRArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLPSTRArray>()) == 0 }
+        self.cValues == other.cValues && self.lppszA == other.lppszA
     }
 }
 impl ::core::cmp::Eq for SLPSTRArray {}
@@ -4874,7 +4812,7 @@ unsafe impl ::windows::core::Abi for SLargeIntegerArray {
 }
 impl ::core::cmp::PartialEq for SLargeIntegerArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLargeIntegerArray>()) == 0 }
+        self.cValues == other.cValues && self.lpli == other.lpli
     }
 }
 impl ::core::cmp::Eq for SLargeIntegerArray {}
@@ -4905,7 +4843,7 @@ unsafe impl ::windows::core::Abi for SLongArray {
 }
 impl ::core::cmp::PartialEq for SLongArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLongArray>()) == 0 }
+        self.cValues == other.cValues && self.lpl == other.lpl
     }
 }
 impl ::core::cmp::Eq for SLongArray {}
@@ -4942,7 +4880,7 @@ unsafe impl ::windows::core::Abi for SNotRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SNotRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SNotRestriction>()) == 0 }
+        self.ulReserved == other.ulReserved && self.lpRes == other.lpRes
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4981,7 +4919,7 @@ unsafe impl ::windows::core::Abi for SOrRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SOrRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOrRestriction>()) == 0 }
+        self.cRes == other.cRes && self.lpRes == other.lpRes
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5015,7 +4953,7 @@ unsafe impl ::windows::core::Abi for SPropProblem {
 }
 impl ::core::cmp::PartialEq for SPropProblem {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropProblem>()) == 0 }
+        self.ulIndex == other.ulIndex && self.ulPropTag == other.ulPropTag && self.scode == other.scode
     }
 }
 impl ::core::cmp::Eq for SPropProblem {}
@@ -5046,7 +4984,7 @@ unsafe impl ::windows::core::Abi for SPropProblemArray {
 }
 impl ::core::cmp::PartialEq for SPropProblemArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropProblemArray>()) == 0 }
+        self.cProblem == other.cProblem && self.aProblem == other.aProblem
     }
 }
 impl ::core::cmp::Eq for SPropProblemArray {}
@@ -5077,7 +5015,7 @@ unsafe impl ::windows::core::Abi for SPropTagArray {
 }
 impl ::core::cmp::PartialEq for SPropTagArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropTagArray>()) == 0 }
+        self.cValues == other.cValues && self.aulPropTag == other.aulPropTag
     }
 }
 impl ::core::cmp::Eq for SPropTagArray {}
@@ -5106,14 +5044,6 @@ impl ::core::clone::Clone for SPropValue {
 unsafe impl ::windows::core::Abi for SPropValue {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SPropValue {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropValue>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SPropValue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SPropValue {
     fn default() -> Self {
@@ -5149,7 +5079,7 @@ unsafe impl ::windows::core::Abi for SPropertyRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SPropertyRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SPropertyRestriction>()) == 0 }
+        self.relop == other.relop && self.ulPropTag == other.ulPropTag && self.lpProp == other.lpProp
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5182,7 +5112,7 @@ unsafe impl ::windows::core::Abi for SRealArray {
 }
 impl ::core::cmp::PartialEq for SRealArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRealArray>()) == 0 }
+        self.cValues == other.cValues && self.lpflt == other.lpflt
     }
 }
 impl ::core::cmp::Eq for SRealArray {}
@@ -5210,14 +5140,6 @@ impl ::core::clone::Clone for SRestriction {
 unsafe impl ::windows::core::Abi for SRestriction {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SRestriction {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRestriction>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SRestriction {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SRestriction {
     fn default() -> Self {
@@ -5253,14 +5175,6 @@ unsafe impl ::windows::core::Abi for SRestriction_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SRestriction_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRestriction_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SRestriction_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SRestriction_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5295,7 +5209,7 @@ unsafe impl ::windows::core::Abi for SRow {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SRow {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRow>()) == 0 }
+        self.ulAdrEntryPad == other.ulAdrEntryPad && self.cValues == other.cValues && self.lpProps == other.lpProps
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5334,7 +5248,7 @@ unsafe impl ::windows::core::Abi for SRowSet {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SRowSet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRowSet>()) == 0 }
+        self.cRows == other.cRows && self.aRow == other.aRow
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5367,7 +5281,7 @@ unsafe impl ::windows::core::Abi for SShortArray {
 }
 impl ::core::cmp::PartialEq for SShortArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SShortArray>()) == 0 }
+        self.cValues == other.cValues && self.lpi == other.lpi
     }
 }
 impl ::core::cmp::Eq for SShortArray {}
@@ -5399,7 +5313,7 @@ unsafe impl ::windows::core::Abi for SSizeRestriction {
 }
 impl ::core::cmp::PartialEq for SSizeRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSizeRestriction>()) == 0 }
+        self.relop == other.relop && self.ulPropTag == other.ulPropTag && self.cb == other.cb
     }
 }
 impl ::core::cmp::Eq for SSizeRestriction {}
@@ -5430,7 +5344,7 @@ unsafe impl ::windows::core::Abi for SSortOrder {
 }
 impl ::core::cmp::PartialEq for SSortOrder {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSortOrder>()) == 0 }
+        self.ulPropTag == other.ulPropTag && self.ulOrder == other.ulOrder
     }
 }
 impl ::core::cmp::Eq for SSortOrder {}
@@ -5463,7 +5377,7 @@ unsafe impl ::windows::core::Abi for SSortOrderSet {
 }
 impl ::core::cmp::PartialEq for SSortOrderSet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSortOrderSet>()) == 0 }
+        self.cSorts == other.cSorts && self.cCategories == other.cCategories && self.cExpanded == other.cExpanded && self.aSort == other.aSort
     }
 }
 impl ::core::cmp::Eq for SSortOrderSet {}
@@ -5500,7 +5414,7 @@ unsafe impl ::windows::core::Abi for SSubRestriction {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SSubRestriction {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSubRestriction>()) == 0 }
+        self.ulSubObject == other.ulSubObject && self.lpRes == other.lpRes
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5541,7 +5455,7 @@ unsafe impl ::windows::core::Abi for STATUS_OBJECT_NOTIFICATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for STATUS_OBJECT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STATUS_OBJECT_NOTIFICATION>()) == 0 }
+        self.cbEntryID == other.cbEntryID && self.lpEntryID == other.lpEntryID && self.cValues == other.cValues && self.lpPropVals == other.lpPropVals
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -5574,7 +5488,7 @@ unsafe impl ::windows::core::Abi for SWStringArray {
 }
 impl ::core::cmp::PartialEq for SWStringArray {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWStringArray>()) == 0 }
+        self.cValues == other.cValues && self.lppszW == other.lppszW
     }
 }
 impl ::core::cmp::Eq for SWStringArray {}
@@ -5606,14 +5520,6 @@ impl ::core::clone::Clone for TABLE_NOTIFICATION {
 unsafe impl ::windows::core::Abi for TABLE_NOTIFICATION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for TABLE_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TABLE_NOTIFICATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for TABLE_NOTIFICATION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for TABLE_NOTIFICATION {
     fn default() -> Self {
@@ -5745,7 +5651,7 @@ unsafe impl ::windows::core::Abi for WAB_PARAM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WAB_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAB_PARAM>()) == 0 }
+        self.cbSize == other.cbSize && self.hwnd == other.hwnd && self.szFileName == other.szFileName && self.ulFlags == other.ulFlags && self.guidPSExt == other.guidPSExt
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5803,14 +5709,6 @@ impl ::core::clone::Clone for __UPV {
 unsafe impl ::windows::core::Abi for __UPV {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for __UPV {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<__UPV>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for __UPV {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for __UPV {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
@@ -572,7 +572,7 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_AX_INFO {
 }
 impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_AX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_AX_INFO>()) == 0 }
+        self.ulLength == other.ulLength && self.lpwszLocalInstallPath == other.lpwszLocalInstallPath && self.lpwszSourceURL == other.lpwszSourceURL
     }
 }
 impl ::core::cmp::Eq for AMSI_UAC_REQUEST_AX_INFO {}
@@ -605,7 +605,7 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_COM_INFO {
 }
 impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_COM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_COM_INFO>()) == 0 }
+        self.ulLength == other.ulLength && self.lpwszServerBinary == other.lpwszServerBinary && self.lpwszRequestor == other.lpwszRequestor && self.Clsid == other.Clsid
     }
 }
 impl ::core::cmp::Eq for AMSI_UAC_REQUEST_COM_INFO {}
@@ -638,14 +638,6 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_CONTEXT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AMSI_UAC_REQUEST_CONTEXT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AMSI_UAC_REQUEST_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -673,14 +665,6 @@ impl ::core::clone::Clone for AMSI_UAC_REQUEST_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_CONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_CONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AMSI_UAC_REQUEST_CONTEXT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AMSI_UAC_REQUEST_CONTEXT_0 {
     fn default() -> Self {
@@ -711,7 +695,7 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_EXE_INFO {
 }
 impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_EXE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_EXE_INFO>()) == 0 }
+        self.ulLength == other.ulLength && self.lpwszApplicationName == other.lpwszApplicationName && self.lpwszCommandLine == other.lpwszCommandLine && self.lpwszDLLParameter == other.lpwszDLLParameter
     }
 }
 impl ::core::cmp::Eq for AMSI_UAC_REQUEST_EXE_INFO {}
@@ -763,7 +747,7 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_MSI_INFO {
 }
 impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_MSI_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_MSI_INFO>()) == 0 }
+        self.ulLength == other.ulLength && self.MsiAction == other.MsiAction && self.lpwszProductName == other.lpwszProductName && self.lpwszVersion == other.lpwszVersion && self.lpwszLanguage == other.lpwszLanguage && self.lpwszManufacturer == other.lpwszManufacturer && self.lpwszPackagePath == other.lpwszPackagePath && self.lpwszPackageSource == other.lpwszPackageSource && self.ulUpdates == other.ulUpdates && self.ppwszUpdates == other.ppwszUpdates && self.ppwszUpdateSources == other.ppwszUpdateSources
     }
 }
 impl ::core::cmp::Eq for AMSI_UAC_REQUEST_MSI_INFO {}
@@ -797,7 +781,7 @@ unsafe impl ::windows::core::Abi for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
 }
 impl ::core::cmp::PartialEq for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AMSI_UAC_REQUEST_PACKAGED_APP_INFO>()) == 0 }
+        self.ulLength == other.ulLength && self.lpwszApplicationName == other.lpwszApplicationName && self.lpwszCommandLine == other.lpwszCommandLine && self.lpPackageFamilyName == other.lpPackageFamilyName && self.lpApplicationId == other.lpApplicationId
     }
 }
 impl ::core::cmp::Eq for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -11179,7 +11179,7 @@ unsafe impl ::windows::core::Abi for ACTCTXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ACTCTXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTCTXA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpSource == other.lpSource && self.wProcessorArchitecture == other.wProcessorArchitecture && self.wLangId == other.wLangId && self.lpAssemblyDirectory == other.lpAssemblyDirectory && self.lpResourceName == other.lpResourceName && self.lpApplicationName == other.lpApplicationName && self.hModule == other.hModule
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11225,7 +11225,7 @@ unsafe impl ::windows::core::Abi for ACTCTXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ACTCTXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTCTXW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpSource == other.lpSource && self.wProcessorArchitecture == other.wProcessorArchitecture && self.wLangId == other.wLangId && self.lpAssemblyDirectory == other.lpAssemblyDirectory && self.lpResourceName == other.lpResourceName && self.lpApplicationName == other.lpApplicationName && self.hModule == other.hModule
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11287,7 +11287,7 @@ unsafe impl ::windows::core::Abi for ACTCTX_SECTION_KEYED_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_WindowsProgramming"))]
 impl ::core::cmp::PartialEq for ACTCTX_SECTION_KEYED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTCTX_SECTION_KEYED_DATA>()) == 0 }
+        self.cbSize == other.cbSize && self.ulDataFormatVersion == other.ulDataFormatVersion && self.lpData == other.lpData && self.ulLength == other.ulLength && self.lpSectionGlobalData == other.lpSectionGlobalData && self.ulSectionGlobalDataLength == other.ulSectionGlobalDataLength && self.lpSectionBase == other.lpSectionBase && self.ulSectionTotalLength == other.ulSectionTotalLength && self.hActCtx == other.hActCtx && self.ulAssemblyRosterIndex == other.ulAssemblyRosterIndex && self.ulFlags == other.ulFlags && self.AssemblyMetadata == other.AssemblyMetadata
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_WindowsProgramming"))]
@@ -11357,7 +11357,25 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORM
 }
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION>()) == 0 }
+        self.ulFlags == other.ulFlags
+            && self.ulEncodedAssemblyIdentityLength == other.ulEncodedAssemblyIdentityLength
+            && self.ulManifestPathType == other.ulManifestPathType
+            && self.ulManifestPathLength == other.ulManifestPathLength
+            && self.liManifestLastWriteTime == other.liManifestLastWriteTime
+            && self.ulPolicyPathType == other.ulPolicyPathType
+            && self.ulPolicyPathLength == other.ulPolicyPathLength
+            && self.liPolicyLastWriteTime == other.liPolicyLastWriteTime
+            && self.ulMetadataSatelliteRosterIndex == other.ulMetadataSatelliteRosterIndex
+            && self.ulManifestVersionMajor == other.ulManifestVersionMajor
+            && self.ulManifestVersionMinor == other.ulManifestVersionMinor
+            && self.ulPolicyVersionMajor == other.ulPolicyVersionMajor
+            && self.ulPolicyVersionMinor == other.ulPolicyVersionMinor
+            && self.ulAssemblyDirectoryNameLength == other.ulAssemblyDirectoryNameLength
+            && self.lpAssemblyEncodedAssemblyIdentity == other.lpAssemblyEncodedAssemblyIdentity
+            && self.lpAssemblyManifestPath == other.lpAssemblyManifestPath
+            && self.lpAssemblyPolicyPath == other.lpAssemblyPolicyPath
+            && self.lpAssemblyDirectoryName == other.lpAssemblyDirectoryName
+            && self.ulFileCount == other.ulFileCount
     }
 }
 impl ::core::cmp::Eq for ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {}
@@ -11388,7 +11406,7 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATIO
 }
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION>()) == 0 }
+        self.ElementCount == other.ElementCount && self.Elements == other.Elements
     }
 }
 impl ::core::cmp::Eq for ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION {}
@@ -11442,7 +11460,7 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_DETAILED_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_DETAILED_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_DETAILED_INFORMATION>()) == 0 }
+        self.dwFlags == other.dwFlags && self.ulFormatVersion == other.ulFormatVersion && self.ulAssemblyCount == other.ulAssemblyCount && self.ulRootManifestPathType == other.ulRootManifestPathType && self.ulRootManifestPathChars == other.ulRootManifestPathChars && self.ulRootConfigurationPathType == other.ulRootConfigurationPathType && self.ulRootConfigurationPathChars == other.ulRootConfigurationPathChars && self.ulAppDirPathType == other.ulAppDirPathType && self.ulAppDirPathChars == other.ulAppDirPathChars && self.lpRootManifestPath == other.lpRootManifestPath && self.lpRootConfigurationPath == other.lpRootConfigurationPath && self.lpAppDirPath == other.lpAppDirPath
     }
 }
 impl ::core::cmp::Eq for ACTIVATION_CONTEXT_DETAILED_INFORMATION {}
@@ -11473,7 +11491,7 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_QUERY_INDEX {
 }
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_QUERY_INDEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_QUERY_INDEX>()) == 0 }
+        self.ulAssemblyIndex == other.ulAssemblyIndex && self.ulFileIndexInAssembly == other.ulFileIndexInAssembly
     }
 }
 impl ::core::cmp::Eq for ACTIVATION_CONTEXT_QUERY_INDEX {}
@@ -11505,7 +11523,7 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION>()) == 0 }
+        self.ulFlags == other.ulFlags && self.RunLevel == other.RunLevel && self.UiAccess == other.UiAccess
     }
 }
 impl ::core::cmp::Eq for ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION {}
@@ -11539,7 +11557,7 @@ unsafe impl ::windows::core::Abi for ASSEMBLY_FILE_DETAILED_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ASSEMBLY_FILE_DETAILED_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASSEMBLY_FILE_DETAILED_INFORMATION>()) == 0 }
+        self.ulFlags == other.ulFlags && self.ulFilenameLength == other.ulFilenameLength && self.ulPathLength == other.ulPathLength && self.lpFileName == other.lpFileName && self.lpFilePath == other.lpFilePath
     }
 }
 impl ::core::cmp::Eq for ASSEMBLY_FILE_DETAILED_INFORMATION {}
@@ -11573,7 +11591,7 @@ unsafe impl ::windows::core::Abi for ASSEMBLY_INFO {
 }
 impl ::core::cmp::PartialEq for ASSEMBLY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASSEMBLY_INFO>()) == 0 }
+        self.cbAssemblyInfo == other.cbAssemblyInfo && self.dwAssemblyFlags == other.dwAssemblyFlags && self.uliAssemblySizeInKB == other.uliAssemblySizeInKB && self.pszCurrentAssemblyPathBuf == other.pszCurrentAssemblyPathBuf && self.cchBuf == other.cchBuf
     }
 }
 impl ::core::cmp::Eq for ASSEMBLY_INFO {}
@@ -11605,7 +11623,7 @@ unsafe impl ::windows::core::Abi for COMPATIBILITY_CONTEXT_ELEMENT {
 }
 impl ::core::cmp::PartialEq for COMPATIBILITY_CONTEXT_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPATIBILITY_CONTEXT_ELEMENT>()) == 0 }
+        self.Id == other.Id && self.Type == other.Type && self.MaxVersionTested == other.MaxVersionTested
     }
 }
 impl ::core::cmp::Eq for COMPATIBILITY_CONTEXT_ELEMENT {}
@@ -11636,7 +11654,7 @@ unsafe impl ::windows::core::Abi for DELTA_HASH {
 }
 impl ::core::cmp::PartialEq for DELTA_HASH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELTA_HASH>()) == 0 }
+        self.HashSize == other.HashSize && self.HashValue == other.HashValue
     }
 }
 impl ::core::cmp::Eq for DELTA_HASH {}
@@ -11678,7 +11696,7 @@ unsafe impl ::windows::core::Abi for DELTA_HEADER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DELTA_HEADER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELTA_HEADER_INFO>()) == 0 }
+        self.FileTypeSet == other.FileTypeSet && self.FileType == other.FileType && self.Flags == other.Flags && self.TargetSize == other.TargetSize && self.TargetFileTime == other.TargetFileTime && self.TargetHashAlgId == other.TargetHashAlgId && self.TargetHash == other.TargetHash
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11710,14 +11728,6 @@ unsafe impl ::windows::core::Abi for DELTA_INPUT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DELTA_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELTA_INPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DELTA_INPUT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DELTA_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11742,14 +11752,6 @@ impl ::core::clone::Clone for DELTA_INPUT_0 {
 unsafe impl ::windows::core::Abi for DELTA_INPUT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DELTA_INPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELTA_INPUT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DELTA_INPUT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DELTA_INPUT_0 {
     fn default() -> Self {
@@ -11778,7 +11780,7 @@ unsafe impl ::windows::core::Abi for DELTA_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DELTA_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELTA_OUTPUT>()) == 0 }
+        self.lpStart == other.lpStart && self.uSize == other.uSize
     }
 }
 impl ::core::cmp::Eq for DELTA_OUTPUT {}
@@ -11812,7 +11814,7 @@ unsafe impl ::windows::core::Abi for FUSION_INSTALL_REFERENCE {
 }
 impl ::core::cmp::PartialEq for FUSION_INSTALL_REFERENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FUSION_INSTALL_REFERENCE>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.guidScheme == other.guidScheme && self.szIdentifier == other.szIdentifier && self.szNonCannonicalData == other.szNonCannonicalData
     }
 }
 impl ::core::cmp::Eq for FUSION_INSTALL_REFERENCE {}
@@ -11843,7 +11845,7 @@ unsafe impl ::windows::core::Abi for MSIFILEHASHINFO {
 }
 impl ::core::cmp::PartialEq for MSIFILEHASHINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSIFILEHASHINFO>()) == 0 }
+        self.dwFileHashInfoSize == other.dwFileHashInfoSize && self.dwData == other.dwData
     }
 }
 impl ::core::cmp::Eq for MSIFILEHASHINFO {}
@@ -11908,7 +11910,7 @@ unsafe impl ::windows::core::Abi for MSIPATCHSEQUENCEINFOA {
 }
 impl ::core::cmp::PartialEq for MSIPATCHSEQUENCEINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSIPATCHSEQUENCEINFOA>()) == 0 }
+        self.szPatchData == other.szPatchData && self.ePatchDataType == other.ePatchDataType && self.dwOrder == other.dwOrder && self.uStatus == other.uStatus
     }
 }
 impl ::core::cmp::Eq for MSIPATCHSEQUENCEINFOA {}
@@ -11941,7 +11943,7 @@ unsafe impl ::windows::core::Abi for MSIPATCHSEQUENCEINFOW {
 }
 impl ::core::cmp::PartialEq for MSIPATCHSEQUENCEINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSIPATCHSEQUENCEINFOW>()) == 0 }
+        self.szPatchData == other.szPatchData && self.ePatchDataType == other.ePatchDataType && self.dwOrder == other.dwOrder && self.uStatus == other.uStatus
     }
 }
 impl ::core::cmp::Eq for MSIPATCHSEQUENCEINFOW {}
@@ -11972,7 +11974,7 @@ unsafe impl ::windows::core::Abi for PATCH_IGNORE_RANGE {
 }
 impl ::core::cmp::PartialEq for PATCH_IGNORE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_IGNORE_RANGE>()) == 0 }
+        self.OffsetInOldFile == other.OffsetInOldFile && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for PATCH_IGNORE_RANGE {}
@@ -12003,7 +12005,7 @@ unsafe impl ::windows::core::Abi for PATCH_INTERLEAVE_MAP {
 }
 impl ::core::cmp::PartialEq for PATCH_INTERLEAVE_MAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_INTERLEAVE_MAP>()) == 0 }
+        self.CountRanges == other.CountRanges && self.Range == other.Range
     }
 }
 impl ::core::cmp::Eq for PATCH_INTERLEAVE_MAP {}
@@ -12035,7 +12037,7 @@ unsafe impl ::windows::core::Abi for PATCH_INTERLEAVE_MAP_0 {
 }
 impl ::core::cmp::PartialEq for PATCH_INTERLEAVE_MAP_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_INTERLEAVE_MAP_0>()) == 0 }
+        self.OldOffset == other.OldOffset && self.OldLength == other.OldLength && self.NewLength == other.NewLength
     }
 }
 impl ::core::cmp::Eq for PATCH_INTERLEAVE_MAP_0 {}
@@ -12068,14 +12070,6 @@ unsafe impl ::windows::core::Abi for PATCH_OLD_FILE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PATCH_OLD_FILE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OLD_FILE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PATCH_OLD_FILE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PATCH_OLD_FILE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12101,14 +12095,6 @@ impl ::core::clone::Clone for PATCH_OLD_FILE_INFO_0 {
 unsafe impl ::windows::core::Abi for PATCH_OLD_FILE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PATCH_OLD_FILE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OLD_FILE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PATCH_OLD_FILE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PATCH_OLD_FILE_INFO_0 {
     fn default() -> Self {
@@ -12141,7 +12127,7 @@ unsafe impl ::windows::core::Abi for PATCH_OLD_FILE_INFO_A {
 }
 impl ::core::cmp::PartialEq for PATCH_OLD_FILE_INFO_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OLD_FILE_INFO_A>()) == 0 }
+        self.SizeOfThisStruct == other.SizeOfThisStruct && self.OldFileName == other.OldFileName && self.IgnoreRangeCount == other.IgnoreRangeCount && self.IgnoreRangeArray == other.IgnoreRangeArray && self.RetainRangeCount == other.RetainRangeCount && self.RetainRangeArray == other.RetainRangeArray
     }
 }
 impl ::core::cmp::Eq for PATCH_OLD_FILE_INFO_A {}
@@ -12182,7 +12168,7 @@ unsafe impl ::windows::core::Abi for PATCH_OLD_FILE_INFO_H {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PATCH_OLD_FILE_INFO_H {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OLD_FILE_INFO_H>()) == 0 }
+        self.SizeOfThisStruct == other.SizeOfThisStruct && self.OldFileHandle == other.OldFileHandle && self.IgnoreRangeCount == other.IgnoreRangeCount && self.IgnoreRangeArray == other.IgnoreRangeArray && self.RetainRangeCount == other.RetainRangeCount && self.RetainRangeArray == other.RetainRangeArray
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12219,7 +12205,7 @@ unsafe impl ::windows::core::Abi for PATCH_OLD_FILE_INFO_W {
 }
 impl ::core::cmp::PartialEq for PATCH_OLD_FILE_INFO_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OLD_FILE_INFO_W>()) == 0 }
+        self.SizeOfThisStruct == other.SizeOfThisStruct && self.OldFileName == other.OldFileName && self.IgnoreRangeCount == other.IgnoreRangeCount && self.IgnoreRangeArray == other.IgnoreRangeArray && self.RetainRangeCount == other.RetainRangeCount && self.RetainRangeArray == other.RetainRangeArray
     }
 }
 impl ::core::cmp::Eq for PATCH_OLD_FILE_INFO_W {}
@@ -12253,31 +12239,13 @@ impl ::core::clone::Clone for PATCH_OPTION_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PATCH_OPTION_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PATCH_OPTION_DATA")
-            .field("SizeOfThisStruct", &self.SizeOfThisStruct)
-            .field("SymbolOptionFlags", &self.SymbolOptionFlags)
-            .field("NewFileSymbolPath", &self.NewFileSymbolPath)
-            .field("OldFileSymbolPathArray", &self.OldFileSymbolPathArray)
-            .field("ExtendedOptionFlags", &self.ExtendedOptionFlags)
-            .field("SymLoadCallback", &self.SymLoadCallback.map(|f| f as usize))
-            .field("SymLoadContext", &self.SymLoadContext)
-            .field("InterleaveMapArray", &self.InterleaveMapArray)
-            .field("MaxLzxWindowSize", &self.MaxLzxWindowSize)
-            .finish()
+        f.debug_struct("PATCH_OPTION_DATA").field("SizeOfThisStruct", &self.SizeOfThisStruct).field("SymbolOptionFlags", &self.SymbolOptionFlags).field("NewFileSymbolPath", &self.NewFileSymbolPath).field("OldFileSymbolPathArray", &self.OldFileSymbolPathArray).field("ExtendedOptionFlags", &self.ExtendedOptionFlags).field("SymLoadContext", &self.SymLoadContext).field("InterleaveMapArray", &self.InterleaveMapArray).field("MaxLzxWindowSize", &self.MaxLzxWindowSize).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PATCH_OPTION_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PATCH_OPTION_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_OPTION_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PATCH_OPTION_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PATCH_OPTION_DATA {
     fn default() -> Self {
@@ -12307,7 +12275,7 @@ unsafe impl ::windows::core::Abi for PATCH_RETAIN_RANGE {
 }
 impl ::core::cmp::PartialEq for PATCH_RETAIN_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATCH_RETAIN_RANGE>()) == 0 }
+        self.OffsetInOldFile == other.OffsetInOldFile && self.LengthInBytes == other.LengthInBytes && self.OffsetInNewFile == other.OffsetInNewFile
     }
 }
 impl ::core::cmp::Eq for PATCH_RETAIN_RANGE {}
@@ -12337,7 +12305,7 @@ unsafe impl ::windows::core::Abi for PMSIHANDLE {
 }
 impl ::core::cmp::PartialEq for PMSIHANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PMSIHANDLE>()) == 0 }
+        self.m_h == other.m_h
     }
 }
 impl ::core::cmp::Eq for PMSIHANDLE {}
@@ -12368,7 +12336,7 @@ unsafe impl ::windows::core::Abi for PM_APPTASKTYPE {
 }
 impl ::core::cmp::PartialEq for PM_APPTASKTYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PM_APPTASKTYPE>()) == 0 }
+        self.ProductID == other.ProductID && self.TaskType == other.TaskType
     }
 }
 impl ::core::cmp::Eq for PM_APPTASKTYPE {}
@@ -12451,12 +12419,6 @@ impl ::core::clone::Clone for PM_ENUM_FILTER {
 unsafe impl ::windows::core::Abi for PM_ENUM_FILTER {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for PM_ENUM_FILTER {
-    fn eq(&self, other: &Self) -> bool {
-        self.FilterType == other.FilterType && self.FilterParameter == other.FilterParameter
-    }
-}
-impl ::core::cmp::Eq for PM_ENUM_FILTER {}
 impl ::core::default::Default for PM_ENUM_FILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12491,12 +12453,6 @@ impl ::core::clone::Clone for PM_ENUM_FILTER_0 {
 unsafe impl ::windows::core::Abi for PM_ENUM_FILTER_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for PM_ENUM_FILTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PM_ENUM_FILTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PM_ENUM_FILTER_0 {}
 impl ::core::default::Default for PM_ENUM_FILTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12856,7 +12812,7 @@ unsafe impl ::windows::core::Abi for PROTECTED_FILE_DATA {
 }
 impl ::core::cmp::PartialEq for PROTECTED_FILE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTECTED_FILE_DATA>()) == 0 }
+        self.FileName == other.FileName && self.FileNumber == other.FileNumber
     }
 }
 impl ::core::cmp::Eq for PROTECTED_FILE_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
@@ -233,7 +233,7 @@ unsafe impl ::windows::core::Abi for AVRF_BACKTRACE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for AVRF_BACKTRACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVRF_BACKTRACE_INFORMATION>()) == 0 }
+        self.Depth == other.Depth && self.Index == other.Index && self.ReturnAddresses == other.ReturnAddresses
     }
 }
 impl ::core::cmp::Eq for AVRF_BACKTRACE_INFORMATION {}
@@ -268,7 +268,7 @@ unsafe impl ::windows::core::Abi for AVRF_HANDLE_OPERATION {
 }
 impl ::core::cmp::PartialEq for AVRF_HANDLE_OPERATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVRF_HANDLE_OPERATION>()) == 0 }
+        self.Handle == other.Handle && self.ProcessId == other.ProcessId && self.ThreadId == other.ThreadId && self.OperationType == other.OperationType && self.Spare0 == other.Spare0 && self.BackTraceInformation == other.BackTraceInformation
     }
 }
 impl ::core::cmp::Eq for AVRF_HANDLE_OPERATION {}
@@ -306,7 +306,7 @@ unsafe impl ::windows::core::Abi for AVRF_HEAP_ALLOCATION {
 }
 impl ::core::cmp::PartialEq for AVRF_HEAP_ALLOCATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AVRF_HEAP_ALLOCATION>()) == 0 }
+        self.HeapHandle == other.HeapHandle && self.UserAllocation == other.UserAllocation && self.UserAllocationSize == other.UserAllocationSize && self.Allocation == other.Allocation && self.AllocationSize == other.AllocationSize && self.UserAllocationState == other.UserAllocationState && self.HeapState == other.HeapState && self.HeapContext == other.HeapContext && self.BackTraceInformation == other.BackTraceInformation
     }
 }
 impl ::core::cmp::Eq for AVRF_HEAP_ALLOCATION {}

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
@@ -666,7 +666,7 @@ unsafe impl ::windows::core::Abi for CALLFRAMEINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CALLFRAMEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CALLFRAMEINFO>()) == 0 }
+        self.iMethod == other.iMethod && self.fHasInValues == other.fHasInValues && self.fHasInOutValues == other.fHasInOutValues && self.fHasOutValues == other.fHasOutValues && self.fDerivesFromIDispatch == other.fDerivesFromIDispatch && self.cInInterfacesMax == other.cInInterfacesMax && self.cInOutInterfacesMax == other.cInOutInterfacesMax && self.cOutInterfacesMax == other.cOutInterfacesMax && self.cTopLevelInInterfaces == other.cTopLevelInInterfaces && self.iid == other.iid && self.cMethod == other.cMethod && self.cParams == other.cParams
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -707,7 +707,7 @@ unsafe impl ::windows::core::Abi for CALLFRAMEPARAMINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CALLFRAMEPARAMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CALLFRAMEPARAMINFO>()) == 0 }
+        self.fIn == other.fIn && self.fOut == other.fOut && self.stackOffset == other.stackOffset && self.cbParam == other.cbParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -1646,7 +1646,7 @@ unsafe impl ::windows::core::Abi for BSTRBLOB {
 }
 impl ::core::cmp::PartialEq for BSTRBLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BSTRBLOB>()) == 0 }
+        self.cbSize == other.cbSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for BSTRBLOB {}
@@ -1683,7 +1683,7 @@ unsafe impl ::windows::core::Abi for CABOOL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CABOOL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABOOL>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1716,7 +1716,7 @@ unsafe impl ::windows::core::Abi for CABSTR {
 }
 impl ::core::cmp::PartialEq for CABSTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABSTR>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CABSTR {}
@@ -1747,7 +1747,7 @@ unsafe impl ::windows::core::Abi for CABSTRBLOB {
 }
 impl ::core::cmp::PartialEq for CABSTRBLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABSTRBLOB>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CABSTRBLOB {}
@@ -1778,7 +1778,7 @@ unsafe impl ::windows::core::Abi for CAC {
 }
 impl ::core::cmp::PartialEq for CAC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAC>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAC {}
@@ -1809,7 +1809,7 @@ unsafe impl ::windows::core::Abi for CACLIPDATA {
 }
 impl ::core::cmp::PartialEq for CACLIPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACLIPDATA>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CACLIPDATA {}
@@ -1840,7 +1840,7 @@ unsafe impl ::windows::core::Abi for CACLSID {
 }
 impl ::core::cmp::PartialEq for CACLSID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACLSID>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CACLSID {}
@@ -1871,7 +1871,7 @@ unsafe impl ::windows::core::Abi for CACY {
 }
 impl ::core::cmp::PartialEq for CACY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACY>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CACY {}
@@ -1902,7 +1902,7 @@ unsafe impl ::windows::core::Abi for CADATE {
 }
 impl ::core::cmp::PartialEq for CADATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CADATE>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CADATE {}
@@ -1933,7 +1933,7 @@ unsafe impl ::windows::core::Abi for CADBL {
 }
 impl ::core::cmp::PartialEq for CADBL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CADBL>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CADBL {}
@@ -1970,7 +1970,7 @@ unsafe impl ::windows::core::Abi for CAFILETIME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CAFILETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAFILETIME>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2003,7 +2003,7 @@ unsafe impl ::windows::core::Abi for CAFLT {
 }
 impl ::core::cmp::PartialEq for CAFLT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAFLT>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAFLT {}
@@ -2034,7 +2034,7 @@ unsafe impl ::windows::core::Abi for CAH {
 }
 impl ::core::cmp::PartialEq for CAH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAH>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAH {}
@@ -2065,7 +2065,7 @@ unsafe impl ::windows::core::Abi for CAI {
 }
 impl ::core::cmp::PartialEq for CAI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAI>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAI {}
@@ -2096,7 +2096,7 @@ unsafe impl ::windows::core::Abi for CAL {
 }
 impl ::core::cmp::PartialEq for CAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAL>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAL {}
@@ -2127,7 +2127,7 @@ unsafe impl ::windows::core::Abi for CALPSTR {
 }
 impl ::core::cmp::PartialEq for CALPSTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CALPSTR>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CALPSTR {}
@@ -2158,7 +2158,7 @@ unsafe impl ::windows::core::Abi for CALPWSTR {
 }
 impl ::core::cmp::PartialEq for CALPWSTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CALPWSTR>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CALPWSTR {}
@@ -2195,7 +2195,7 @@ unsafe impl ::windows::core::Abi for CAPROPVARIANT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CAPROPVARIANT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAPROPVARIANT>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2228,7 +2228,7 @@ unsafe impl ::windows::core::Abi for CASCODE {
 }
 impl ::core::cmp::PartialEq for CASCODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CASCODE>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CASCODE {}
@@ -2259,7 +2259,7 @@ unsafe impl ::windows::core::Abi for CAUB {
 }
 impl ::core::cmp::PartialEq for CAUB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAUB>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAUB {}
@@ -2290,7 +2290,7 @@ unsafe impl ::windows::core::Abi for CAUH {
 }
 impl ::core::cmp::PartialEq for CAUH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAUH>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAUH {}
@@ -2321,7 +2321,7 @@ unsafe impl ::windows::core::Abi for CAUI {
 }
 impl ::core::cmp::PartialEq for CAUI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAUI>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAUI {}
@@ -2352,7 +2352,7 @@ unsafe impl ::windows::core::Abi for CAUL {
 }
 impl ::core::cmp::PartialEq for CAUL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAUL>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAUL {}
@@ -2384,7 +2384,7 @@ unsafe impl ::windows::core::Abi for CLIPDATA {
 }
 impl ::core::cmp::PartialEq for CLIPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIPDATA>()) == 0 }
+        self.cbSize == other.cbSize && self.ulClipFmt == other.ulClipFmt && self.pClipData == other.pClipData
     }
 }
 impl ::core::cmp::Eq for CLIPDATA {}
@@ -2414,7 +2414,7 @@ unsafe impl ::windows::core::Abi for OLESTREAM {
 }
 impl ::core::cmp::PartialEq for OLESTREAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLESTREAM>()) == 0 }
+        self.lpstbl == other.lpstbl
     }
 }
 impl ::core::cmp::Eq for OLESTREAM {}
@@ -2445,7 +2445,7 @@ unsafe impl ::windows::core::Abi for OLESTREAMVTBL {
 }
 impl ::core::cmp::PartialEq for OLESTREAMVTBL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLESTREAMVTBL>()) == 0 }
+        self.Get == other.Get && self.Put == other.Put
     }
 }
 impl ::core::cmp::Eq for OLESTREAMVTBL {}
@@ -2482,7 +2482,7 @@ unsafe impl ::windows::core::Abi for PROPBAG2 {
 }
 impl ::core::cmp::PartialEq for PROPBAG2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPBAG2>()) == 0 }
+        self.dwType == other.dwType && self.vt == other.vt && self.cfType == other.cfType && self.dwHint == other.dwHint && self.pstrName == other.pstrName && self.clsid == other.clsid
     }
 }
 impl ::core::cmp::Eq for PROPBAG2 {}
@@ -2506,12 +2506,6 @@ impl ::core::clone::Clone for PROPSPEC {
 unsafe impl ::windows::core::Abi for PROPSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROPSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROPSPEC {}
 impl ::core::default::Default for PROPSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2532,12 +2526,6 @@ impl ::core::clone::Clone for PROPSPEC_0 {
 unsafe impl ::windows::core::Abi for PROPSPEC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROPSPEC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSPEC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROPSPEC_0 {}
 impl ::core::default::Default for PROPSPEC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2559,14 +2547,6 @@ impl ::core::clone::Clone for PROPVARIANT {
 unsafe impl ::windows::core::Abi for PROPVARIANT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPVARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPVARIANT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPVARIANT {
     fn default() -> Self {
@@ -2590,14 +2570,6 @@ impl ::core::clone::Clone for PROPVARIANT_0 {
 unsafe impl ::windows::core::Abi for PROPVARIANT_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPVARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPVARIANT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPVARIANT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPVARIANT_0 {
     fn default() -> Self {
@@ -2624,14 +2596,6 @@ impl ::core::clone::Clone for PROPVARIANT_0_0 {
 unsafe impl ::windows::core::Abi for PROPVARIANT_0_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPVARIANT_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        self.vt == other.vt && self.wReserved1 == other.wReserved1 && self.wReserved2 == other.wReserved2 && self.wReserved3 == other.wReserved3 && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPVARIANT_0_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPVARIANT_0_0 {
     fn default() -> Self {
@@ -2727,14 +2691,6 @@ unsafe impl ::windows::core::Abi for PROPVARIANT_0_0_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPVARIANT_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPVARIANT_0_0_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPVARIANT_0_0_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPVARIANT_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2763,7 +2719,7 @@ unsafe impl ::windows::core::Abi for RemSNB {
 }
 impl ::core::cmp::PartialEq for RemSNB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemSNB>()) == 0 }
+        self.ulCntStr == other.ulCntStr && self.ulCntChar == other.ulCntChar && self.rgString == other.rgString
     }
 }
 impl ::core::cmp::Eq for RemSNB {}
@@ -2794,7 +2750,7 @@ unsafe impl ::windows::core::Abi for SERIALIZEDPROPERTYVALUE {
 }
 impl ::core::cmp::PartialEq for SERIALIZEDPROPERTYVALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERIALIZEDPROPERTYVALUE>()) == 0 }
+        self.dwType == other.dwType && self.rgb == other.rgb
     }
 }
 impl ::core::cmp::Eq for SERIALIZEDPROPERTYVALUE {}
@@ -2836,7 +2792,7 @@ unsafe impl ::windows::core::Abi for STATPROPSETSTG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STATPROPSETSTG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STATPROPSETSTG>()) == 0 }
+        self.fmtid == other.fmtid && self.clsid == other.clsid && self.grfFlags == other.grfFlags && self.mtime == other.mtime && self.ctime == other.ctime && self.atime == other.atime && self.dwOSVersion == other.dwOSVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2870,7 +2826,7 @@ unsafe impl ::windows::core::Abi for STATPROPSTG {
 }
 impl ::core::cmp::PartialEq for STATPROPSTG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STATPROPSTG>()) == 0 }
+        self.lpwstrName == other.lpwstrName && self.propid == other.propid && self.vt == other.vt
     }
 }
 impl ::core::cmp::Eq for STATPROPSTG {}
@@ -2903,7 +2859,7 @@ unsafe impl ::windows::core::Abi for STGOPTIONS {
 }
 impl ::core::cmp::PartialEq for STGOPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STGOPTIONS>()) == 0 }
+        self.usVersion == other.usVersion && self.reserved == other.reserved && self.ulSectorSize == other.ulSectorSize && self.pwcsTemplateFile == other.pwcsTemplateFile
     }
 }
 impl ::core::cmp::Eq for STGOPTIONS {}

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
@@ -5343,7 +5343,7 @@ unsafe impl ::windows::core::Abi for CODEBASEHOLD {
 }
 impl ::core::cmp::PartialEq for CODEBASEHOLD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CODEBASEHOLD>()) == 0 }
+        self.cbSize == other.cbSize && self.szDistUnit == other.szDistUnit && self.szCodeBase == other.szCodeBase && self.dwVersionMS == other.dwVersionMS && self.dwVersionLS == other.dwVersionLS && self.dwStyle == other.dwStyle
     }
 }
 impl ::core::cmp::Eq for CODEBASEHOLD {}
@@ -5407,7 +5407,7 @@ unsafe impl ::windows::core::Abi for DATAINFO {
 }
 impl ::core::cmp::PartialEq for DATAINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATAINFO>()) == 0 }
+        self.ulTotalSize == other.ulTotalSize && self.ulavrPacketSize == other.ulavrPacketSize && self.ulConnectSpeed == other.ulConnectSpeed && self.ulProcessorSpeed == other.ulProcessorSpeed
     }
 }
 impl ::core::cmp::Eq for DATAINFO {}
@@ -5447,7 +5447,7 @@ unsafe impl ::windows::core::Abi for HIT_LOGGING_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HIT_LOGGING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIT_LOGGING_INFO>()) == 0 }
+        self.dwStructSize == other.dwStructSize && self.lpszLoggedUrlName == other.lpszLoggedUrlName && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.lpszExtendedInfo == other.lpszExtendedInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5482,7 +5482,7 @@ unsafe impl ::windows::core::Abi for PROTOCOLDATA {
 }
 impl ::core::cmp::PartialEq for PROTOCOLDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTOCOLDATA>()) == 0 }
+        self.grfFlags == other.grfFlags && self.dwState == other.dwState && self.pData == other.pData && self.cbData == other.cbData
     }
 }
 impl ::core::cmp::Eq for PROTOCOLDATA {}
@@ -5552,7 +5552,7 @@ unsafe impl ::windows::core::Abi for PROTOCOL_ARGUMENT {
 }
 impl ::core::cmp::PartialEq for PROTOCOL_ARGUMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROTOCOL_ARGUMENT>()) == 0 }
+        self.szMethod == other.szMethod && self.szTargetUrl == other.szTargetUrl
     }
 }
 impl ::core::cmp::Eq for PROTOCOL_ARGUMENT {}
@@ -5590,7 +5590,7 @@ unsafe impl ::windows::core::Abi for REMSECURITY_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REMSECURITY_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REMSECURITY_ATTRIBUTES>()) == 0 }
+        self.nLength == other.nLength && self.lpSecurityDescriptor == other.lpSecurityDescriptor && self.bInheritHandle == other.bInheritHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5702,7 +5702,7 @@ unsafe impl ::windows::core::Abi for RemFORMATETC {
 }
 impl ::core::cmp::PartialEq for RemFORMATETC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemFORMATETC>()) == 0 }
+        self.cfFormat == other.cfFormat && self.ptd == other.ptd && self.dwAspect == other.dwAspect && self.lindex == other.lindex && self.tymed == other.tymed
     }
 }
 impl ::core::cmp::Eq for RemFORMATETC {}
@@ -5758,7 +5758,7 @@ unsafe impl ::windows::core::Abi for SOFTDISTINFO {
 }
 impl ::core::cmp::PartialEq for SOFTDISTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOFTDISTINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.dwAdState == other.dwAdState && self.szTitle == other.szTitle && self.szAbstract == other.szAbstract && self.szHREF == other.szHREF && self.dwInstalledVersionMS == other.dwInstalledVersionMS && self.dwInstalledVersionLS == other.dwInstalledVersionLS && self.dwUpdateVersionMS == other.dwUpdateVersionMS && self.dwUpdateVersionLS == other.dwUpdateVersionLS && self.dwAdvertisedVersionMS == other.dwAdvertisedVersionMS && self.dwAdvertisedVersionLS == other.dwAdvertisedVersionLS && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for SOFTDISTINFO {}
@@ -5826,7 +5826,7 @@ unsafe impl ::windows::core::Abi for ZONEATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for ZONEATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ZONEATTRIBUTES>()) == 0 }
+        self.cbSize == other.cbSize && self.szDisplayName == other.szDisplayName && self.szDescription == other.szDescription && self.szIconPath == other.szIconPath && self.dwTemplateMinLevel == other.dwTemplateMinLevel && self.dwTemplateRecommended == other.dwTemplateRecommended && self.dwTemplateCurrentLevel == other.dwTemplateCurrentLevel && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for ZONEATTRIBUTES {}

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -10353,7 +10353,7 @@ unsafe impl ::windows::core::Abi for AUTHENTICATEINFO {
 }
 impl ::core::cmp::PartialEq for AUTHENTICATEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHENTICATEINFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for AUTHENTICATEINFO {}
@@ -10407,14 +10407,6 @@ unsafe impl ::windows::core::Abi for BINDINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for BINDINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbSize == other.cbSize && self.szExtraInfo == other.szExtraInfo && self.stgmedData == other.stgmedData && self.grfBindInfoF == other.grfBindInfoF && self.dwBindVerb == other.dwBindVerb && self.szCustomVerb == other.szCustomVerb && self.cbstgmedData == other.cbstgmedData && self.dwOptions == other.dwOptions && self.dwOptionsFlags == other.dwOptionsFlags && self.dwCodePage == other.dwCodePage && self.securityAttributes == other.securityAttributes && self.iid == other.iid && self.pUnk == other.pUnk && self.dwReserved == other.dwReserved
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for BINDINFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for BINDINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10438,14 +10430,6 @@ impl ::core::clone::Clone for BINDPTR {
 unsafe impl ::windows::core::Abi for BINDPTR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for BINDPTR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BINDPTR>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for BINDPTR {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for BINDPTR {
     fn default() -> Self {
@@ -10476,7 +10460,7 @@ unsafe impl ::windows::core::Abi for BIND_OPTS {
 }
 impl ::core::cmp::PartialEq for BIND_OPTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIND_OPTS>()) == 0 }
+        self.cbStruct == other.cbStruct && self.grfFlags == other.grfFlags && self.grfMode == other.grfMode && self.dwTickCountDeadline == other.dwTickCountDeadline
     }
 }
 impl ::core::cmp::Eq for BIND_OPTS {}
@@ -10510,7 +10494,7 @@ unsafe impl ::windows::core::Abi for BIND_OPTS2 {
 }
 impl ::core::cmp::PartialEq for BIND_OPTS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIND_OPTS2>()) == 0 }
+        self.Base == other.Base && self.dwTrackFlags == other.dwTrackFlags && self.dwClassContext == other.dwClassContext && self.locale == other.locale && self.pServerInfo == other.pServerInfo
     }
 }
 impl ::core::cmp::Eq for BIND_OPTS2 {}
@@ -10547,7 +10531,7 @@ unsafe impl ::windows::core::Abi for BIND_OPTS3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BIND_OPTS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIND_OPTS3>()) == 0 }
+        self.Base == other.Base && self.hwnd == other.hwnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10580,7 +10564,7 @@ unsafe impl ::windows::core::Abi for BLOB {
 }
 impl ::core::cmp::PartialEq for BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BLOB>()) == 0 }
+        self.cbSize == other.cbSize && self.pBlobData == other.pBlobData
     }
 }
 impl ::core::cmp::Eq for BLOB {}
@@ -10611,7 +10595,7 @@ unsafe impl ::windows::core::Abi for BYTE_BLOB {
 }
 impl ::core::cmp::PartialEq for BYTE_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BYTE_BLOB>()) == 0 }
+        self.clSize == other.clSize && self.abData == other.abData
     }
 }
 impl ::core::cmp::Eq for BYTE_BLOB {}
@@ -10642,7 +10626,7 @@ unsafe impl ::windows::core::Abi for BYTE_SIZEDARR {
 }
 impl ::core::cmp::PartialEq for BYTE_SIZEDARR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BYTE_SIZEDARR>()) == 0 }
+        self.clSize == other.clSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for BYTE_SIZEDARR {}
@@ -10674,7 +10658,7 @@ unsafe impl ::windows::core::Abi for CATEGORYINFO {
 }
 impl ::core::cmp::PartialEq for CATEGORYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATEGORYINFO>()) == 0 }
+        self.catid == other.catid && self.lcid == other.lcid && self.szDescription == other.szDescription
     }
 }
 impl ::core::cmp::Eq for CATEGORYINFO {}
@@ -10710,7 +10694,7 @@ unsafe impl ::windows::core::Abi for COAUTHIDENTITY {
 }
 impl ::core::cmp::PartialEq for COAUTHIDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COAUTHIDENTITY>()) == 0 }
+        self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for COAUTHIDENTITY {}
@@ -10746,7 +10730,7 @@ unsafe impl ::windows::core::Abi for COAUTHINFO {
 }
 impl ::core::cmp::PartialEq for COAUTHINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COAUTHINFO>()) == 0 }
+        self.dwAuthnSvc == other.dwAuthnSvc && self.dwAuthzSvc == other.dwAuthzSvc && self.pwszServerPrincName == other.pwszServerPrincName && self.dwAuthnLevel == other.dwAuthnLevel && self.dwImpersonationLevel == other.dwImpersonationLevel && self.pAuthIdentityData == other.pAuthIdentityData && self.dwCapabilities == other.dwCapabilities
     }
 }
 impl ::core::cmp::Eq for COAUTHINFO {}
@@ -10809,7 +10793,7 @@ unsafe impl ::windows::core::Abi for COSERVERINFO {
 }
 impl ::core::cmp::PartialEq for COSERVERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COSERVERINFO>()) == 0 }
+        self.dwReserved1 == other.dwReserved1 && self.pwszName == other.pwszName && self.pAuthInfo == other.pAuthInfo && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for COSERVERINFO {}
@@ -10906,7 +10890,7 @@ unsafe impl ::windows::core::Abi for CSPLATFORM {
 }
 impl ::core::cmp::PartialEq for CSPLATFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSPLATFORM>()) == 0 }
+        self.dwPlatformId == other.dwPlatformId && self.dwVersionHi == other.dwVersionHi && self.dwVersionLo == other.dwVersionLo && self.dwProcessorArch == other.dwProcessorArch
     }
 }
 impl ::core::cmp::Eq for CSPLATFORM {}
@@ -10943,7 +10927,7 @@ unsafe impl ::windows::core::Abi for CUSTDATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for CUSTDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CUSTDATA>()) == 0 }
+        self.cCustData == other.cCustData && self.prgCustData == other.prgCustData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
@@ -10972,14 +10956,6 @@ unsafe impl ::windows::core::Abi for CUSTDATAITEM {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for CUSTDATAITEM {
-    fn eq(&self, other: &Self) -> bool {
-        self.guid == other.guid && self.varValue == other.varValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for CUSTDATAITEM {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for CUSTDATAITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11000,12 +10976,6 @@ impl ::core::clone::Clone for CY {
 unsafe impl ::windows::core::Abi for CY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CY {}
 impl ::core::default::Default for CY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11033,7 +11003,7 @@ unsafe impl ::windows::core::Abi for CY_0 {
 }
 impl ::core::cmp::PartialEq for CY_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CY_0>()) == 0 }
+        self.Lo == other.Lo && self.Hi == other.Hi
     }
 }
 impl ::core::cmp::Eq for CY_0 {}
@@ -11065,7 +11035,7 @@ unsafe impl ::windows::core::Abi for ComCallData {
 }
 impl ::core::cmp::PartialEq for ComCallData {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ComCallData>()) == 0 }
+        self.dwDispid == other.dwDispid && self.dwReserved == other.dwReserved && self.pUserDefined == other.pUserDefined
     }
 }
 impl ::core::cmp::Eq for ComCallData {}
@@ -11104,7 +11074,7 @@ unsafe impl ::windows::core::Abi for DISPPARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for DISPPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPPARAMS>()) == 0 }
+        self.rgvarg == other.rgvarg && self.rgdispidNamedArgs == other.rgdispidNamedArgs && self.cArgs == other.cArgs && self.cNamedArgs == other.cNamedArgs
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
@@ -11141,7 +11111,7 @@ unsafe impl ::windows::core::Abi for DVTARGETDEVICE {
 }
 impl ::core::cmp::PartialEq for DVTARGETDEVICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DVTARGETDEVICE>()) == 0 }
+        self.tdSize == other.tdSize && self.tdDriverNameOffset == other.tdDriverNameOffset && self.tdDeviceNameOffset == other.tdDeviceNameOffset && self.tdPortNameOffset == other.tdPortNameOffset && self.tdExtDevmodeOffset == other.tdExtDevmodeOffset && self.tdData == other.tdData
     }
 }
 impl ::core::cmp::Eq for DVTARGETDEVICE {}
@@ -11172,7 +11142,7 @@ unsafe impl ::windows::core::Abi for DWORD_BLOB {
 }
 impl ::core::cmp::PartialEq for DWORD_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWORD_BLOB>()) == 0 }
+        self.clSize == other.clSize && self.alData == other.alData
     }
 }
 impl ::core::cmp::Eq for DWORD_BLOB {}
@@ -11203,7 +11173,7 @@ unsafe impl ::windows::core::Abi for DWORD_SIZEDARR {
 }
 impl ::core::cmp::PartialEq for DWORD_SIZEDARR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DWORD_SIZEDARR>()) == 0 }
+        self.clSize == other.clSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for DWORD_SIZEDARR {}
@@ -11232,14 +11202,6 @@ unsafe impl ::windows::core::Abi for ELEMDESC {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for ELEMDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ELEMDESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for ELEMDESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for ELEMDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11264,14 +11226,6 @@ impl ::core::clone::Clone for ELEMDESC_0 {
 unsafe impl ::windows::core::Abi for ELEMDESC_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for ELEMDESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ELEMDESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for ELEMDESC_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for ELEMDESC_0 {
     fn default() -> Self {
@@ -11308,18 +11262,12 @@ impl ::core::clone::Clone for EXCEPINFO {
 }
 impl ::core::fmt::Debug for EXCEPINFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("EXCEPINFO").field("wCode", &self.wCode).field("wReserved", &self.wReserved).field("bstrSource", &self.bstrSource).field("bstrDescription", &self.bstrDescription).field("bstrHelpFile", &self.bstrHelpFile).field("dwHelpContext", &self.dwHelpContext).field("pvReserved", &self.pvReserved).field("pfnDeferredFillIn", &self.pfnDeferredFillIn.map(|f| f as usize)).field("scode", &self.scode).finish()
+        f.debug_struct("EXCEPINFO").field("wCode", &self.wCode).field("wReserved", &self.wReserved).field("bstrSource", &self.bstrSource).field("bstrDescription", &self.bstrDescription).field("bstrHelpFile", &self.bstrHelpFile).field("dwHelpContext", &self.dwHelpContext).field("pvReserved", &self.pvReserved).field("scode", &self.scode).finish()
     }
 }
 unsafe impl ::windows::core::Abi for EXCEPINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for EXCEPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.wCode == other.wCode && self.wReserved == other.wReserved && self.bstrSource == other.bstrSource && self.bstrDescription == other.bstrDescription && self.bstrHelpFile == other.bstrHelpFile && self.dwHelpContext == other.dwHelpContext && self.pvReserved == other.pvReserved && self.pfnDeferredFillIn.map(|f| f as usize) == other.pfnDeferredFillIn.map(|f| f as usize) && self.scode == other.scode
-    }
-}
-impl ::core::cmp::Eq for EXCEPINFO {}
 impl ::core::default::Default for EXCEPINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11348,7 +11296,7 @@ unsafe impl ::windows::core::Abi for FLAGGED_BYTE_BLOB {
 }
 impl ::core::cmp::PartialEq for FLAGGED_BYTE_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLAGGED_BYTE_BLOB>()) == 0 }
+        self.fFlags == other.fFlags && self.clSize == other.clSize && self.abData == other.abData
     }
 }
 impl ::core::cmp::Eq for FLAGGED_BYTE_BLOB {}
@@ -11380,7 +11328,7 @@ unsafe impl ::windows::core::Abi for FLAGGED_WORD_BLOB {
 }
 impl ::core::cmp::PartialEq for FLAGGED_WORD_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLAGGED_WORD_BLOB>()) == 0 }
+        self.fFlags == other.fFlags && self.clSize == other.clSize && self.asData == other.asData
     }
 }
 impl ::core::cmp::Eq for FLAGGED_WORD_BLOB {}
@@ -11407,14 +11355,6 @@ impl ::core::clone::Clone for FLAG_STGMEDIUM {
 unsafe impl ::windows::core::Abi for FLAG_STGMEDIUM {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for FLAG_STGMEDIUM {
-    fn eq(&self, other: &Self) -> bool {
-        self.ContextFlags == other.ContextFlags && self.fPassOwnership == other.fPassOwnership && self.Stgmed == other.Stgmed
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for FLAG_STGMEDIUM {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for FLAG_STGMEDIUM {
     fn default() -> Self {
@@ -11446,7 +11386,7 @@ unsafe impl ::windows::core::Abi for FORMATETC {
 }
 impl ::core::cmp::PartialEq for FORMATETC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORMATETC>()) == 0 }
+        self.cfFormat == other.cfFormat && self.ptd == other.ptd && self.dwAspect == other.dwAspect && self.lindex == other.lindex && self.tymed == other.tymed
     }
 }
 impl ::core::cmp::Eq for FORMATETC {}
@@ -11485,14 +11425,6 @@ unsafe impl ::windows::core::Abi for FUNCDESC {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for FUNCDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FUNCDESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for FUNCDESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for FUNCDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11517,14 +11449,6 @@ impl ::core::clone::Clone for GDI_OBJECT {
 unsafe impl ::windows::core::Abi for GDI_OBJECT {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for GDI_OBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GDI_OBJECT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for GDI_OBJECT {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for GDI_OBJECT {
     fn default() -> Self {
@@ -11551,14 +11475,6 @@ impl ::core::clone::Clone for GDI_OBJECT_0 {
 unsafe impl ::windows::core::Abi for GDI_OBJECT_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for GDI_OBJECT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GDI_OBJECT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for GDI_OBJECT_0 {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for GDI_OBJECT_0 {
     fn default() -> Self {
@@ -11587,7 +11503,7 @@ unsafe impl ::windows::core::Abi for HYPER_SIZEDARR {
 }
 impl ::core::cmp::PartialEq for HYPER_SIZEDARR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYPER_SIZEDARR>()) == 0 }
+        self.clSize == other.clSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for HYPER_SIZEDARR {}
@@ -11620,7 +11536,7 @@ unsafe impl ::windows::core::Abi for IDLDESC {
 }
 impl ::core::cmp::PartialEq for IDLDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IDLDESC>()) == 0 }
+        self.dwReserved == other.dwReserved && self.wIDLFlags == other.wIDLFlags
     }
 }
 impl ::core::cmp::Eq for IDLDESC {}
@@ -11714,7 +11630,7 @@ unsafe impl ::windows::core::Abi for MachineGlobalObjectTableRegistrationToken__
 }
 impl ::core::cmp::PartialEq for MachineGlobalObjectTableRegistrationToken__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MachineGlobalObjectTableRegistrationToken__>()) == 0 }
+        self.unused == other.unused
     }
 }
 impl ::core::cmp::Eq for MachineGlobalObjectTableRegistrationToken__ {}
@@ -11748,7 +11664,7 @@ unsafe impl ::windows::core::Abi for QUERYCONTEXT {
 }
 impl ::core::cmp::PartialEq for QUERYCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERYCONTEXT>()) == 0 }
+        self.dwContext == other.dwContext && self.Platform == other.Platform && self.Locale == other.Locale && self.dwVersionHi == other.dwVersionHi && self.dwVersionLo == other.dwVersionLo
     }
 }
 impl ::core::cmp::Eq for QUERYCONTEXT {}
@@ -11784,7 +11700,7 @@ unsafe impl ::windows::core::Abi for RPCOLEMESSAGE {
 }
 impl ::core::cmp::PartialEq for RPCOLEMESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPCOLEMESSAGE>()) == 0 }
+        self.reserved1 == other.reserved1 && self.dataRepresentation == other.dataRepresentation && self.Buffer == other.Buffer && self.cbBuffer == other.cbBuffer && self.iMethod == other.iMethod && self.reserved2 == other.reserved2 && self.rpcFlags == other.rpcFlags
     }
 }
 impl ::core::cmp::Eq for RPCOLEMESSAGE {}
@@ -11819,7 +11735,7 @@ unsafe impl ::windows::core::Abi for RemSTGMEDIUM {
 }
 impl ::core::cmp::PartialEq for RemSTGMEDIUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemSTGMEDIUM>()) == 0 }
+        self.tymed == other.tymed && self.dwHandleType == other.dwHandleType && self.pData == other.pData && self.pUnkForRelease == other.pUnkForRelease && self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemSTGMEDIUM {}
@@ -11854,7 +11770,7 @@ unsafe impl ::windows::core::Abi for SAFEARRAY {
 }
 impl ::core::cmp::PartialEq for SAFEARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARRAY>()) == 0 }
+        self.cDims == other.cDims && self.fFeatures == other.fFeatures && self.cbElements == other.cbElements && self.cLocks == other.cLocks && self.pvData == other.pvData && self.rgsabound == other.rgsabound
     }
 }
 impl ::core::cmp::Eq for SAFEARRAY {}
@@ -11885,7 +11801,7 @@ unsafe impl ::windows::core::Abi for SAFEARRAYBOUND {
 }
 impl ::core::cmp::PartialEq for SAFEARRAYBOUND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARRAYBOUND>()) == 0 }
+        self.cElements == other.cElements && self.lLbound == other.lLbound
     }
 }
 impl ::core::cmp::Eq for SAFEARRAYBOUND {}
@@ -11920,7 +11836,7 @@ unsafe impl ::windows::core::Abi for SChannelHookCallInfo {
 }
 impl ::core::cmp::PartialEq for SChannelHookCallInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SChannelHookCallInfo>()) == 0 }
+        self.iid == other.iid && self.cbSize == other.cbSize && self.uCausality == other.uCausality && self.dwServerPid == other.dwServerPid && self.iMethod == other.iMethod && self.pObject == other.pObject
     }
 }
 impl ::core::cmp::Eq for SChannelHookCallInfo {}
@@ -11952,7 +11868,7 @@ unsafe impl ::windows::core::Abi for SOLE_AUTHENTICATION_INFO {
 }
 impl ::core::cmp::PartialEq for SOLE_AUTHENTICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOLE_AUTHENTICATION_INFO>()) == 0 }
+        self.dwAuthnSvc == other.dwAuthnSvc && self.dwAuthzSvc == other.dwAuthzSvc && self.pAuthInfo == other.pAuthInfo
     }
 }
 impl ::core::cmp::Eq for SOLE_AUTHENTICATION_INFO {}
@@ -11983,7 +11899,7 @@ unsafe impl ::windows::core::Abi for SOLE_AUTHENTICATION_LIST {
 }
 impl ::core::cmp::PartialEq for SOLE_AUTHENTICATION_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOLE_AUTHENTICATION_LIST>()) == 0 }
+        self.cAuthInfo == other.cAuthInfo && self.aAuthInfo == other.aAuthInfo
     }
 }
 impl ::core::cmp::Eq for SOLE_AUTHENTICATION_LIST {}
@@ -12016,7 +11932,7 @@ unsafe impl ::windows::core::Abi for SOLE_AUTHENTICATION_SERVICE {
 }
 impl ::core::cmp::PartialEq for SOLE_AUTHENTICATION_SERVICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOLE_AUTHENTICATION_SERVICE>()) == 0 }
+        self.dwAuthnSvc == other.dwAuthnSvc && self.dwAuthzSvc == other.dwAuthzSvc && self.pPrincipalName == other.pPrincipalName && self.hr == other.hr
     }
 }
 impl ::core::cmp::Eq for SOLE_AUTHENTICATION_SERVICE {}
@@ -12094,7 +12010,7 @@ unsafe impl ::windows::core::Abi for STATSTG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STATSTG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STATSTG>()) == 0 }
+        self.pwcsName == other.pwcsName && self.r#type == other.r#type && self.cbSize == other.cbSize && self.mtime == other.mtime && self.ctime == other.ctime && self.atime == other.atime && self.grfMode == other.grfMode && self.grfLocksSupported == other.grfLocksSupported && self.clsid == other.clsid && self.grfStateBits == other.grfStateBits && self.reserved == other.reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12124,14 +12040,6 @@ unsafe impl ::windows::core::Abi for STGMEDIUM {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for STGMEDIUM {
-    fn eq(&self, other: &Self) -> bool {
-        self.tymed == other.tymed && self.Anonymous == other.Anonymous && self.pUnkForRelease == other.pUnkForRelease
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for STGMEDIUM {}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for STGMEDIUM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12159,14 +12067,6 @@ impl ::core::clone::Clone for STGMEDIUM_0 {
 unsafe impl ::windows::core::Abi for STGMEDIUM_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for STGMEDIUM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STGMEDIUM_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for STGMEDIUM_0 {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for STGMEDIUM_0 {
     fn default() -> Self {
@@ -12197,7 +12097,7 @@ unsafe impl ::windows::core::Abi for StorageLayout {
 }
 impl ::core::cmp::PartialEq for StorageLayout {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<StorageLayout>()) == 0 }
+        self.LayoutType == other.LayoutType && self.pwcsElementName == other.pwcsElementName && self.cOffset == other.cOffset && self.cBytes == other.cBytes
     }
 }
 impl ::core::cmp::Eq for StorageLayout {}
@@ -12232,7 +12132,7 @@ unsafe impl ::windows::core::Abi for TLIBATTR {
 }
 impl ::core::cmp::PartialEq for TLIBATTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TLIBATTR>()) == 0 }
+        self.guid == other.guid && self.lcid == other.lcid && self.syskind == other.syskind && self.wMajorVerNum == other.wMajorVerNum && self.wMinorVerNum == other.wMinorVerNum && self.wLibFlags == other.wLibFlags
     }
 }
 impl ::core::cmp::Eq for TLIBATTR {}
@@ -12277,14 +12177,6 @@ unsafe impl ::windows::core::Abi for TYPEATTR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::PartialEq for TYPEATTR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TYPEATTR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::Eq for TYPEATTR {}
-#[cfg(feature = "Win32_System_Ole")]
 impl ::core::default::Default for TYPEATTR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12309,14 +12201,6 @@ impl ::core::clone::Clone for TYPEDESC {
 unsafe impl ::windows::core::Abi for TYPEDESC {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::PartialEq for TYPEDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TYPEDESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::Eq for TYPEDESC {}
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::default::Default for TYPEDESC {
     fn default() -> Self {
@@ -12343,14 +12227,6 @@ impl ::core::clone::Clone for TYPEDESC_0 {
 unsafe impl ::windows::core::Abi for TYPEDESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::PartialEq for TYPEDESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TYPEDESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::cmp::Eq for TYPEDESC_0 {}
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::default::Default for TYPEDESC_0 {
     fn default() -> Self {
@@ -12381,14 +12257,6 @@ unsafe impl ::windows::core::Abi for VARDESC {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VARDESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARDESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12414,14 +12282,6 @@ unsafe impl ::windows::core::Abi for VARDESC_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARDESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VARDESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARDESC_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARDESC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12443,14 +12303,6 @@ impl ::core::clone::Clone for VARIANT {
 unsafe impl ::windows::core::Abi for VARIANT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARIANT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARIANT {
     fn default() -> Self {
@@ -12474,14 +12326,6 @@ impl ::core::clone::Clone for VARIANT_0 {
 unsafe impl ::windows::core::Abi for VARIANT_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VARIANT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARIANT_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARIANT_0 {
     fn default() -> Self {
@@ -12508,14 +12352,6 @@ impl ::core::clone::Clone for VARIANT_0_0 {
 unsafe impl ::windows::core::Abi for VARIANT_0_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARIANT_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        self.vt == other.vt && self.wReserved1 == other.wReserved1 && self.wReserved2 == other.wReserved2 && self.wReserved3 == other.wReserved3 && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARIANT_0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARIANT_0_0 {
     fn default() -> Self {
@@ -12584,14 +12420,6 @@ unsafe impl ::windows::core::Abi for VARIANT_0_0_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for VARIANT_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VARIANT_0_0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for VARIANT_0_0_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for VARIANT_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12656,7 +12484,7 @@ unsafe impl ::windows::core::Abi for WORD_BLOB {
 }
 impl ::core::cmp::PartialEq for WORD_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WORD_BLOB>()) == 0 }
+        self.clSize == other.clSize && self.asData == other.asData
     }
 }
 impl ::core::cmp::Eq for WORD_BLOB {}
@@ -12687,7 +12515,7 @@ unsafe impl ::windows::core::Abi for WORD_SIZEDARR {
 }
 impl ::core::cmp::PartialEq for WORD_SIZEDARR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WORD_SIZEDARR>()) == 0 }
+        self.clSize == other.clSize && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for WORD_SIZEDARR {}
@@ -12711,12 +12539,6 @@ impl ::core::clone::Clone for uCLSSPEC {
 unsafe impl ::windows::core::Abi for uCLSSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for uCLSSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<uCLSSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for uCLSSPEC {}
 impl ::core::default::Default for uCLSSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12742,12 +12564,6 @@ impl ::core::clone::Clone for uCLSSPEC_0 {
 unsafe impl ::windows::core::Abi for uCLSSPEC_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for uCLSSPEC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<uCLSSPEC_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for uCLSSPEC_0 {}
 impl ::core::default::Default for uCLSSPEC_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12775,7 +12591,7 @@ unsafe impl ::windows::core::Abi for uCLSSPEC_0_0 {
 }
 impl ::core::cmp::PartialEq for uCLSSPEC_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<uCLSSPEC_0_0>()) == 0 }
+        self.pPackageName == other.pPackageName && self.PolicyId == other.PolicyId
     }
 }
 impl ::core::cmp::Eq for uCLSSPEC_0_0 {}
@@ -12806,7 +12622,7 @@ unsafe impl ::windows::core::Abi for uCLSSPEC_0_1 {
 }
 impl ::core::cmp::PartialEq for uCLSSPEC_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<uCLSSPEC_0_1>()) == 0 }
+        self.ObjectId == other.ObjectId && self.PolicyId == other.PolicyId
     }
 }
 impl ::core::cmp::Eq for uCLSSPEC_0_1 {}
@@ -12895,14 +12711,6 @@ unsafe impl ::windows::core::Abi for userSTGMEDIUM_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for userSTGMEDIUM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userSTGMEDIUM_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for userSTGMEDIUM_0 {}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for userSTGMEDIUM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12932,14 +12740,6 @@ impl ::core::clone::Clone for userSTGMEDIUM_0_0 {
 unsafe impl ::windows::core::Abi for userSTGMEDIUM_0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::PartialEq for userSTGMEDIUM_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userSTGMEDIUM_0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl ::core::cmp::Eq for userSTGMEDIUM_0_0 {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 impl ::core::default::Default for userSTGMEDIUM_0_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
@@ -9566,7 +9566,7 @@ unsafe impl ::windows::core::Abi for APPDATA {
 }
 impl ::core::cmp::PartialEq for APPDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPDATA>()) == 0 }
+        self.m_idApp == other.m_idApp && self.m_szAppGuid == other.m_szAppGuid && self.m_dwAppProcessId == other.m_dwAppProcessId && self.m_AppStatistics == other.m_AppStatistics
     }
 }
 impl ::core::cmp::Eq for APPDATA {}
@@ -9599,7 +9599,7 @@ unsafe impl ::windows::core::Abi for APPSTATISTICS {
 }
 impl ::core::cmp::PartialEq for APPSTATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPSTATISTICS>()) == 0 }
+        self.m_cTotalCalls == other.m_cTotalCalls && self.m_cTotalInstances == other.m_cTotalInstances && self.m_cTotalClasses == other.m_cTotalClasses && self.m_cCallsPerSecond == other.m_cCallsPerSecond
     }
 }
 impl ::core::cmp::Eq for APPSTATISTICS {}
@@ -9663,7 +9663,7 @@ unsafe impl ::windows::core::Abi for ApplicationProcessRecycleInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ApplicationProcessRecycleInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ApplicationProcessRecycleInfo>()) == 0 }
+        self.IsRecyclable == other.IsRecyclable && self.IsRecycled == other.IsRecycled && self.TimeRecycled == other.TimeRecycled && self.TimeToTerminate == other.TimeToTerminate && self.RecycleReasonCode == other.RecycleReasonCode && self.IsPendingRecycle == other.IsPendingRecycle && self.HasAutomaticLifetimeRecycling == other.HasAutomaticLifetimeRecycling && self.TimeForAutomaticRecycling == other.TimeForAutomaticRecycling && self.MemoryLimitInKB == other.MemoryLimitInKB && self.MemoryUsageInKBLastCheck == other.MemoryUsageInKBLastCheck && self.ActivationLimit == other.ActivationLimit && self.NumActivationsLastReported == other.NumActivationsLastReported && self.CallLimit == other.CallLimit && self.NumCallsLastReported == other.NumCallsLastReported
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9702,7 +9702,7 @@ unsafe impl ::windows::core::Abi for ApplicationProcessStatistics {
 }
 impl ::core::cmp::PartialEq for ApplicationProcessStatistics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ApplicationProcessStatistics>()) == 0 }
+        self.NumCallsOutstanding == other.NumCallsOutstanding && self.NumTrackedComponents == other.NumTrackedComponents && self.NumComponentInstances == other.NumComponentInstances && self.AvgCallsPerSecond == other.AvgCallsPerSecond && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4
     }
 }
 impl ::core::cmp::Eq for ApplicationProcessStatistics {}
@@ -9756,7 +9756,7 @@ unsafe impl ::windows::core::Abi for ApplicationProcessSummary {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ApplicationProcessSummary {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ApplicationProcessSummary>()) == 0 }
+        self.PartitionIdPrimaryApplication == other.PartitionIdPrimaryApplication && self.ApplicationIdPrimaryApplication == other.ApplicationIdPrimaryApplication && self.ApplicationInstanceId == other.ApplicationInstanceId && self.ProcessId == other.ProcessId && self.Type == other.Type && self.ProcessExeName == other.ProcessExeName && self.IsService == other.IsService && self.IsPaused == other.IsPaused && self.IsRecycled == other.IsRecycled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9794,7 +9794,7 @@ unsafe impl ::windows::core::Abi for ApplicationSummary {
 }
 impl ::core::cmp::PartialEq for ApplicationSummary {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ApplicationSummary>()) == 0 }
+        self.ApplicationInstanceId == other.ApplicationInstanceId && self.PartitionId == other.PartitionId && self.ApplicationId == other.ApplicationId && self.Type == other.Type && self.ApplicationName == other.ApplicationName && self.NumTrackedComponents == other.NumTrackedComponents && self.NumComponentInstances == other.NumComponentInstances
     }
 }
 impl ::core::cmp::Eq for ApplicationSummary {}
@@ -9831,7 +9831,7 @@ unsafe impl ::windows::core::Abi for CLSIDDATA {
 }
 impl ::core::cmp::PartialEq for CLSIDDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLSIDDATA>()) == 0 }
+        self.m_clsid == other.m_clsid && self.m_cReferences == other.m_cReferences && self.m_cBound == other.m_cBound && self.m_cPooled == other.m_cPooled && self.m_cInCall == other.m_cInCall && self.m_dwRespTime == other.m_dwRespTime && self.m_cCallsCompleted == other.m_cCallsCompleted && self.m_cCallsFailed == other.m_cCallsFailed
     }
 }
 impl ::core::cmp::Eq for CLSIDDATA {}
@@ -9887,7 +9887,7 @@ unsafe impl ::windows::core::Abi for CLSIDDATA2 {
 }
 impl ::core::cmp::PartialEq for CLSIDDATA2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLSIDDATA2>()) == 0 }
+        self.m_clsid == other.m_clsid && self.m_appid == other.m_appid && self.m_partid == other.m_partid && self.m_pwszAppName == other.m_pwszAppName && self.m_pwszCtxName == other.m_pwszCtxName && self.m_eAppType == other.m_eAppType && self.m_cReferences == other.m_cReferences && self.m_cBound == other.m_cBound && self.m_cPooled == other.m_cPooled && self.m_cInCall == other.m_cInCall && self.m_dwRespTime == other.m_dwRespTime && self.m_cCallsCompleted == other.m_cCallsCompleted && self.m_cCallsFailed == other.m_cCallsFailed
     }
 }
 impl ::core::cmp::Eq for CLSIDDATA2 {}
@@ -9923,7 +9923,7 @@ unsafe impl ::windows::core::Abi for COMSVCSEVENTINFO {
 }
 impl ::core::cmp::PartialEq for COMSVCSEVENTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMSVCSEVENTINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwPid == other.dwPid && self.lTime == other.lTime && self.lMicroTime == other.lMicroTime && self.perfCount == other.perfCount && self.guidApp == other.guidApp && self.sMachineName == other.sMachineName
     }
 }
 impl ::core::cmp::Eq for COMSVCSEVENTINFO {}
@@ -9961,7 +9961,7 @@ unsafe impl ::windows::core::Abi for ComponentHangMonitorInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ComponentHangMonitorInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ComponentHangMonitorInfo>()) == 0 }
+        self.IsMonitored == other.IsMonitored && self.TerminateOnHang == other.TerminateOnHang && self.AvgCallThresholdInMs == other.AvgCallThresholdInMs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10019,7 +10019,7 @@ unsafe impl ::windows::core::Abi for ComponentStatistics {
 }
 impl ::core::cmp::PartialEq for ComponentStatistics {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ComponentStatistics>()) == 0 }
+        self.NumInstances == other.NumInstances && self.NumBoundReferences == other.NumBoundReferences && self.NumPooledObjects == other.NumPooledObjects && self.NumObjectsInCall == other.NumObjectsInCall && self.AvgResponseTimeInMs == other.AvgResponseTimeInMs && self.NumCallsCompletedRecent == other.NumCallsCompletedRecent && self.NumCallsFailedRecent == other.NumCallsFailedRecent && self.NumCallsCompletedTotal == other.NumCallsCompletedTotal && self.NumCallsFailedTotal == other.NumCallsFailedTotal && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4
     }
 }
 impl ::core::cmp::Eq for ComponentStatistics {}
@@ -10054,7 +10054,7 @@ unsafe impl ::windows::core::Abi for ComponentSummary {
 }
 impl ::core::cmp::PartialEq for ComponentSummary {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ComponentSummary>()) == 0 }
+        self.ApplicationInstanceId == other.ApplicationInstanceId && self.PartitionId == other.PartitionId && self.ApplicationId == other.ApplicationId && self.Clsid == other.Clsid && self.ClassName == other.ClassName && self.ApplicationName == other.ApplicationName
     }
 }
 impl ::core::cmp::Eq for ComponentSummary {}
@@ -10092,7 +10092,7 @@ unsafe impl ::windows::core::Abi for CrmLogRecordRead {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for CrmLogRecordRead {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CrmLogRecordRead>()) == 0 }
+        self.dwCrmFlags == other.dwCrmFlags && self.dwSequenceNumber == other.dwSequenceNumber && self.blobUserData == other.blobUserData
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -10135,7 +10135,7 @@ unsafe impl ::windows::core::Abi for HANG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HANG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HANG_INFO>()) == 0 }
+        self.fAppHangMonitorEnabled == other.fAppHangMonitorEnabled && self.fTerminateOnHang == other.fTerminateOnHang && self.DumpType == other.DumpType && self.dwHangTimeout == other.dwHangTimeout && self.dwDumpCount == other.dwDumpCount && self.dwInfoMsgCount == other.dwInfoMsgCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10171,7 +10171,7 @@ unsafe impl ::windows::core::Abi for RECYCLE_INFO {
 }
 impl ::core::cmp::PartialEq for RECYCLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECYCLE_INFO>()) == 0 }
+        self.guidCombaseProcessIdentifier == other.guidCombaseProcessIdentifier && self.ProcessStartTime == other.ProcessStartTime && self.dwRecycleLifetimeLimit == other.dwRecycleLifetimeLimit && self.dwRecycleMemoryLimit == other.dwRecycleMemoryLimit && self.dwRecycleExpirationTimeout == other.dwRecycleExpirationTimeout
     }
 }
 impl ::core::cmp::Eq for RECYCLE_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
@@ -1164,14 +1164,6 @@ unsafe impl ::windows::core::Abi for CHAR_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHAR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHAR_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHAR_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHAR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1196,14 +1188,6 @@ impl ::core::clone::Clone for CHAR_INFO_0 {
 unsafe impl ::windows::core::Abi for CHAR_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHAR_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHAR_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHAR_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHAR_INFO_0 {
     fn default() -> Self {
@@ -1238,7 +1222,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_CURSOR_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONSOLE_CURSOR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_CURSOR_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.bVisible == other.bVisible
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1271,7 +1255,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_FONT_INFO {
 }
 impl ::core::cmp::PartialEq for CONSOLE_FONT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_FONT_INFO>()) == 0 }
+        self.nFont == other.nFont && self.dwFontSize == other.dwFontSize
     }
 }
 impl ::core::cmp::Eq for CONSOLE_FONT_INFO {}
@@ -1306,7 +1290,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_FONT_INFOEX {
 }
 impl ::core::cmp::PartialEq for CONSOLE_FONT_INFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_FONT_INFOEX>()) == 0 }
+        self.cbSize == other.cbSize && self.nFont == other.nFont && self.dwFontSize == other.dwFontSize && self.FontFamily == other.FontFamily && self.FontWeight == other.FontWeight && self.FaceName == other.FaceName
     }
 }
 impl ::core::cmp::Eq for CONSOLE_FONT_INFOEX {}
@@ -1339,7 +1323,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_HISTORY_INFO {
 }
 impl ::core::cmp::PartialEq for CONSOLE_HISTORY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_HISTORY_INFO>()) == 0 }
+        self.cbSize == other.cbSize && self.HistoryBufferSize == other.HistoryBufferSize && self.NumberOfHistoryBuffers == other.NumberOfHistoryBuffers && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CONSOLE_HISTORY_INFO {}
@@ -1372,7 +1356,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_READCONSOLE_CONTROL {
 }
 impl ::core::cmp::PartialEq for CONSOLE_READCONSOLE_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_READCONSOLE_CONTROL>()) == 0 }
+        self.nLength == other.nLength && self.nInitialChars == other.nInitialChars && self.dwCtrlWakeupMask == other.dwCtrlWakeupMask && self.dwControlKeyState == other.dwControlKeyState
     }
 }
 impl ::core::cmp::Eq for CONSOLE_READCONSOLE_CONTROL {}
@@ -1406,7 +1390,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_SCREEN_BUFFER_INFO {
 }
 impl ::core::cmp::PartialEq for CONSOLE_SCREEN_BUFFER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_SCREEN_BUFFER_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCursorPosition == other.dwCursorPosition && self.wAttributes == other.wAttributes && self.srWindow == other.srWindow && self.dwMaximumWindowSize == other.dwMaximumWindowSize
     }
 }
 impl ::core::cmp::Eq for CONSOLE_SCREEN_BUFFER_INFO {}
@@ -1450,7 +1434,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_SCREEN_BUFFER_INFOEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CONSOLE_SCREEN_BUFFER_INFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_SCREEN_BUFFER_INFOEX>()) == 0 }
+        self.cbSize == other.cbSize && self.dwSize == other.dwSize && self.dwCursorPosition == other.dwCursorPosition && self.wAttributes == other.wAttributes && self.srWindow == other.srWindow && self.dwMaximumWindowSize == other.dwMaximumWindowSize && self.wPopupAttributes == other.wPopupAttributes && self.bFullscreenSupported == other.bFullscreenSupported && self.ColorTable == other.ColorTable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1484,7 +1468,7 @@ unsafe impl ::windows::core::Abi for CONSOLE_SELECTION_INFO {
 }
 impl ::core::cmp::PartialEq for CONSOLE_SELECTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONSOLE_SELECTION_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwSelectionAnchor == other.dwSelectionAnchor && self.srSelection == other.srSelection
     }
 }
 impl ::core::cmp::Eq for CONSOLE_SELECTION_INFO {}
@@ -1515,7 +1499,7 @@ unsafe impl ::windows::core::Abi for COORD {
 }
 impl ::core::cmp::PartialEq for COORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COORD>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for COORD {}
@@ -1551,7 +1535,7 @@ unsafe impl ::windows::core::Abi for FOCUS_EVENT_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FOCUS_EVENT_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FOCUS_EVENT_RECORD>()) == 0 }
+        self.bSetFocus == other.bSetFocus
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1614,14 +1598,6 @@ unsafe impl ::windows::core::Abi for INPUT_RECORD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INPUT_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_RECORD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INPUT_RECORD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INPUT_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1649,14 +1625,6 @@ impl ::core::clone::Clone for INPUT_RECORD_0 {
 unsafe impl ::windows::core::Abi for INPUT_RECORD_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for INPUT_RECORD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_RECORD_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for INPUT_RECORD_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for INPUT_RECORD_0 {
     fn default() -> Self {
@@ -1687,14 +1655,6 @@ unsafe impl ::windows::core::Abi for KEY_EVENT_RECORD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KEY_EVENT_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEY_EVENT_RECORD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KEY_EVENT_RECORD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KEY_EVENT_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1719,14 +1679,6 @@ impl ::core::clone::Clone for KEY_EVENT_RECORD_0 {
 unsafe impl ::windows::core::Abi for KEY_EVENT_RECORD_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for KEY_EVENT_RECORD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEY_EVENT_RECORD_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for KEY_EVENT_RECORD_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for KEY_EVENT_RECORD_0 {
     fn default() -> Self {
@@ -1754,7 +1706,7 @@ unsafe impl ::windows::core::Abi for MENU_EVENT_RECORD {
 }
 impl ::core::cmp::PartialEq for MENU_EVENT_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENU_EVENT_RECORD>()) == 0 }
+        self.dwCommandId == other.dwCommandId
     }
 }
 impl ::core::cmp::Eq for MENU_EVENT_RECORD {}
@@ -1787,7 +1739,7 @@ unsafe impl ::windows::core::Abi for MOUSE_EVENT_RECORD {
 }
 impl ::core::cmp::PartialEq for MOUSE_EVENT_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSE_EVENT_RECORD>()) == 0 }
+        self.dwMousePosition == other.dwMousePosition && self.dwButtonState == other.dwButtonState && self.dwControlKeyState == other.dwControlKeyState && self.dwEventFlags == other.dwEventFlags
     }
 }
 impl ::core::cmp::Eq for MOUSE_EVENT_RECORD {}
@@ -1820,7 +1772,7 @@ unsafe impl ::windows::core::Abi for SMALL_RECT {
 }
 impl ::core::cmp::PartialEq for SMALL_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMALL_RECT>()) == 0 }
+        self.Left == other.Left && self.Top == other.Top && self.Right == other.Right && self.Bottom == other.Bottom
     }
 }
 impl ::core::cmp::Eq for SMALL_RECT {}
@@ -1850,7 +1802,7 @@ unsafe impl ::windows::core::Abi for WINDOW_BUFFER_SIZE_RECORD {
 }
 impl ::core::cmp::PartialEq for WINDOW_BUFFER_SIZE_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOW_BUFFER_SIZE_RECORD>()) == 0 }
+        self.dwSize == other.dwSize
     }
 }
 impl ::core::cmp::Eq for WINDOW_BUFFER_SIZE_RECORD {}

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -1706,7 +1706,7 @@ unsafe impl ::windows::core::Abi for CONTACT_AGGREGATION_BLOB {
 }
 impl ::core::cmp::PartialEq for CONTACT_AGGREGATION_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTACT_AGGREGATION_BLOB>()) == 0 }
+        self.dwCount == other.dwCount && self.lpb == other.lpb
     }
 }
 impl ::core::cmp::Eq for CONTACT_AGGREGATION_BLOB {}

--- a/crates/libs/windows/src/Windows/Win32/System/CorrelationVector/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/CorrelationVector/mod.rs
@@ -64,7 +64,7 @@ unsafe impl ::windows::core::Abi for CORRELATION_VECTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CORRELATION_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CORRELATION_VECTOR>()) == 0 }
+        self.Version == other.Version && self.Vector == other.Vector
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
@@ -1181,7 +1181,7 @@ unsafe impl ::windows::core::Abi for CONVCONTEXT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for CONVCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONVCONTEXT>()) == 0 }
+        self.cb == other.cb && self.wFlags == other.wFlags && self.wCountryID == other.wCountryID && self.iCodePage == other.iCodePage && self.dwLangID == other.dwLangID && self.dwSecurity == other.dwSecurity && self.qos == other.qos
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -1251,7 +1251,7 @@ unsafe impl ::windows::core::Abi for CONVINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for CONVINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONVINFO>()) == 0 }
+        self.cb == other.cb && self.hUser == other.hUser && self.hConvPartner == other.hConvPartner && self.hszSvcPartner == other.hszSvcPartner && self.hszServiceReq == other.hszServiceReq && self.hszTopic == other.hszTopic && self.hszItem == other.hszItem && self.wFmt == other.wFmt && self.wType == other.wType && self.wStatus == other.wStatus && self.wConvst == other.wConvst && self.wLastError == other.wLastError && self.hConvList == other.hConvList && self.ConvCtxt == other.ConvCtxt && self.hwnd == other.hwnd && self.hwndPartner == other.hwndPartner
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -1285,7 +1285,7 @@ unsafe impl ::windows::core::Abi for COPYDATASTRUCT {
 }
 impl ::core::cmp::PartialEq for COPYDATASTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COPYDATASTRUCT>()) == 0 }
+        self.dwData == other.dwData && self.cbData == other.cbData && self.lpData == other.lpData
     }
 }
 impl ::core::cmp::Eq for COPYDATASTRUCT {}
@@ -1315,7 +1315,7 @@ unsafe impl ::windows::core::Abi for DDEACK {
 }
 impl ::core::cmp::PartialEq for DDEACK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEACK>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DDEACK {}
@@ -1346,7 +1346,7 @@ unsafe impl ::windows::core::Abi for DDEADVISE {
 }
 impl ::core::cmp::PartialEq for DDEADVISE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEADVISE>()) == 0 }
+        self._bitfield == other._bitfield && self.cfFormat == other.cfFormat
     }
 }
 impl ::core::cmp::Eq for DDEADVISE {}
@@ -1378,7 +1378,7 @@ unsafe impl ::windows::core::Abi for DDEDATA {
 }
 impl ::core::cmp::PartialEq for DDEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEDATA>()) == 0 }
+        self._bitfield == other._bitfield && self.cfFormat == other.cfFormat && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DDEDATA {}
@@ -1409,7 +1409,7 @@ unsafe impl ::windows::core::Abi for DDELN {
 }
 impl ::core::cmp::PartialEq for DDELN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDELN>()) == 0 }
+        self._bitfield == other._bitfield && self.cfFormat == other.cfFormat
     }
 }
 impl ::core::cmp::Eq for DDELN {}
@@ -1442,7 +1442,7 @@ unsafe impl ::windows::core::Abi for DDEML_MSG_HOOK_DATA {
 }
 impl ::core::cmp::PartialEq for DDEML_MSG_HOOK_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEML_MSG_HOOK_DATA>()) == 0 }
+        self.uiLo == other.uiLo && self.uiHi == other.uiHi && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DDEML_MSG_HOOK_DATA {}
@@ -1474,7 +1474,7 @@ unsafe impl ::windows::core::Abi for DDEPOKE {
 }
 impl ::core::cmp::PartialEq for DDEPOKE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEPOKE>()) == 0 }
+        self._bitfield == other._bitfield && self.cfFormat == other.cfFormat && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for DDEPOKE {}
@@ -1506,7 +1506,7 @@ unsafe impl ::windows::core::Abi for DDEUP {
 }
 impl ::core::cmp::PartialEq for DDEUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DDEUP>()) == 0 }
+        self._bitfield == other._bitfield && self.cfFormat == other.cfFormat && self.rgb == other.rgb
     }
 }
 impl ::core::cmp::Eq for DDEUP {}
@@ -1665,7 +1665,7 @@ unsafe impl ::windows::core::Abi for HSZPAIR {
 }
 impl ::core::cmp::PartialEq for HSZPAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSZPAIR>()) == 0 }
+        self.hszSvc == other.hszSvc && self.hszTopic == other.hszTopic
     }
 }
 impl ::core::cmp::Eq for HSZPAIR {}
@@ -1704,7 +1704,7 @@ unsafe impl ::windows::core::Abi for METAFILEPICT {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for METAFILEPICT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METAFILEPICT>()) == 0 }
+        self.mm == other.mm && self.xExt == other.xExt && self.yExt == other.yExt && self.hMF == other.hMF
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1756,7 +1756,7 @@ unsafe impl ::windows::core::Abi for MONCBSTRUCT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for MONCBSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONCBSTRUCT>()) == 0 }
+        self.cb == other.cb && self.dwTime == other.dwTime && self.hTask == other.hTask && self.dwRet == other.dwRet && self.wType == other.wType && self.wFmt == other.wFmt && self.hConv == other.hConv && self.hsz1 == other.hsz1 && self.hsz2 == other.hsz2 && self.hData == other.hData && self.dwData1 == other.dwData1 && self.dwData2 == other.dwData2 && self.cc == other.cc && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -1801,7 +1801,7 @@ unsafe impl ::windows::core::Abi for MONCONVSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONCONVSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONCONVSTRUCT>()) == 0 }
+        self.cb == other.cb && self.fConnect == other.fConnect && self.dwTime == other.dwTime && self.hTask == other.hTask && self.hszSvc == other.hszSvc && self.hszTopic == other.hszTopic && self.hConvClient == other.hConvClient && self.hConvServer == other.hConvServer
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1842,7 +1842,7 @@ unsafe impl ::windows::core::Abi for MONERRSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONERRSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONERRSTRUCT>()) == 0 }
+        self.cb == other.cb && self.wLastError == other.wLastError && self.dwTime == other.dwTime && self.hTask == other.hTask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1885,7 +1885,7 @@ unsafe impl ::windows::core::Abi for MONHSZSTRUCTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONHSZSTRUCTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONHSZSTRUCTA>()) == 0 }
+        self.cb == other.cb && self.fsAction == other.fsAction && self.dwTime == other.dwTime && self.hsz == other.hsz && self.hTask == other.hTask && self.str == other.str
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1928,7 +1928,7 @@ unsafe impl ::windows::core::Abi for MONHSZSTRUCTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONHSZSTRUCTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONHSZSTRUCTW>()) == 0 }
+        self.cb == other.cb && self.fsAction == other.fsAction && self.dwTime == other.dwTime && self.hsz == other.hsz && self.hTask == other.hTask && self.str == other.str
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1977,7 +1977,7 @@ unsafe impl ::windows::core::Abi for MONLINKSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONLINKSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONLINKSTRUCT>()) == 0 }
+        self.cb == other.cb && self.dwTime == other.dwTime && self.hTask == other.hTask && self.fEstablished == other.fEstablished && self.fNoData == other.fNoData && self.hszSvc == other.hszSvc && self.hszTopic == other.hszTopic && self.hszItem == other.hszItem && self.wFmt == other.wFmt && self.fServer == other.fServer && self.hConvServer == other.hConvServer && self.hConvClient == other.hConvClient
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2022,7 +2022,7 @@ unsafe impl ::windows::core::Abi for MONMSGSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MONMSGSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONMSGSTRUCT>()) == 0 }
+        self.cb == other.cb && self.hwndTo == other.hwndTo && self.dwTime == other.dwTime && self.hTask == other.hTask && self.wMsg == other.wMsg && self.wParam == other.wParam && self.lParam == other.lParam && self.dmhd == other.dmhd
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
@@ -4287,12 +4287,6 @@ impl ::core::clone::Clone for PXE_ADDRESS {
 unsafe impl ::windows::core::Abi for PXE_ADDRESS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_ADDRESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_ADDRESS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_ADDRESS {}
 impl ::core::default::Default for PXE_ADDRESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4313,12 +4307,6 @@ impl ::core::clone::Clone for PXE_ADDRESS_0 {
 unsafe impl ::windows::core::Abi for PXE_ADDRESS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_ADDRESS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_ADDRESS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_ADDRESS_0 {}
 impl ::core::default::Default for PXE_ADDRESS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4342,12 +4330,6 @@ impl ::core::clone::Clone for PXE_DHCPV6_MESSAGE {
 unsafe impl ::windows::core::Abi for PXE_DHCPV6_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCPV6_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCPV6_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCPV6_MESSAGE {}
 impl ::core::default::Default for PXE_DHCPV6_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4368,12 +4350,6 @@ impl ::core::clone::Clone for PXE_DHCPV6_MESSAGE_HEADER {
 unsafe impl ::windows::core::Abi for PXE_DHCPV6_MESSAGE_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCPV6_MESSAGE_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCPV6_MESSAGE_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCPV6_MESSAGE_HEADER {}
 impl ::core::default::Default for PXE_DHCPV6_MESSAGE_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4403,7 +4379,7 @@ unsafe impl ::windows::core::Abi for PXE_DHCPV6_NESTED_RELAY_MESSAGE {
 }
 impl ::core::cmp::PartialEq for PXE_DHCPV6_NESTED_RELAY_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCPV6_NESTED_RELAY_MESSAGE>()) == 0 }
+        self.pRelayMessage == other.pRelayMessage && self.cbRelayMessage == other.cbRelayMessage && self.pInterfaceIdOption == other.pInterfaceIdOption && self.cbInterfaceIdOption == other.cbInterfaceIdOption
     }
 }
 impl ::core::cmp::Eq for PXE_DHCPV6_NESTED_RELAY_MESSAGE {}
@@ -4428,12 +4404,6 @@ impl ::core::clone::Clone for PXE_DHCPV6_OPTION {
 unsafe impl ::windows::core::Abi for PXE_DHCPV6_OPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCPV6_OPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCPV6_OPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCPV6_OPTION {}
 impl ::core::default::Default for PXE_DHCPV6_OPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4457,12 +4427,6 @@ impl ::core::clone::Clone for PXE_DHCPV6_RELAY_MESSAGE {
 unsafe impl ::windows::core::Abi for PXE_DHCPV6_RELAY_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCPV6_RELAY_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCPV6_RELAY_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCPV6_RELAY_MESSAGE {}
 impl ::core::default::Default for PXE_DHCPV6_RELAY_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4497,12 +4461,6 @@ impl ::core::clone::Clone for PXE_DHCP_MESSAGE {
 unsafe impl ::windows::core::Abi for PXE_DHCP_MESSAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCP_MESSAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCP_MESSAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCP_MESSAGE {}
 impl ::core::default::Default for PXE_DHCP_MESSAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4523,12 +4481,6 @@ impl ::core::clone::Clone for PXE_DHCP_MESSAGE_0 {
 unsafe impl ::windows::core::Abi for PXE_DHCP_MESSAGE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCP_MESSAGE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCP_MESSAGE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCP_MESSAGE_0 {}
 impl ::core::default::Default for PXE_DHCP_MESSAGE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4550,12 +4502,6 @@ impl ::core::clone::Clone for PXE_DHCP_OPTION {
 unsafe impl ::windows::core::Abi for PXE_DHCP_OPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PXE_DHCP_OPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_DHCP_OPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PXE_DHCP_OPTION {}
 impl ::core::default::Default for PXE_DHCP_OPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4592,7 +4538,7 @@ unsafe impl ::windows::core::Abi for PXE_PROVIDER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PXE_PROVIDER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PXE_PROVIDER>()) == 0 }
+        self.uSizeOfStruct == other.uSizeOfStruct && self.pwszName == other.pwszName && self.pwszFilePath == other.pwszFilePath && self.bIsCritical == other.bIsCritical && self.uIndex == other.uIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4626,7 +4572,7 @@ unsafe impl ::windows::core::Abi for TRANSPORTCLIENT_SESSION_INFO {
 }
 impl ::core::cmp::PartialEq for TRANSPORTCLIENT_SESSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORTCLIENT_SESSION_INFO>()) == 0 }
+        self.ulStructureLength == other.ulStructureLength && self.ullFileSize == other.ullFileSize && self.ulBlockSize == other.ulBlockSize
     }
 }
 impl ::core::cmp::Eq for TRANSPORTCLIENT_SESSION_INFO {}
@@ -4658,7 +4604,7 @@ unsafe impl ::windows::core::Abi for WDS_CLI_CRED {
 }
 impl ::core::cmp::PartialEq for WDS_CLI_CRED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDS_CLI_CRED>()) == 0 }
+        self.pwszUserName == other.pwszUserName && self.pwszDomain == other.pwszDomain && self.pwszPassword == other.pwszPassword
     }
 }
 impl ::core::cmp::Eq for WDS_CLI_CRED {}
@@ -4689,21 +4635,13 @@ impl ::core::clone::Clone for WDS_TRANSPORTCLIENT_CALLBACKS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for WDS_TRANSPORTCLIENT_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WDS_TRANSPORTCLIENT_CALLBACKS").field("SessionStart", &self.SessionStart.map(|f| f as usize)).field("SessionStartEx", &self.SessionStartEx.map(|f| f as usize)).field("ReceiveContents", &self.ReceiveContents.map(|f| f as usize)).field("ReceiveMetadata", &self.ReceiveMetadata.map(|f| f as usize)).field("SessionComplete", &self.SessionComplete.map(|f| f as usize)).field("SessionNegotiate", &self.SessionNegotiate.map(|f| f as usize)).finish()
+        f.debug_struct("WDS_TRANSPORTCLIENT_CALLBACKS").finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for WDS_TRANSPORTCLIENT_CALLBACKS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WDS_TRANSPORTCLIENT_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDS_TRANSPORTCLIENT_CALLBACKS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WDS_TRANSPORTCLIENT_CALLBACKS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WDS_TRANSPORTCLIENT_CALLBACKS {
     fn default() -> Self {
@@ -4740,7 +4678,7 @@ unsafe impl ::windows::core::Abi for WDS_TRANSPORTCLIENT_REQUEST {
 }
 impl ::core::cmp::PartialEq for WDS_TRANSPORTCLIENT_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDS_TRANSPORTCLIENT_REQUEST>()) == 0 }
+        self.ulLength == other.ulLength && self.ulApiVersion == other.ulApiVersion && self.ulAuthLevel == other.ulAuthLevel && self.pwszServer == other.pwszServer && self.pwszNamespace == other.pwszNamespace && self.pwszObjectName == other.pwszObjectName && self.ulCacheSize == other.ulCacheSize && self.ulProtocol == other.ulProtocol && self.pvProtocolData == other.pvProtocolData && self.ulProtocolDataLength == other.ulProtocolDataLength
     }
 }
 impl ::core::cmp::Eq for WDS_TRANSPORTCLIENT_REQUEST {}
@@ -4779,7 +4717,7 @@ unsafe impl ::windows::core::Abi for WDS_TRANSPORTPROVIDER_INIT_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::cmp::PartialEq for WDS_TRANSPORTPROVIDER_INIT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDS_TRANSPORTPROVIDER_INIT_PARAMS>()) == 0 }
+        self.ulLength == other.ulLength && self.ulMcServerVersion == other.ulMcServerVersion && self.hRegistryKey == other.hRegistryKey && self.hProvider == other.hProvider
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
@@ -4812,7 +4750,7 @@ unsafe impl ::windows::core::Abi for WDS_TRANSPORTPROVIDER_SETTINGS {
 }
 impl ::core::cmp::PartialEq for WDS_TRANSPORTPROVIDER_SETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDS_TRANSPORTPROVIDER_SETTINGS>()) == 0 }
+        self.ulLength == other.ulLength && self.ulProviderVersion == other.ulProviderVersion
     }
 }
 impl ::core::cmp::Eq for WDS_TRANSPORTPROVIDER_SETTINGS {}

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
@@ -2684,7 +2684,7 @@ unsafe impl ::windows::core::Abi for __ReferenceRemainingTypes__ {
 }
 impl ::core::cmp::PartialEq for __ReferenceRemainingTypes__ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<__ReferenceRemainingTypes__>()) == 0 }
+        self.__ctrlLevel__ == other.__ctrlLevel__ && self.__attendeeDisconnectReason__ == other.__attendeeDisconnectReason__ && self.__channelPriority__ == other.__channelPriority__ && self.__channelFlags__ == other.__channelFlags__ && self.__channelAccessEnum__ == other.__channelAccessEnum__ && self.__rdpencomapiAttendeeFlags__ == other.__rdpencomapiAttendeeFlags__ && self.__rdpsrapiWndFlags__ == other.__rdpsrapiWndFlags__ && self.__rdpsrapiAppFlags__ == other.__rdpsrapiAppFlags__
     }
 }
 impl ::core::cmp::Eq for __ReferenceRemainingTypes__ {}

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -41116,7 +41116,7 @@ unsafe impl ::windows::core::Abi for ADDRESS {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRESS>()) == 0 }
+        self.Offset == other.Offset && self.Segment == other.Segment && self.Mode == other.Mode
     }
 }
 #[cfg(target_arch = "x86")]
@@ -41150,7 +41150,7 @@ unsafe impl ::windows::core::Abi for ADDRESS64 {
 }
 impl ::core::cmp::PartialEq for ADDRESS64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADDRESS64>()) == 0 }
+        self.Offset == other.Offset && self.Segment == other.Segment && self.Mode == other.Mode
     }
 }
 impl ::core::cmp::Eq for ADDRESS64 {}
@@ -41174,12 +41174,6 @@ impl ::core::clone::Clone for AER_BRIDGE_DESCRIPTOR_FLAGS {
 unsafe impl ::windows::core::Abi for AER_BRIDGE_DESCRIPTOR_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_BRIDGE_DESCRIPTOR_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_BRIDGE_DESCRIPTOR_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_BRIDGE_DESCRIPTOR_FLAGS {}
 impl ::core::default::Default for AER_BRIDGE_DESCRIPTOR_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41199,12 +41193,6 @@ impl ::core::clone::Clone for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
 unsafe impl ::windows::core::Abi for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_BRIDGE_DESCRIPTOR_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {}
 impl ::core::default::Default for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41225,12 +41213,6 @@ impl ::core::clone::Clone for AER_ENDPOINT_DESCRIPTOR_FLAGS {
 unsafe impl ::windows::core::Abi for AER_ENDPOINT_DESCRIPTOR_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_ENDPOINT_DESCRIPTOR_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_ENDPOINT_DESCRIPTOR_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_ENDPOINT_DESCRIPTOR_FLAGS {}
 impl ::core::default::Default for AER_ENDPOINT_DESCRIPTOR_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41250,12 +41232,6 @@ impl ::core::clone::Clone for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
 unsafe impl ::windows::core::Abi for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_ENDPOINT_DESCRIPTOR_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {}
 impl ::core::default::Default for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41276,12 +41252,6 @@ impl ::core::clone::Clone for AER_ROOTPORT_DESCRIPTOR_FLAGS {
 unsafe impl ::windows::core::Abi for AER_ROOTPORT_DESCRIPTOR_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_ROOTPORT_DESCRIPTOR_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_ROOTPORT_DESCRIPTOR_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_ROOTPORT_DESCRIPTOR_FLAGS {}
 impl ::core::default::Default for AER_ROOTPORT_DESCRIPTOR_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41301,12 +41271,6 @@ impl ::core::clone::Clone for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
 unsafe impl ::windows::core::Abi for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AER_ROOTPORT_DESCRIPTOR_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {}
 impl ::core::default::Default for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41336,7 +41300,7 @@ unsafe impl ::windows::core::Abi for API_VERSION {
 }
 impl ::core::cmp::PartialEq for API_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<API_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.Revision == other.Revision && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for API_VERSION {}
@@ -41375,14 +41339,6 @@ unsafe impl ::windows::core::Abi for ARM64_NT_CONTEXT {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for ARM64_NT_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARM64_NT_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for ARM64_NT_CONTEXT {}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl ::core::default::Default for ARM64_NT_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41407,14 +41363,6 @@ impl ::core::clone::Clone for ARM64_NT_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for ARM64_NT_CONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for ARM64_NT_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARM64_NT_CONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for ARM64_NT_CONTEXT_0 {}
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl ::core::default::Default for ARM64_NT_CONTEXT_0 {
     fn default() -> Self {
@@ -41510,7 +41458,7 @@ unsafe impl ::windows::core::Abi for ARM64_NT_CONTEXT_0_0 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for ARM64_NT_CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARM64_NT_CONTEXT_0_0>()) == 0 }
+        self.X0 == other.X0 && self.X1 == other.X1 && self.X2 == other.X2 && self.X3 == other.X3 && self.X4 == other.X4 && self.X5 == other.X5 && self.X6 == other.X6 && self.X7 == other.X7 && self.X8 == other.X8 && self.X9 == other.X9 && self.X10 == other.X10 && self.X11 == other.X11 && self.X12 == other.X12 && self.X13 == other.X13 && self.X14 == other.X14 && self.X15 == other.X15 && self.X16 == other.X16 && self.X17 == other.X17 && self.X18 == other.X18 && self.X19 == other.X19 && self.X20 == other.X20 && self.X21 == other.X21 && self.X22 == other.X22 && self.X23 == other.X23 && self.X24 == other.X24 && self.X25 == other.X25 && self.X26 == other.X26 && self.X27 == other.X27 && self.X28 == other.X28 && self.Fp == other.Fp && self.Lr == other.Lr
     }
 }
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -41539,12 +41487,6 @@ impl ::core::clone::Clone for ARM64_NT_NEON128 {
 unsafe impl ::windows::core::Abi for ARM64_NT_NEON128 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ARM64_NT_NEON128 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARM64_NT_NEON128>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ARM64_NT_NEON128 {}
 impl ::core::default::Default for ARM64_NT_NEON128 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41572,7 +41514,7 @@ unsafe impl ::windows::core::Abi for ARM64_NT_NEON128_0 {
 }
 impl ::core::cmp::PartialEq for ARM64_NT_NEON128_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARM64_NT_NEON128_0>()) == 0 }
+        self.Low == other.Low && self.High == other.High
     }
 }
 impl ::core::cmp::Eq for ARM64_NT_NEON128_0 {}
@@ -41604,7 +41546,7 @@ unsafe impl ::windows::core::Abi for ArrayDimension {
 }
 impl ::core::cmp::PartialEq for ArrayDimension {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ArrayDimension>()) == 0 }
+        self.LowerBound == other.LowerBound && self.Length == other.Length && self.Stride == other.Stride
     }
 }
 impl ::core::cmp::Eq for ArrayDimension {}
@@ -41639,7 +41581,7 @@ unsafe impl ::windows::core::Abi for BUSDATA {
 }
 impl ::core::cmp::PartialEq for BUSDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUSDATA>()) == 0 }
+        self.BusDataType == other.BusDataType && self.BusNumber == other.BusNumber && self.SlotNumber == other.SlotNumber && self.Buffer == other.Buffer && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for BUSDATA {}
@@ -41683,16 +41625,6 @@ unsafe impl ::windows::core::Abi for CONTEXT {
 }
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for CONTEXT {}
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41721,16 +41653,6 @@ impl ::core::clone::Clone for CONTEXT_0 {
 unsafe impl ::windows::core::Abi for CONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for CONTEXT_0 {}
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for CONTEXT_0 {
@@ -41833,7 +41755,7 @@ unsafe impl ::windows::core::Abi for CONTEXT_0_0 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT_0_0>()) == 0 }
+        self.X0 == other.X0 && self.X1 == other.X1 && self.X2 == other.X2 && self.X3 == other.X3 && self.X4 == other.X4 && self.X5 == other.X5 && self.X6 == other.X6 && self.X7 == other.X7 && self.X8 == other.X8 && self.X9 == other.X9 && self.X10 == other.X10 && self.X11 == other.X11 && self.X12 == other.X12 && self.X13 == other.X13 && self.X14 == other.X14 && self.X15 == other.X15 && self.X16 == other.X16 && self.X17 == other.X17 && self.X18 == other.X18 && self.X19 == other.X19 && self.X20 == other.X20 && self.X21 == other.X21 && self.X22 == other.X22 && self.X23 == other.X23 && self.X24 == other.X24 && self.X25 == other.X25 && self.X26 == other.X26 && self.X27 == other.X27 && self.X28 == other.X28 && self.Fp == other.Fp && self.Lr == other.Lr
     }
 }
 #[cfg(target_arch = "aarch64")]
@@ -41915,16 +41837,6 @@ unsafe impl ::windows::core::Abi for CONTEXT {
 }
 #[cfg(target_arch = "x86_64")]
 #[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for CONTEXT {}
-#[cfg(target_arch = "x86_64")]
-#[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -41953,16 +41865,6 @@ impl ::core::clone::Clone for CONTEXT_0 {
 unsafe impl ::windows::core::Abi for CONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86_64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for CONTEXT_0 {}
 #[cfg(target_arch = "x86_64")]
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for CONTEXT_0 {
@@ -42039,7 +41941,7 @@ unsafe impl ::windows::core::Abi for CONTEXT_0_0 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT_0_0>()) == 0 }
+        self.Header == other.Header && self.Legacy == other.Legacy && self.Xmm0 == other.Xmm0 && self.Xmm1 == other.Xmm1 && self.Xmm2 == other.Xmm2 && self.Xmm3 == other.Xmm3 && self.Xmm4 == other.Xmm4 && self.Xmm5 == other.Xmm5 && self.Xmm6 == other.Xmm6 && self.Xmm7 == other.Xmm7 && self.Xmm8 == other.Xmm8 && self.Xmm9 == other.Xmm9 && self.Xmm10 == other.Xmm10 && self.Xmm11 == other.Xmm11 && self.Xmm12 == other.Xmm12 && self.Xmm13 == other.Xmm13 && self.Xmm14 == other.Xmm14 && self.Xmm15 == other.Xmm15
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -42100,16 +42002,6 @@ unsafe impl ::windows::core::Abi for CONTEXT {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for CONTEXT {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -42130,12 +42022,6 @@ impl ::core::clone::Clone for CPU_INFORMATION {
 unsafe impl ::windows::core::Abi for CPU_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CPU_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPU_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CPU_INFORMATION {}
 impl ::core::default::Default for CPU_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -42155,12 +42041,6 @@ impl ::core::clone::Clone for CPU_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for CPU_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CPU_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPU_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CPU_INFORMATION_0 {}
 impl ::core::default::Default for CPU_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -42190,7 +42070,7 @@ unsafe impl ::windows::core::Abi for CPU_INFORMATION_1 {
 }
 impl ::core::cmp::PartialEq for CPU_INFORMATION_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPU_INFORMATION_1>()) == 0 }
+        self.VendorId == other.VendorId && self.VersionInformation == other.VersionInformation && self.FeatureInformation == other.FeatureInformation && self.AMDExtendedCpuFeatures == other.AMDExtendedCpuFeatures
     }
 }
 impl ::core::cmp::Eq for CPU_INFORMATION_1 {}
@@ -42225,32 +42105,13 @@ impl ::core::clone::Clone for CREATE_PROCESS_DEBUG_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::fmt::Debug for CREATE_PROCESS_DEBUG_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CREATE_PROCESS_DEBUG_INFO")
-            .field("hFile", &self.hFile)
-            .field("hProcess", &self.hProcess)
-            .field("hThread", &self.hThread)
-            .field("lpBaseOfImage", &self.lpBaseOfImage)
-            .field("dwDebugInfoFileOffset", &self.dwDebugInfoFileOffset)
-            .field("nDebugInfoSize", &self.nDebugInfoSize)
-            .field("lpThreadLocalBase", &self.lpThreadLocalBase)
-            .field("lpStartAddress", &self.lpStartAddress.map(|f| f as usize))
-            .field("lpImageName", &self.lpImageName)
-            .field("fUnicode", &self.fUnicode)
-            .finish()
+        f.debug_struct("CREATE_PROCESS_DEBUG_INFO").field("hFile", &self.hFile).field("hProcess", &self.hProcess).field("hThread", &self.hThread).field("lpBaseOfImage", &self.lpBaseOfImage).field("dwDebugInfoFileOffset", &self.dwDebugInfoFileOffset).field("nDebugInfoSize", &self.nDebugInfoSize).field("lpThreadLocalBase", &self.lpThreadLocalBase).field("lpImageName", &self.lpImageName).field("fUnicode", &self.fUnicode).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 unsafe impl ::windows::core::Abi for CREATE_PROCESS_DEBUG_INFO {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for CREATE_PROCESS_DEBUG_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_PROCESS_DEBUG_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for CREATE_PROCESS_DEBUG_INFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for CREATE_PROCESS_DEBUG_INFO {
     fn default() -> Self {
@@ -42276,21 +42137,13 @@ impl ::core::clone::Clone for CREATE_THREAD_DEBUG_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::fmt::Debug for CREATE_THREAD_DEBUG_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CREATE_THREAD_DEBUG_INFO").field("hThread", &self.hThread).field("lpThreadLocalBase", &self.lpThreadLocalBase).field("lpStartAddress", &self.lpStartAddress.map(|f| f as usize)).finish()
+        f.debug_struct("CREATE_THREAD_DEBUG_INFO").field("hThread", &self.hThread).field("lpThreadLocalBase", &self.lpThreadLocalBase).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 unsafe impl ::windows::core::Abi for CREATE_THREAD_DEBUG_INFO {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for CREATE_THREAD_DEBUG_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_THREAD_DEBUG_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for CREATE_THREAD_DEBUG_INFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for CREATE_THREAD_DEBUG_INFO {
     fn default() -> Self {
@@ -42319,7 +42172,7 @@ unsafe impl ::windows::core::Abi for DBGHELP_DATA_REPORT_STRUCT {
 }
 impl ::core::cmp::PartialEq for DBGHELP_DATA_REPORT_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBGHELP_DATA_REPORT_STRUCT>()) == 0 }
+        self.pBinPathNonExist == other.pBinPathNonExist && self.pSymbolPathNonExist == other.pSymbolPathNonExist
     }
 }
 impl ::core::cmp::Eq for DBGHELP_DATA_REPORT_STRUCT {}
@@ -42357,7 +42210,7 @@ unsafe impl ::windows::core::Abi for DBGKD_DEBUG_DATA_HEADER32 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for DBGKD_DEBUG_DATA_HEADER32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBGKD_DEBUG_DATA_HEADER32>()) == 0 }
+        self.List == other.List && self.OwnerTag == other.OwnerTag && self.Size == other.Size
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -42397,7 +42250,7 @@ unsafe impl ::windows::core::Abi for DBGKD_DEBUG_DATA_HEADER64 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for DBGKD_DEBUG_DATA_HEADER64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBGKD_DEBUG_DATA_HEADER64>()) == 0 }
+        self.List == other.List && self.OwnerTag == other.OwnerTag && self.Size == other.Size
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -42457,7 +42310,7 @@ unsafe impl ::windows::core::Abi for DBGKD_GET_VERSION32 {
 }
 impl ::core::cmp::PartialEq for DBGKD_GET_VERSION32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBGKD_GET_VERSION32>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.ProtocolVersion == other.ProtocolVersion && self.Flags == other.Flags && self.KernBase == other.KernBase && self.PsLoadedModuleList == other.PsLoadedModuleList && self.MachineType == other.MachineType && self.ThCallbackStack == other.ThCallbackStack && self.NextCallback == other.NextCallback && self.FramePointer == other.FramePointer && self.KiCallUserMode == other.KiCallUserMode && self.KeUserCallbackDispatcher == other.KeUserCallbackDispatcher && self.BreakpointWithStatus == other.BreakpointWithStatus && self.DebuggerDataList == other.DebuggerDataList
     }
 }
 impl ::core::cmp::Eq for DBGKD_GET_VERSION32 {}
@@ -42515,7 +42368,7 @@ unsafe impl ::windows::core::Abi for DBGKD_GET_VERSION64 {
 }
 impl ::core::cmp::PartialEq for DBGKD_GET_VERSION64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBGKD_GET_VERSION64>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.ProtocolVersion == other.ProtocolVersion && self.KdSecondaryVersion == other.KdSecondaryVersion && self.Flags == other.Flags && self.MachineType == other.MachineType && self.MaxPacketType == other.MaxPacketType && self.MaxStateChange == other.MaxStateChange && self.MaxManipulate == other.MaxManipulate && self.Simulation == other.Simulation && self.Unused == other.Unused && self.KernBase == other.KernBase && self.PsLoadedModuleList == other.PsLoadedModuleList && self.DebuggerDataList == other.DebuggerDataList
     }
 }
 impl ::core::cmp::Eq for DBGKD_GET_VERSION64 {}
@@ -42569,7 +42422,7 @@ unsafe impl ::windows::core::Abi for DEBUG_BREAKPOINT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEBUG_BREAKPOINT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_BREAKPOINT_PARAMETERS>()) == 0 }
+        self.Offset == other.Offset && self.Id == other.Id && self.BreakType == other.BreakType && self.ProcType == other.ProcType && self.Flags == other.Flags && self.DataSize == other.DataSize && self.DataAccessType == other.DataAccessType && self.PassCount == other.PassCount && self.CurrentPassCount == other.CurrentPassCount && self.MatchThread == other.MatchThread && self.CommandSize == other.CommandSize && self.OffsetExpressionSize == other.OffsetExpressionSize
     }
 }
 impl ::core::cmp::Eq for DEBUG_BREAKPOINT_PARAMETERS {}
@@ -42603,7 +42456,7 @@ unsafe impl ::windows::core::Abi for DEBUG_CACHED_SYMBOL_INFO {
 }
 impl ::core::cmp::PartialEq for DEBUG_CACHED_SYMBOL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_CACHED_SYMBOL_INFO>()) == 0 }
+        self.ModBase == other.ModBase && self.Arg1 == other.Arg1 && self.Arg2 == other.Arg2 && self.Id == other.Id && self.Arg3 == other.Arg3
     }
 }
 impl ::core::cmp::Eq for DEBUG_CACHED_SYMBOL_INFO {}
@@ -42634,7 +42487,7 @@ unsafe impl ::windows::core::Abi for DEBUG_CLIENT_CONTEXT {
 }
 impl ::core::cmp::PartialEq for DEBUG_CLIENT_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_CLIENT_CONTEXT>()) == 0 }
+        self.cbSize == other.cbSize && self.eClient == other.eClient
     }
 }
 impl ::core::cmp::Eq for DEBUG_CLIENT_CONTEXT {}
@@ -42667,7 +42520,7 @@ unsafe impl ::windows::core::Abi for DEBUG_CREATE_PROCESS_OPTIONS {
 }
 impl ::core::cmp::PartialEq for DEBUG_CREATE_PROCESS_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_CREATE_PROCESS_OPTIONS>()) == 0 }
+        self.CreateFlags == other.CreateFlags && self.EngCreateFlags == other.EngCreateFlags && self.VerifierFlags == other.VerifierFlags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_CREATE_PROCESS_OPTIONS {}
@@ -42697,14 +42550,6 @@ impl ::core::clone::Clone for DEBUG_EVENT {
 unsafe impl ::windows::core::Abi for DEBUG_EVENT {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for DEBUG_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_EVENT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for DEBUG_EVENT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for DEBUG_EVENT {
     fn default() -> Self {
@@ -42738,14 +42583,6 @@ unsafe impl ::windows::core::Abi for DEBUG_EVENT_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for DEBUG_EVENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_EVENT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for DEBUG_EVENT_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for DEBUG_EVENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -42775,7 +42612,7 @@ unsafe impl ::windows::core::Abi for DEBUG_EVENT_CONTEXT {
 }
 impl ::core::cmp::PartialEq for DEBUG_EVENT_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_EVENT_CONTEXT>()) == 0 }
+        self.Size == other.Size && self.ProcessEngineId == other.ProcessEngineId && self.ThreadEngineId == other.ThreadEngineId && self.FrameEngineId == other.FrameEngineId
     }
 }
 impl ::core::cmp::Eq for DEBUG_EVENT_CONTEXT {}
@@ -42810,7 +42647,7 @@ unsafe impl ::windows::core::Abi for DEBUG_EXCEPTION_FILTER_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEBUG_EXCEPTION_FILTER_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_EXCEPTION_FILTER_PARAMETERS>()) == 0 }
+        self.ExecutionOption == other.ExecutionOption && self.ContinueOption == other.ContinueOption && self.TextSize == other.TextSize && self.CommandSize == other.CommandSize && self.SecondCommandSize == other.SecondCommandSize && self.ExceptionCode == other.ExceptionCode
     }
 }
 impl ::core::cmp::Eq for DEBUG_EXCEPTION_FILTER_PARAMETERS {}
@@ -42842,7 +42679,7 @@ unsafe impl ::windows::core::Abi for DEBUG_GET_TEXT_COMPLETIONS_IN {
 }
 impl ::core::cmp::PartialEq for DEBUG_GET_TEXT_COMPLETIONS_IN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_GET_TEXT_COMPLETIONS_IN>()) == 0 }
+        self.Flags == other.Flags && self.MatchCountLimit == other.MatchCountLimit && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_GET_TEXT_COMPLETIONS_IN {}
@@ -42876,7 +42713,7 @@ unsafe impl ::windows::core::Abi for DEBUG_GET_TEXT_COMPLETIONS_OUT {
 }
 impl ::core::cmp::PartialEq for DEBUG_GET_TEXT_COMPLETIONS_OUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_GET_TEXT_COMPLETIONS_OUT>()) == 0 }
+        self.Flags == other.Flags && self.ReplaceIndex == other.ReplaceIndex && self.MatchCount == other.MatchCount && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for DEBUG_GET_TEXT_COMPLETIONS_OUT {}
@@ -42911,7 +42748,7 @@ unsafe impl ::windows::core::Abi for DEBUG_HANDLE_DATA_BASIC {
 }
 impl ::core::cmp::PartialEq for DEBUG_HANDLE_DATA_BASIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_HANDLE_DATA_BASIC>()) == 0 }
+        self.TypeNameSize == other.TypeNameSize && self.ObjectNameSize == other.ObjectNameSize && self.Attributes == other.Attributes && self.GrantedAccess == other.GrantedAccess && self.HandleCount == other.HandleCount && self.PointerCount == other.PointerCount
     }
 }
 impl ::core::cmp::Eq for DEBUG_HANDLE_DATA_BASIC {}
@@ -42941,7 +42778,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_BREAKPOINT {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_BREAKPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_BREAKPOINT>()) == 0 }
+        self.Id == other.Id
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_BREAKPOINT {}
@@ -42978,7 +42815,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_EXCEPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_EXCEPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_EXCEPTION>()) == 0 }
+        self.ExceptionRecord == other.ExceptionRecord && self.FirstChance == other.FirstChance
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43010,7 +42847,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_EXIT_PROCESS>()) == 0 }
+        self.ExitCode == other.ExitCode
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {}
@@ -43040,7 +42877,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_EXIT_THREAD {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_EXIT_THREAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_EXIT_THREAD>()) == 0 }
+        self.ExitCode == other.ExitCode
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_EXIT_THREAD {}
@@ -43070,7 +42907,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_LOAD_MODULE {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_LOAD_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_LOAD_MODULE>()) == 0 }
+        self.Base == other.Base
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_LOAD_MODULE {}
@@ -43102,7 +42939,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION>()) == 0 }
+        self.Kind == other.Kind && self.DataSize == other.DataSize && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION {}
@@ -43133,7 +42970,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR>()) == 0 }
+        self.Error == other.Error && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {}
@@ -43163,7 +43000,7 @@ unsafe impl ::windows::core::Abi for DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {
 }
 impl ::core::cmp::PartialEq for DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE>()) == 0 }
+        self.Base == other.Base
     }
 }
 impl ::core::cmp::Eq for DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {}
@@ -43194,7 +43031,7 @@ unsafe impl ::windows::core::Abi for DEBUG_MODULE_AND_ID {
 }
 impl ::core::cmp::PartialEq for DEBUG_MODULE_AND_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_MODULE_AND_ID>()) == 0 }
+        self.ModuleBase == other.ModuleBase && self.Id == other.Id
     }
 }
 impl ::core::cmp::Eq for DEBUG_MODULE_AND_ID {}
@@ -43248,7 +43085,7 @@ unsafe impl ::windows::core::Abi for DEBUG_MODULE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEBUG_MODULE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_MODULE_PARAMETERS>()) == 0 }
+        self.Base == other.Base && self.Size == other.Size && self.TimeDateStamp == other.TimeDateStamp && self.Checksum == other.Checksum && self.Flags == other.Flags && self.SymbolType == other.SymbolType && self.ImageNameSize == other.ImageNameSize && self.ModuleNameSize == other.ModuleNameSize && self.LoadedImageNameSize == other.LoadedImageNameSize && self.SymbolFileNameSize == other.SymbolFileNameSize && self.MappedImageNameSize == other.MappedImageNameSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_MODULE_PARAMETERS {}
@@ -43279,7 +43116,7 @@ unsafe impl ::windows::core::Abi for DEBUG_OFFSET_REGION {
 }
 impl ::core::cmp::PartialEq for DEBUG_OFFSET_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_OFFSET_REGION>()) == 0 }
+        self.Base == other.Base && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for DEBUG_OFFSET_REGION {}
@@ -43312,14 +43149,6 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_ALL {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_ALL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_ALL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DEBUG_PROCESSOR_IDENTIFICATION_ALL {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DEBUG_PROCESSOR_IDENTIFICATION_ALL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -43347,7 +43176,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {
 }
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_ALPHA>()) == 0 }
+        self.Type == other.Type && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {}
@@ -43386,7 +43215,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_AMD64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_AMD64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_AMD64>()) == 0 }
+        self.Family == other.Family && self.Model == other.Model && self.Stepping == other.Stepping && self.VendorString == other.VendorString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43426,7 +43255,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_ARM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_ARM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_ARM>()) == 0 }
+        self.Model == other.Model && self.Revision == other.Revision && self.VendorString == other.VendorString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43466,7 +43295,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_ARM64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_ARM64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_ARM64>()) == 0 }
+        self.Model == other.Model && self.Revision == other.Revision && self.VendorString == other.VendorString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43508,7 +43337,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_IA64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_IA64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_IA64>()) == 0 }
+        self.Model == other.Model && self.Revision == other.Revision && self.Family == other.Family && self.ArchRev == other.ArchRev && self.VendorString == other.VendorString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43549,7 +43378,7 @@ unsafe impl ::windows::core::Abi for DEBUG_PROCESSOR_IDENTIFICATION_X86 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_PROCESSOR_IDENTIFICATION_X86 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_PROCESSOR_IDENTIFICATION_X86>()) == 0 }
+        self.Family == other.Family && self.Model == other.Model && self.Stepping == other.Stepping && self.VendorString == other.VendorString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43586,7 +43415,7 @@ unsafe impl ::windows::core::Abi for DEBUG_READ_USER_MINIDUMP_STREAM {
 }
 impl ::core::cmp::PartialEq for DEBUG_READ_USER_MINIDUMP_STREAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_READ_USER_MINIDUMP_STREAM>()) == 0 }
+        self.StreamType == other.StreamType && self.Flags == other.Flags && self.Offset == other.Offset && self.Buffer == other.Buffer && self.BufferSize == other.BufferSize && self.BufferUsed == other.BufferUsed
     }
 }
 impl ::core::cmp::Eq for DEBUG_READ_USER_MINIDUMP_STREAM {}
@@ -43622,7 +43451,7 @@ unsafe impl ::windows::core::Abi for DEBUG_REGISTER_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for DEBUG_REGISTER_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_REGISTER_DESCRIPTION>()) == 0 }
+        self.Type == other.Type && self.Flags == other.Flags && self.SubregMaster == other.SubregMaster && self.SubregLength == other.SubregLength && self.SubregMask == other.SubregMask && self.SubregShift == other.SubregShift && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for DEBUG_REGISTER_DESCRIPTION {}
@@ -43656,7 +43485,7 @@ unsafe impl ::windows::core::Abi for DEBUG_SPECIFIC_FILTER_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEBUG_SPECIFIC_FILTER_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_SPECIFIC_FILTER_PARAMETERS>()) == 0 }
+        self.ExecutionOption == other.ExecutionOption && self.ContinueOption == other.ContinueOption && self.TextSize == other.TextSize && self.CommandSize == other.CommandSize && self.ArgumentSize == other.ArgumentSize
     }
 }
 impl ::core::cmp::Eq for DEBUG_SPECIFIC_FILTER_PARAMETERS {}
@@ -43700,7 +43529,7 @@ unsafe impl ::windows::core::Abi for DEBUG_STACK_FRAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_STACK_FRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_STACK_FRAME>()) == 0 }
+        self.InstructionOffset == other.InstructionOffset && self.ReturnOffset == other.ReturnOffset && self.FrameOffset == other.FrameOffset && self.StackOffset == other.StackOffset && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Reserved == other.Reserved && self.Virtual == other.Virtual && self.FrameNumber == other.FrameNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43760,7 +43589,7 @@ unsafe impl ::windows::core::Abi for DEBUG_STACK_FRAME_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_STACK_FRAME_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_STACK_FRAME_EX>()) == 0 }
+        self.InstructionOffset == other.InstructionOffset && self.ReturnOffset == other.ReturnOffset && self.FrameOffset == other.FrameOffset && self.StackOffset == other.StackOffset && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Reserved == other.Reserved && self.Virtual == other.Virtual && self.FrameNumber == other.FrameNumber && self.InlineFrameContext == other.InlineFrameContext && self.Reserved1 == other.Reserved1
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -43803,7 +43632,7 @@ unsafe impl ::windows::core::Abi for DEBUG_SYMBOL_ENTRY {
 }
 impl ::core::cmp::PartialEq for DEBUG_SYMBOL_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_SYMBOL_ENTRY>()) == 0 }
+        self.ModuleBase == other.ModuleBase && self.Offset == other.Offset && self.Id == other.Id && self.Arg64 == other.Arg64 && self.Size == other.Size && self.Flags == other.Flags && self.TypeId == other.TypeId && self.NameSize == other.NameSize && self.Token == other.Token && self.Tag == other.Tag && self.Arg32 == other.Arg32 && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_SYMBOL_ENTRY {}
@@ -43838,7 +43667,7 @@ unsafe impl ::windows::core::Abi for DEBUG_SYMBOL_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEBUG_SYMBOL_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_SYMBOL_PARAMETERS>()) == 0 }
+        self.Module == other.Module && self.TypeId == other.TypeId && self.ParentSymbol == other.ParentSymbol && self.SubElements == other.SubElements && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_SYMBOL_PARAMETERS {}
@@ -43879,7 +43708,7 @@ unsafe impl ::windows::core::Abi for DEBUG_SYMBOL_SOURCE_ENTRY {
 }
 impl ::core::cmp::PartialEq for DEBUG_SYMBOL_SOURCE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_SYMBOL_SOURCE_ENTRY>()) == 0 }
+        self.ModuleBase == other.ModuleBase && self.Offset == other.Offset && self.FileNameId == other.FileNameId && self.EngineInternal == other.EngineInternal && self.Size == other.Size && self.Flags == other.Flags && self.FileNameSize == other.FileNameSize && self.StartLine == other.StartLine && self.EndLine == other.EndLine && self.StartColumn == other.StartColumn && self.EndColumn == other.EndColumn && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEBUG_SYMBOL_SOURCE_ENTRY {}
@@ -43918,7 +43747,7 @@ unsafe impl ::windows::core::Abi for DEBUG_THREAD_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for DEBUG_THREAD_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_THREAD_BASIC_INFORMATION>()) == 0 }
+        self.Valid == other.Valid && self.ExitStatus == other.ExitStatus && self.PriorityClass == other.PriorityClass && self.Priority == other.Priority && self.CreateTime == other.CreateTime && self.ExitTime == other.ExitTime && self.KernelTime == other.KernelTime && self.UserTime == other.UserTime && self.StartOffset == other.StartOffset && self.Affinity == other.Affinity
     }
 }
 impl ::core::cmp::Eq for DEBUG_THREAD_BASIC_INFORMATION {}
@@ -43958,7 +43787,7 @@ unsafe impl ::windows::core::Abi for DEBUG_TYPED_DATA {
 }
 impl ::core::cmp::PartialEq for DEBUG_TYPED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_TYPED_DATA>()) == 0 }
+        self.ModBase == other.ModBase && self.Offset == other.Offset && self.EngineHandle == other.EngineHandle && self.Data == other.Data && self.Size == other.Size && self.Flags == other.Flags && self.TypeId == other.TypeId && self.BaseTypeId == other.BaseTypeId && self.Tag == other.Tag && self.Register == other.Register && self.Internal == other.Internal
     }
 }
 impl ::core::cmp::Eq for DEBUG_TYPED_DATA {}
@@ -43987,14 +43816,6 @@ impl ::core::clone::Clone for DEBUG_VALUE {
 unsafe impl ::windows::core::Abi for DEBUG_VALUE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DEBUG_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_VALUE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DEBUG_VALUE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DEBUG_VALUE {
     fn default() -> Self {
@@ -44037,14 +43858,6 @@ unsafe impl ::windows::core::Abi for DEBUG_VALUE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DEBUG_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_VALUE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DEBUG_VALUE_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DEBUG_VALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -44078,7 +43891,7 @@ unsafe impl ::windows::core::Abi for DEBUG_VALUE_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_VALUE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_VALUE_0_0>()) == 0 }
+        self.I64 == other.I64 && self.Nat == other.Nat
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44117,7 +43930,7 @@ unsafe impl ::windows::core::Abi for DEBUG_VALUE_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_VALUE_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_VALUE_0_1>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44156,7 +43969,7 @@ unsafe impl ::windows::core::Abi for DEBUG_VALUE_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUG_VALUE_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUG_VALUE_0_2>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44206,7 +44019,6 @@ impl ::core::fmt::Debug for DISPATCHER_CONTEXT {
             .field("EstablisherFrame", &self.EstablisherFrame)
             .field("TargetPc", &self.TargetPc)
             .field("ContextRecord", &self.ContextRecord)
-            .field("LanguageHandler", &self.LanguageHandler.map(|f| f as usize))
             .field("HandlerData", &self.HandlerData)
             .field("HistoryTable", &self.HistoryTable)
             .field("ScopeIndex", &self.ScopeIndex)
@@ -44220,16 +44032,6 @@ impl ::core::fmt::Debug for DISPATCHER_CONTEXT {
 unsafe impl ::windows::core::Abi for DISPATCHER_CONTEXT {
     type Abi = Self;
 }
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for DISPATCHER_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPATCHER_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for DISPATCHER_CONTEXT {}
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for DISPATCHER_CONTEXT {
@@ -44268,19 +44070,7 @@ impl ::core::clone::Clone for DISPATCHER_CONTEXT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::fmt::Debug for DISPATCHER_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DISPATCHER_CONTEXT")
-            .field("ControlPc", &self.ControlPc)
-            .field("ImageBase", &self.ImageBase)
-            .field("FunctionEntry", &self.FunctionEntry)
-            .field("EstablisherFrame", &self.EstablisherFrame)
-            .field("TargetIp", &self.TargetIp)
-            .field("ContextRecord", &self.ContextRecord)
-            .field("LanguageHandler", &self.LanguageHandler.map(|f| f as usize))
-            .field("HandlerData", &self.HandlerData)
-            .field("HistoryTable", &self.HistoryTable)
-            .field("ScopeIndex", &self.ScopeIndex)
-            .field("Fill0", &self.Fill0)
-            .finish()
+        f.debug_struct("DISPATCHER_CONTEXT").field("ControlPc", &self.ControlPc).field("ImageBase", &self.ImageBase).field("FunctionEntry", &self.FunctionEntry).field("EstablisherFrame", &self.EstablisherFrame).field("TargetIp", &self.TargetIp).field("ContextRecord", &self.ContextRecord).field("HandlerData", &self.HandlerData).field("HistoryTable", &self.HistoryTable).field("ScopeIndex", &self.ScopeIndex).field("Fill0", &self.Fill0).finish()
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -44288,16 +44078,6 @@ impl ::core::fmt::Debug for DISPATCHER_CONTEXT {
 unsafe impl ::windows::core::Abi for DISPATCHER_CONTEXT {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86_64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for DISPATCHER_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPATCHER_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for DISPATCHER_CONTEXT {}
 #[cfg(target_arch = "x86_64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for DISPATCHER_CONTEXT {
@@ -44320,12 +44100,6 @@ impl ::core::clone::Clone for DUMP_FILE_ATTRIBUTES {
 unsafe impl ::windows::core::Abi for DUMP_FILE_ATTRIBUTES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DUMP_FILE_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_FILE_ATTRIBUTES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DUMP_FILE_ATTRIBUTES {}
 impl ::core::default::Default for DUMP_FILE_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -44352,7 +44126,7 @@ unsafe impl ::windows::core::Abi for DUMP_FILE_ATTRIBUTES_0 {
 }
 impl ::core::cmp::PartialEq for DUMP_FILE_ATTRIBUTES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_FILE_ATTRIBUTES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DUMP_FILE_ATTRIBUTES_0 {}
@@ -44417,14 +44191,6 @@ unsafe impl ::windows::core::Abi for DUMP_HEADER32 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DUMP_HEADER32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_HEADER32>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DUMP_HEADER32 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DUMP_HEADER32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -44449,14 +44215,6 @@ impl ::core::clone::Clone for DUMP_HEADER32_0 {
 unsafe impl ::windows::core::Abi for DUMP_HEADER32_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DUMP_HEADER32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_HEADER32_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DUMP_HEADER32_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DUMP_HEADER32_0 {
     fn default() -> Self {
@@ -44517,14 +44275,6 @@ unsafe impl ::windows::core::Abi for DUMP_HEADER64 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DUMP_HEADER64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_HEADER64>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DUMP_HEADER64 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DUMP_HEADER64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -44549,14 +44299,6 @@ impl ::core::clone::Clone for DUMP_HEADER64_0 {
 unsafe impl ::windows::core::Abi for DUMP_HEADER64_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DUMP_HEADER64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUMP_HEADER64_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DUMP_HEADER64_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DUMP_HEADER64_0 {
     fn default() -> Self {
@@ -44714,7 +44456,7 @@ unsafe impl ::windows::core::Abi for EXCEPTION_DEBUG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXCEPTION_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_DEBUG_INFO>()) == 0 }
+        self.ExceptionRecord == other.ExceptionRecord && self.dwFirstChance == other.dwFirstChance
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44753,7 +44495,7 @@ unsafe impl ::windows::core::Abi for EXCEPTION_POINTERS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for EXCEPTION_POINTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_POINTERS>()) == 0 }
+        self.ExceptionRecord == other.ExceptionRecord && self.ContextRecord == other.ContextRecord
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -44796,7 +44538,7 @@ unsafe impl ::windows::core::Abi for EXCEPTION_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXCEPTION_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_RECORD>()) == 0 }
+        self.ExceptionCode == other.ExceptionCode && self.ExceptionFlags == other.ExceptionFlags && self.ExceptionRecord == other.ExceptionRecord && self.ExceptionAddress == other.ExceptionAddress && self.NumberParameters == other.NumberParameters && self.ExceptionInformation == other.ExceptionInformation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44839,7 +44581,7 @@ unsafe impl ::windows::core::Abi for EXCEPTION_RECORD32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXCEPTION_RECORD32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_RECORD32>()) == 0 }
+        self.ExceptionCode == other.ExceptionCode && self.ExceptionFlags == other.ExceptionFlags && self.ExceptionRecord == other.ExceptionRecord && self.ExceptionAddress == other.ExceptionAddress && self.NumberParameters == other.NumberParameters && self.ExceptionInformation == other.ExceptionInformation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44883,7 +44625,7 @@ unsafe impl ::windows::core::Abi for EXCEPTION_RECORD64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXCEPTION_RECORD64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_RECORD64>()) == 0 }
+        self.ExceptionCode == other.ExceptionCode && self.ExceptionFlags == other.ExceptionFlags && self.ExceptionRecord == other.ExceptionRecord && self.ExceptionAddress == other.ExceptionAddress && self.NumberParameters == other.NumberParameters && self.__unusedAlignment == other.__unusedAlignment && self.ExceptionInformation == other.ExceptionInformation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -44915,7 +44657,7 @@ unsafe impl ::windows::core::Abi for EXIT_PROCESS_DEBUG_INFO {
 }
 impl ::core::cmp::PartialEq for EXIT_PROCESS_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXIT_PROCESS_DEBUG_INFO>()) == 0 }
+        self.dwExitCode == other.dwExitCode
     }
 }
 impl ::core::cmp::Eq for EXIT_PROCESS_DEBUG_INFO {}
@@ -44945,7 +44687,7 @@ unsafe impl ::windows::core::Abi for EXIT_THREAD_DEBUG_INFO {
 }
 impl ::core::cmp::PartialEq for EXIT_THREAD_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXIT_THREAD_DEBUG_INFO>()) == 0 }
+        self.dwExitCode == other.dwExitCode
     }
 }
 impl ::core::cmp::Eq for EXIT_THREAD_DEBUG_INFO {}
@@ -44978,7 +44720,7 @@ unsafe impl ::windows::core::Abi for EXTSTACKTRACE {
 }
 impl ::core::cmp::PartialEq for EXTSTACKTRACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTSTACKTRACE>()) == 0 }
+        self.FramePointer == other.FramePointer && self.ProgramCounter == other.ProgramCounter && self.ReturnAddress == other.ReturnAddress && self.Args == other.Args
     }
 }
 impl ::core::cmp::Eq for EXTSTACKTRACE {}
@@ -45011,7 +44753,7 @@ unsafe impl ::windows::core::Abi for EXTSTACKTRACE32 {
 }
 impl ::core::cmp::PartialEq for EXTSTACKTRACE32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTSTACKTRACE32>()) == 0 }
+        self.FramePointer == other.FramePointer && self.ProgramCounter == other.ProgramCounter && self.ReturnAddress == other.ReturnAddress && self.Args == other.Args
     }
 }
 impl ::core::cmp::Eq for EXTSTACKTRACE32 {}
@@ -45044,7 +44786,7 @@ unsafe impl ::windows::core::Abi for EXTSTACKTRACE64 {
 }
 impl ::core::cmp::PartialEq for EXTSTACKTRACE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTSTACKTRACE64>()) == 0 }
+        self.FramePointer == other.FramePointer && self.ProgramCounter == other.ProgramCounter && self.ReturnAddress == other.ReturnAddress && self.Args == other.Args
     }
 }
 impl ::core::cmp::Eq for EXTSTACKTRACE64 {}
@@ -45077,7 +44819,7 @@ unsafe impl ::windows::core::Abi for EXT_API_VERSION {
 }
 impl ::core::cmp::PartialEq for EXT_API_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXT_API_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.Revision == other.Revision && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for EXT_API_VERSION {}
@@ -45137,7 +44879,7 @@ unsafe impl ::windows::core::Abi for EXT_FIND_FILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXT_FIND_FILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXT_FIND_FILE>()) == 0 }
+        self.FileName == other.FileName && self.IndexedSize == other.IndexedSize && self.ImageTimeDateStamp == other.ImageTimeDateStamp && self.ImageCheckSum == other.ImageCheckSum && self.ExtraInfo == other.ExtraInfo && self.ExtraInfoSize == other.ExtraInfoSize && self.Flags == other.Flags && self.FileMapping == other.FileMapping && self.FileMappingSize == other.FileMappingSize && self.FileHandle == other.FileHandle && self.FoundFileName == other.FoundFileName && self.FoundFileNameChars == other.FoundFileNameChars
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -45171,7 +44913,7 @@ unsafe impl ::windows::core::Abi for EXT_MATCH_PATTERN_A {
 }
 impl ::core::cmp::PartialEq for EXT_MATCH_PATTERN_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXT_MATCH_PATTERN_A>()) == 0 }
+        self.Str == other.Str && self.Pattern == other.Pattern && self.CaseSensitive == other.CaseSensitive
     }
 }
 impl ::core::cmp::Eq for EXT_MATCH_PATTERN_A {}
@@ -45235,7 +44977,7 @@ unsafe impl ::windows::core::Abi for EXT_TYPED_DATA {
 }
 impl ::core::cmp::PartialEq for EXT_TYPED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXT_TYPED_DATA>()) == 0 }
+        self.Operation == other.Operation && self.Flags == other.Flags && self.InData == other.InData && self.OutData == other.OutData && self.InStrIndex == other.InStrIndex && self.In32 == other.In32 && self.Out32 == other.Out32 && self.In64 == other.In64 && self.Out64 == other.Out64 && self.StrBufferIndex == other.StrBufferIndex && self.StrBufferChars == other.StrBufferChars && self.StrCharsNeeded == other.StrCharsNeeded && self.DataBufferIndex == other.DataBufferIndex && self.DataBufferBytes == other.DataBufferBytes && self.DataBytesNeeded == other.DataBytesNeeded && self.Status == other.Status && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for EXT_TYPED_DATA {}
@@ -45285,14 +45027,6 @@ unsafe impl ::windows::core::Abi for ExtendedDebugPropertyInfo {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for ExtendedDebugPropertyInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwValidFields == other.dwValidFields && self.pszName == other.pszName && self.pszType == other.pszType && self.pszValue == other.pszValue && self.pszFullName == other.pszFullName && self.dwAttrib == other.dwAttrib && self.pDebugProp == other.pDebugProp && self.nDISPID == other.nDISPID && self.nType == other.nType && self.varValue == other.varValue && self.plbValue == other.plbValue && self.pDebugExtProp == other.pDebugExtProp
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for ExtendedDebugPropertyInfo {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for ExtendedDebugPropertyInfo {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -45322,12 +45056,6 @@ impl ::core::clone::Clone for FIELD_INFO {
 unsafe impl ::windows::core::Abi for FIELD_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FIELD_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIELD_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FIELD_INFO {}
 impl ::core::default::Default for FIELD_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -45348,12 +45076,6 @@ impl ::core::clone::Clone for FIELD_INFO_0 {
 unsafe impl ::windows::core::Abi for FIELD_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FIELD_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIELD_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FIELD_INFO_0 {}
 impl ::core::default::Default for FIELD_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -45381,7 +45103,7 @@ unsafe impl ::windows::core::Abi for FIELD_INFO_1 {
 }
 impl ::core::cmp::PartialEq for FIELD_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIELD_INFO_1>()) == 0 }
+        self.Position == other.Position && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for FIELD_INFO_1 {}
@@ -45415,7 +45137,7 @@ unsafe impl ::windows::core::Abi for FPO_DATA {
 }
 impl ::core::cmp::PartialEq for FPO_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FPO_DATA>()) == 0 }
+        self.ulOffStart == other.ulOffStart && self.cbProcSize == other.cbProcSize && self.cdwLocals == other.cdwLocals && self.cdwParams == other.cdwParams && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for FPO_DATA {}
@@ -45447,7 +45169,7 @@ unsafe impl ::windows::core::Abi for GET_CONTEXT_EX {
 }
 impl ::core::cmp::PartialEq for GET_CONTEXT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_CONTEXT_EX>()) == 0 }
+        self.Status == other.Status && self.ContextSize == other.ContextSize && self.pContext == other.pContext
     }
 }
 impl ::core::cmp::Eq for GET_CONTEXT_EX {}
@@ -45479,7 +45201,7 @@ unsafe impl ::windows::core::Abi for GET_CURRENT_PROCESS_ADDRESS {
 }
 impl ::core::cmp::PartialEq for GET_CURRENT_PROCESS_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_CURRENT_PROCESS_ADDRESS>()) == 0 }
+        self.Processor == other.Processor && self.CurrentThread == other.CurrentThread && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for GET_CURRENT_PROCESS_ADDRESS {}
@@ -45510,7 +45232,7 @@ unsafe impl ::windows::core::Abi for GET_CURRENT_THREAD_ADDRESS {
 }
 impl ::core::cmp::PartialEq for GET_CURRENT_THREAD_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_CURRENT_THREAD_ADDRESS>()) == 0 }
+        self.Processor == other.Processor && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for GET_CURRENT_THREAD_ADDRESS {}
@@ -45542,7 +45264,7 @@ unsafe impl ::windows::core::Abi for GET_EXPRESSION_EX {
 }
 impl ::core::cmp::PartialEq for GET_EXPRESSION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_EXPRESSION_EX>()) == 0 }
+        self.Expression == other.Expression && self.Remainder == other.Remainder && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for GET_EXPRESSION_EX {}
@@ -45575,7 +45297,7 @@ unsafe impl ::windows::core::Abi for GET_INPUT_LINE {
 }
 impl ::core::cmp::PartialEq for GET_INPUT_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_INPUT_LINE>()) == 0 }
+        self.Prompt == other.Prompt && self.Buffer == other.Buffer && self.BufferSize == other.BufferSize && self.InputSize == other.InputSize
     }
 }
 impl ::core::cmp::Eq for GET_INPUT_LINE {}
@@ -45606,7 +45328,7 @@ unsafe impl ::windows::core::Abi for GET_PEB_ADDRESS {
 }
 impl ::core::cmp::PartialEq for GET_PEB_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_PEB_ADDRESS>()) == 0 }
+        self.CurrentThread == other.CurrentThread && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for GET_PEB_ADDRESS {}
@@ -45638,7 +45360,7 @@ unsafe impl ::windows::core::Abi for GET_SET_SYMPATH {
 }
 impl ::core::cmp::PartialEq for GET_SET_SYMPATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_SET_SYMPATH>()) == 0 }
+        self.Args == other.Args && self.Result == other.Result && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for GET_SET_SYMPATH {}
@@ -45668,7 +45390,7 @@ unsafe impl ::windows::core::Abi for GET_TEB_ADDRESS {
 }
 impl ::core::cmp::PartialEq for GET_TEB_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_TEB_ADDRESS>()) == 0 }
+        self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for GET_TEB_ADDRESS {}
@@ -45701,7 +45423,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_CBA_EVENT {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_CBA_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_CBA_EVENT>()) == 0 }
+        self.severity == other.severity && self.code == other.code && self.desc == other.desc && self.object == other.object
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_CBA_EVENT {}
@@ -45734,7 +45456,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_CBA_EVENTW {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_CBA_EVENTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_CBA_EVENTW>()) == 0 }
+        self.severity == other.severity && self.code == other.code && self.desc == other.desc && self.object == other.object
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_CBA_EVENTW {}
@@ -45767,7 +45489,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_CBA_READ_MEMORY {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_CBA_READ_MEMORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_CBA_READ_MEMORY>()) == 0 }
+        self.addr == other.addr && self.buf == other.buf && self.bytes == other.bytes && self.bytesread == other.bytesread
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_CBA_READ_MEMORY {}
@@ -45815,7 +45537,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_DEFERRED_SYMBOL_LOAD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_DEFERRED_SYMBOL_LOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_DEFERRED_SYMBOL_LOAD>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.BaseOfImage == other.BaseOfImage && self.CheckSum == other.CheckSum && self.TimeDateStamp == other.TimeDateStamp && self.FileName == other.FileName && self.Reparse == other.Reparse && self.hFile == other.hFile
     }
 }
 #[cfg(target_arch = "x86")]
@@ -45862,7 +45584,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_DEFERRED_SYMBOL_LOAD64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_DEFERRED_SYMBOL_LOAD64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_DEFERRED_SYMBOL_LOAD64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.BaseOfImage == other.BaseOfImage && self.CheckSum == other.CheckSum && self.TimeDateStamp == other.TimeDateStamp && self.FileName == other.FileName && self.Reparse == other.Reparse && self.hFile == other.hFile && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -45907,7 +45629,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_DEFERRED_SYMBOL_LOADW64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_DEFERRED_SYMBOL_LOADW64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_DEFERRED_SYMBOL_LOADW64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.BaseOfImage == other.BaseOfImage && self.CheckSum == other.CheckSum && self.TimeDateStamp == other.TimeDateStamp && self.FileName == other.FileName && self.Reparse == other.Reparse && self.hFile == other.hFile && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -45954,7 +45676,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_DUPLICATE_SYMBOL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_DUPLICATE_SYMBOL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_DUPLICATE_SYMBOL>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.NumberOfDups == other.NumberOfDups && self.Symbol == other.Symbol && self.SelectedSymbol == other.SelectedSymbol
     }
 }
 #[cfg(target_arch = "x86")]
@@ -45997,7 +45719,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_DUPLICATE_SYMBOL64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_DUPLICATE_SYMBOL64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_DUPLICATE_SYMBOL64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.NumberOfDups == other.NumberOfDups && self.Symbol == other.Symbol && self.SelectedSymbol == other.SelectedSymbol
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46065,7 +45787,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_GET_TYPE_INFO_PARAMS {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_GET_TYPE_INFO_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_GET_TYPE_INFO_PARAMS>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Flags == other.Flags && self.NumIds == other.NumIds && self.TypeIds == other.TypeIds && self.TagFilter == other.TagFilter && self.NumReqs == other.NumReqs && self.ReqKinds == other.ReqKinds && self.ReqOffsets == other.ReqOffsets && self.ReqSizes == other.ReqSizes && self.ReqStride == other.ReqStride && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer && self.EntriesMatched == other.EntriesMatched && self.EntriesFilled == other.EntriesFilled && self.TagsFound == other.TagsFound && self.AllReqsValid == other.AllReqsValid && self.NumReqsValid == other.NumReqsValid && self.ReqsValid == other.ReqsValid
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_GET_TYPE_INFO_PARAMS {}
@@ -46097,7 +45819,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_JIT_SYMBOLMAP {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_JIT_SYMBOLMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_JIT_SYMBOLMAP>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Address == other.Address && self.BaseOfImage == other.BaseOfImage
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_JIT_SYMBOLMAP {}
@@ -46137,7 +45859,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_LINE {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for IMAGEHLP_LINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_LINE>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.LineNumber == other.LineNumber && self.FileName == other.FileName && self.Address == other.Address
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46173,7 +45895,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_LINE64 {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_LINE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_LINE64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.LineNumber == other.LineNumber && self.FileName == other.FileName && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_LINE64 {}
@@ -46213,7 +45935,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_LINEW {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for IMAGEHLP_LINEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_LINEW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.LineNumber == other.LineNumber && self.FileName == other.FileName && self.Address == other.Address
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46249,7 +45971,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_LINEW64 {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_LINEW64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_LINEW64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.LineNumber == other.LineNumber && self.FileName == other.FileName && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_LINEW64 {}
@@ -46300,7 +46022,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULE>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.BaseOfImage == other.BaseOfImage && self.ImageSize == other.ImageSize && self.TimeDateStamp == other.TimeDateStamp && self.CheckSum == other.CheckSum && self.NumSyms == other.NumSyms && self.SymType == other.SymType && self.ModuleName == other.ModuleName && self.ImageName == other.ImageName && self.LoadedImageName == other.LoadedImageName
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46390,7 +46112,31 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULE64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULE64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.BaseOfImage == other.BaseOfImage
+            && self.ImageSize == other.ImageSize
+            && self.TimeDateStamp == other.TimeDateStamp
+            && self.CheckSum == other.CheckSum
+            && self.NumSyms == other.NumSyms
+            && self.SymType == other.SymType
+            && self.ModuleName == other.ModuleName
+            && self.ImageName == other.ImageName
+            && self.LoadedImageName == other.LoadedImageName
+            && self.LoadedPdbName == other.LoadedPdbName
+            && self.CVSig == other.CVSig
+            && self.CVData == other.CVData
+            && self.PdbSig == other.PdbSig
+            && self.PdbSig70 == other.PdbSig70
+            && self.PdbAge == other.PdbAge
+            && self.PdbUnmatched == other.PdbUnmatched
+            && self.DbgUnmatched == other.DbgUnmatched
+            && self.LineNumbers == other.LineNumbers
+            && self.GlobalSymbols == other.GlobalSymbols
+            && self.TypeInfo == other.TypeInfo
+            && self.SourceIndexed == other.SourceIndexed
+            && self.Publics == other.Publics
+            && self.MachineType == other.MachineType
+            && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46429,7 +46175,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULE64_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULE64_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULE64_EX>()) == 0 }
+        self.Module == other.Module && self.RegionFlags == other.RegionFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46476,7 +46222,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULEW {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULEW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.BaseOfImage == other.BaseOfImage && self.ImageSize == other.ImageSize && self.TimeDateStamp == other.TimeDateStamp && self.CheckSum == other.CheckSum && self.NumSyms == other.NumSyms && self.SymType == other.SymType && self.ModuleName == other.ModuleName && self.ImageName == other.ImageName && self.LoadedImageName == other.LoadedImageName
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46564,7 +46310,31 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULEW64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULEW64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULEW64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct
+            && self.BaseOfImage == other.BaseOfImage
+            && self.ImageSize == other.ImageSize
+            && self.TimeDateStamp == other.TimeDateStamp
+            && self.CheckSum == other.CheckSum
+            && self.NumSyms == other.NumSyms
+            && self.SymType == other.SymType
+            && self.ModuleName == other.ModuleName
+            && self.ImageName == other.ImageName
+            && self.LoadedImageName == other.LoadedImageName
+            && self.LoadedPdbName == other.LoadedPdbName
+            && self.CVSig == other.CVSig
+            && self.CVData == other.CVData
+            && self.PdbSig == other.PdbSig
+            && self.PdbSig70 == other.PdbSig70
+            && self.PdbAge == other.PdbAge
+            && self.PdbUnmatched == other.PdbUnmatched
+            && self.DbgUnmatched == other.DbgUnmatched
+            && self.LineNumbers == other.LineNumbers
+            && self.GlobalSymbols == other.GlobalSymbols
+            && self.TypeInfo == other.TypeInfo
+            && self.SourceIndexed == other.SourceIndexed
+            && self.Publics == other.Publics
+            && self.MachineType == other.MachineType
+            && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46603,7 +46373,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_MODULEW64_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_MODULEW64_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_MODULEW64_EX>()) == 0 }
+        self.Module == other.Module && self.RegionFlags == other.RegionFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46650,7 +46420,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_STACK_FRAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_STACK_FRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_STACK_FRAME>()) == 0 }
+        self.InstructionOffset == other.InstructionOffset && self.ReturnOffset == other.ReturnOffset && self.FrameOffset == other.FrameOffset && self.StackOffset == other.StackOffset && self.BackingStoreOffset == other.BackingStoreOffset && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Reserved == other.Reserved && self.Virtual == other.Virtual && self.Reserved2 == other.Reserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46699,7 +46469,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOL>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Address == other.Address && self.Size == other.Size && self.Flags == other.Flags && self.MaxNameLength == other.MaxNameLength && self.Name == other.Name
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46744,7 +46514,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOL64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOL64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOL64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Address == other.Address && self.Size == other.Size && self.Flags == other.Flags && self.MaxNameLength == other.MaxNameLength && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46783,7 +46553,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOL64_PACKAGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOL64_PACKAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOL64_PACKAGE>()) == 0 }
+        self.sym == other.sym && self.name == other.name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -46826,7 +46596,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOLW {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOLW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOLW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Address == other.Address && self.Size == other.Size && self.Flags == other.Flags && self.MaxNameLength == other.MaxNameLength && self.Name == other.Name
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46863,7 +46633,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOLW64 {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOLW64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOLW64>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Address == other.Address && self.Size == other.Size && self.Flags == other.Flags && self.MaxNameLength == other.MaxNameLength && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_SYMBOLW64 {}
@@ -46894,7 +46664,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOLW64_PACKAGE {
 }
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOLW64_PACKAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOLW64_PACKAGE>()) == 0 }
+        self.sym == other.sym && self.name == other.name
     }
 }
 impl ::core::cmp::Eq for IMAGEHLP_SYMBOLW64_PACKAGE {}
@@ -46931,7 +46701,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOLW_PACKAGE {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOLW_PACKAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOLW_PACKAGE>()) == 0 }
+        self.sym == other.sym && self.name == other.name
     }
 }
 #[cfg(target_arch = "x86")]
@@ -46976,7 +46746,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOL_PACKAGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOL_PACKAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOL_PACKAGE>()) == 0 }
+        self.sym == other.sym && self.name == other.name
     }
 }
 #[cfg(target_arch = "x86")]
@@ -47018,7 +46788,7 @@ unsafe impl ::windows::core::Abi for IMAGEHLP_SYMBOL_SRC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGEHLP_SYMBOL_SRC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEHLP_SYMBOL_SRC>()) == 0 }
+        self.sizeofstruct == other.sizeofstruct && self.r#type == other.r#type && self.file == other.file
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -47044,12 +46814,6 @@ impl ::core::clone::Clone for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {}
 impl ::core::default::Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47070,12 +46834,6 @@ impl ::core::clone::Clone for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
 unsafe impl ::windows::core::Abi for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {}
 impl ::core::default::Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47102,7 +46860,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {}
@@ -47148,7 +46906,7 @@ unsafe impl ::windows::core::Abi for IMAGE_COFF_SYMBOLS_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_COFF_SYMBOLS_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_COFF_SYMBOLS_HEADER>()) == 0 }
+        self.NumberOfSymbols == other.NumberOfSymbols && self.LvaToFirstSymbol == other.LvaToFirstSymbol && self.NumberOfLinenumbers == other.NumberOfLinenumbers && self.LvaToFirstLinenumber == other.LvaToFirstLinenumber && self.RvaToFirstByteOfCode == other.RvaToFirstByteOfCode && self.RvaToLastByteOfCode == other.RvaToLastByteOfCode && self.RvaToFirstByteOfData == other.RvaToFirstByteOfData && self.RvaToLastByteOfData == other.RvaToLastByteOfData
     }
 }
 impl ::core::cmp::Eq for IMAGE_COFF_SYMBOLS_HEADER {}
@@ -47182,12 +46940,6 @@ impl ::core::clone::Clone for IMAGE_COR20_HEADER {
 unsafe impl ::windows::core::Abi for IMAGE_COR20_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_COR20_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_COR20_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_COR20_HEADER {}
 impl ::core::default::Default for IMAGE_COR20_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47208,12 +46960,6 @@ impl ::core::clone::Clone for IMAGE_COR20_HEADER_0 {
 unsafe impl ::windows::core::Abi for IMAGE_COR20_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_COR20_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_COR20_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_COR20_HEADER_0 {}
 impl ::core::default::Default for IMAGE_COR20_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47241,7 +46987,7 @@ unsafe impl ::windows::core::Abi for IMAGE_DATA_DIRECTORY {
 }
 impl ::core::cmp::PartialEq for IMAGE_DATA_DIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DATA_DIRECTORY>()) == 0 }
+        self.VirtualAddress == other.VirtualAddress && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for IMAGE_DATA_DIRECTORY {}
@@ -47278,7 +47024,7 @@ unsafe impl ::windows::core::Abi for IMAGE_DEBUG_DIRECTORY {
 }
 impl ::core::cmp::PartialEq for IMAGE_DEBUG_DIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DEBUG_DIRECTORY>()) == 0 }
+        self.Characteristics == other.Characteristics && self.TimeDateStamp == other.TimeDateStamp && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.Type == other.Type && self.SizeOfData == other.SizeOfData && self.AddressOfRawData == other.AddressOfRawData && self.PointerToRawData == other.PointerToRawData
     }
 }
 impl ::core::cmp::Eq for IMAGE_DEBUG_DIRECTORY {}
@@ -47382,7 +47128,37 @@ unsafe impl ::windows::core::Abi for IMAGE_DEBUG_INFORMATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for IMAGE_DEBUG_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DEBUG_INFORMATION>()) == 0 }
+        self.List == other.List
+            && self.ReservedSize == other.ReservedSize
+            && self.ReservedMappedBase == other.ReservedMappedBase
+            && self.ReservedMachine == other.ReservedMachine
+            && self.ReservedCharacteristics == other.ReservedCharacteristics
+            && self.ReservedCheckSum == other.ReservedCheckSum
+            && self.ImageBase == other.ImageBase
+            && self.SizeOfImage == other.SizeOfImage
+            && self.ReservedNumberOfSections == other.ReservedNumberOfSections
+            && self.ReservedSections == other.ReservedSections
+            && self.ReservedExportedNamesSize == other.ReservedExportedNamesSize
+            && self.ReservedExportedNames == other.ReservedExportedNames
+            && self.ReservedNumberOfFunctionTableEntries == other.ReservedNumberOfFunctionTableEntries
+            && self.ReservedFunctionTableEntries == other.ReservedFunctionTableEntries
+            && self.ReservedLowestFunctionStartingAddress == other.ReservedLowestFunctionStartingAddress
+            && self.ReservedHighestFunctionEndingAddress == other.ReservedHighestFunctionEndingAddress
+            && self.ReservedNumberOfFpoTableEntries == other.ReservedNumberOfFpoTableEntries
+            && self.ReservedFpoTableEntries == other.ReservedFpoTableEntries
+            && self.SizeOfCoffSymbols == other.SizeOfCoffSymbols
+            && self.CoffSymbols == other.CoffSymbols
+            && self.ReservedSizeOfCodeViewSymbols == other.ReservedSizeOfCodeViewSymbols
+            && self.ReservedCodeViewSymbols == other.ReservedCodeViewSymbols
+            && self.ImageFilePath == other.ImageFilePath
+            && self.ImageFileName == other.ImageFileName
+            && self.ReservedDebugFilePath == other.ReservedDebugFilePath
+            && self.ReservedTimeDateStamp == other.ReservedTimeDateStamp
+            && self.ReservedRomImage == other.ReservedRomImage
+            && self.ReservedDebugDirectory == other.ReservedDebugDirectory
+            && self.ReservedNumberOfDebugDirectories == other.ReservedNumberOfDebugDirectories
+            && self.ReservedOriginalFunctionTableBaseAddress == other.ReservedOriginalFunctionTableBaseAddress
+            && self.Reserved == other.Reserved
     }
 }
 #[cfg(target_arch = "x86")]
@@ -47428,7 +47204,7 @@ unsafe impl ::windows::core::Abi for IMAGE_FILE_HEADER {
 #[cfg(feature = "Win32_System_SystemInformation")]
 impl ::core::cmp::PartialEq for IMAGE_FILE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_FILE_HEADER>()) == 0 }
+        self.Machine == other.Machine && self.NumberOfSections == other.NumberOfSections && self.TimeDateStamp == other.TimeDateStamp && self.PointerToSymbolTable == other.PointerToSymbolTable && self.NumberOfSymbols == other.NumberOfSymbols && self.SizeOfOptionalHeader == other.SizeOfOptionalHeader && self.Characteristics == other.Characteristics
     }
 }
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -47462,7 +47238,7 @@ unsafe impl ::windows::core::Abi for IMAGE_FUNCTION_ENTRY {
 }
 impl ::core::cmp::PartialEq for IMAGE_FUNCTION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_FUNCTION_ENTRY>()) == 0 }
+        self.StartingAddress == other.StartingAddress && self.EndingAddress == other.EndingAddress && self.EndOfPrologue == other.EndOfPrologue
     }
 }
 impl ::core::cmp::Eq for IMAGE_FUNCTION_ENTRY {}
@@ -47487,12 +47263,6 @@ impl ::core::clone::Clone for IMAGE_FUNCTION_ENTRY64 {
 unsafe impl ::windows::core::Abi for IMAGE_FUNCTION_ENTRY64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_FUNCTION_ENTRY64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_FUNCTION_ENTRY64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_FUNCTION_ENTRY64 {}
 impl ::core::default::Default for IMAGE_FUNCTION_ENTRY64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47513,12 +47283,6 @@ impl ::core::clone::Clone for IMAGE_FUNCTION_ENTRY64_0 {
 unsafe impl ::windows::core::Abi for IMAGE_FUNCTION_ENTRY64_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_FUNCTION_ENTRY64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_FUNCTION_ENTRY64_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_FUNCTION_ENTRY64_0 {}
 impl ::core::default::Default for IMAGE_FUNCTION_ENTRY64_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47548,7 +47312,7 @@ unsafe impl ::windows::core::Abi for IMAGE_LOAD_CONFIG_CODE_INTEGRITY {
 }
 impl ::core::cmp::PartialEq for IMAGE_LOAD_CONFIG_CODE_INTEGRITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_LOAD_CONFIG_CODE_INTEGRITY>()) == 0 }
+        self.Flags == other.Flags && self.Catalog == other.Catalog && self.CatalogOffset == other.CatalogOffset && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for IMAGE_LOAD_CONFIG_CODE_INTEGRITY {}
@@ -47674,7 +47438,54 @@ unsafe impl ::windows::core::Abi for IMAGE_LOAD_CONFIG_DIRECTORY32 {
 }
 impl ::core::cmp::PartialEq for IMAGE_LOAD_CONFIG_DIRECTORY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_LOAD_CONFIG_DIRECTORY32>()) == 0 }
+        self.Size == other.Size
+            && self.TimeDateStamp == other.TimeDateStamp
+            && self.MajorVersion == other.MajorVersion
+            && self.MinorVersion == other.MinorVersion
+            && self.GlobalFlagsClear == other.GlobalFlagsClear
+            && self.GlobalFlagsSet == other.GlobalFlagsSet
+            && self.CriticalSectionDefaultTimeout == other.CriticalSectionDefaultTimeout
+            && self.DeCommitFreeBlockThreshold == other.DeCommitFreeBlockThreshold
+            && self.DeCommitTotalFreeThreshold == other.DeCommitTotalFreeThreshold
+            && self.LockPrefixTable == other.LockPrefixTable
+            && self.MaximumAllocationSize == other.MaximumAllocationSize
+            && self.VirtualMemoryThreshold == other.VirtualMemoryThreshold
+            && self.ProcessHeapFlags == other.ProcessHeapFlags
+            && self.ProcessAffinityMask == other.ProcessAffinityMask
+            && self.CSDVersion == other.CSDVersion
+            && self.DependentLoadFlags == other.DependentLoadFlags
+            && self.EditList == other.EditList
+            && self.SecurityCookie == other.SecurityCookie
+            && self.SEHandlerTable == other.SEHandlerTable
+            && self.SEHandlerCount == other.SEHandlerCount
+            && self.GuardCFCheckFunctionPointer == other.GuardCFCheckFunctionPointer
+            && self.GuardCFDispatchFunctionPointer == other.GuardCFDispatchFunctionPointer
+            && self.GuardCFFunctionTable == other.GuardCFFunctionTable
+            && self.GuardCFFunctionCount == other.GuardCFFunctionCount
+            && self.GuardFlags == other.GuardFlags
+            && self.CodeIntegrity == other.CodeIntegrity
+            && self.GuardAddressTakenIatEntryTable == other.GuardAddressTakenIatEntryTable
+            && self.GuardAddressTakenIatEntryCount == other.GuardAddressTakenIatEntryCount
+            && self.GuardLongJumpTargetTable == other.GuardLongJumpTargetTable
+            && self.GuardLongJumpTargetCount == other.GuardLongJumpTargetCount
+            && self.DynamicValueRelocTable == other.DynamicValueRelocTable
+            && self.CHPEMetadataPointer == other.CHPEMetadataPointer
+            && self.GuardRFFailureRoutine == other.GuardRFFailureRoutine
+            && self.GuardRFFailureRoutineFunctionPointer == other.GuardRFFailureRoutineFunctionPointer
+            && self.DynamicValueRelocTableOffset == other.DynamicValueRelocTableOffset
+            && self.DynamicValueRelocTableSection == other.DynamicValueRelocTableSection
+            && self.Reserved2 == other.Reserved2
+            && self.GuardRFVerifyStackPointerFunctionPointer == other.GuardRFVerifyStackPointerFunctionPointer
+            && self.HotPatchTableOffset == other.HotPatchTableOffset
+            && self.Reserved3 == other.Reserved3
+            && self.EnclaveConfigurationPointer == other.EnclaveConfigurationPointer
+            && self.VolatileMetadataPointer == other.VolatileMetadataPointer
+            && self.GuardEHContinuationTable == other.GuardEHContinuationTable
+            && self.GuardEHContinuationCount == other.GuardEHContinuationCount
+            && self.GuardXFGCheckFunctionPointer == other.GuardXFGCheckFunctionPointer
+            && self.GuardXFGDispatchFunctionPointer == other.GuardXFGDispatchFunctionPointer
+            && self.GuardXFGTableDispatchFunctionPointer == other.GuardXFGTableDispatchFunctionPointer
+            && self.CastGuardOsDeterminedFailureMode == other.CastGuardOsDeterminedFailureMode
     }
 }
 impl ::core::cmp::Eq for IMAGE_LOAD_CONFIG_DIRECTORY32 {}
@@ -47744,12 +47555,6 @@ impl ::core::clone::Clone for IMAGE_LOAD_CONFIG_DIRECTORY64 {
 unsafe impl ::windows::core::Abi for IMAGE_LOAD_CONFIG_DIRECTORY64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_LOAD_CONFIG_DIRECTORY64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_LOAD_CONFIG_DIRECTORY64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_LOAD_CONFIG_DIRECTORY64 {}
 impl ::core::default::Default for IMAGE_LOAD_CONFIG_DIRECTORY64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -47784,7 +47589,7 @@ unsafe impl ::windows::core::Abi for IMAGE_NT_HEADERS32 {
 #[cfg(feature = "Win32_System_SystemInformation")]
 impl ::core::cmp::PartialEq for IMAGE_NT_HEADERS32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_NT_HEADERS32>()) == 0 }
+        self.Signature == other.Signature && self.FileHeader == other.FileHeader && self.OptionalHeader == other.OptionalHeader
     }
 }
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -47815,14 +47620,6 @@ impl ::core::clone::Clone for IMAGE_NT_HEADERS64 {
 unsafe impl ::windows::core::Abi for IMAGE_NT_HEADERS64 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl ::core::cmp::PartialEq for IMAGE_NT_HEADERS64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_NT_HEADERS64>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl ::core::cmp::Eq for IMAGE_NT_HEADERS64 {}
 #[cfg(feature = "Win32_System_SystemInformation")]
 impl ::core::default::Default for IMAGE_NT_HEADERS64 {
     fn default() -> Self {
@@ -47912,7 +47709,37 @@ unsafe impl ::windows::core::Abi for IMAGE_OPTIONAL_HEADER32 {
 }
 impl ::core::cmp::PartialEq for IMAGE_OPTIONAL_HEADER32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_OPTIONAL_HEADER32>()) == 0 }
+        self.Magic == other.Magic
+            && self.MajorLinkerVersion == other.MajorLinkerVersion
+            && self.MinorLinkerVersion == other.MinorLinkerVersion
+            && self.SizeOfCode == other.SizeOfCode
+            && self.SizeOfInitializedData == other.SizeOfInitializedData
+            && self.SizeOfUninitializedData == other.SizeOfUninitializedData
+            && self.AddressOfEntryPoint == other.AddressOfEntryPoint
+            && self.BaseOfCode == other.BaseOfCode
+            && self.BaseOfData == other.BaseOfData
+            && self.ImageBase == other.ImageBase
+            && self.SectionAlignment == other.SectionAlignment
+            && self.FileAlignment == other.FileAlignment
+            && self.MajorOperatingSystemVersion == other.MajorOperatingSystemVersion
+            && self.MinorOperatingSystemVersion == other.MinorOperatingSystemVersion
+            && self.MajorImageVersion == other.MajorImageVersion
+            && self.MinorImageVersion == other.MinorImageVersion
+            && self.MajorSubsystemVersion == other.MajorSubsystemVersion
+            && self.MinorSubsystemVersion == other.MinorSubsystemVersion
+            && self.Win32VersionValue == other.Win32VersionValue
+            && self.SizeOfImage == other.SizeOfImage
+            && self.SizeOfHeaders == other.SizeOfHeaders
+            && self.CheckSum == other.CheckSum
+            && self.Subsystem == other.Subsystem
+            && self.DllCharacteristics == other.DllCharacteristics
+            && self.SizeOfStackReserve == other.SizeOfStackReserve
+            && self.SizeOfStackCommit == other.SizeOfStackCommit
+            && self.SizeOfHeapReserve == other.SizeOfHeapReserve
+            && self.SizeOfHeapCommit == other.SizeOfHeapCommit
+            && self.LoaderFlags == other.LoaderFlags
+            && self.NumberOfRvaAndSizes == other.NumberOfRvaAndSizes
+            && self.DataDirectory == other.DataDirectory
     }
 }
 impl ::core::cmp::Eq for IMAGE_OPTIONAL_HEADER32 {}
@@ -47964,12 +47791,6 @@ impl ::core::clone::Clone for IMAGE_OPTIONAL_HEADER64 {
 unsafe impl ::windows::core::Abi for IMAGE_OPTIONAL_HEADER64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_OPTIONAL_HEADER64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_OPTIONAL_HEADER64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_OPTIONAL_HEADER64 {}
 impl ::core::default::Default for IMAGE_OPTIONAL_HEADER64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48003,7 +47824,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ROM_HEADERS {
 #[cfg(feature = "Win32_System_SystemInformation")]
 impl ::core::cmp::PartialEq for IMAGE_ROM_HEADERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ROM_HEADERS>()) == 0 }
+        self.FileHeader == other.FileHeader && self.OptionalHeader == other.OptionalHeader
     }
 }
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -48061,7 +47882,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ROM_OPTIONAL_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_ROM_OPTIONAL_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ROM_OPTIONAL_HEADER>()) == 0 }
+        self.Magic == other.Magic && self.MajorLinkerVersion == other.MajorLinkerVersion && self.MinorLinkerVersion == other.MinorLinkerVersion && self.SizeOfCode == other.SizeOfCode && self.SizeOfInitializedData == other.SizeOfInitializedData && self.SizeOfUninitializedData == other.SizeOfUninitializedData && self.AddressOfEntryPoint == other.AddressOfEntryPoint && self.BaseOfCode == other.BaseOfCode && self.BaseOfData == other.BaseOfData && self.BaseOfBss == other.BaseOfBss && self.GprMask == other.GprMask && self.CprMask == other.CprMask && self.GpValue == other.GpValue
     }
 }
 impl ::core::cmp::Eq for IMAGE_ROM_OPTIONAL_HEADER {}
@@ -48086,12 +47907,6 @@ impl ::core::clone::Clone for IMAGE_RUNTIME_FUNCTION_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_RUNTIME_FUNCTION_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RUNTIME_FUNCTION_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RUNTIME_FUNCTION_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RUNTIME_FUNCTION_ENTRY {}
 impl ::core::default::Default for IMAGE_RUNTIME_FUNCTION_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48112,12 +47927,6 @@ impl ::core::clone::Clone for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
 unsafe impl ::windows::core::Abi for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RUNTIME_FUNCTION_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {}
 impl ::core::default::Default for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48146,12 +47955,6 @@ impl ::core::clone::Clone for IMAGE_SECTION_HEADER {
 unsafe impl ::windows::core::Abi for IMAGE_SECTION_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SECTION_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SECTION_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SECTION_HEADER {}
 impl ::core::default::Default for IMAGE_SECTION_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48172,12 +47975,6 @@ impl ::core::clone::Clone for IMAGE_SECTION_HEADER_0 {
 unsafe impl ::windows::core::Abi for IMAGE_SECTION_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SECTION_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SECTION_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SECTION_HEADER_0 {}
 impl ::core::default::Default for IMAGE_SECTION_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48198,12 +47995,6 @@ impl ::core::clone::Clone for INLINE_FRAME_CONTEXT {
 unsafe impl ::windows::core::Abi for INLINE_FRAME_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INLINE_FRAME_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INLINE_FRAME_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INLINE_FRAME_CONTEXT {}
 impl ::core::default::Default for INLINE_FRAME_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48232,7 +48023,7 @@ unsafe impl ::windows::core::Abi for INLINE_FRAME_CONTEXT_0 {
 }
 impl ::core::cmp::PartialEq for INLINE_FRAME_CONTEXT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INLINE_FRAME_CONTEXT_0>()) == 0 }
+        self.FrameId == other.FrameId && self.FrameType == other.FrameType && self.FrameSignature == other.FrameSignature
     }
 }
 impl ::core::cmp::Eq for INLINE_FRAME_CONTEXT_0 {}
@@ -48264,7 +48055,7 @@ unsafe impl ::windows::core::Abi for IOSPACE {
 }
 impl ::core::cmp::PartialEq for IOSPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for IOSPACE {}
@@ -48296,7 +48087,7 @@ unsafe impl ::windows::core::Abi for IOSPACE32 {
 }
 impl ::core::cmp::PartialEq for IOSPACE32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE32>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for IOSPACE32 {}
@@ -48328,7 +48119,7 @@ unsafe impl ::windows::core::Abi for IOSPACE64 {
 }
 impl ::core::cmp::PartialEq for IOSPACE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE64>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for IOSPACE64 {}
@@ -48363,7 +48154,7 @@ unsafe impl ::windows::core::Abi for IOSPACE_EX {
 }
 impl ::core::cmp::PartialEq for IOSPACE_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE_EX>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data && self.InterfaceType == other.InterfaceType && self.BusNumber == other.BusNumber && self.AddressSpace == other.AddressSpace
     }
 }
 impl ::core::cmp::Eq for IOSPACE_EX {}
@@ -48398,7 +48189,7 @@ unsafe impl ::windows::core::Abi for IOSPACE_EX32 {
 }
 impl ::core::cmp::PartialEq for IOSPACE_EX32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE_EX32>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data && self.InterfaceType == other.InterfaceType && self.BusNumber == other.BusNumber && self.AddressSpace == other.AddressSpace
     }
 }
 impl ::core::cmp::Eq for IOSPACE_EX32 {}
@@ -48433,7 +48224,7 @@ unsafe impl ::windows::core::Abi for IOSPACE_EX64 {
 }
 impl ::core::cmp::PartialEq for IOSPACE_EX64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IOSPACE_EX64>()) == 0 }
+        self.Address == other.Address && self.Length == other.Length && self.Data == other.Data && self.InterfaceType == other.InterfaceType && self.BusNumber == other.BusNumber && self.AddressSpace == other.AddressSpace
     }
 }
 impl ::core::cmp::Eq for IOSPACE_EX64 {}
@@ -48461,12 +48252,6 @@ impl ::core::clone::Clone for IPMI_OS_SEL_RECORD {
 unsafe impl ::windows::core::Abi for IPMI_OS_SEL_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IPMI_OS_SEL_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IPMI_OS_SEL_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IPMI_OS_SEL_RECORD {}
 impl ::core::default::Default for IPMI_OS_SEL_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -48496,7 +48281,7 @@ unsafe impl ::windows::core::Abi for JS_NATIVE_FRAME {
 }
 impl ::core::cmp::PartialEq for JS_NATIVE_FRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JS_NATIVE_FRAME>()) == 0 }
+        self.InstructionOffset == other.InstructionOffset && self.ReturnOffset == other.ReturnOffset && self.FrameOffset == other.FrameOffset && self.StackOffset == other.StackOffset
     }
 }
 impl ::core::cmp::Eq for JS_NATIVE_FRAME {}
@@ -48697,7 +48482,72 @@ unsafe impl ::windows::core::Abi for KDDEBUGGER_DATA32 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for KDDEBUGGER_DATA32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KDDEBUGGER_DATA32>()) == 0 }
+        self.Header == other.Header
+            && self.KernBase == other.KernBase
+            && self.BreakpointWithStatus == other.BreakpointWithStatus
+            && self.SavedContext == other.SavedContext
+            && self.ThCallbackStack == other.ThCallbackStack
+            && self.NextCallback == other.NextCallback
+            && self.FramePointer == other.FramePointer
+            && self._bitfield == other._bitfield
+            && self.KiCallUserMode == other.KiCallUserMode
+            && self.KeUserCallbackDispatcher == other.KeUserCallbackDispatcher
+            && self.PsLoadedModuleList == other.PsLoadedModuleList
+            && self.PsActiveProcessHead == other.PsActiveProcessHead
+            && self.PspCidTable == other.PspCidTable
+            && self.ExpSystemResourcesList == other.ExpSystemResourcesList
+            && self.ExpPagedPoolDescriptor == other.ExpPagedPoolDescriptor
+            && self.ExpNumberOfPagedPools == other.ExpNumberOfPagedPools
+            && self.KeTimeIncrement == other.KeTimeIncrement
+            && self.KeBugCheckCallbackListHead == other.KeBugCheckCallbackListHead
+            && self.KiBugcheckData == other.KiBugcheckData
+            && self.IopErrorLogListHead == other.IopErrorLogListHead
+            && self.ObpRootDirectoryObject == other.ObpRootDirectoryObject
+            && self.ObpTypeObjectType == other.ObpTypeObjectType
+            && self.MmSystemCacheStart == other.MmSystemCacheStart
+            && self.MmSystemCacheEnd == other.MmSystemCacheEnd
+            && self.MmSystemCacheWs == other.MmSystemCacheWs
+            && self.MmPfnDatabase == other.MmPfnDatabase
+            && self.MmSystemPtesStart == other.MmSystemPtesStart
+            && self.MmSystemPtesEnd == other.MmSystemPtesEnd
+            && self.MmSubsectionBase == other.MmSubsectionBase
+            && self.MmNumberOfPagingFiles == other.MmNumberOfPagingFiles
+            && self.MmLowestPhysicalPage == other.MmLowestPhysicalPage
+            && self.MmHighestPhysicalPage == other.MmHighestPhysicalPage
+            && self.MmNumberOfPhysicalPages == other.MmNumberOfPhysicalPages
+            && self.MmMaximumNonPagedPoolInBytes == other.MmMaximumNonPagedPoolInBytes
+            && self.MmNonPagedSystemStart == other.MmNonPagedSystemStart
+            && self.MmNonPagedPoolStart == other.MmNonPagedPoolStart
+            && self.MmNonPagedPoolEnd == other.MmNonPagedPoolEnd
+            && self.MmPagedPoolStart == other.MmPagedPoolStart
+            && self.MmPagedPoolEnd == other.MmPagedPoolEnd
+            && self.MmPagedPoolInformation == other.MmPagedPoolInformation
+            && self.MmPageSize == other.MmPageSize
+            && self.MmSizeOfPagedPoolInBytes == other.MmSizeOfPagedPoolInBytes
+            && self.MmTotalCommitLimit == other.MmTotalCommitLimit
+            && self.MmTotalCommittedPages == other.MmTotalCommittedPages
+            && self.MmSharedCommit == other.MmSharedCommit
+            && self.MmDriverCommit == other.MmDriverCommit
+            && self.MmProcessCommit == other.MmProcessCommit
+            && self.MmPagedPoolCommit == other.MmPagedPoolCommit
+            && self.MmExtendedCommit == other.MmExtendedCommit
+            && self.MmZeroedPageListHead == other.MmZeroedPageListHead
+            && self.MmFreePageListHead == other.MmFreePageListHead
+            && self.MmStandbyPageListHead == other.MmStandbyPageListHead
+            && self.MmModifiedPageListHead == other.MmModifiedPageListHead
+            && self.MmModifiedNoWritePageListHead == other.MmModifiedNoWritePageListHead
+            && self.MmAvailablePages == other.MmAvailablePages
+            && self.MmResidentAvailablePages == other.MmResidentAvailablePages
+            && self.PoolTrackTable == other.PoolTrackTable
+            && self.NonPagedPoolDescriptor == other.NonPagedPoolDescriptor
+            && self.MmHighestUserAddress == other.MmHighestUserAddress
+            && self.MmSystemRangeStart == other.MmSystemRangeStart
+            && self.MmUserProbeAddress == other.MmUserProbeAddress
+            && self.KdPrintCircularBuffer == other.KdPrintCircularBuffer
+            && self.KdPrintCircularBufferEnd == other.KdPrintCircularBufferEnd
+            && self.KdPrintWritePointer == other.KdPrintWritePointer
+            && self.KdPrintRolloverCount == other.KdPrintRolloverCount
+            && self.MmLoadedUserImageList == other.MmLoadedUserImageList
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -49051,7 +48901,164 @@ unsafe impl ::windows::core::Abi for KDDEBUGGER_DATA64 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for KDDEBUGGER_DATA64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KDDEBUGGER_DATA64>()) == 0 }
+        self.Header == other.Header
+            && self.KernBase == other.KernBase
+            && self.BreakpointWithStatus == other.BreakpointWithStatus
+            && self.SavedContext == other.SavedContext
+            && self.ThCallbackStack == other.ThCallbackStack
+            && self.NextCallback == other.NextCallback
+            && self.FramePointer == other.FramePointer
+            && self._bitfield == other._bitfield
+            && self.KiCallUserMode == other.KiCallUserMode
+            && self.KeUserCallbackDispatcher == other.KeUserCallbackDispatcher
+            && self.PsLoadedModuleList == other.PsLoadedModuleList
+            && self.PsActiveProcessHead == other.PsActiveProcessHead
+            && self.PspCidTable == other.PspCidTable
+            && self.ExpSystemResourcesList == other.ExpSystemResourcesList
+            && self.ExpPagedPoolDescriptor == other.ExpPagedPoolDescriptor
+            && self.ExpNumberOfPagedPools == other.ExpNumberOfPagedPools
+            && self.KeTimeIncrement == other.KeTimeIncrement
+            && self.KeBugCheckCallbackListHead == other.KeBugCheckCallbackListHead
+            && self.KiBugcheckData == other.KiBugcheckData
+            && self.IopErrorLogListHead == other.IopErrorLogListHead
+            && self.ObpRootDirectoryObject == other.ObpRootDirectoryObject
+            && self.ObpTypeObjectType == other.ObpTypeObjectType
+            && self.MmSystemCacheStart == other.MmSystemCacheStart
+            && self.MmSystemCacheEnd == other.MmSystemCacheEnd
+            && self.MmSystemCacheWs == other.MmSystemCacheWs
+            && self.MmPfnDatabase == other.MmPfnDatabase
+            && self.MmSystemPtesStart == other.MmSystemPtesStart
+            && self.MmSystemPtesEnd == other.MmSystemPtesEnd
+            && self.MmSubsectionBase == other.MmSubsectionBase
+            && self.MmNumberOfPagingFiles == other.MmNumberOfPagingFiles
+            && self.MmLowestPhysicalPage == other.MmLowestPhysicalPage
+            && self.MmHighestPhysicalPage == other.MmHighestPhysicalPage
+            && self.MmNumberOfPhysicalPages == other.MmNumberOfPhysicalPages
+            && self.MmMaximumNonPagedPoolInBytes == other.MmMaximumNonPagedPoolInBytes
+            && self.MmNonPagedSystemStart == other.MmNonPagedSystemStart
+            && self.MmNonPagedPoolStart == other.MmNonPagedPoolStart
+            && self.MmNonPagedPoolEnd == other.MmNonPagedPoolEnd
+            && self.MmPagedPoolStart == other.MmPagedPoolStart
+            && self.MmPagedPoolEnd == other.MmPagedPoolEnd
+            && self.MmPagedPoolInformation == other.MmPagedPoolInformation
+            && self.MmPageSize == other.MmPageSize
+            && self.MmSizeOfPagedPoolInBytes == other.MmSizeOfPagedPoolInBytes
+            && self.MmTotalCommitLimit == other.MmTotalCommitLimit
+            && self.MmTotalCommittedPages == other.MmTotalCommittedPages
+            && self.MmSharedCommit == other.MmSharedCommit
+            && self.MmDriverCommit == other.MmDriverCommit
+            && self.MmProcessCommit == other.MmProcessCommit
+            && self.MmPagedPoolCommit == other.MmPagedPoolCommit
+            && self.MmExtendedCommit == other.MmExtendedCommit
+            && self.MmZeroedPageListHead == other.MmZeroedPageListHead
+            && self.MmFreePageListHead == other.MmFreePageListHead
+            && self.MmStandbyPageListHead == other.MmStandbyPageListHead
+            && self.MmModifiedPageListHead == other.MmModifiedPageListHead
+            && self.MmModifiedNoWritePageListHead == other.MmModifiedNoWritePageListHead
+            && self.MmAvailablePages == other.MmAvailablePages
+            && self.MmResidentAvailablePages == other.MmResidentAvailablePages
+            && self.PoolTrackTable == other.PoolTrackTable
+            && self.NonPagedPoolDescriptor == other.NonPagedPoolDescriptor
+            && self.MmHighestUserAddress == other.MmHighestUserAddress
+            && self.MmSystemRangeStart == other.MmSystemRangeStart
+            && self.MmUserProbeAddress == other.MmUserProbeAddress
+            && self.KdPrintCircularBuffer == other.KdPrintCircularBuffer
+            && self.KdPrintCircularBufferEnd == other.KdPrintCircularBufferEnd
+            && self.KdPrintWritePointer == other.KdPrintWritePointer
+            && self.KdPrintRolloverCount == other.KdPrintRolloverCount
+            && self.MmLoadedUserImageList == other.MmLoadedUserImageList
+            && self.NtBuildLab == other.NtBuildLab
+            && self.KiNormalSystemCall == other.KiNormalSystemCall
+            && self.KiProcessorBlock == other.KiProcessorBlock
+            && self.MmUnloadedDrivers == other.MmUnloadedDrivers
+            && self.MmLastUnloadedDriver == other.MmLastUnloadedDriver
+            && self.MmTriageActionTaken == other.MmTriageActionTaken
+            && self.MmSpecialPoolTag == other.MmSpecialPoolTag
+            && self.KernelVerifier == other.KernelVerifier
+            && self.MmVerifierData == other.MmVerifierData
+            && self.MmAllocatedNonPagedPool == other.MmAllocatedNonPagedPool
+            && self.MmPeakCommitment == other.MmPeakCommitment
+            && self.MmTotalCommitLimitMaximum == other.MmTotalCommitLimitMaximum
+            && self.CmNtCSDVersion == other.CmNtCSDVersion
+            && self.MmPhysicalMemoryBlock == other.MmPhysicalMemoryBlock
+            && self.MmSessionBase == other.MmSessionBase
+            && self.MmSessionSize == other.MmSessionSize
+            && self.MmSystemParentTablePage == other.MmSystemParentTablePage
+            && self.MmVirtualTranslationBase == other.MmVirtualTranslationBase
+            && self.OffsetKThreadNextProcessor == other.OffsetKThreadNextProcessor
+            && self.OffsetKThreadTeb == other.OffsetKThreadTeb
+            && self.OffsetKThreadKernelStack == other.OffsetKThreadKernelStack
+            && self.OffsetKThreadInitialStack == other.OffsetKThreadInitialStack
+            && self.OffsetKThreadApcProcess == other.OffsetKThreadApcProcess
+            && self.OffsetKThreadState == other.OffsetKThreadState
+            && self.OffsetKThreadBStore == other.OffsetKThreadBStore
+            && self.OffsetKThreadBStoreLimit == other.OffsetKThreadBStoreLimit
+            && self.SizeEProcess == other.SizeEProcess
+            && self.OffsetEprocessPeb == other.OffsetEprocessPeb
+            && self.OffsetEprocessParentCID == other.OffsetEprocessParentCID
+            && self.OffsetEprocessDirectoryTableBase == other.OffsetEprocessDirectoryTableBase
+            && self.SizePrcb == other.SizePrcb
+            && self.OffsetPrcbDpcRoutine == other.OffsetPrcbDpcRoutine
+            && self.OffsetPrcbCurrentThread == other.OffsetPrcbCurrentThread
+            && self.OffsetPrcbMhz == other.OffsetPrcbMhz
+            && self.OffsetPrcbCpuType == other.OffsetPrcbCpuType
+            && self.OffsetPrcbVendorString == other.OffsetPrcbVendorString
+            && self.OffsetPrcbProcStateContext == other.OffsetPrcbProcStateContext
+            && self.OffsetPrcbNumber == other.OffsetPrcbNumber
+            && self.SizeEThread == other.SizeEThread
+            && self.L1tfHighPhysicalBitIndex == other.L1tfHighPhysicalBitIndex
+            && self.L1tfSwizzleBitIndex == other.L1tfSwizzleBitIndex
+            && self.Padding0 == other.Padding0
+            && self.KdPrintCircularBufferPtr == other.KdPrintCircularBufferPtr
+            && self.KdPrintBufferSize == other.KdPrintBufferSize
+            && self.KeLoaderBlock == other.KeLoaderBlock
+            && self.SizePcr == other.SizePcr
+            && self.OffsetPcrSelfPcr == other.OffsetPcrSelfPcr
+            && self.OffsetPcrCurrentPrcb == other.OffsetPcrCurrentPrcb
+            && self.OffsetPcrContainedPrcb == other.OffsetPcrContainedPrcb
+            && self.OffsetPcrInitialBStore == other.OffsetPcrInitialBStore
+            && self.OffsetPcrBStoreLimit == other.OffsetPcrBStoreLimit
+            && self.OffsetPcrInitialStack == other.OffsetPcrInitialStack
+            && self.OffsetPcrStackLimit == other.OffsetPcrStackLimit
+            && self.OffsetPrcbPcrPage == other.OffsetPrcbPcrPage
+            && self.OffsetPrcbProcStateSpecialReg == other.OffsetPrcbProcStateSpecialReg
+            && self.GdtR0Code == other.GdtR0Code
+            && self.GdtR0Data == other.GdtR0Data
+            && self.GdtR0Pcr == other.GdtR0Pcr
+            && self.GdtR3Code == other.GdtR3Code
+            && self.GdtR3Data == other.GdtR3Data
+            && self.GdtR3Teb == other.GdtR3Teb
+            && self.GdtLdt == other.GdtLdt
+            && self.GdtTss == other.GdtTss
+            && self.Gdt64R3CmCode == other.Gdt64R3CmCode
+            && self.Gdt64R3CmTeb == other.Gdt64R3CmTeb
+            && self.IopNumTriageDumpDataBlocks == other.IopNumTriageDumpDataBlocks
+            && self.IopTriageDumpDataBlocks == other.IopTriageDumpDataBlocks
+            && self.VfCrashDataBlock == other.VfCrashDataBlock
+            && self.MmBadPagesDetected == other.MmBadPagesDetected
+            && self.MmZeroedPageSingleBitErrorsDetected == other.MmZeroedPageSingleBitErrorsDetected
+            && self.EtwpDebuggerData == other.EtwpDebuggerData
+            && self.OffsetPrcbContext == other.OffsetPrcbContext
+            && self.OffsetPrcbMaxBreakpoints == other.OffsetPrcbMaxBreakpoints
+            && self.OffsetPrcbMaxWatchpoints == other.OffsetPrcbMaxWatchpoints
+            && self.OffsetKThreadStackLimit == other.OffsetKThreadStackLimit
+            && self.OffsetKThreadStackBase == other.OffsetKThreadStackBase
+            && self.OffsetKThreadQueueListEntry == other.OffsetKThreadQueueListEntry
+            && self.OffsetEThreadIrpList == other.OffsetEThreadIrpList
+            && self.OffsetPrcbIdleThread == other.OffsetPrcbIdleThread
+            && self.OffsetPrcbNormalDpcState == other.OffsetPrcbNormalDpcState
+            && self.OffsetPrcbDpcStack == other.OffsetPrcbDpcStack
+            && self.OffsetPrcbIsrStack == other.OffsetPrcbIsrStack
+            && self.SizeKDPC_STACK_FRAME == other.SizeKDPC_STACK_FRAME
+            && self.OffsetKPriQueueThreadListHead == other.OffsetKPriQueueThreadListHead
+            && self.OffsetKThreadWaitReason == other.OffsetKThreadWaitReason
+            && self.Padding1 == other.Padding1
+            && self.PteBase == other.PteBase
+            && self.RetpolineStubFunctionTable == other.RetpolineStubFunctionTable
+            && self.RetpolineStubFunctionTableSize == other.RetpolineStubFunctionTableSize
+            && self.RetpolineStubOffset == other.RetpolineStubOffset
+            && self.RetpolineStubSize == other.RetpolineStubSize
+            && self.OffsetEProcessMmHotPatchContext == other.OffsetEProcessMmHotPatchContext
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -49113,7 +49120,7 @@ unsafe impl ::windows::core::Abi for KDHELP {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for KDHELP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KDHELP>()) == 0 }
+        self.Thread == other.Thread && self.ThCallbackStack == other.ThCallbackStack && self.NextCallback == other.NextCallback && self.FramePointer == other.FramePointer && self.KiCallUserMode == other.KiCallUserMode && self.KeUserCallbackDispatcher == other.KeUserCallbackDispatcher && self.SystemRangeStart == other.SystemRangeStart && self.ThCallbackBStore == other.ThCallbackBStore && self.KiUserExceptionDispatcher == other.KiUserExceptionDispatcher && self.StackBase == other.StackBase && self.StackLimit == other.StackLimit && self.Reserved == other.Reserved
     }
 }
 #[cfg(target_arch = "x86")]
@@ -49179,7 +49186,23 @@ unsafe impl ::windows::core::Abi for KDHELP64 {
 }
 impl ::core::cmp::PartialEq for KDHELP64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KDHELP64>()) == 0 }
+        self.Thread == other.Thread
+            && self.ThCallbackStack == other.ThCallbackStack
+            && self.ThCallbackBStore == other.ThCallbackBStore
+            && self.NextCallback == other.NextCallback
+            && self.FramePointer == other.FramePointer
+            && self.KiCallUserMode == other.KiCallUserMode
+            && self.KeUserCallbackDispatcher == other.KeUserCallbackDispatcher
+            && self.SystemRangeStart == other.SystemRangeStart
+            && self.KiUserExceptionDispatcher == other.KiUserExceptionDispatcher
+            && self.StackBase == other.StackBase
+            && self.StackLimit == other.StackLimit
+            && self.BuildVersion == other.BuildVersion
+            && self.RetpolineStubFunctionTableSize == other.RetpolineStubFunctionTableSize
+            && self.RetpolineStubFunctionTable == other.RetpolineStubFunctionTable
+            && self.RetpolineStubOffset == other.RetpolineStubOffset
+            && self.RetpolineStubSize == other.RetpolineStubSize
+            && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for KDHELP64 {}
@@ -49208,14 +49231,6 @@ unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86_64")]
-impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::Eq for KNONVOLATILE_CONTEXT_POINTERS {}
-#[cfg(target_arch = "x86_64")]
 impl ::core::default::Default for KNONVOLATILE_CONTEXT_POINTERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49240,14 +49255,6 @@ impl ::core::clone::Clone for KNONVOLATILE_CONTEXT_POINTERS_0 {
 unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::Eq for KNONVOLATILE_CONTEXT_POINTERS_0 {}
 #[cfg(target_arch = "x86_64")]
 impl ::core::default::Default for KNONVOLATILE_CONTEXT_POINTERS_0 {
     fn default() -> Self {
@@ -49313,7 +49320,7 @@ unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS_0_0 {
 #[cfg(target_arch = "x86_64")]
 impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_0_0>()) == 0 }
+        self.Xmm0 == other.Xmm0 && self.Xmm1 == other.Xmm1 && self.Xmm2 == other.Xmm2 && self.Xmm3 == other.Xmm3 && self.Xmm4 == other.Xmm4 && self.Xmm5 == other.Xmm5 && self.Xmm6 == other.Xmm6 && self.Xmm7 == other.Xmm7 && self.Xmm8 == other.Xmm8 && self.Xmm9 == other.Xmm9 && self.Xmm10 == other.Xmm10 && self.Xmm11 == other.Xmm11 && self.Xmm12 == other.Xmm12 && self.Xmm13 == other.Xmm13 && self.Xmm14 == other.Xmm14 && self.Xmm15 == other.Xmm15
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -49343,14 +49350,6 @@ impl ::core::clone::Clone for KNONVOLATILE_CONTEXT_POINTERS_1 {
 unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS_1 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_1>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::Eq for KNONVOLATILE_CONTEXT_POINTERS_1 {}
 #[cfg(target_arch = "x86_64")]
 impl ::core::default::Default for KNONVOLATILE_CONTEXT_POINTERS_1 {
     fn default() -> Self {
@@ -49399,7 +49398,7 @@ unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS_1_0 {
 #[cfg(target_arch = "x86_64")]
 impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_1_0>()) == 0 }
+        self.Rax == other.Rax && self.Rcx == other.Rcx && self.Rdx == other.Rdx && self.Rbx == other.Rbx && self.Rsp == other.Rsp && self.Rbp == other.Rbp && self.Rsi == other.Rsi && self.Rdi == other.Rdi && self.R8 == other.R8 && self.R9 == other.R9 && self.R10 == other.R10 && self.R11 == other.R11 && self.R12 == other.R12 && self.R13 == other.R13 && self.R14 == other.R14 && self.R15 == other.R15
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -49428,14 +49427,6 @@ impl ::core::clone::Clone for KNONVOLATILE_CONTEXT_POINTERS {
 unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for KNONVOLATILE_CONTEXT_POINTERS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for KNONVOLATILE_CONTEXT_POINTERS {
     fn default() -> Self {
@@ -49509,7 +49500,7 @@ unsafe impl ::windows::core::Abi for KNONVOLATILE_CONTEXT_POINTERS_ARM64 {
 #[cfg(target_arch = "aarch64")]
 impl ::core::cmp::PartialEq for KNONVOLATILE_CONTEXT_POINTERS_ARM64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_ARM64>()) == 0 }
+        self.X19 == other.X19 && self.X20 == other.X20 && self.X21 == other.X21 && self.X22 == other.X22 && self.X23 == other.X23 && self.X24 == other.X24 && self.X25 == other.X25 && self.X26 == other.X26 && self.X27 == other.X27 && self.X28 == other.X28 && self.Fp == other.Fp && self.Lr == other.Lr && self.D8 == other.D8 && self.D9 == other.D9 && self.D10 == other.D10 && self.D11 == other.D11 && self.D12 == other.D12 && self.D13 == other.D13 && self.D14 == other.D14 && self.D15 == other.D15
     }
 }
 #[cfg(target_arch = "aarch64")]
@@ -49536,12 +49527,6 @@ impl ::core::clone::Clone for LDT_ENTRY {
 unsafe impl ::windows::core::Abi for LDT_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDT_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDT_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDT_ENTRY {}
 impl ::core::default::Default for LDT_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49562,12 +49547,6 @@ impl ::core::clone::Clone for LDT_ENTRY_0 {
 unsafe impl ::windows::core::Abi for LDT_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LDT_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDT_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LDT_ENTRY_0 {}
 impl ::core::default::Default for LDT_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49594,7 +49573,7 @@ unsafe impl ::windows::core::Abi for LDT_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for LDT_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDT_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for LDT_ENTRY_0_0 {}
@@ -49627,7 +49606,7 @@ unsafe impl ::windows::core::Abi for LDT_ENTRY_0_1 {
 }
 impl ::core::cmp::PartialEq for LDT_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDT_ENTRY_0_1>()) == 0 }
+        self.BaseMid == other.BaseMid && self.Flags1 == other.Flags1 && self.Flags2 == other.Flags2 && self.BaseHi == other.BaseHi
     }
 }
 impl ::core::cmp::Eq for LDT_ENTRY_0_1 {}
@@ -49697,7 +49676,7 @@ unsafe impl ::windows::core::Abi for LOADED_IMAGE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel", feature = "Win32_System_SystemInformation"))]
 impl ::core::cmp::PartialEq for LOADED_IMAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOADED_IMAGE>()) == 0 }
+        self.ModuleName == other.ModuleName && self.hFile == other.hFile && self.MappedAddress == other.MappedAddress && self.FileHeader == other.FileHeader && self.LastRvaSection == other.LastRvaSection && self.NumberOfSections == other.NumberOfSections && self.Sections == other.Sections && self.Characteristics == other.Characteristics && self.fSystemImage == other.fSystemImage && self.fDOSImage == other.fDOSImage && self.fReadOnly == other.fReadOnly && self.Version == other.Version && self.Links == other.Links && self.SizeOfImage == other.SizeOfImage
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -49771,7 +49750,7 @@ unsafe impl ::windows::core::Abi for LOADED_IMAGE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel", feature = "Win32_System_SystemInformation"))]
 impl ::core::cmp::PartialEq for LOADED_IMAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOADED_IMAGE>()) == 0 }
+        self.ModuleName == other.ModuleName && self.hFile == other.hFile && self.MappedAddress == other.MappedAddress && self.FileHeader == other.FileHeader && self.LastRvaSection == other.LastRvaSection && self.NumberOfSections == other.NumberOfSections && self.Sections == other.Sections && self.Characteristics == other.Characteristics && self.fSystemImage == other.fSystemImage && self.fDOSImage == other.fDOSImage && self.fReadOnly == other.fReadOnly && self.Version == other.Version && self.Links == other.Links && self.SizeOfImage == other.SizeOfImage
     }
 }
 #[cfg(target_arch = "x86")]
@@ -49816,7 +49795,7 @@ unsafe impl ::windows::core::Abi for LOAD_DLL_DEBUG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LOAD_DLL_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOAD_DLL_DEBUG_INFO>()) == 0 }
+        self.hFile == other.hFile && self.lpBaseOfDll == other.lpBaseOfDll && self.dwDebugInfoFileOffset == other.dwDebugInfoFileOffset && self.nDebugInfoSize == other.nDebugInfoSize && self.lpImageName == other.lpImageName && self.fUnicode == other.fUnicode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -49849,7 +49828,7 @@ unsafe impl ::windows::core::Abi for Location {
 }
 impl ::core::cmp::PartialEq for Location {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<Location>()) == 0 }
+        self.HostDefined == other.HostDefined && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for Location {}
@@ -49880,7 +49859,7 @@ unsafe impl ::windows::core::Abi for M128A {
 }
 impl ::core::cmp::PartialEq for M128A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<M128A>()) == 0 }
+        self.Low == other.Low && self.High == other.High
     }
 }
 impl ::core::cmp::Eq for M128A {}
@@ -49909,14 +49888,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_INFORMATION {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_INFORMATION {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -49943,14 +49914,6 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_INPUT {
 unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_INPUT {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_INPUT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_INPUT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_INPUT {
     fn default() -> Self {
@@ -49987,14 +49950,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_INPUT_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_INPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_INPUT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_INPUT_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_INPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50018,14 +49973,6 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_OUTPUT {
 unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_OUTPUT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT {
     fn default() -> Self {
@@ -50060,14 +50007,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_OUTPUT_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50092,14 +50031,6 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_OUTPUT_0_0 {
 unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_OUTPUT_0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0_0 {
     fn default() -> Self {
@@ -50134,7 +50065,7 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0_1>()) == 0 }
+        self.CheckCancel == other.CheckCancel && self.Cancel == other.Cancel
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
@@ -50165,14 +50096,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0_2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_OUTPUT_0_2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50197,14 +50120,6 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_OUTPUT_0_3 {
 unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0_3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
-impl ::core::cmp::Eq for MINIDUMP_CALLBACK_OUTPUT_0_3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0_3 {
     fn default() -> Self {
@@ -50239,7 +50154,7 @@ unsafe impl ::windows::core::Abi for MINIDUMP_CALLBACK_OUTPUT_0_4 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::cmp::PartialEq for MINIDUMP_CALLBACK_OUTPUT_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_CALLBACK_OUTPUT_0_4>()) == 0 }
+        self.VmReadStatus == other.VmReadStatus && self.VmReadBytesCompleted == other.VmReadBytesCompleted
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
@@ -50265,12 +50180,6 @@ impl ::core::clone::Clone for MINIDUMP_DIRECTORY {
 unsafe impl ::windows::core::Abi for MINIDUMP_DIRECTORY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_DIRECTORY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_DIRECTORY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_DIRECTORY {}
 impl ::core::default::Default for MINIDUMP_DIRECTORY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50296,12 +50205,6 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION {
 unsafe impl ::windows::core::Abi for MINIDUMP_EXCEPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_EXCEPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_EXCEPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_EXCEPTION {}
 impl ::core::default::Default for MINIDUMP_EXCEPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50327,14 +50230,6 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_EXCEPTION_INFORMATION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_EXCEPTION_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_EXCEPTION_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_EXCEPTION_INFORMATION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_EXCEPTION_INFORMATION {
     fn default() -> Self {
@@ -50363,14 +50258,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_EXCEPTION_INFORMATION64 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MINIDUMP_EXCEPTION_INFORMATION64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_EXCEPTION_INFORMATION64>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MINIDUMP_EXCEPTION_INFORMATION64 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MINIDUMP_EXCEPTION_INFORMATION64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50393,12 +50280,6 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION_STREAM {
 unsafe impl ::windows::core::Abi for MINIDUMP_EXCEPTION_STREAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_EXCEPTION_STREAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_EXCEPTION_STREAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_EXCEPTION_STREAM {}
 impl ::core::default::Default for MINIDUMP_EXCEPTION_STREAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50422,12 +50303,6 @@ impl ::core::clone::Clone for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_FUNCTION_TABLE_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {}
 impl ::core::default::Default for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50452,12 +50327,6 @@ impl ::core::clone::Clone for MINIDUMP_FUNCTION_TABLE_STREAM {
 unsafe impl ::windows::core::Abi for MINIDUMP_FUNCTION_TABLE_STREAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_FUNCTION_TABLE_STREAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_FUNCTION_TABLE_STREAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_FUNCTION_TABLE_STREAM {}
 impl ::core::default::Default for MINIDUMP_FUNCTION_TABLE_STREAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50480,12 +50349,6 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DATA_STREAM {
 unsafe impl ::windows::core::Abi for MINIDUMP_HANDLE_DATA_STREAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HANDLE_DATA_STREAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HANDLE_DATA_STREAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HANDLE_DATA_STREAM {}
 impl ::core::default::Default for MINIDUMP_HANDLE_DATA_STREAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50511,12 +50374,6 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for MINIDUMP_HANDLE_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HANDLE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HANDLE_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HANDLE_DESCRIPTOR {}
 impl ::core::default::Default for MINIDUMP_HANDLE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50544,12 +50401,6 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DESCRIPTOR_2 {
 unsafe impl ::windows::core::Abi for MINIDUMP_HANDLE_DESCRIPTOR_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HANDLE_DESCRIPTOR_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HANDLE_DESCRIPTOR_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HANDLE_DESCRIPTOR_2 {}
 impl ::core::default::Default for MINIDUMP_HANDLE_DESCRIPTOR_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50571,12 +50422,6 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_OBJECT_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_HANDLE_OBJECT_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HANDLE_OBJECT_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HANDLE_OBJECT_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HANDLE_OBJECT_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_HANDLE_OBJECT_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50599,12 +50444,6 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_OPERATION_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_HANDLE_OPERATION_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HANDLE_OPERATION_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HANDLE_OPERATION_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HANDLE_OPERATION_LIST {}
 impl ::core::default::Default for MINIDUMP_HANDLE_OPERATION_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50630,12 +50469,6 @@ impl ::core::clone::Clone for MINIDUMP_HEADER {
 unsafe impl ::windows::core::Abi for MINIDUMP_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HEADER {}
 impl ::core::default::Default for MINIDUMP_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50656,12 +50489,6 @@ impl ::core::clone::Clone for MINIDUMP_HEADER_0 {
 unsafe impl ::windows::core::Abi for MINIDUMP_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_HEADER_0 {}
 impl ::core::default::Default for MINIDUMP_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50681,12 +50508,6 @@ impl ::core::clone::Clone for MINIDUMP_INCLUDE_MODULE_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_INCLUDE_MODULE_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_INCLUDE_MODULE_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_INCLUDE_MODULE_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_INCLUDE_MODULE_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_INCLUDE_MODULE_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50706,12 +50527,6 @@ impl ::core::clone::Clone for MINIDUMP_INCLUDE_THREAD_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_INCLUDE_THREAD_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_INCLUDE_THREAD_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_INCLUDE_THREAD_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_INCLUDE_THREAD_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_INCLUDE_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50739,14 +50554,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_IO_CALLBACK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MINIDUMP_IO_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_IO_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MINIDUMP_IO_CALLBACK {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MINIDUMP_IO_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50767,12 +50574,6 @@ impl ::core::clone::Clone for MINIDUMP_LOCATION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for MINIDUMP_LOCATION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_LOCATION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_LOCATION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_LOCATION_DESCRIPTOR {}
 impl ::core::default::Default for MINIDUMP_LOCATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50793,12 +50594,6 @@ impl ::core::clone::Clone for MINIDUMP_LOCATION_DESCRIPTOR64 {
 unsafe impl ::windows::core::Abi for MINIDUMP_LOCATION_DESCRIPTOR64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_LOCATION_DESCRIPTOR64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_LOCATION_DESCRIPTOR64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_LOCATION_DESCRIPTOR64 {}
 impl ::core::default::Default for MINIDUMP_LOCATION_DESCRIPTOR64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50820,12 +50615,6 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY64_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY64_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY64_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY64_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MEMORY64_LIST {}
 impl ::core::default::Default for MINIDUMP_MEMORY64_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50846,12 +50635,6 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MEMORY_DESCRIPTOR {}
 impl ::core::default::Default for MINIDUMP_MEMORY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50872,12 +50655,6 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_DESCRIPTOR64 {
 unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY_DESCRIPTOR64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY_DESCRIPTOR64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY_DESCRIPTOR64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MEMORY_DESCRIPTOR64 {}
 impl ::core::default::Default for MINIDUMP_MEMORY_DESCRIPTOR64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50910,14 +50687,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Memory")]
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl ::core::cmp::Eq for MINIDUMP_MEMORY_INFO {}
-#[cfg(feature = "Win32_System_Memory")]
 impl ::core::default::Default for MINIDUMP_MEMORY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50939,12 +50708,6 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_INFO_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY_INFO_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY_INFO_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY_INFO_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MEMORY_INFO_LIST {}
 impl ::core::default::Default for MINIDUMP_MEMORY_INFO_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50965,12 +50728,6 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_MEMORY_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MEMORY_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MEMORY_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MEMORY_LIST {}
 impl ::core::default::Default for MINIDUMP_MEMORY_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -50995,12 +50752,6 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO {
 unsafe impl ::windows::core::Abi for MINIDUMP_MISC_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MISC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MISC_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MISC_INFO {}
 impl ::core::default::Default for MINIDUMP_MISC_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51030,12 +50781,6 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_2 {
 unsafe impl ::windows::core::Abi for MINIDUMP_MISC_INFO_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_MISC_INFO_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MISC_INFO_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_MISC_INFO_2 {}
 impl ::core::default::Default for MINIDUMP_MISC_INFO_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51074,14 +50819,6 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_3 {
 unsafe impl ::windows::core::Abi for MINIDUMP_MISC_INFO_3 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for MINIDUMP_MISC_INFO_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MISC_INFO_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for MINIDUMP_MISC_INFO_3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for MINIDUMP_MISC_INFO_3 {
     fn default() -> Self {
@@ -51123,14 +50860,6 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_4 {
 unsafe impl ::windows::core::Abi for MINIDUMP_MISC_INFO_4 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for MINIDUMP_MISC_INFO_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MISC_INFO_4>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for MINIDUMP_MISC_INFO_4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for MINIDUMP_MISC_INFO_4 {
     fn default() -> Self {
@@ -51175,14 +50904,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_MISC_INFO_5 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for MINIDUMP_MISC_INFO_5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MISC_INFO_5>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for MINIDUMP_MISC_INFO_5 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for MINIDUMP_MISC_INFO_5 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51215,14 +50936,6 @@ impl ::core::clone::Clone for MINIDUMP_MODULE {
 unsafe impl ::windows::core::Abi for MINIDUMP_MODULE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for MINIDUMP_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MODULE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for MINIDUMP_MODULE {}
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for MINIDUMP_MODULE {
     fn default() -> Self {
@@ -51257,14 +50970,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_MODULE_CALLBACK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for MINIDUMP_MODULE_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MODULE_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for MINIDUMP_MODULE_CALLBACK {}
-#[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for MINIDUMP_MODULE_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51289,14 +50994,6 @@ impl ::core::clone::Clone for MINIDUMP_MODULE_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_MODULE_LIST {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for MINIDUMP_MODULE_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_MODULE_LIST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for MINIDUMP_MODULE_LIST {}
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for MINIDUMP_MODULE_LIST {
     fn default() -> Self {
@@ -51327,12 +51024,6 @@ impl ::core::clone::Clone for MINIDUMP_PROCESS_VM_COUNTERS_1 {
 unsafe impl ::windows::core::Abi for MINIDUMP_PROCESS_VM_COUNTERS_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_PROCESS_VM_COUNTERS_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_PROCESS_VM_COUNTERS_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_PROCESS_VM_COUNTERS_1 {}
 impl ::core::default::Default for MINIDUMP_PROCESS_VM_COUNTERS_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51372,12 +51063,6 @@ impl ::core::clone::Clone for MINIDUMP_PROCESS_VM_COUNTERS_2 {
 unsafe impl ::windows::core::Abi for MINIDUMP_PROCESS_VM_COUNTERS_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_PROCESS_VM_COUNTERS_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_PROCESS_VM_COUNTERS_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_PROCESS_VM_COUNTERS_2 {}
 impl ::core::default::Default for MINIDUMP_PROCESS_VM_COUNTERS_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51399,12 +51084,6 @@ impl ::core::clone::Clone for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_READ_MEMORY_FAILURE_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51425,12 +51104,6 @@ impl ::core::clone::Clone for MINIDUMP_STRING {
 unsafe impl ::windows::core::Abi for MINIDUMP_STRING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_STRING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_STRING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_STRING {}
 impl ::core::default::Default for MINIDUMP_STRING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51459,12 +51132,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_BASIC_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_BASIC_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_BASIC_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_BASIC_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_BASIC_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51487,12 +51154,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51520,12 +51181,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_FILECACHE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51555,12 +51210,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_INFO {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_INFO {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51581,12 +51230,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_INFO_0 {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_INFO_0 {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51614,7 +51257,7 @@ unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_INFO_0_0>()) == 0 }
+        self.NumberOfProcessors == other.NumberOfProcessors && self.ProductType == other.ProductType
     }
 }
 impl ::core::cmp::Eq for MINIDUMP_SYSTEM_INFO_0_0 {}
@@ -51638,12 +51281,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_INFO_1 {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_INFO_1 {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51671,7 +51308,7 @@ unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_INFO_1_0 {
 }
 impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_INFO_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_INFO_1_0>()) == 0 }
+        self.SuiteMask == other.SuiteMask && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for MINIDUMP_SYSTEM_INFO_1_0 {}
@@ -51699,12 +51336,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_MEMORY_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_MEMORY_INFO_1 {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51801,12 +51432,6 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51832,12 +51457,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD {}
 impl ::core::default::Default for MINIDUMP_THREAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51873,16 +51492,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_CALLBACK {
 }
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_THREAD_CALLBACK {}
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51917,16 +51526,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_CALLBACK {
 }
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_THREAD_CALLBACK {}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51953,12 +51552,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_EX {}
 impl ::core::default::Default for MINIDUMP_THREAD_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -51996,16 +51589,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_EX_CALLBACK {
 }
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_EX_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_EX_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_THREAD_EX_CALLBACK {}
-#[cfg(target_arch = "aarch64")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_THREAD_EX_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52042,16 +51625,6 @@ unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_EX_CALLBACK {
 }
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_EX_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_EX_CALLBACK>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for MINIDUMP_THREAD_EX_CALLBACK {}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for MINIDUMP_THREAD_EX_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52072,12 +51645,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_EX_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_EX_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_EX_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_EX_LIST {}
 impl ::core::default::Default for MINIDUMP_THREAD_EX_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52106,12 +51673,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_INFO {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_INFO {}
 impl ::core::default::Default for MINIDUMP_THREAD_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52133,12 +51694,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_INFO_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_INFO_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_INFO_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_INFO_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_INFO_LIST {}
 impl ::core::default::Default for MINIDUMP_THREAD_INFO_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52159,12 +51714,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_LIST {}
 impl ::core::default::Default for MINIDUMP_THREAD_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52185,12 +51734,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_NAME {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_NAME {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_NAME {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_NAME>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_NAME {}
 impl ::core::default::Default for MINIDUMP_THREAD_NAME {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52211,12 +51754,6 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_NAME_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_THREAD_NAME_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_THREAD_NAME_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_THREAD_NAME_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_THREAD_NAME_LIST {}
 impl ::core::default::Default for MINIDUMP_THREAD_NAME_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52238,12 +51775,6 @@ impl ::core::clone::Clone for MINIDUMP_TOKEN_INFO_HEADER {
 unsafe impl ::windows::core::Abi for MINIDUMP_TOKEN_INFO_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_TOKEN_INFO_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_TOKEN_INFO_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_TOKEN_INFO_HEADER {}
 impl ::core::default::Default for MINIDUMP_TOKEN_INFO_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52266,12 +51797,6 @@ impl ::core::clone::Clone for MINIDUMP_TOKEN_INFO_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_TOKEN_INFO_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_TOKEN_INFO_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_TOKEN_INFO_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_TOKEN_INFO_LIST {}
 impl ::core::default::Default for MINIDUMP_TOKEN_INFO_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52295,12 +51820,6 @@ impl ::core::clone::Clone for MINIDUMP_UNLOADED_MODULE {
 unsafe impl ::windows::core::Abi for MINIDUMP_UNLOADED_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_UNLOADED_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_UNLOADED_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_UNLOADED_MODULE {}
 impl ::core::default::Default for MINIDUMP_UNLOADED_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52322,12 +51841,6 @@ impl ::core::clone::Clone for MINIDUMP_UNLOADED_MODULE_LIST {
 unsafe impl ::windows::core::Abi for MINIDUMP_UNLOADED_MODULE_LIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_UNLOADED_MODULE_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_UNLOADED_MODULE_LIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_UNLOADED_MODULE_LIST {}
 impl ::core::default::Default for MINIDUMP_UNLOADED_MODULE_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52348,12 +51861,6 @@ impl ::core::clone::Clone for MINIDUMP_USER_RECORD {
 unsafe impl ::windows::core::Abi for MINIDUMP_USER_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_USER_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_USER_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_USER_RECORD {}
 impl ::core::default::Default for MINIDUMP_USER_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52375,12 +51882,6 @@ impl ::core::clone::Clone for MINIDUMP_USER_STREAM {
 unsafe impl ::windows::core::Abi for MINIDUMP_USER_STREAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_USER_STREAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_USER_STREAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_USER_STREAM {}
 impl ::core::default::Default for MINIDUMP_USER_STREAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52401,12 +51902,6 @@ impl ::core::clone::Clone for MINIDUMP_USER_STREAM_INFORMATION {
 unsafe impl ::windows::core::Abi for MINIDUMP_USER_STREAM_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_USER_STREAM_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_USER_STREAM_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_USER_STREAM_INFORMATION {}
 impl ::core::default::Default for MINIDUMP_USER_STREAM_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52430,12 +51925,6 @@ impl ::core::clone::Clone for MINIDUMP_VM_POST_READ_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_VM_POST_READ_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_VM_POST_READ_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_VM_POST_READ_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_VM_POST_READ_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_VM_POST_READ_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52457,12 +51946,6 @@ impl ::core::clone::Clone for MINIDUMP_VM_PRE_READ_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_VM_PRE_READ_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_VM_PRE_READ_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_VM_PRE_READ_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_VM_PRE_READ_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_VM_PRE_READ_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52482,12 +51965,6 @@ impl ::core::clone::Clone for MINIDUMP_VM_QUERY_CALLBACK {
 unsafe impl ::windows::core::Abi for MINIDUMP_VM_QUERY_CALLBACK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MINIDUMP_VM_QUERY_CALLBACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIDUMP_VM_QUERY_CALLBACK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MINIDUMP_VM_QUERY_CALLBACK {}
 impl ::core::default::Default for MINIDUMP_VM_QUERY_CALLBACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -52519,7 +51996,7 @@ unsafe impl ::windows::core::Abi for MODLOAD_CVMISC {
 }
 impl ::core::cmp::PartialEq for MODLOAD_CVMISC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODLOAD_CVMISC>()) == 0 }
+        self.oCV == other.oCV && self.cCV == other.cCV && self.oMisc == other.oMisc && self.cMisc == other.cMisc && self.dtImage == other.dtImage && self.cImage == other.cImage
     }
 }
 impl ::core::cmp::Eq for MODLOAD_CVMISC {}
@@ -52553,7 +52030,7 @@ unsafe impl ::windows::core::Abi for MODLOAD_DATA {
 }
 impl ::core::cmp::PartialEq for MODLOAD_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODLOAD_DATA>()) == 0 }
+        self.ssize == other.ssize && self.ssig == other.ssig && self.data == other.data && self.size == other.size && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MODLOAD_DATA {}
@@ -52584,7 +52061,7 @@ unsafe impl ::windows::core::Abi for MODLOAD_PDBGUID_PDBAGE {
 }
 impl ::core::cmp::PartialEq for MODLOAD_PDBGUID_PDBAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODLOAD_PDBGUID_PDBAGE>()) == 0 }
+        self.PdbGuid == other.PdbGuid && self.PdbAge == other.PdbAge
     }
 }
 impl ::core::cmp::Eq for MODLOAD_PDBGUID_PDBAGE {}
@@ -52616,7 +52093,7 @@ unsafe impl ::windows::core::Abi for MODULE_TYPE_INFO {
 }
 impl ::core::cmp::PartialEq for MODULE_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULE_TYPE_INFO>()) == 0 }
+        self.dataLength == other.dataLength && self.leaf == other.leaf && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for MODULE_TYPE_INFO {}
@@ -52647,7 +52124,7 @@ unsafe impl ::windows::core::Abi for OMAP {
 }
 impl ::core::cmp::PartialEq for OMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OMAP>()) == 0 }
+        self.rva == other.rva && self.rvaTo == other.rvaTo
     }
 }
 impl ::core::cmp::Eq for OMAP {}
@@ -52679,7 +52156,7 @@ unsafe impl ::windows::core::Abi for OUTPUT_DEBUG_STRING_INFO {
 }
 impl ::core::cmp::PartialEq for OUTPUT_DEBUG_STRING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OUTPUT_DEBUG_STRING_INFO>()) == 0 }
+        self.lpDebugStringData == other.lpDebugStringData && self.fUnicode == other.fUnicode && self.nDebugStringLength == other.nDebugStringLength
     }
 }
 impl ::core::cmp::Eq for OUTPUT_DEBUG_STRING_INFO {}
@@ -52711,7 +52188,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL {
 }
 impl ::core::cmp::PartialEq for PHYSICAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL>()) == 0 }
+        self.Address == other.Address && self.BufLen == other.BufLen && self.Buf == other.Buf
     }
 }
 impl ::core::cmp::Eq for PHYSICAL {}
@@ -52743,7 +52220,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_MEMORY_DESCRIPTOR32 {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_MEMORY_DESCRIPTOR32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_MEMORY_DESCRIPTOR32>()) == 0 }
+        self.NumberOfRuns == other.NumberOfRuns && self.NumberOfPages == other.NumberOfPages && self.Run == other.Run
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_MEMORY_DESCRIPTOR32 {}
@@ -52775,7 +52252,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_MEMORY_DESCRIPTOR64 {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_MEMORY_DESCRIPTOR64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_MEMORY_DESCRIPTOR64>()) == 0 }
+        self.NumberOfRuns == other.NumberOfRuns && self.NumberOfPages == other.NumberOfPages && self.Run == other.Run
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_MEMORY_DESCRIPTOR64 {}
@@ -52806,7 +52283,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_MEMORY_RUN32 {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_MEMORY_RUN32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_MEMORY_RUN32>()) == 0 }
+        self.BasePage == other.BasePage && self.PageCount == other.PageCount
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_MEMORY_RUN32 {}
@@ -52837,7 +52314,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_MEMORY_RUN64 {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_MEMORY_RUN64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_MEMORY_RUN64>()) == 0 }
+        self.BasePage == other.BasePage && self.PageCount == other.PageCount
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_MEMORY_RUN64 {}
@@ -52869,7 +52346,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_TO_VIRTUAL {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_TO_VIRTUAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_TO_VIRTUAL>()) == 0 }
+        self.Status == other.Status && self.Size == other.Size && self.PdeAddress == other.PdeAddress
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_TO_VIRTUAL {}
@@ -52902,7 +52379,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_WITH_FLAGS {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_WITH_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_WITH_FLAGS>()) == 0 }
+        self.Address == other.Address && self.BufLen == other.BufLen && self.Flags == other.Flags && self.Buf == other.Buf
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_WITH_FLAGS {}
@@ -52939,7 +52416,7 @@ unsafe impl ::windows::core::Abi for POINTER_SEARCH_PHYSICAL {
 }
 impl ::core::cmp::PartialEq for POINTER_SEARCH_PHYSICAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_SEARCH_PHYSICAL>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length && self.PointerMin == other.PointerMin && self.PointerMax == other.PointerMax && self.Flags == other.Flags && self.MatchOffsets == other.MatchOffsets && self.MatchOffsetsSize == other.MatchOffsetsSize && self.MatchOffsetsCount == other.MatchOffsetsCount
     }
 }
 impl ::core::cmp::Eq for POINTER_SEARCH_PHYSICAL {}
@@ -52970,7 +52447,7 @@ unsafe impl ::windows::core::Abi for PROCESSORINFO {
 }
 impl ::core::cmp::PartialEq for PROCESSORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSORINFO>()) == 0 }
+        self.Processor == other.Processor && self.NumberProcessors == other.NumberProcessors
     }
 }
 impl ::core::cmp::Eq for PROCESSORINFO {}
@@ -53003,7 +52480,7 @@ unsafe impl ::windows::core::Abi for PROCESS_NAME_ENTRY {
 }
 impl ::core::cmp::PartialEq for PROCESS_NAME_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_NAME_ENTRY>()) == 0 }
+        self.ProcessId == other.ProcessId && self.NameOffset == other.NameOffset && self.NameSize == other.NameSize && self.NextEntry == other.NextEntry
     }
 }
 impl ::core::cmp::Eq for PROCESS_NAME_ENTRY {}
@@ -53031,12 +52508,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53057,12 +52528,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_0 {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_0 {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53083,12 +52548,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT_OPTIONAL_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53120,12 +52579,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53146,12 +52599,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_RELATIONSHIP {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_RELATIONSHIP {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_RELATIONSHIP {
-    fn eq(&self, other: &Self) -> bool {
-        self.relationshipId == other.relationshipId && self.relationshipInfo == other.relationshipInfo && self.Anonymous == other.Anonymous
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_RELATIONSHIP {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_RELATIONSHIP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53175,12 +52622,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT_RELATIONSHIP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53200,12 +52641,6 @@ impl ::core::clone::Clone for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
 unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
-    fn eq(&self, other: &Self) -> bool {
-        self.count == other.count && self.elements == other.elements
-    }
-}
-impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {}
 impl ::core::default::Default for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -53233,7 +52668,7 @@ unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_SCOPE_LIST {
 }
 impl ::core::cmp::PartialEq for PROFILER_HEAP_OBJECT_SCOPE_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_OBJECT_SCOPE_LIST>()) == 0 }
+        self.count == other.count && self.scopes == other.scopes
     }
 }
 impl ::core::cmp::Eq for PROFILER_HEAP_OBJECT_SCOPE_LIST {}
@@ -53264,7 +52699,7 @@ unsafe impl ::windows::core::Abi for PROFILER_HEAP_SUMMARY {
 }
 impl ::core::cmp::PartialEq for PROFILER_HEAP_SUMMARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_HEAP_SUMMARY>()) == 0 }
+        self.version == other.version && self.totalHeapSize == other.totalHeapSize
     }
 }
 impl ::core::cmp::Eq for PROFILER_HEAP_SUMMARY {}
@@ -53295,7 +52730,7 @@ unsafe impl ::windows::core::Abi for PROFILER_PROPERTY_TYPE_SUBSTRING_INFO {
 }
 impl ::core::cmp::PartialEq for PROFILER_PROPERTY_TYPE_SUBSTRING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILER_PROPERTY_TYPE_SUBSTRING_INFO>()) == 0 }
+        self.length == other.length && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for PROFILER_PROPERTY_TYPE_SUBSTRING_INFO {}
@@ -53328,7 +52763,7 @@ unsafe impl ::windows::core::Abi for READCONTROLSPACE {
 }
 impl ::core::cmp::PartialEq for READCONTROLSPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READCONTROLSPACE>()) == 0 }
+        self.Processor == other.Processor && self.Address == other.Address && self.BufLen == other.BufLen && self.Buf == other.Buf
     }
 }
 impl ::core::cmp::Eq for READCONTROLSPACE {}
@@ -53361,7 +52796,7 @@ unsafe impl ::windows::core::Abi for READCONTROLSPACE32 {
 }
 impl ::core::cmp::PartialEq for READCONTROLSPACE32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READCONTROLSPACE32>()) == 0 }
+        self.Processor == other.Processor && self.Address == other.Address && self.BufLen == other.BufLen && self.Buf == other.Buf
     }
 }
 impl ::core::cmp::Eq for READCONTROLSPACE32 {}
@@ -53394,7 +52829,7 @@ unsafe impl ::windows::core::Abi for READCONTROLSPACE64 {
 }
 impl ::core::cmp::PartialEq for READCONTROLSPACE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READCONTROLSPACE64>()) == 0 }
+        self.Processor == other.Processor && self.Address == other.Address && self.BufLen == other.BufLen && self.Buf == other.Buf
     }
 }
 impl ::core::cmp::Eq for READCONTROLSPACE64 {}
@@ -53425,7 +52860,7 @@ unsafe impl ::windows::core::Abi for READ_WRITE_MSR {
 }
 impl ::core::cmp::PartialEq for READ_WRITE_MSR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READ_WRITE_MSR>()) == 0 }
+        self.Msr == other.Msr && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for READ_WRITE_MSR {}
@@ -53456,7 +52891,7 @@ unsafe impl ::windows::core::Abi for RIP_INFO {
 }
 impl ::core::cmp::PartialEq for RIP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RIP_INFO>()) == 0 }
+        self.dwError == other.dwError && self.dwType == other.dwType
     }
 }
 impl ::core::cmp::Eq for RIP_INFO {}
@@ -53490,7 +52925,7 @@ unsafe impl ::windows::core::Abi for SEARCHMEMORY {
 }
 impl ::core::cmp::PartialEq for SEARCHMEMORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEARCHMEMORY>()) == 0 }
+        self.SearchAddress == other.SearchAddress && self.SearchLength == other.SearchLength && self.FoundAddress == other.FoundAddress && self.PatternLength == other.PatternLength && self.Pattern == other.Pattern
     }
 }
 impl ::core::cmp::Eq for SEARCHMEMORY {}
@@ -53521,7 +52956,7 @@ unsafe impl ::windows::core::Abi for SOURCEFILE {
 }
 impl ::core::cmp::PartialEq for SOURCEFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCEFILE>()) == 0 }
+        self.ModBase == other.ModBase && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for SOURCEFILE {}
@@ -53552,7 +52987,7 @@ unsafe impl ::windows::core::Abi for SOURCEFILEW {
 }
 impl ::core::cmp::PartialEq for SOURCEFILEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOURCEFILEW>()) == 0 }
+        self.ModBase == other.ModBase && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for SOURCEFILEW {}
@@ -53594,7 +53029,7 @@ unsafe impl ::windows::core::Abi for SRCCODEINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SRCCODEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRCCODEINFO>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.ModBase == other.ModBase && self.Obj == other.Obj && self.FileName == other.FileName && self.LineNumber == other.LineNumber && self.Address == other.Address
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53632,7 +53067,7 @@ unsafe impl ::windows::core::Abi for SRCCODEINFOW {
 }
 impl ::core::cmp::PartialEq for SRCCODEINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SRCCODEINFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.Key == other.Key && self.ModBase == other.ModBase && self.Obj == other.Obj && self.FileName == other.FileName && self.LineNumber == other.LineNumber && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for SRCCODEINFOW {}
@@ -53684,7 +53119,7 @@ unsafe impl ::windows::core::Abi for STACKFRAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STACKFRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STACKFRAME>()) == 0 }
+        self.AddrPC == other.AddrPC && self.AddrReturn == other.AddrReturn && self.AddrFrame == other.AddrFrame && self.AddrStack == other.AddrStack && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Far == other.Far && self.Virtual == other.Virtual && self.Reserved == other.Reserved && self.KdHelp == other.KdHelp && self.AddrBStore == other.AddrBStore
     }
 }
 #[cfg(target_arch = "x86")]
@@ -53734,7 +53169,7 @@ unsafe impl ::windows::core::Abi for STACKFRAME64 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STACKFRAME64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STACKFRAME64>()) == 0 }
+        self.AddrPC == other.AddrPC && self.AddrReturn == other.AddrReturn && self.AddrFrame == other.AddrFrame && self.AddrStack == other.AddrStack && self.AddrBStore == other.AddrBStore && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Far == other.Far && self.Virtual == other.Virtual && self.Reserved == other.Reserved && self.KdHelp == other.KdHelp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53798,7 +53233,7 @@ unsafe impl ::windows::core::Abi for STACKFRAME_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STACKFRAME_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STACKFRAME_EX>()) == 0 }
+        self.AddrPC == other.AddrPC && self.AddrReturn == other.AddrReturn && self.AddrFrame == other.AddrFrame && self.AddrStack == other.AddrStack && self.AddrBStore == other.AddrBStore && self.FuncTableEntry == other.FuncTableEntry && self.Params == other.Params && self.Far == other.Far && self.Virtual == other.Virtual && self.Reserved == other.Reserved && self.KdHelp == other.KdHelp && self.StackFrameSize == other.StackFrameSize && self.InlineFrameContext == other.InlineFrameContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53835,7 +53270,7 @@ unsafe impl ::windows::core::Abi for STACK_SRC_INFO {
 }
 impl ::core::cmp::PartialEq for STACK_SRC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STACK_SRC_INFO>()) == 0 }
+        self.ImagePath == other.ImagePath && self.ModuleName == other.ModuleName && self.Function == other.Function && self.Displacement == other.Displacement && self.Row == other.Row && self.Column == other.Column
     }
 }
 impl ::core::cmp::Eq for STACK_SRC_INFO {}
@@ -53872,7 +53307,7 @@ unsafe impl ::windows::core::Abi for STACK_SYM_FRAME_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STACK_SYM_FRAME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STACK_SYM_FRAME_INFO>()) == 0 }
+        self.StackFrameEx == other.StackFrameEx && self.SrcInfo == other.SrcInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -53940,7 +53375,7 @@ unsafe impl ::windows::core::Abi for SYMBOL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYMBOL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMBOL_INFO>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.TypeIndex == other.TypeIndex && self.Reserved == other.Reserved && self.Index == other.Index && self.Size == other.Size && self.ModBase == other.ModBase && self.Flags == other.Flags && self.Value == other.Value && self.Address == other.Address && self.Register == other.Register && self.Scope == other.Scope && self.Tag == other.Tag && self.NameLen == other.NameLen && self.MaxNameLen == other.MaxNameLen && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54002,7 +53437,7 @@ unsafe impl ::windows::core::Abi for SYMBOL_INFOW {
 }
 impl ::core::cmp::PartialEq for SYMBOL_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMBOL_INFOW>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.TypeIndex == other.TypeIndex && self.Reserved == other.Reserved && self.Index == other.Index && self.Size == other.Size && self.ModBase == other.ModBase && self.Flags == other.Flags && self.Value == other.Value && self.Address == other.Address && self.Register == other.Register && self.Scope == other.Scope && self.Tag == other.Tag && self.NameLen == other.NameLen && self.MaxNameLen == other.MaxNameLen && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for SYMBOL_INFOW {}
@@ -54037,7 +53472,7 @@ unsafe impl ::windows::core::Abi for SYMBOL_INFO_EX {
 }
 impl ::core::cmp::PartialEq for SYMBOL_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMBOL_INFO_EX>()) == 0 }
+        self.SizeOfStruct == other.SizeOfStruct && self.TypeOfInfo == other.TypeOfInfo && self.Offset == other.Offset && self.Line == other.Line && self.Displacement == other.Displacement && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for SYMBOL_INFO_EX {}
@@ -54074,7 +53509,7 @@ unsafe impl ::windows::core::Abi for SYMBOL_INFO_PACKAGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYMBOL_INFO_PACKAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMBOL_INFO_PACKAGE>()) == 0 }
+        self.si == other.si && self.name == other.name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54107,7 +53542,7 @@ unsafe impl ::windows::core::Abi for SYMBOL_INFO_PACKAGEW {
 }
 impl ::core::cmp::PartialEq for SYMBOL_INFO_PACKAGEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMBOL_INFO_PACKAGEW>()) == 0 }
+        self.si == other.si && self.name == other.name
     }
 }
 impl ::core::cmp::Eq for SYMBOL_INFO_PACKAGEW {}
@@ -54139,7 +53574,7 @@ unsafe impl ::windows::core::Abi for SYMSRV_EXTENDED_OUTPUT_DATA {
 }
 impl ::core::cmp::PartialEq for SYMSRV_EXTENDED_OUTPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMSRV_EXTENDED_OUTPUT_DATA>()) == 0 }
+        self.sizeOfStruct == other.sizeOfStruct && self.version == other.version && self.filePtrMsg == other.filePtrMsg
     }
 }
 impl ::core::cmp::Eq for SYMSRV_EXTENDED_OUTPUT_DATA {}
@@ -54184,7 +53619,7 @@ unsafe impl ::windows::core::Abi for SYMSRV_INDEX_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYMSRV_INDEX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMSRV_INDEX_INFO>()) == 0 }
+        self.sizeofstruct == other.sizeofstruct && self.file == other.file && self.stripped == other.stripped && self.timestamp == other.timestamp && self.size == other.size && self.dbgfile == other.dbgfile && self.pdbfile == other.pdbfile && self.guid == other.guid && self.sig == other.sig && self.age == other.age
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54231,7 +53666,7 @@ unsafe impl ::windows::core::Abi for SYMSRV_INDEX_INFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYMSRV_INDEX_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYMSRV_INDEX_INFOW>()) == 0 }
+        self.sizeofstruct == other.sizeofstruct && self.file == other.file && self.stripped == other.stripped && self.timestamp == other.timestamp && self.size == other.size && self.dbgfile == other.dbgfile && self.pdbfile == other.pdbfile && self.guid == other.guid && self.sig == other.sig && self.age == other.age
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54269,12 +53704,6 @@ impl ::core::clone::Clone for SYM_DUMP_PARAM {
 unsafe impl ::windows::core::Abi for SYM_DUMP_PARAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYM_DUMP_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYM_DUMP_PARAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYM_DUMP_PARAM {}
 impl ::core::default::Default for SYM_DUMP_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54295,12 +53724,6 @@ impl ::core::clone::Clone for SYM_DUMP_PARAM_0 {
 unsafe impl ::windows::core::Abi for SYM_DUMP_PARAM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYM_DUMP_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYM_DUMP_PARAM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYM_DUMP_PARAM_0 {}
 impl ::core::default::Default for SYM_DUMP_PARAM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54323,12 +53746,6 @@ impl ::core::clone::Clone for ScriptDebugEventInformation {
 unsafe impl ::windows::core::Abi for ScriptDebugEventInformation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ScriptDebugEventInformation {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ScriptDebugEventInformation>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ScriptDebugEventInformation {}
 impl ::core::default::Default for ScriptDebugEventInformation {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54349,12 +53766,6 @@ impl ::core::clone::Clone for ScriptDebugEventInformation_0 {
 unsafe impl ::windows::core::Abi for ScriptDebugEventInformation_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ScriptDebugEventInformation_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ScriptDebugEventInformation_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ScriptDebugEventInformation_0 {}
 impl ::core::default::Default for ScriptDebugEventInformation_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54381,7 +53792,7 @@ unsafe impl ::windows::core::Abi for ScriptDebugEventInformation_0_0 {
 }
 impl ::core::cmp::PartialEq for ScriptDebugEventInformation_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ScriptDebugEventInformation_0_0>()) == 0 }
+        self.BreakpointId == other.BreakpointId
     }
 }
 impl ::core::cmp::Eq for ScriptDebugEventInformation_0_0 {}
@@ -54411,7 +53822,7 @@ unsafe impl ::windows::core::Abi for ScriptDebugEventInformation_0_1 {
 }
 impl ::core::cmp::PartialEq for ScriptDebugEventInformation_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ScriptDebugEventInformation_0_1>()) == 0 }
+        self.IsUncaught == other.IsUncaught
     }
 }
 impl ::core::cmp::Eq for ScriptDebugEventInformation_0_1 {}
@@ -54442,7 +53853,7 @@ unsafe impl ::windows::core::Abi for ScriptDebugPosition {
 }
 impl ::core::cmp::PartialEq for ScriptDebugPosition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ScriptDebugPosition>()) == 0 }
+        self.Line == other.Line && self.Column == other.Column
     }
 }
 impl ::core::cmp::Eq for ScriptDebugPosition {}
@@ -54473,7 +53884,7 @@ unsafe impl ::windows::core::Abi for TEXT_DOCUMENT_ARRAY {
 }
 impl ::core::cmp::PartialEq for TEXT_DOCUMENT_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXT_DOCUMENT_ARRAY>()) == 0 }
+        self.dwCount == other.dwCount && self.Members == other.Members
     }
 }
 impl ::core::cmp::Eq for TEXT_DOCUMENT_ARRAY {}
@@ -54505,7 +53916,7 @@ unsafe impl ::windows::core::Abi for TI_FINDCHILDREN_PARAMS {
 }
 impl ::core::cmp::PartialEq for TI_FINDCHILDREN_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TI_FINDCHILDREN_PARAMS>()) == 0 }
+        self.Count == other.Count && self.Start == other.Start && self.ChildId == other.ChildId
     }
 }
 impl ::core::cmp::Eq for TI_FINDCHILDREN_PARAMS {}
@@ -54536,7 +53947,7 @@ unsafe impl ::windows::core::Abi for TRANSLATE_VIRTUAL_TO_PHYSICAL {
 }
 impl ::core::cmp::PartialEq for TRANSLATE_VIRTUAL_TO_PHYSICAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSLATE_VIRTUAL_TO_PHYSICAL>()) == 0 }
+        self.Virtual == other.Virtual && self.Physical == other.Physical
     }
 }
 impl ::core::cmp::Eq for TRANSLATE_VIRTUAL_TO_PHYSICAL {}
@@ -54566,7 +53977,7 @@ unsafe impl ::windows::core::Abi for UNLOAD_DLL_DEBUG_INFO {
 }
 impl ::core::cmp::PartialEq for UNLOAD_DLL_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNLOAD_DLL_DEBUG_INFO>()) == 0 }
+        self.lpBaseOfDll == other.lpBaseOfDll
     }
 }
 impl ::core::cmp::Eq for UNLOAD_DLL_DEBUG_INFO {}
@@ -54609,7 +54020,7 @@ unsafe impl ::windows::core::Abi for UNWIND_HISTORY_TABLE {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for UNWIND_HISTORY_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNWIND_HISTORY_TABLE>()) == 0 }
+        self.Count == other.Count && self.LocalHint == other.LocalHint && self.GlobalHint == other.GlobalHint && self.Search == other.Search && self.Once == other.Once && self.LowAddress == other.LowAddress && self.HighAddress == other.HighAddress && self.Entry == other.Entry
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -54648,7 +54059,7 @@ unsafe impl ::windows::core::Abi for UNWIND_HISTORY_TABLE_ENTRY {
 #[cfg(target_arch = "aarch64")]
 impl ::core::cmp::PartialEq for UNWIND_HISTORY_TABLE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNWIND_HISTORY_TABLE_ENTRY>()) == 0 }
+        self.ImageBase == other.ImageBase && self.FunctionEntry == other.FunctionEntry
     }
 }
 #[cfg(target_arch = "aarch64")]
@@ -54687,7 +54098,7 @@ unsafe impl ::windows::core::Abi for UNWIND_HISTORY_TABLE_ENTRY {
 #[cfg(target_arch = "x86_64")]
 impl ::core::cmp::PartialEq for UNWIND_HISTORY_TABLE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNWIND_HISTORY_TABLE_ENTRY>()) == 0 }
+        self.ImageBase == other.ImageBase && self.FunctionEntry == other.FunctionEntry
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -54723,7 +54134,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_TO_PHYSICAL {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_TO_PHYSICAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_TO_PHYSICAL>()) == 0 }
+        self.Status == other.Status && self.Size == other.Size && self.PdeAddress == other.PdeAddress && self.Virtual == other.Virtual && self.Physical == other.Physical
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_TO_PHYSICAL {}
@@ -54753,14 +54164,6 @@ unsafe impl ::windows::core::Abi for WAITCHAIN_NODE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAITCHAIN_NODE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAITCHAIN_NODE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAITCHAIN_NODE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAITCHAIN_NODE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -54785,14 +54188,6 @@ impl ::core::clone::Clone for WAITCHAIN_NODE_INFO_0 {
 unsafe impl ::windows::core::Abi for WAITCHAIN_NODE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WAITCHAIN_NODE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAITCHAIN_NODE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WAITCHAIN_NODE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WAITCHAIN_NODE_INFO_0 {
     fn default() -> Self {
@@ -54828,7 +54223,7 @@ unsafe impl ::windows::core::Abi for WAITCHAIN_NODE_INFO_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WAITCHAIN_NODE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAITCHAIN_NODE_INFO_0_0>()) == 0 }
+        self.ObjectName == other.ObjectName && self.Timeout == other.Timeout && self.Alertable == other.Alertable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54869,7 +54264,7 @@ unsafe impl ::windows::core::Abi for WAITCHAIN_NODE_INFO_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WAITCHAIN_NODE_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAITCHAIN_NODE_INFO_0_1>()) == 0 }
+        self.ProcessId == other.ProcessId && self.ThreadId == other.ThreadId && self.WaitTime == other.WaitTime && self.ContextSwitches == other.ContextSwitches
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -54902,7 +54297,7 @@ unsafe impl ::windows::core::Abi for WDBGEXTS_CLR_DATA_INTERFACE {
 }
 impl ::core::cmp::PartialEq for WDBGEXTS_CLR_DATA_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDBGEXTS_CLR_DATA_INTERFACE>()) == 0 }
+        self.Iid == other.Iid && self.Iface == other.Iface
     }
 }
 impl ::core::cmp::Eq for WDBGEXTS_CLR_DATA_INTERFACE {}
@@ -54940,7 +54335,7 @@ unsafe impl ::windows::core::Abi for WDBGEXTS_DISASSEMBLE_BUFFER {
 }
 impl ::core::cmp::PartialEq for WDBGEXTS_DISASSEMBLE_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDBGEXTS_DISASSEMBLE_BUFFER>()) == 0 }
+        self.InOffset == other.InOffset && self.OutOffset == other.OutOffset && self.AddrFlags == other.AddrFlags && self.FormatFlags == other.FormatFlags && self.DataBufferBytes == other.DataBufferBytes && self.DisasmBufferChars == other.DisasmBufferChars && self.DataBuffer == other.DataBuffer && self.DisasmBuffer == other.DisasmBuffer && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for WDBGEXTS_DISASSEMBLE_BUFFER {}
@@ -54973,7 +54368,7 @@ unsafe impl ::windows::core::Abi for WDBGEXTS_MODULE_IN_RANGE {
 }
 impl ::core::cmp::PartialEq for WDBGEXTS_MODULE_IN_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDBGEXTS_MODULE_IN_RANGE>()) == 0 }
+        self.Start == other.Start && self.End == other.End && self.FoundModBase == other.FoundModBase && self.FoundModSize == other.FoundModSize
     }
 }
 impl ::core::cmp::Eq for WDBGEXTS_MODULE_IN_RANGE {}
@@ -55004,7 +54399,7 @@ unsafe impl ::windows::core::Abi for WDBGEXTS_QUERY_INTERFACE {
 }
 impl ::core::cmp::PartialEq for WDBGEXTS_QUERY_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDBGEXTS_QUERY_INTERFACE>()) == 0 }
+        self.Iid == other.Iid && self.Iface == other.Iface
     }
 }
 impl ::core::cmp::Eq for WDBGEXTS_QUERY_INTERFACE {}
@@ -55043,7 +54438,7 @@ unsafe impl ::windows::core::Abi for WDBGEXTS_THREAD_OS_INFO {
 }
 impl ::core::cmp::PartialEq for WDBGEXTS_THREAD_OS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDBGEXTS_THREAD_OS_INFO>()) == 0 }
+        self.ThreadId == other.ThreadId && self.ExitStatus == other.ExitStatus && self.PriorityClass == other.PriorityClass && self.Priority == other.Priority && self.CreateTime == other.CreateTime && self.ExitTime == other.ExitTime && self.KernelTime == other.KernelTime && self.UserTime == other.UserTime && self.StartOffset == other.StartOffset && self.Affinity == other.Affinity
     }
 }
 impl ::core::cmp::Eq for WDBGEXTS_THREAD_OS_INFO {}
@@ -55084,14 +54479,6 @@ unsafe impl ::windows::core::Abi for WHEA_AER_BRIDGE_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_AER_BRIDGE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_AER_BRIDGE_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_AER_BRIDGE_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_AER_BRIDGE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55125,14 +54512,6 @@ impl ::core::clone::Clone for WHEA_AER_ENDPOINT_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_AER_ENDPOINT_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_AER_ENDPOINT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_AER_ENDPOINT_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_AER_ENDPOINT_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_AER_ENDPOINT_DESCRIPTOR {
     fn default() -> Self {
@@ -55168,14 +54547,6 @@ impl ::core::clone::Clone for WHEA_AER_ROOTPORT_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_AER_ROOTPORT_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_AER_ROOTPORT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_AER_ROOTPORT_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_AER_ROOTPORT_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_AER_ROOTPORT_DESCRIPTOR {
     fn default() -> Self {
@@ -55216,14 +54587,6 @@ unsafe impl ::windows::core::Abi for WHEA_DEVICE_DRIVER_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_DEVICE_DRIVER_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_DEVICE_DRIVER_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_DEVICE_DRIVER_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_DEVICE_DRIVER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55248,12 +54611,6 @@ impl ::core::clone::Clone for WHEA_DRIVER_BUFFER_SET {
 unsafe impl ::windows::core::Abi for WHEA_DRIVER_BUFFER_SET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_DRIVER_BUFFER_SET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_DRIVER_BUFFER_SET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_DRIVER_BUFFER_SET {}
 impl ::core::default::Default for WHEA_DRIVER_BUFFER_SET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55279,14 +54636,6 @@ impl ::core::clone::Clone for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
 unsafe impl ::windows::core::Abi for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_ERROR_SOURCE_CONFIGURATION_DD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_ERROR_SOURCE_CONFIGURATION_DD {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
     fn default() -> Self {
@@ -55321,14 +54670,6 @@ unsafe impl ::windows::core::Abi for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIV
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55357,14 +54698,6 @@ impl ::core::clone::Clone for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
 unsafe impl ::windows::core::Abi for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
     fn default() -> Self {
@@ -55399,14 +54732,6 @@ impl ::core::clone::Clone for WHEA_ERROR_SOURCE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_ERROR_SOURCE_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_ERROR_SOURCE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_ERROR_SOURCE_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_ERROR_SOURCE_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_ERROR_SOURCE_DESCRIPTOR {
     fn default() -> Self {
@@ -55443,14 +54768,6 @@ unsafe impl ::windows::core::Abi for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_ERROR_SOURCE_DESCRIPTOR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55480,12 +54797,6 @@ impl ::core::clone::Clone for WHEA_GENERIC_ERROR_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_GENERIC_ERROR_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_GENERIC_ERROR_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_GENERIC_ERROR_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_GENERIC_ERROR_DESCRIPTOR {}
 impl ::core::default::Default for WHEA_GENERIC_ERROR_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55522,12 +54833,6 @@ impl ::core::clone::Clone for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
 unsafe impl ::windows::core::Abi for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_GENERIC_ERROR_DESCRIPTOR_V2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {}
 impl ::core::default::Default for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55549,12 +54854,6 @@ impl ::core::clone::Clone for WHEA_IPF_CMC_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_IPF_CMC_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_IPF_CMC_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_IPF_CMC_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_IPF_CMC_DESCRIPTOR {}
 impl ::core::default::Default for WHEA_IPF_CMC_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55576,12 +54875,6 @@ impl ::core::clone::Clone for WHEA_IPF_CPE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_IPF_CPE_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_IPF_CPE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_IPF_CPE_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_IPF_CPE_DESCRIPTOR {}
 impl ::core::default::Default for WHEA_IPF_CPE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55603,12 +54896,6 @@ impl ::core::clone::Clone for WHEA_IPF_MCA_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_IPF_MCA_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_IPF_MCA_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_IPF_MCA_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_IPF_MCA_DESCRIPTOR {}
 impl ::core::default::Default for WHEA_IPF_MCA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55631,12 +54918,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55663,12 +54944,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55693,12 +54968,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55723,12 +54992,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55753,12 +55016,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55783,12 +55040,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55808,12 +55059,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55838,12 +55083,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_5>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55868,12 +55107,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_6>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55898,12 +55131,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_DESCRIPTOR_0_7>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55924,12 +55151,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_FLAGS {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_FLAGS {}
 impl ::core::default::Default for WHEA_NOTIFICATION_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55949,12 +55170,6 @@ impl ::core::clone::Clone for WHEA_NOTIFICATION_FLAGS_0 {
 unsafe impl ::windows::core::Abi for WHEA_NOTIFICATION_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_NOTIFICATION_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_NOTIFICATION_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_NOTIFICATION_FLAGS_0 {}
 impl ::core::default::Default for WHEA_NOTIFICATION_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -55974,12 +55189,6 @@ impl ::core::clone::Clone for WHEA_PCI_SLOT_NUMBER {
 unsafe impl ::windows::core::Abi for WHEA_PCI_SLOT_NUMBER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_PCI_SLOT_NUMBER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_PCI_SLOT_NUMBER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_PCI_SLOT_NUMBER {}
 impl ::core::default::Default for WHEA_PCI_SLOT_NUMBER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56000,12 +55209,6 @@ impl ::core::clone::Clone for WHEA_PCI_SLOT_NUMBER_0 {
 unsafe impl ::windows::core::Abi for WHEA_PCI_SLOT_NUMBER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_PCI_SLOT_NUMBER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_PCI_SLOT_NUMBER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_PCI_SLOT_NUMBER_0 {}
 impl ::core::default::Default for WHEA_PCI_SLOT_NUMBER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56025,12 +55228,6 @@ impl ::core::clone::Clone for WHEA_PCI_SLOT_NUMBER_0_0 {
 unsafe impl ::windows::core::Abi for WHEA_PCI_SLOT_NUMBER_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHEA_PCI_SLOT_NUMBER_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_PCI_SLOT_NUMBER_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHEA_PCI_SLOT_NUMBER_0_0 {}
 impl ::core::default::Default for WHEA_PCI_SLOT_NUMBER_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56059,14 +55256,6 @@ impl ::core::clone::Clone for WHEA_XPF_CMC_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_XPF_CMC_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_XPF_CMC_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_XPF_CMC_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_XPF_CMC_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_XPF_CMC_DESCRIPTOR {
     fn default() -> Self {
@@ -56097,14 +55286,6 @@ impl ::core::clone::Clone for WHEA_XPF_MCE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_XPF_MCE_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_XPF_MCE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_XPF_MCE_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_XPF_MCE_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_XPF_MCE_DESCRIPTOR {
     fn default() -> Self {
@@ -56138,14 +55319,6 @@ unsafe impl ::windows::core::Abi for WHEA_XPF_MC_BANK_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_XPF_MC_BANK_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_XPF_MC_BANK_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_XPF_MC_BANK_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_XPF_MC_BANK_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56170,14 +55343,6 @@ impl ::core::clone::Clone for WHEA_XPF_NMI_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for WHEA_XPF_NMI_DESCRIPTOR {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHEA_XPF_NMI_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHEA_XPF_NMI_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHEA_XPF_NMI_DESCRIPTOR {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHEA_XPF_NMI_DESCRIPTOR {
     fn default() -> Self {
@@ -56212,34 +55377,13 @@ impl ::core::clone::Clone for WINDBG_EXTENSION_APIS {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::fmt::Debug for WINDBG_EXTENSION_APIS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINDBG_EXTENSION_APIS")
-            .field("nSize", &self.nSize)
-            .field("lpOutputRoutine", &self.lpOutputRoutine.map(|f| f as usize))
-            .field("lpGetExpressionRoutine", &self.lpGetExpressionRoutine.map(|f| f as usize))
-            .field("lpGetSymbolRoutine", &self.lpGetSymbolRoutine.map(|f| f as usize))
-            .field("lpDisasmRoutine", &self.lpDisasmRoutine.map(|f| f as usize))
-            .field("lpCheckControlCRoutine", &self.lpCheckControlCRoutine.map(|f| f as usize))
-            .field("lpReadProcessMemoryRoutine", &self.lpReadProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpWriteProcessMemoryRoutine", &self.lpWriteProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpGetThreadContextRoutine", &self.lpGetThreadContextRoutine.map(|f| f as usize))
-            .field("lpSetThreadContextRoutine", &self.lpSetThreadContextRoutine.map(|f| f as usize))
-            .field("lpIoctlRoutine", &self.lpIoctlRoutine.map(|f| f as usize))
-            .field("lpStackTraceRoutine", &self.lpStackTraceRoutine.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINDBG_EXTENSION_APIS").field("nSize", &self.nSize).finish()
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
 unsafe impl ::windows::core::Abi for WINDBG_EXTENSION_APIS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for WINDBG_EXTENSION_APIS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDBG_EXTENSION_APIS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for WINDBG_EXTENSION_APIS {}
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for WINDBG_EXTENSION_APIS {
     fn default() -> Self {
@@ -56274,34 +55418,13 @@ impl ::core::clone::Clone for WINDBG_EXTENSION_APIS32 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::fmt::Debug for WINDBG_EXTENSION_APIS32 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINDBG_EXTENSION_APIS32")
-            .field("nSize", &self.nSize)
-            .field("lpOutputRoutine", &self.lpOutputRoutine.map(|f| f as usize))
-            .field("lpGetExpressionRoutine", &self.lpGetExpressionRoutine.map(|f| f as usize))
-            .field("lpGetSymbolRoutine", &self.lpGetSymbolRoutine.map(|f| f as usize))
-            .field("lpDisasmRoutine", &self.lpDisasmRoutine.map(|f| f as usize))
-            .field("lpCheckControlCRoutine", &self.lpCheckControlCRoutine.map(|f| f as usize))
-            .field("lpReadProcessMemoryRoutine", &self.lpReadProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpWriteProcessMemoryRoutine", &self.lpWriteProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpGetThreadContextRoutine", &self.lpGetThreadContextRoutine.map(|f| f as usize))
-            .field("lpSetThreadContextRoutine", &self.lpSetThreadContextRoutine.map(|f| f as usize))
-            .field("lpIoctlRoutine", &self.lpIoctlRoutine.map(|f| f as usize))
-            .field("lpStackTraceRoutine", &self.lpStackTraceRoutine.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINDBG_EXTENSION_APIS32").field("nSize", &self.nSize).finish()
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
 unsafe impl ::windows::core::Abi for WINDBG_EXTENSION_APIS32 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for WINDBG_EXTENSION_APIS32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDBG_EXTENSION_APIS32>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for WINDBG_EXTENSION_APIS32 {}
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for WINDBG_EXTENSION_APIS32 {
     fn default() -> Self {
@@ -56336,34 +55459,13 @@ impl ::core::clone::Clone for WINDBG_EXTENSION_APIS64 {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::fmt::Debug for WINDBG_EXTENSION_APIS64 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINDBG_EXTENSION_APIS64")
-            .field("nSize", &self.nSize)
-            .field("lpOutputRoutine", &self.lpOutputRoutine.map(|f| f as usize))
-            .field("lpGetExpressionRoutine", &self.lpGetExpressionRoutine.map(|f| f as usize))
-            .field("lpGetSymbolRoutine", &self.lpGetSymbolRoutine.map(|f| f as usize))
-            .field("lpDisasmRoutine", &self.lpDisasmRoutine.map(|f| f as usize))
-            .field("lpCheckControlCRoutine", &self.lpCheckControlCRoutine.map(|f| f as usize))
-            .field("lpReadProcessMemoryRoutine", &self.lpReadProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpWriteProcessMemoryRoutine", &self.lpWriteProcessMemoryRoutine.map(|f| f as usize))
-            .field("lpGetThreadContextRoutine", &self.lpGetThreadContextRoutine.map(|f| f as usize))
-            .field("lpSetThreadContextRoutine", &self.lpSetThreadContextRoutine.map(|f| f as usize))
-            .field("lpIoctlRoutine", &self.lpIoctlRoutine.map(|f| f as usize))
-            .field("lpStackTraceRoutine", &self.lpStackTraceRoutine.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINDBG_EXTENSION_APIS64").field("nSize", &self.nSize).finish()
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
 unsafe impl ::windows::core::Abi for WINDBG_EXTENSION_APIS64 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::PartialEq for WINDBG_EXTENSION_APIS64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDBG_EXTENSION_APIS64>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl ::core::cmp::Eq for WINDBG_EXTENSION_APIS64 {}
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::default::Default for WINDBG_EXTENSION_APIS64 {
     fn default() -> Self {
@@ -56392,29 +55494,12 @@ impl ::core::clone::Clone for WINDBG_OLDKD_EXTENSION_APIS {
 }
 impl ::core::fmt::Debug for WINDBG_OLDKD_EXTENSION_APIS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINDBG_OLDKD_EXTENSION_APIS")
-            .field("nSize", &self.nSize)
-            .field("lpOutputRoutine", &self.lpOutputRoutine.map(|f| f as usize))
-            .field("lpGetExpressionRoutine", &self.lpGetExpressionRoutine.map(|f| f as usize))
-            .field("lpGetSymbolRoutine", &self.lpGetSymbolRoutine.map(|f| f as usize))
-            .field("lpDisasmRoutine", &self.lpDisasmRoutine.map(|f| f as usize))
-            .field("lpCheckControlCRoutine", &self.lpCheckControlCRoutine.map(|f| f as usize))
-            .field("lpReadVirtualMemRoutine", &self.lpReadVirtualMemRoutine.map(|f| f as usize))
-            .field("lpWriteVirtualMemRoutine", &self.lpWriteVirtualMemRoutine.map(|f| f as usize))
-            .field("lpReadPhysicalMemRoutine", &self.lpReadPhysicalMemRoutine.map(|f| f as usize))
-            .field("lpWritePhysicalMemRoutine", &self.lpWritePhysicalMemRoutine.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WINDBG_OLDKD_EXTENSION_APIS").field("nSize", &self.nSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WINDBG_OLDKD_EXTENSION_APIS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINDBG_OLDKD_EXTENSION_APIS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDBG_OLDKD_EXTENSION_APIS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINDBG_OLDKD_EXTENSION_APIS {}
 impl ::core::default::Default for WINDBG_OLDKD_EXTENSION_APIS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56438,18 +55523,12 @@ impl ::core::clone::Clone for WINDBG_OLD_EXTENSION_APIS {
 }
 impl ::core::fmt::Debug for WINDBG_OLD_EXTENSION_APIS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WINDBG_OLD_EXTENSION_APIS").field("nSize", &self.nSize).field("lpOutputRoutine", &self.lpOutputRoutine.map(|f| f as usize)).field("lpGetExpressionRoutine", &self.lpGetExpressionRoutine.map(|f| f as usize)).field("lpGetSymbolRoutine", &self.lpGetSymbolRoutine.map(|f| f as usize)).field("lpDisasmRoutine", &self.lpDisasmRoutine.map(|f| f as usize)).field("lpCheckControlCRoutine", &self.lpCheckControlCRoutine.map(|f| f as usize)).finish()
+        f.debug_struct("WINDBG_OLD_EXTENSION_APIS").field("nSize", &self.nSize).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WINDBG_OLD_EXTENSION_APIS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WINDBG_OLD_EXTENSION_APIS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDBG_OLD_EXTENSION_APIS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WINDBG_OLD_EXTENSION_APIS {}
 impl ::core::default::Default for WINDBG_OLD_EXTENSION_APIS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56526,7 +55605,7 @@ unsafe impl ::windows::core::Abi for WOW64_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WOW64_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_CONTEXT>()) == 0 }
+        self.ContextFlags == other.ContextFlags && self.Dr0 == other.Dr0 && self.Dr1 == other.Dr1 && self.Dr2 == other.Dr2 && self.Dr3 == other.Dr3 && self.Dr6 == other.Dr6 && self.Dr7 == other.Dr7 && self.FloatSave == other.FloatSave && self.SegGs == other.SegGs && self.SegFs == other.SegFs && self.SegEs == other.SegEs && self.SegDs == other.SegDs && self.Edi == other.Edi && self.Esi == other.Esi && self.Ebx == other.Ebx && self.Edx == other.Edx && self.Ecx == other.Ecx && self.Eax == other.Eax && self.Ebp == other.Ebp && self.Eip == other.Eip && self.SegCs == other.SegCs && self.EFlags == other.EFlags && self.Esp == other.Esp && self.SegSs == other.SegSs && self.ExtendedRegisters == other.ExtendedRegisters
     }
 }
 impl ::core::cmp::Eq for WOW64_CONTEXT {}
@@ -56550,12 +55629,6 @@ impl ::core::clone::Clone for WOW64_DESCRIPTOR_TABLE_ENTRY {
 unsafe impl ::windows::core::Abi for WOW64_DESCRIPTOR_TABLE_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WOW64_DESCRIPTOR_TABLE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_DESCRIPTOR_TABLE_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WOW64_DESCRIPTOR_TABLE_ENTRY {}
 impl ::core::default::Default for WOW64_DESCRIPTOR_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56590,7 +55663,7 @@ unsafe impl ::windows::core::Abi for WOW64_FLOATING_SAVE_AREA {
 }
 impl ::core::cmp::PartialEq for WOW64_FLOATING_SAVE_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_FLOATING_SAVE_AREA>()) == 0 }
+        self.ControlWord == other.ControlWord && self.StatusWord == other.StatusWord && self.TagWord == other.TagWord && self.ErrorOffset == other.ErrorOffset && self.ErrorSelector == other.ErrorSelector && self.DataOffset == other.DataOffset && self.DataSelector == other.DataSelector && self.RegisterArea == other.RegisterArea && self.Cr0NpxState == other.Cr0NpxState
     }
 }
 impl ::core::cmp::Eq for WOW64_FLOATING_SAVE_AREA {}
@@ -56615,12 +55688,6 @@ impl ::core::clone::Clone for WOW64_LDT_ENTRY {
 unsafe impl ::windows::core::Abi for WOW64_LDT_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WOW64_LDT_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_LDT_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WOW64_LDT_ENTRY {}
 impl ::core::default::Default for WOW64_LDT_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56641,12 +55708,6 @@ impl ::core::clone::Clone for WOW64_LDT_ENTRY_0 {
 unsafe impl ::windows::core::Abi for WOW64_LDT_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WOW64_LDT_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_LDT_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WOW64_LDT_ENTRY_0 {}
 impl ::core::default::Default for WOW64_LDT_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56673,7 +55734,7 @@ unsafe impl ::windows::core::Abi for WOW64_LDT_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for WOW64_LDT_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_LDT_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WOW64_LDT_ENTRY_0_0 {}
@@ -56706,7 +55767,7 @@ unsafe impl ::windows::core::Abi for WOW64_LDT_ENTRY_0_1 {
 }
 impl ::core::cmp::PartialEq for WOW64_LDT_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOW64_LDT_ENTRY_0_1>()) == 0 }
+        self.BaseMid == other.BaseMid && self.Flags1 == other.Flags1 && self.Flags2 == other.Flags2 && self.BaseHi == other.BaseHi
     }
 }
 impl ::core::cmp::Eq for WOW64_LDT_ENTRY_0_1 {}
@@ -56730,12 +55791,6 @@ impl ::core::clone::Clone for XPF_MCE_FLAGS {
 unsafe impl ::windows::core::Abi for XPF_MCE_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XPF_MCE_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPF_MCE_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XPF_MCE_FLAGS {}
 impl ::core::default::Default for XPF_MCE_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56755,12 +55810,6 @@ impl ::core::clone::Clone for XPF_MCE_FLAGS_0 {
 unsafe impl ::windows::core::Abi for XPF_MCE_FLAGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XPF_MCE_FLAGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPF_MCE_FLAGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XPF_MCE_FLAGS_0 {}
 impl ::core::default::Default for XPF_MCE_FLAGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56781,12 +55830,6 @@ impl ::core::clone::Clone for XPF_MC_BANK_FLAGS {
 unsafe impl ::windows::core::Abi for XPF_MC_BANK_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XPF_MC_BANK_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPF_MC_BANK_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XPF_MC_BANK_FLAGS {}
 impl ::core::default::Default for XPF_MC_BANK_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -56813,7 +55856,7 @@ unsafe impl ::windows::core::Abi for XPF_MC_BANK_FLAGS_0 {
 }
 impl ::core::cmp::PartialEq for XPF_MC_BANK_FLAGS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XPF_MC_BANK_FLAGS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for XPF_MC_BANK_FLAGS_0 {}
@@ -56844,7 +55887,7 @@ unsafe impl ::windows::core::Abi for XSAVE_AREA {
 }
 impl ::core::cmp::PartialEq for XSAVE_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSAVE_AREA>()) == 0 }
+        self.LegacyState == other.LegacyState && self.Header == other.Header
     }
 }
 impl ::core::cmp::Eq for XSAVE_AREA {}
@@ -56876,7 +55919,7 @@ unsafe impl ::windows::core::Abi for XSAVE_AREA_HEADER {
 }
 impl ::core::cmp::PartialEq for XSAVE_AREA_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSAVE_AREA_HEADER>()) == 0 }
+        self.Mask == other.Mask && self.CompactionMask == other.CompactionMask && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for XSAVE_AREA_HEADER {}
@@ -56944,7 +55987,7 @@ unsafe impl ::windows::core::Abi for XSAVE_FORMAT {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for XSAVE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSAVE_FORMAT>()) == 0 }
+        self.ControlWord == other.ControlWord && self.StatusWord == other.StatusWord && self.TagWord == other.TagWord && self.Reserved1 == other.Reserved1 && self.ErrorOpcode == other.ErrorOpcode && self.ErrorOffset == other.ErrorOffset && self.ErrorSelector == other.ErrorSelector && self.Reserved2 == other.Reserved2 && self.DataOffset == other.DataOffset && self.DataSelector == other.DataSelector && self.Reserved3 == other.Reserved3 && self.MxCsr == other.MxCsr && self.MxCsr_Mask == other.MxCsr_Mask && self.FloatRegisters == other.FloatRegisters && self.XmmRegisters == other.XmmRegisters && self.Reserved4 == other.Reserved4
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -57014,7 +56057,7 @@ unsafe impl ::windows::core::Abi for XSAVE_FORMAT {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for XSAVE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSAVE_FORMAT>()) == 0 }
+        self.ControlWord == other.ControlWord && self.StatusWord == other.StatusWord && self.TagWord == other.TagWord && self.Reserved1 == other.Reserved1 && self.ErrorOpcode == other.ErrorOpcode && self.ErrorOffset == other.ErrorOffset && self.ErrorSelector == other.ErrorSelector && self.Reserved2 == other.Reserved2 && self.DataOffset == other.DataOffset && self.DataSelector == other.DataSelector && self.Reserved3 == other.Reserved3 && self.MxCsr == other.MxCsr && self.MxCsr_Mask == other.MxCsr_Mask && self.FloatRegisters == other.FloatRegisters && self.XmmRegisters == other.XmmRegisters && self.Reserved4 == other.Reserved4
     }
 }
 #[cfg(target_arch = "x86")]
@@ -57051,12 +56094,6 @@ impl ::core::clone::Clone for XSTATE_CONFIGURATION {
 unsafe impl ::windows::core::Abi for XSTATE_CONFIGURATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XSTATE_CONFIGURATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONFIGURATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XSTATE_CONFIGURATION {}
 impl ::core::default::Default for XSTATE_CONFIGURATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57077,12 +56114,6 @@ impl ::core::clone::Clone for XSTATE_CONFIGURATION_0 {
 unsafe impl ::windows::core::Abi for XSTATE_CONFIGURATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XSTATE_CONFIGURATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONFIGURATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XSTATE_CONFIGURATION_0 {}
 impl ::core::default::Default for XSTATE_CONFIGURATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57109,7 +56140,7 @@ unsafe impl ::windows::core::Abi for XSTATE_CONFIGURATION_0_0 {
 }
 impl ::core::cmp::PartialEq for XSTATE_CONFIGURATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONFIGURATION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for XSTATE_CONFIGURATION_0_0 {}
@@ -57135,12 +56166,6 @@ impl ::core::clone::Clone for XSTATE_CONFIG_FEATURE_MSC_INFO {
 unsafe impl ::windows::core::Abi for XSTATE_CONFIG_FEATURE_MSC_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XSTATE_CONFIG_FEATURE_MSC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONFIG_FEATURE_MSC_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for XSTATE_CONFIG_FEATURE_MSC_INFO {}
 impl ::core::default::Default for XSTATE_CONFIG_FEATURE_MSC_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57177,7 +56202,7 @@ unsafe impl ::windows::core::Abi for XSTATE_CONTEXT {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for XSTATE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONTEXT>()) == 0 }
+        self.Mask == other.Mask && self.Length == other.Length && self.Reserved1 == other.Reserved1 && self.Area == other.Area && self.Buffer == other.Buffer
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -57221,7 +56246,7 @@ unsafe impl ::windows::core::Abi for XSTATE_CONTEXT {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for XSTATE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_CONTEXT>()) == 0 }
+        self.Mask == other.Mask && self.Length == other.Length && self.Reserved1 == other.Reserved1 && self.Area == other.Area && self.Reserved2 == other.Reserved2 && self.Buffer == other.Buffer && self.Reserved3 == other.Reserved3
     }
 }
 #[cfg(target_arch = "x86")]
@@ -57254,7 +56279,7 @@ unsafe impl ::windows::core::Abi for XSTATE_FEATURE {
 }
 impl ::core::cmp::PartialEq for XSTATE_FEATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSTATE_FEATURE>()) == 0 }
+        self.Offset == other.Offset && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for XSTATE_FEATURE {}

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -2845,7 +2845,7 @@ unsafe impl ::windows::core::Abi for CLASSIC_EVENT_ID {
 }
 impl ::core::cmp::PartialEq for CLASSIC_EVENT_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLASSIC_EVENT_ID>()) == 0 }
+        self.EventGuid == other.EventGuid && self.Type == other.Type && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for CLASSIC_EVENT_ID {}
@@ -2912,7 +2912,7 @@ unsafe impl ::windows::core::Abi for ENABLE_TRACE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for ENABLE_TRACE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENABLE_TRACE_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.EnableProperty == other.EnableProperty && self.ControlFlags == other.ControlFlags && self.SourceId == other.SourceId && self.EnableFilterDesc == other.EnableFilterDesc && self.FilterDescCount == other.FilterDescCount
     }
 }
 impl ::core::cmp::Eq for ENABLE_TRACE_PARAMETERS {}
@@ -2946,7 +2946,7 @@ unsafe impl ::windows::core::Abi for ENABLE_TRACE_PARAMETERS_V1 {
 }
 impl ::core::cmp::PartialEq for ENABLE_TRACE_PARAMETERS_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENABLE_TRACE_PARAMETERS_V1>()) == 0 }
+        self.Version == other.Version && self.EnableProperty == other.EnableProperty && self.ControlFlags == other.ControlFlags && self.SourceId == other.SourceId && self.EnableFilterDesc == other.EnableFilterDesc
     }
 }
 impl ::core::cmp::Eq for ENABLE_TRACE_PARAMETERS_V1 {}
@@ -2970,12 +2970,6 @@ impl ::core::clone::Clone for ETW_BUFFER_CONTEXT {
 unsafe impl ::windows::core::Abi for ETW_BUFFER_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ETW_BUFFER_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_BUFFER_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ETW_BUFFER_CONTEXT {}
 impl ::core::default::Default for ETW_BUFFER_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2996,12 +2990,6 @@ impl ::core::clone::Clone for ETW_BUFFER_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for ETW_BUFFER_CONTEXT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ETW_BUFFER_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_BUFFER_CONTEXT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ETW_BUFFER_CONTEXT_0 {}
 impl ::core::default::Default for ETW_BUFFER_CONTEXT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3029,7 +3017,7 @@ unsafe impl ::windows::core::Abi for ETW_BUFFER_CONTEXT_0_0 {
 }
 impl ::core::cmp::PartialEq for ETW_BUFFER_CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_BUFFER_CONTEXT_0_0>()) == 0 }
+        self.ProcessorNumber == other.ProcessorNumber && self.Alignment == other.Alignment
     }
 }
 impl ::core::cmp::Eq for ETW_BUFFER_CONTEXT_0_0 {}
@@ -3061,7 +3049,7 @@ unsafe impl ::windows::core::Abi for ETW_PMC_COUNTER_OWNER {
 }
 impl ::core::cmp::PartialEq for ETW_PMC_COUNTER_OWNER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_PMC_COUNTER_OWNER>()) == 0 }
+        self.OwnerType == other.OwnerType && self.ProfileSource == other.ProfileSource && self.OwnerTag == other.OwnerTag
     }
 }
 impl ::core::cmp::Eq for ETW_PMC_COUNTER_OWNER {}
@@ -3093,7 +3081,7 @@ unsafe impl ::windows::core::Abi for ETW_PMC_COUNTER_OWNERSHIP_STATUS {
 }
 impl ::core::cmp::PartialEq for ETW_PMC_COUNTER_OWNERSHIP_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_PMC_COUNTER_OWNERSHIP_STATUS>()) == 0 }
+        self.ProcessorNumber == other.ProcessorNumber && self.NumberOfCounters == other.NumberOfCounters && self.CounterOwners == other.CounterOwners
     }
 }
 impl ::core::cmp::Eq for ETW_PMC_COUNTER_OWNERSHIP_STATUS {}
@@ -3126,7 +3114,7 @@ unsafe impl ::windows::core::Abi for ETW_TRACE_PARTITION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ETW_TRACE_PARTITION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_TRACE_PARTITION_INFORMATION>()) == 0 }
+        self.PartitionId == other.PartitionId && self.ParentId == other.ParentId && self.QpcOffsetFromRoot == other.QpcOffsetFromRoot && self.PartitionType == other.PartitionType
     }
 }
 impl ::core::cmp::Eq for ETW_TRACE_PARTITION_INFORMATION {}
@@ -3159,7 +3147,7 @@ unsafe impl ::windows::core::Abi for ETW_TRACE_PARTITION_INFORMATION_V2 {
 }
 impl ::core::cmp::PartialEq for ETW_TRACE_PARTITION_INFORMATION_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ETW_TRACE_PARTITION_INFORMATION_V2>()) == 0 }
+        self.QpcOffsetFromRoot == other.QpcOffsetFromRoot && self.PartitionType == other.PartitionType && self.PartitionId == other.PartitionId && self.ParentId == other.ParentId
     }
 }
 impl ::core::cmp::Eq for ETW_TRACE_PARTITION_INFORMATION_V2 {}
@@ -3184,12 +3172,6 @@ impl ::core::clone::Clone for EVENT_DATA_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for EVENT_DATA_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_DATA_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_DATA_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_DATA_DESCRIPTOR {}
 impl ::core::default::Default for EVENT_DATA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3210,12 +3192,6 @@ impl ::core::clone::Clone for EVENT_DATA_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for EVENT_DATA_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_DATA_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_DATA_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_DATA_DESCRIPTOR_0 {}
 impl ::core::default::Default for EVENT_DATA_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3244,7 +3220,7 @@ unsafe impl ::windows::core::Abi for EVENT_DATA_DESCRIPTOR_0_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_DATA_DESCRIPTOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_DATA_DESCRIPTOR_0_0>()) == 0 }
+        self.Type == other.Type && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for EVENT_DATA_DESCRIPTOR_0_0 {}
@@ -3280,7 +3256,7 @@ unsafe impl ::windows::core::Abi for EVENT_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for EVENT_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_DESCRIPTOR>()) == 0 }
+        self.Id == other.Id && self.Version == other.Version && self.Channel == other.Channel && self.Level == other.Level && self.Opcode == other.Opcode && self.Task == other.Task && self.Keyword == other.Keyword
     }
 }
 impl ::core::cmp::Eq for EVENT_DESCRIPTOR {}
@@ -3310,7 +3286,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_EVENT_KEY {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_EVENT_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_EVENT_KEY>()) == 0 }
+        self.Key == other.Key
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_EVENT_KEY {}
@@ -3342,7 +3318,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_INSTANCE {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_INSTANCE>()) == 0 }
+        self.InstanceId == other.InstanceId && self.ParentInstanceId == other.ParentInstanceId && self.ParentGuid == other.ParentGuid
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_INSTANCE {}
@@ -3372,7 +3348,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_PEBS_INDEX {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_PEBS_INDEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_PEBS_INDEX>()) == 0 }
+        self.PebsIndex == other.PebsIndex
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_PEBS_INDEX {}
@@ -3402,7 +3378,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_PMC_COUNTERS {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_PMC_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_PMC_COUNTERS>()) == 0 }
+        self.Counter == other.Counter
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_PMC_COUNTERS {}
@@ -3432,7 +3408,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_PROCESS_START_KEY {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_PROCESS_START_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_PROCESS_START_KEY>()) == 0 }
+        self.ProcessStartKey == other.ProcessStartKey
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_PROCESS_START_KEY {}
@@ -3462,7 +3438,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID>()) == 0 }
+        self.RelatedActivityId == other.RelatedActivityId
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {}
@@ -3494,7 +3470,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_STACK_KEY32 {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_STACK_KEY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_STACK_KEY32>()) == 0 }
+        self.MatchId == other.MatchId && self.StackKey == other.StackKey && self.Padding == other.Padding
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_STACK_KEY32 {}
@@ -3525,7 +3501,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_STACK_KEY64 {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_STACK_KEY64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_STACK_KEY64>()) == 0 }
+        self.MatchId == other.MatchId && self.StackKey == other.StackKey
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_STACK_KEY64 {}
@@ -3556,7 +3532,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_STACK_TRACE32 {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_STACK_TRACE32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_STACK_TRACE32>()) == 0 }
+        self.MatchId == other.MatchId && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_STACK_TRACE32 {}
@@ -3587,7 +3563,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_STACK_TRACE64 {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_STACK_TRACE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_STACK_TRACE64>()) == 0 }
+        self.MatchId == other.MatchId && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_STACK_TRACE64 {}
@@ -3617,7 +3593,7 @@ unsafe impl ::windows::core::Abi for EVENT_EXTENDED_ITEM_TS_ID {
 }
 impl ::core::cmp::PartialEq for EVENT_EXTENDED_ITEM_TS_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_EXTENDED_ITEM_TS_ID>()) == 0 }
+        self.SessionId == other.SessionId
     }
 }
 impl ::core::cmp::Eq for EVENT_EXTENDED_ITEM_TS_ID {}
@@ -3649,7 +3625,7 @@ unsafe impl ::windows::core::Abi for EVENT_FILTER_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for EVENT_FILTER_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_FILTER_DESCRIPTOR>()) == 0 }
+        self.Ptr == other.Ptr && self.Size == other.Size && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for EVENT_FILTER_DESCRIPTOR {}
@@ -3688,7 +3664,7 @@ unsafe impl ::windows::core::Abi for EVENT_FILTER_EVENT_ID {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_FILTER_EVENT_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_FILTER_EVENT_ID>()) == 0 }
+        self.FilterIn == other.FilterIn && self.Reserved == other.Reserved && self.Count == other.Count && self.Events == other.Events
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3731,7 +3707,7 @@ unsafe impl ::windows::core::Abi for EVENT_FILTER_EVENT_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_FILTER_EVENT_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_FILTER_EVENT_NAME>()) == 0 }
+        self.MatchAnyKeyword == other.MatchAnyKeyword && self.MatchAllKeyword == other.MatchAllKeyword && self.Level == other.Level && self.FilterIn == other.FilterIn && self.NameCount == other.NameCount && self.Names == other.Names
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3768,7 +3744,7 @@ unsafe impl ::windows::core::Abi for EVENT_FILTER_HEADER {
 }
 impl ::core::cmp::PartialEq for EVENT_FILTER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_FILTER_HEADER>()) == 0 }
+        self.Id == other.Id && self.Version == other.Version && self.Reserved == other.Reserved && self.InstanceId == other.InstanceId && self.Size == other.Size && self.NextOffset == other.NextOffset
     }
 }
 impl ::core::cmp::Eq for EVENT_FILTER_HEADER {}
@@ -3807,7 +3783,7 @@ unsafe impl ::windows::core::Abi for EVENT_FILTER_LEVEL_KW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_FILTER_LEVEL_KW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_FILTER_LEVEL_KW>()) == 0 }
+        self.MatchAnyKeyword == other.MatchAnyKeyword && self.MatchAllKeyword == other.MatchAllKeyword && self.Level == other.Level && self.FilterIn == other.FilterIn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3842,12 +3818,6 @@ impl ::core::clone::Clone for EVENT_HEADER {
 unsafe impl ::windows::core::Abi for EVENT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_HEADER {}
 impl ::core::default::Default for EVENT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3868,12 +3838,6 @@ impl ::core::clone::Clone for EVENT_HEADER_0 {
 unsafe impl ::windows::core::Abi for EVENT_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_HEADER_0 {}
 impl ::core::default::Default for EVENT_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3901,7 +3865,7 @@ unsafe impl ::windows::core::Abi for EVENT_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_HEADER_0_0>()) == 0 }
+        self.KernelTime == other.KernelTime && self.UserTime == other.UserTime
     }
 }
 impl ::core::cmp::Eq for EVENT_HEADER_0_0 {}
@@ -3935,7 +3899,7 @@ unsafe impl ::windows::core::Abi for EVENT_HEADER_EXTENDED_DATA_ITEM {
 }
 impl ::core::cmp::PartialEq for EVENT_HEADER_EXTENDED_DATA_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_HEADER_EXTENDED_DATA_ITEM>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.ExtType == other.ExtType && self.Anonymous == other.Anonymous && self.DataSize == other.DataSize && self.DataPtr == other.DataPtr
     }
 }
 impl ::core::cmp::Eq for EVENT_HEADER_EXTENDED_DATA_ITEM {}
@@ -3965,7 +3929,7 @@ unsafe impl ::windows::core::Abi for EVENT_HEADER_EXTENDED_DATA_ITEM_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_HEADER_EXTENDED_DATA_ITEM_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_HEADER_EXTENDED_DATA_ITEM_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for EVENT_HEADER_EXTENDED_DATA_ITEM_0 {}
@@ -3998,12 +3962,6 @@ impl ::core::clone::Clone for EVENT_INSTANCE_HEADER {
 unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER {}
 impl ::core::default::Default for EVENT_INSTANCE_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4024,12 +3982,6 @@ impl ::core::clone::Clone for EVENT_INSTANCE_HEADER_0 {
 unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_0 {}
 impl ::core::default::Default for EVENT_INSTANCE_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4057,7 +4009,7 @@ unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_0_0>()) == 0 }
+        self.HeaderType == other.HeaderType && self.MarkerFlags == other.MarkerFlags
     }
 }
 impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_0_0 {}
@@ -4081,12 +4033,6 @@ impl ::core::clone::Clone for EVENT_INSTANCE_HEADER_1 {
 unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_1 {}
 impl ::core::default::Default for EVENT_INSTANCE_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4115,7 +4061,7 @@ unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_1_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_1_0>()) == 0 }
+        self.Type == other.Type && self.Level == other.Level && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_1_0 {}
@@ -4140,12 +4086,6 @@ impl ::core::clone::Clone for EVENT_INSTANCE_HEADER_2 {
 unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_2 {}
 impl ::core::default::Default for EVENT_INSTANCE_HEADER_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4173,7 +4113,7 @@ unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_2_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_2_0>()) == 0 }
+        self.KernelTime == other.KernelTime && self.UserTime == other.UserTime
     }
 }
 impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_2_0 {}
@@ -4204,7 +4144,7 @@ unsafe impl ::windows::core::Abi for EVENT_INSTANCE_HEADER_2_1 {
 }
 impl ::core::cmp::PartialEq for EVENT_INSTANCE_HEADER_2_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_HEADER_2_1>()) == 0 }
+        self.EventId == other.EventId && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for EVENT_INSTANCE_HEADER_2_1 {}
@@ -4241,7 +4181,7 @@ unsafe impl ::windows::core::Abi for EVENT_INSTANCE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_INSTANCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_INSTANCE_INFO>()) == 0 }
+        self.RegHandle == other.RegHandle && self.InstanceId == other.InstanceId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4267,12 +4207,6 @@ impl ::core::clone::Clone for EVENT_MAP_ENTRY {
 unsafe impl ::windows::core::Abi for EVENT_MAP_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_MAP_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_MAP_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_MAP_ENTRY {}
 impl ::core::default::Default for EVENT_MAP_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4293,12 +4227,6 @@ impl ::core::clone::Clone for EVENT_MAP_ENTRY_0 {
 unsafe impl ::windows::core::Abi for EVENT_MAP_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_MAP_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_MAP_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_MAP_ENTRY_0 {}
 impl ::core::default::Default for EVENT_MAP_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4322,12 +4250,6 @@ impl ::core::clone::Clone for EVENT_MAP_INFO {
 unsafe impl ::windows::core::Abi for EVENT_MAP_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_MAP_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_MAP_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_MAP_INFO {}
 impl ::core::default::Default for EVENT_MAP_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4348,12 +4270,6 @@ impl ::core::clone::Clone for EVENT_MAP_INFO_0 {
 unsafe impl ::windows::core::Abi for EVENT_MAP_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_MAP_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_MAP_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_MAP_INFO_0 {}
 impl ::core::default::Default for EVENT_MAP_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4378,12 +4294,6 @@ impl ::core::clone::Clone for EVENT_PROPERTY_INFO {
 unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_PROPERTY_INFO {}
 impl ::core::default::Default for EVENT_PROPERTY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4405,12 +4315,6 @@ impl ::core::clone::Clone for EVENT_PROPERTY_INFO_0 {
 unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_0 {}
 impl ::core::default::Default for EVENT_PROPERTY_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4439,7 +4343,7 @@ unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_0_0>()) == 0 }
+        self.InType == other.InType && self.OutType == other.OutType && self.CustomSchemaOffset == other.CustomSchemaOffset
     }
 }
 impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_0_0 {}
@@ -4471,7 +4375,7 @@ unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_0_1 {
 }
 impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_0_1>()) == 0 }
+        self.InType == other.InType && self.OutType == other.OutType && self.MapNameOffset == other.MapNameOffset
     }
 }
 impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_0_1 {}
@@ -4503,7 +4407,7 @@ unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_0_2 {
 }
 impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_0_2>()) == 0 }
+        self.StructStartIndex == other.StructStartIndex && self.NumOfStructMembers == other.NumOfStructMembers && self.padding == other.padding
     }
 }
 impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_0_2 {}
@@ -4527,12 +4431,6 @@ impl ::core::clone::Clone for EVENT_PROPERTY_INFO_1 {
 unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_1 {}
 impl ::core::default::Default for EVENT_PROPERTY_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4553,12 +4451,6 @@ impl ::core::clone::Clone for EVENT_PROPERTY_INFO_2 {
 unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_2 {}
 impl ::core::default::Default for EVENT_PROPERTY_INFO_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4579,12 +4471,6 @@ impl ::core::clone::Clone for EVENT_PROPERTY_INFO_3 {
 unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_3 {}
 impl ::core::default::Default for EVENT_PROPERTY_INFO_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4611,7 +4497,7 @@ unsafe impl ::windows::core::Abi for EVENT_PROPERTY_INFO_3_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_PROPERTY_INFO_3_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_PROPERTY_INFO_3_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for EVENT_PROPERTY_INFO_3_0 {}
@@ -4640,12 +4526,6 @@ impl ::core::clone::Clone for EVENT_RECORD {
 unsafe impl ::windows::core::Abi for EVENT_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_RECORD {}
 impl ::core::default::Default for EVENT_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4671,12 +4551,6 @@ impl ::core::clone::Clone for EVENT_TRACE {
 unsafe impl ::windows::core::Abi for EVENT_TRACE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE {}
 impl ::core::default::Default for EVENT_TRACE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4697,12 +4571,6 @@ impl ::core::clone::Clone for EVENT_TRACE_0 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_0 {}
 impl ::core::default::Default for EVENT_TRACE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4729,12 +4597,6 @@ impl ::core::clone::Clone for EVENT_TRACE_HEADER {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_HEADER {}
 impl ::core::default::Default for EVENT_TRACE_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4755,12 +4617,6 @@ impl ::core::clone::Clone for EVENT_TRACE_HEADER_0 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_HEADER_0 {}
 impl ::core::default::Default for EVENT_TRACE_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4788,7 +4644,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_0_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_0_0>()) == 0 }
+        self.HeaderType == other.HeaderType && self.MarkerFlags == other.MarkerFlags
     }
 }
 impl ::core::cmp::Eq for EVENT_TRACE_HEADER_0_0 {}
@@ -4812,12 +4668,6 @@ impl ::core::clone::Clone for EVENT_TRACE_HEADER_1 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_HEADER_1 {}
 impl ::core::default::Default for EVENT_TRACE_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4846,7 +4696,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_1_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_1_0>()) == 0 }
+        self.Type == other.Type && self.Level == other.Level && self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for EVENT_TRACE_HEADER_1_0 {}
@@ -4870,12 +4720,6 @@ impl ::core::clone::Clone for EVENT_TRACE_HEADER_2 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_HEADER_2 {}
 impl ::core::default::Default for EVENT_TRACE_HEADER_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4897,12 +4741,6 @@ impl ::core::clone::Clone for EVENT_TRACE_HEADER_3 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_TRACE_HEADER_3 {}
 impl ::core::default::Default for EVENT_TRACE_HEADER_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4930,7 +4768,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_3_0 {
 }
 impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_3_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_3_0>()) == 0 }
+        self.KernelTime == other.KernelTime && self.UserTime == other.UserTime
     }
 }
 impl ::core::cmp::Eq for EVENT_TRACE_HEADER_3_0 {}
@@ -4961,7 +4799,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_HEADER_3_1 {
 }
 impl ::core::cmp::PartialEq for EVENT_TRACE_HEADER_3_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_HEADER_3_1>()) == 0 }
+        self.ClientContext == other.ClientContext && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for EVENT_TRACE_HEADER_3_1 {}
@@ -5002,14 +4840,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5035,14 +4865,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEA_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEA_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5067,14 +4889,6 @@ impl ::core::clone::Clone for EVENT_TRACE_LOGFILEA_1 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEA_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEA_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEA_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEA_1 {
     fn default() -> Self {
@@ -5113,14 +4927,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5146,14 +4952,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEW_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEW_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEW_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5178,14 +4976,6 @@ impl ::core::clone::Clone for EVENT_TRACE_LOGFILEW_1 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_LOGFILEW_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for EVENT_TRACE_LOGFILEW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_LOGFILEW_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for EVENT_TRACE_LOGFILEW_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for EVENT_TRACE_LOGFILEW_1 {
     fn default() -> Self {
@@ -5228,14 +5018,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5260,14 +5042,6 @@ impl ::core::clone::Clone for EVENT_TRACE_PROPERTIES_0 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES_0 {
     fn default() -> Self {
@@ -5314,14 +5088,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES_V2 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5347,14 +5113,6 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES_V2_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES_V2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5379,14 +5137,6 @@ impl ::core::clone::Clone for EVENT_TRACE_PROPERTIES_V2_1 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2_1 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES_V2_1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES_V2_1 {
     fn default() -> Self {
@@ -5420,7 +5170,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2_1_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5450,14 +5200,6 @@ impl ::core::clone::Clone for EVENT_TRACE_PROPERTIES_V2_2 {
 unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2_2 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVENT_TRACE_PROPERTIES_V2_2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVENT_TRACE_PROPERTIES_V2_2 {
     fn default() -> Self {
@@ -5491,7 +5233,7 @@ unsafe impl ::windows::core::Abi for EVENT_TRACE_PROPERTIES_V2_2_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENT_TRACE_PROPERTIES_V2_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_TRACE_PROPERTIES_V2_2_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5525,7 +5267,7 @@ unsafe impl ::windows::core::Abi for MOF_FIELD {
 }
 impl ::core::cmp::PartialEq for MOF_FIELD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOF_FIELD>()) == 0 }
+        self.DataPtr == other.DataPtr && self.Length == other.Length && self.DataType == other.DataType
     }
 }
 impl ::core::cmp::Eq for MOF_FIELD {}
@@ -5556,7 +5298,7 @@ unsafe impl ::windows::core::Abi for OFFSETINSTANCEDATAANDLENGTH {
 }
 impl ::core::cmp::PartialEq for OFFSETINSTANCEDATAANDLENGTH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFFSETINSTANCEDATAANDLENGTH>()) == 0 }
+        self.OffsetInstanceData == other.OffsetInstanceData && self.LengthInstanceData == other.LengthInstanceData
     }
 }
 impl ::core::cmp::Eq for OFFSETINSTANCEDATAANDLENGTH {}
@@ -5588,7 +5330,7 @@ unsafe impl ::windows::core::Abi for PAYLOAD_FILTER_PREDICATE {
 }
 impl ::core::cmp::PartialEq for PAYLOAD_FILTER_PREDICATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAYLOAD_FILTER_PREDICATE>()) == 0 }
+        self.FieldName == other.FieldName && self.CompareOp == other.CompareOp && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for PAYLOAD_FILTER_PREDICATE {}
@@ -5650,7 +5392,7 @@ unsafe impl ::windows::core::Abi for PROFILE_SOURCE_INFO {
 }
 impl ::core::cmp::PartialEq for PROFILE_SOURCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILE_SOURCE_INFO>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.Source == other.Source && self.MinInterval == other.MinInterval && self.MaxInterval == other.MaxInterval && self.Reserved == other.Reserved && self.Description == other.Description
     }
 }
 impl ::core::cmp::Eq for PROFILE_SOURCE_INFO {}
@@ -5682,7 +5424,7 @@ unsafe impl ::windows::core::Abi for PROPERTY_DATA_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for PROPERTY_DATA_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPERTY_DATA_DESCRIPTOR>()) == 0 }
+        self.PropertyName == other.PropertyName && self.ArrayIndex == other.ArrayIndex && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PROPERTY_DATA_DESCRIPTOR {}
@@ -5714,7 +5456,7 @@ unsafe impl ::windows::core::Abi for PROVIDER_ENUMERATION_INFO {
 }
 impl ::core::cmp::PartialEq for PROVIDER_ENUMERATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDER_ENUMERATION_INFO>()) == 0 }
+        self.NumberOfProviders == other.NumberOfProviders && self.Reserved == other.Reserved && self.TraceProviderInfoArray == other.TraceProviderInfoArray
     }
 }
 impl ::core::cmp::Eq for PROVIDER_ENUMERATION_INFO {}
@@ -5746,7 +5488,7 @@ unsafe impl ::windows::core::Abi for PROVIDER_EVENT_INFO {
 }
 impl ::core::cmp::PartialEq for PROVIDER_EVENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDER_EVENT_INFO>()) == 0 }
+        self.NumberOfEvents == other.NumberOfEvents && self.Reserved == other.Reserved && self.EventDescriptorsArray == other.EventDescriptorsArray
     }
 }
 impl ::core::cmp::Eq for PROVIDER_EVENT_INFO {}
@@ -5778,7 +5520,7 @@ unsafe impl ::windows::core::Abi for PROVIDER_FIELD_INFO {
 }
 impl ::core::cmp::PartialEq for PROVIDER_FIELD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDER_FIELD_INFO>()) == 0 }
+        self.NameOffset == other.NameOffset && self.DescriptionOffset == other.DescriptionOffset && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for PROVIDER_FIELD_INFO {}
@@ -5810,7 +5552,7 @@ unsafe impl ::windows::core::Abi for PROVIDER_FIELD_INFOARRAY {
 }
 impl ::core::cmp::PartialEq for PROVIDER_FIELD_INFOARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDER_FIELD_INFOARRAY>()) == 0 }
+        self.NumberOfElements == other.NumberOfElements && self.FieldType == other.FieldType && self.FieldInfoArray == other.FieldInfoArray
     }
 }
 impl ::core::cmp::Eq for PROVIDER_FIELD_INFOARRAY {}
@@ -5838,12 +5580,6 @@ impl ::core::clone::Clone for PROVIDER_FILTER_INFO {
 unsafe impl ::windows::core::Abi for PROVIDER_FILTER_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROVIDER_FILTER_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROVIDER_FILTER_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROVIDER_FILTER_INFO {}
 impl ::core::default::Default for PROVIDER_FILTER_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5904,7 +5640,7 @@ unsafe impl ::windows::core::Abi for TDH_CONTEXT {
 }
 impl ::core::cmp::PartialEq for TDH_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TDH_CONTEXT>()) == 0 }
+        self.ParameterValue == other.ParameterValue && self.ParameterType == other.ParameterType && self.ParameterSize == other.ParameterSize
     }
 }
 impl ::core::cmp::Eq for TDH_CONTEXT {}
@@ -5973,7 +5709,7 @@ unsafe impl ::windows::core::Abi for TRACE_ENABLE_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_ENABLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_ENABLE_INFO>()) == 0 }
+        self.IsEnabled == other.IsEnabled && self.Level == other.Level && self.Reserved1 == other.Reserved1 && self.LoggerId == other.LoggerId && self.EnableProperty == other.EnableProperty && self.Reserved2 == other.Reserved2 && self.MatchAnyKeyword == other.MatchAnyKeyword && self.MatchAllKeyword == other.MatchAllKeyword
     }
 }
 impl ::core::cmp::Eq for TRACE_ENABLE_INFO {}
@@ -6015,12 +5751,6 @@ impl ::core::clone::Clone for TRACE_EVENT_INFO {
 unsafe impl ::windows::core::Abi for TRACE_EVENT_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRACE_EVENT_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_EVENT_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRACE_EVENT_INFO {}
 impl ::core::default::Default for TRACE_EVENT_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6041,12 +5771,6 @@ impl ::core::clone::Clone for TRACE_EVENT_INFO_0 {
 unsafe impl ::windows::core::Abi for TRACE_EVENT_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRACE_EVENT_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_EVENT_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRACE_EVENT_INFO_0 {}
 impl ::core::default::Default for TRACE_EVENT_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6067,12 +5791,6 @@ impl ::core::clone::Clone for TRACE_EVENT_INFO_1 {
 unsafe impl ::windows::core::Abi for TRACE_EVENT_INFO_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRACE_EVENT_INFO_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_EVENT_INFO_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRACE_EVENT_INFO_1 {}
 impl ::core::default::Default for TRACE_EVENT_INFO_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6093,12 +5811,6 @@ impl ::core::clone::Clone for TRACE_EVENT_INFO_2 {
 unsafe impl ::windows::core::Abi for TRACE_EVENT_INFO_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRACE_EVENT_INFO_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_EVENT_INFO_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRACE_EVENT_INFO_2 {}
 impl ::core::default::Default for TRACE_EVENT_INFO_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6125,7 +5837,7 @@ unsafe impl ::windows::core::Abi for TRACE_EVENT_INFO_2_0 {
 }
 impl ::core::cmp::PartialEq for TRACE_EVENT_INFO_2_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_EVENT_INFO_2_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for TRACE_EVENT_INFO_2_0 {}
@@ -6156,7 +5868,7 @@ unsafe impl ::windows::core::Abi for TRACE_GUID_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_GUID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_GUID_INFO>()) == 0 }
+        self.InstanceCount == other.InstanceCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for TRACE_GUID_INFO {}
@@ -6197,7 +5909,7 @@ unsafe impl ::windows::core::Abi for TRACE_GUID_PROPERTIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRACE_GUID_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_GUID_PROPERTIES>()) == 0 }
+        self.Guid == other.Guid && self.GuidType == other.GuidType && self.LoggerId == other.LoggerId && self.EnableLevel == other.EnableLevel && self.EnableFlags == other.EnableFlags && self.IsEnable == other.IsEnable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6236,7 +5948,7 @@ unsafe impl ::windows::core::Abi for TRACE_GUID_REGISTRATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRACE_GUID_REGISTRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_GUID_REGISTRATION>()) == 0 }
+        self.Guid == other.Guid && self.RegHandle == other.RegHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6283,14 +5995,6 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6315,14 +6019,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER_0 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER_0 {
     fn default() -> Self {
@@ -6359,7 +6055,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER_0_0>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.SubVersion == other.SubVersion && self.SubMinorVersion == other.SubMinorVersion
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6389,14 +6085,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER_1 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER_1 {
     fn default() -> Self {
@@ -6433,7 +6121,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER_1_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER_1_0>()) == 0 }
+        self.StartBuffers == other.StartBuffers && self.PointerSize == other.PointerSize && self.EventsLost == other.EventsLost && self.CpuSpeedInMHz == other.CpuSpeedInMHz
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6480,14 +6168,6 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER32 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER32>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER32 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6512,14 +6192,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER32_0 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER32_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER32_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER32_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER32_0 {
     fn default() -> Self {
@@ -6556,7 +6228,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER32_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER32_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER32_0_0>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.SubVersion == other.SubVersion && self.SubMinorVersion == other.SubMinorVersion
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6586,14 +6258,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER32_1 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER32_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER32_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER32_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER32_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER32_1 {
     fn default() -> Self {
@@ -6630,7 +6294,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER32_1_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER32_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER32_1_0>()) == 0 }
+        self.StartBuffers == other.StartBuffers && self.PointerSize == other.PointerSize && self.EventsLost == other.EventsLost && self.CpuSpeedInMHz == other.CpuSpeedInMHz
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6677,14 +6341,6 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER64 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER64>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER64 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6709,14 +6365,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER64_0 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER64_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER64_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER64_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER64_0 {
     fn default() -> Self {
@@ -6753,7 +6401,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER64_0_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER64_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER64_0_0>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.SubVersion == other.SubVersion && self.SubMinorVersion == other.SubMinorVersion
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6783,14 +6431,6 @@ impl ::core::clone::Clone for TRACE_LOGFILE_HEADER64_1 {
 unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER64_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER64_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER64_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
-impl ::core::cmp::Eq for TRACE_LOGFILE_HEADER64_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::default::Default for TRACE_LOGFILE_HEADER64_1 {
     fn default() -> Self {
@@ -6827,7 +6467,7 @@ unsafe impl ::windows::core::Abi for TRACE_LOGFILE_HEADER64_1_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 impl ::core::cmp::PartialEq for TRACE_LOGFILE_HEADER64_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_LOGFILE_HEADER64_1_0>()) == 0 }
+        self.StartBuffers == other.StartBuffers && self.PointerSize == other.PointerSize && self.EventsLost == other.EventsLost && self.CpuSpeedInMHz == other.CpuSpeedInMHz
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
@@ -6861,7 +6501,7 @@ unsafe impl ::windows::core::Abi for TRACE_PERIODIC_CAPTURE_STATE_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_PERIODIC_CAPTURE_STATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_PERIODIC_CAPTURE_STATE_INFO>()) == 0 }
+        self.CaptureStateFrequencyInSeconds == other.CaptureStateFrequencyInSeconds && self.ProviderCount == other.ProviderCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for TRACE_PERIODIC_CAPTURE_STATE_INFO {}
@@ -6892,7 +6532,7 @@ unsafe impl ::windows::core::Abi for TRACE_PROFILE_INTERVAL {
 }
 impl ::core::cmp::PartialEq for TRACE_PROFILE_INTERVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_PROFILE_INTERVAL>()) == 0 }
+        self.Source == other.Source && self.Interval == other.Interval
     }
 }
 impl ::core::cmp::Eq for TRACE_PROFILE_INTERVAL {}
@@ -6924,7 +6564,7 @@ unsafe impl ::windows::core::Abi for TRACE_PROVIDER_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_PROVIDER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_PROVIDER_INFO>()) == 0 }
+        self.ProviderGuid == other.ProviderGuid && self.SchemaSource == other.SchemaSource && self.ProviderNameOffset == other.ProviderNameOffset
     }
 }
 impl ::core::cmp::Eq for TRACE_PROVIDER_INFO {}
@@ -6957,7 +6597,7 @@ unsafe impl ::windows::core::Abi for TRACE_PROVIDER_INSTANCE_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_PROVIDER_INSTANCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_PROVIDER_INSTANCE_INFO>()) == 0 }
+        self.NextOffset == other.NextOffset && self.EnableCount == other.EnableCount && self.Pid == other.Pid && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for TRACE_PROVIDER_INSTANCE_INFO {}
@@ -6995,7 +6635,7 @@ unsafe impl ::windows::core::Abi for TRACE_STACK_CACHING_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRACE_STACK_CACHING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_STACK_CACHING_INFO>()) == 0 }
+        self.Enabled == other.Enabled && self.CacheSize == other.CacheSize && self.BucketCount == other.BucketCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7028,7 +6668,7 @@ unsafe impl ::windows::core::Abi for TRACE_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for TRACE_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACE_VERSION_INFO>()) == 0 }
+        self.EtwTraceProcessingVersion == other.EtwTraceProcessingVersion && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for TRACE_VERSION_INFO {}
@@ -7054,12 +6694,6 @@ impl ::core::clone::Clone for WMIREGGUIDW {
 unsafe impl ::windows::core::Abi for WMIREGGUIDW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMIREGGUIDW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMIREGGUIDW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMIREGGUIDW {}
 impl ::core::default::Default for WMIREGGUIDW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7082,12 +6716,6 @@ impl ::core::clone::Clone for WMIREGGUIDW_0 {
 unsafe impl ::windows::core::Abi for WMIREGGUIDW_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMIREGGUIDW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMIREGGUIDW_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMIREGGUIDW_0 {}
 impl ::core::default::Default for WMIREGGUIDW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7112,12 +6740,6 @@ impl ::core::clone::Clone for WMIREGINFOW {
 unsafe impl ::windows::core::Abi for WMIREGINFOW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WMIREGINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WMIREGINFOW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WMIREGINFOW {}
 impl ::core::default::Default for WMIREGINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7146,14 +6768,6 @@ unsafe impl ::windows::core::Abi for WNODE_ALL_DATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_ALL_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_ALL_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_ALL_DATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_ALL_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7179,14 +6793,6 @@ unsafe impl ::windows::core::Abi for WNODE_ALL_DATA_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_ALL_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_ALL_DATA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_ALL_DATA_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_ALL_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7210,14 +6816,6 @@ impl ::core::clone::Clone for WNODE_EVENT_ITEM {
 unsafe impl ::windows::core::Abi for WNODE_EVENT_ITEM {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_EVENT_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_EVENT_ITEM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_EVENT_ITEM {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_EVENT_ITEM {
     fn default() -> Self {
@@ -7246,14 +6844,6 @@ unsafe impl ::windows::core::Abi for WNODE_EVENT_REFERENCE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_EVENT_REFERENCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_EVENT_REFERENCE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_EVENT_REFERENCE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_EVENT_REFERENCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7278,14 +6868,6 @@ impl ::core::clone::Clone for WNODE_EVENT_REFERENCE_0 {
 unsafe impl ::windows::core::Abi for WNODE_EVENT_REFERENCE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_EVENT_REFERENCE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_EVENT_REFERENCE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_EVENT_REFERENCE_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_EVENT_REFERENCE_0 {
     fn default() -> Self {
@@ -7317,14 +6899,6 @@ unsafe impl ::windows::core::Abi for WNODE_HEADER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_HEADER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_HEADER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7349,14 +6923,6 @@ impl ::core::clone::Clone for WNODE_HEADER_0 {
 unsafe impl ::windows::core::Abi for WNODE_HEADER_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_HEADER_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_HEADER_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_HEADER_0 {
     fn default() -> Self {
@@ -7391,7 +6957,7 @@ unsafe impl ::windows::core::Abi for WNODE_HEADER_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WNODE_HEADER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_HEADER_0_0>()) == 0 }
+        self.Version == other.Version && self.Linkage == other.Linkage
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7423,14 +6989,6 @@ unsafe impl ::windows::core::Abi for WNODE_HEADER_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_HEADER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_HEADER_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_HEADER_1 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_HEADER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7461,14 +7019,6 @@ unsafe impl ::windows::core::Abi for WNODE_METHOD_ITEM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_METHOD_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_METHOD_ITEM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_METHOD_ITEM {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_METHOD_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7497,14 +7047,6 @@ impl ::core::clone::Clone for WNODE_SINGLE_INSTANCE {
 unsafe impl ::windows::core::Abi for WNODE_SINGLE_INSTANCE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_SINGLE_INSTANCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_SINGLE_INSTANCE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_SINGLE_INSTANCE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_SINGLE_INSTANCE {
     fn default() -> Self {
@@ -7536,14 +7078,6 @@ unsafe impl ::windows::core::Abi for WNODE_SINGLE_ITEM {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_SINGLE_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_SINGLE_ITEM>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_SINGLE_ITEM {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_SINGLE_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7568,14 +7102,6 @@ impl ::core::clone::Clone for WNODE_TOO_SMALL {
 unsafe impl ::windows::core::Abi for WNODE_TOO_SMALL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WNODE_TOO_SMALL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNODE_TOO_SMALL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WNODE_TOO_SMALL {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WNODE_TOO_SMALL {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -617,7 +617,7 @@ unsafe impl ::windows::core::Abi for PSS_ALLOCATOR {
 }
 impl ::core::cmp::PartialEq for PSS_ALLOCATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_ALLOCATOR>()) == 0 }
+        self.Context == other.Context && self.AllocRoutine == other.AllocRoutine && self.FreeRoutine == other.FreeRoutine
     }
 }
 impl ::core::cmp::Eq for PSS_ALLOCATOR {}
@@ -647,7 +647,7 @@ unsafe impl ::windows::core::Abi for PSS_AUXILIARY_PAGES_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PSS_AUXILIARY_PAGES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_AUXILIARY_PAGES_INFORMATION>()) == 0 }
+        self.AuxPagesCaptured == other.AuxPagesCaptured
     }
 }
 impl ::core::cmp::Eq for PSS_AUXILIARY_PAGES_INFORMATION {}
@@ -687,7 +687,7 @@ unsafe impl ::windows::core::Abi for PSS_AUXILIARY_PAGE_ENTRY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 impl ::core::cmp::PartialEq for PSS_AUXILIARY_PAGE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_AUXILIARY_PAGE_ENTRY>()) == 0 }
+        self.Address == other.Address && self.BasicInformation == other.BasicInformation && self.CaptureTime == other.CaptureTime && self.PageContents == other.PageContents && self.PageSize == other.PageSize
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
@@ -732,14 +732,6 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PSS_HANDLE_ENTRY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PSS_HANDLE_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -768,14 +760,6 @@ impl ::core::clone::Clone for PSS_HANDLE_ENTRY_0 {
 unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PSS_HANDLE_ENTRY_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PSS_HANDLE_ENTRY_0 {
     fn default() -> Self {
@@ -810,7 +794,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_0>()) == 0 }
+        self.ManualReset == other.ManualReset && self.Signaled == other.Signaled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -851,7 +835,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_1>()) == 0 }
+        self.CurrentCount == other.CurrentCount && self.Abandoned == other.Abandoned && self.OwnerProcessId == other.OwnerProcessId && self.OwnerThreadId == other.OwnerThreadId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -895,7 +879,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_2>()) == 0 }
+        self.ExitStatus == other.ExitStatus && self.PebBaseAddress == other.PebBaseAddress && self.AffinityMask == other.AffinityMask && self.BasePriority == other.BasePriority && self.ProcessId == other.ProcessId && self.ParentProcessId == other.ParentProcessId && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -935,7 +919,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_3>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationAttributes == other.AllocationAttributes && self.MaximumSize == other.MaximumSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -974,7 +958,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_4>()) == 0 }
+        self.CurrentCount == other.CurrentCount && self.MaximumCount == other.MaximumCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1019,7 +1003,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_ENTRY_0_5 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_ENTRY_0_5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_ENTRY_0_5>()) == 0 }
+        self.ExitStatus == other.ExitStatus && self.TebBaseAddress == other.TebBaseAddress && self.ProcessId == other.ProcessId && self.ThreadId == other.ThreadId && self.AffinityMask == other.AffinityMask && self.Priority == other.Priority && self.BasePriority == other.BasePriority && self.Win32StartAddress == other.Win32StartAddress
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1051,7 +1035,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PSS_HANDLE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_INFORMATION>()) == 0 }
+        self.HandlesCaptured == other.HandlesCaptured
     }
 }
 impl ::core::cmp::Eq for PSS_HANDLE_INFORMATION {}
@@ -1088,7 +1072,7 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_TRACE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_HANDLE_TRACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_HANDLE_TRACE_INFORMATION>()) == 0 }
+        self.SectionHandle == other.SectionHandle && self.Size == other.Size
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1144,7 +1128,7 @@ unsafe impl ::windows::core::Abi for PSS_PERFORMANCE_COUNTERS {
 }
 impl ::core::cmp::PartialEq for PSS_PERFORMANCE_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_PERFORMANCE_COUNTERS>()) == 0 }
+        self.TotalCycleCount == other.TotalCycleCount && self.TotalWallClockPeriod == other.TotalWallClockPeriod && self.VaCloneCycleCount == other.VaCloneCycleCount && self.VaCloneWallClockPeriod == other.VaCloneWallClockPeriod && self.VaSpaceCycleCount == other.VaSpaceCycleCount && self.VaSpaceWallClockPeriod == other.VaSpaceWallClockPeriod && self.AuxPagesCycleCount == other.AuxPagesCycleCount && self.AuxPagesWallClockPeriod == other.AuxPagesWallClockPeriod && self.HandlesCycleCount == other.HandlesCycleCount && self.HandlesWallClockPeriod == other.HandlesWallClockPeriod && self.ThreadsCycleCount == other.ThreadsCycleCount && self.ThreadsWallClockPeriod == other.ThreadsWallClockPeriod
     }
 }
 impl ::core::cmp::Eq for PSS_PERFORMANCE_COUNTERS {}
@@ -1232,7 +1216,32 @@ unsafe impl ::windows::core::Abi for PSS_PROCESS_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_PROCESS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_PROCESS_INFORMATION>()) == 0 }
+        self.ExitStatus == other.ExitStatus
+            && self.PebBaseAddress == other.PebBaseAddress
+            && self.AffinityMask == other.AffinityMask
+            && self.BasePriority == other.BasePriority
+            && self.ProcessId == other.ProcessId
+            && self.ParentProcessId == other.ParentProcessId
+            && self.Flags == other.Flags
+            && self.CreateTime == other.CreateTime
+            && self.ExitTime == other.ExitTime
+            && self.KernelTime == other.KernelTime
+            && self.UserTime == other.UserTime
+            && self.PriorityClass == other.PriorityClass
+            && self.PeakVirtualSize == other.PeakVirtualSize
+            && self.VirtualSize == other.VirtualSize
+            && self.PageFaultCount == other.PageFaultCount
+            && self.PeakWorkingSetSize == other.PeakWorkingSetSize
+            && self.WorkingSetSize == other.WorkingSetSize
+            && self.QuotaPeakPagedPoolUsage == other.QuotaPeakPagedPoolUsage
+            && self.QuotaPagedPoolUsage == other.QuotaPagedPoolUsage
+            && self.QuotaPeakNonPagedPoolUsage == other.QuotaPeakNonPagedPoolUsage
+            && self.QuotaNonPagedPoolUsage == other.QuotaNonPagedPoolUsage
+            && self.PagefileUsage == other.PagefileUsage
+            && self.PeakPagefileUsage == other.PeakPagefileUsage
+            && self.PrivateUsage == other.PrivateUsage
+            && self.ExecuteFlags == other.ExecuteFlags
+            && self.ImageFileName == other.ImageFileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1308,7 +1317,25 @@ unsafe impl ::windows::core::Abi for PSS_THREAD_ENTRY {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for PSS_THREAD_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_THREAD_ENTRY>()) == 0 }
+        self.ExitStatus == other.ExitStatus
+            && self.TebBaseAddress == other.TebBaseAddress
+            && self.ProcessId == other.ProcessId
+            && self.ThreadId == other.ThreadId
+            && self.AffinityMask == other.AffinityMask
+            && self.Priority == other.Priority
+            && self.BasePriority == other.BasePriority
+            && self.LastSyscallFirstArgument == other.LastSyscallFirstArgument
+            && self.LastSyscallNumber == other.LastSyscallNumber
+            && self.CreateTime == other.CreateTime
+            && self.ExitTime == other.ExitTime
+            && self.KernelTime == other.KernelTime
+            && self.UserTime == other.UserTime
+            && self.Win32StartAddress == other.Win32StartAddress
+            && self.CaptureTime == other.CaptureTime
+            && self.Flags == other.Flags
+            && self.SuspendCount == other.SuspendCount
+            && self.SizeOfContextRecord == other.SizeOfContextRecord
+            && self.ContextRecord == other.ContextRecord
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
@@ -1341,7 +1368,7 @@ unsafe impl ::windows::core::Abi for PSS_THREAD_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PSS_THREAD_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_THREAD_INFORMATION>()) == 0 }
+        self.ThreadsCaptured == other.ThreadsCaptured && self.ContextLength == other.ContextLength
     }
 }
 impl ::core::cmp::Eq for PSS_THREAD_INFORMATION {}
@@ -1377,7 +1404,7 @@ unsafe impl ::windows::core::Abi for PSS_VA_CLONE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSS_VA_CLONE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_VA_CLONE_INFORMATION>()) == 0 }
+        self.VaCloneHandle == other.VaCloneHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1435,7 +1462,7 @@ unsafe impl ::windows::core::Abi for PSS_VA_SPACE_ENTRY {
 }
 impl ::core::cmp::PartialEq for PSS_VA_SPACE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_VA_SPACE_ENTRY>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationBase == other.AllocationBase && self.AllocationProtect == other.AllocationProtect && self.RegionSize == other.RegionSize && self.State == other.State && self.Protect == other.Protect && self.Type == other.Type && self.TimeDateStamp == other.TimeDateStamp && self.SizeOfImage == other.SizeOfImage && self.ImageBase == other.ImageBase && self.CheckSum == other.CheckSum && self.MappedFileNameLength == other.MappedFileNameLength && self.MappedFileName == other.MappedFileName
     }
 }
 impl ::core::cmp::Eq for PSS_VA_SPACE_ENTRY {}
@@ -1465,7 +1492,7 @@ unsafe impl ::windows::core::Abi for PSS_VA_SPACE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PSS_VA_SPACE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSS_VA_SPACE_INFORMATION>()) == 0 }
+        self.RegionCount == other.RegionCount
     }
 }
 impl ::core::cmp::Eq for PSS_VA_SPACE_INFORMATION {}

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
@@ -282,7 +282,7 @@ unsafe impl ::windows::core::Abi for HEAPENTRY32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HEAPENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAPENTRY32>()) == 0 }
+        self.dwSize == other.dwSize && self.hHandle == other.hHandle && self.dwAddress == other.dwAddress && self.dwBlockSize == other.dwBlockSize && self.dwFlags == other.dwFlags && self.dwLockCount == other.dwLockCount && self.dwResvd == other.dwResvd && self.th32ProcessID == other.th32ProcessID && self.th32HeapID == other.th32HeapID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -317,7 +317,7 @@ unsafe impl ::windows::core::Abi for HEAPLIST32 {
 }
 impl ::core::cmp::PartialEq for HEAPLIST32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAPLIST32>()) == 0 }
+        self.dwSize == other.dwSize && self.th32ProcessID == other.th32ProcessID && self.th32HeapID == other.th32HeapID && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for HEAPLIST32 {}
@@ -362,7 +362,7 @@ unsafe impl ::windows::core::Abi for MODULEENTRY32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MODULEENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULEENTRY32>()) == 0 }
+        self.dwSize == other.dwSize && self.th32ModuleID == other.th32ModuleID && self.th32ProcessID == other.th32ProcessID && self.GlblcntUsage == other.GlblcntUsage && self.ProccntUsage == other.ProccntUsage && self.modBaseAddr == other.modBaseAddr && self.modBaseSize == other.modBaseSize && self.hModule == other.hModule && self.szModule == other.szModule && self.szExePath == other.szExePath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -409,7 +409,7 @@ unsafe impl ::windows::core::Abi for MODULEENTRY32W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MODULEENTRY32W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULEENTRY32W>()) == 0 }
+        self.dwSize == other.dwSize && self.th32ModuleID == other.th32ModuleID && self.th32ProcessID == other.th32ProcessID && self.GlblcntUsage == other.GlblcntUsage && self.ProccntUsage == other.ProccntUsage && self.modBaseAddr == other.modBaseAddr && self.modBaseSize == other.modBaseSize && self.hModule == other.hModule && self.szModule == other.szModule && self.szExePath == other.szExePath
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -456,7 +456,7 @@ unsafe impl ::windows::core::Abi for PROCESSENTRY32 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROCESSENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSENTRY32>()) == 0 }
+        self.dwSize == other.dwSize && self.cntUsage == other.cntUsage && self.th32ProcessID == other.th32ProcessID && self.th32DefaultHeapID == other.th32DefaultHeapID && self.th32ModuleID == other.th32ModuleID && self.cntThreads == other.cntThreads && self.th32ParentProcessID == other.th32ParentProcessID && self.pcPriClassBase == other.pcPriClassBase && self.dwFlags == other.dwFlags && self.szExeFile == other.szExeFile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -497,7 +497,7 @@ unsafe impl ::windows::core::Abi for PROCESSENTRY32W {
 }
 impl ::core::cmp::PartialEq for PROCESSENTRY32W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSENTRY32W>()) == 0 }
+        self.dwSize == other.dwSize && self.cntUsage == other.cntUsage && self.th32ProcessID == other.th32ProcessID && self.th32DefaultHeapID == other.th32DefaultHeapID && self.th32ModuleID == other.th32ModuleID && self.cntThreads == other.cntThreads && self.th32ParentProcessID == other.th32ParentProcessID && self.pcPriClassBase == other.pcPriClassBase && self.dwFlags == other.dwFlags && self.szExeFile == other.szExeFile
     }
 }
 impl ::core::cmp::Eq for PROCESSENTRY32W {}
@@ -533,7 +533,7 @@ unsafe impl ::windows::core::Abi for THREADENTRY32 {
 }
 impl ::core::cmp::PartialEq for THREADENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THREADENTRY32>()) == 0 }
+        self.dwSize == other.dwSize && self.cntUsage == other.cntUsage && self.th32ThreadID == other.th32ThreadID && self.th32OwnerProcessID == other.th32OwnerProcessID && self.tpBasePri == other.tpBasePri && self.tpDeltaPri == other.tpDeltaPri && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for THREADENTRY32 {}

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
@@ -4556,7 +4556,7 @@ unsafe impl ::windows::core::Abi for BOID {
 }
 impl ::core::cmp::PartialEq for BOID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BOID>()) == 0 }
+        self.rgb == other.rgb
     }
 }
 impl ::core::cmp::Eq for BOID {}
@@ -4587,7 +4587,7 @@ unsafe impl ::windows::core::Abi for OLE_TM_CONFIG_PARAMS_V1 {
 }
 impl ::core::cmp::PartialEq for OLE_TM_CONFIG_PARAMS_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLE_TM_CONFIG_PARAMS_V1>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwcConcurrencyHint == other.dwcConcurrencyHint
     }
 }
 impl ::core::cmp::Eq for OLE_TM_CONFIG_PARAMS_V1 {}
@@ -4620,7 +4620,7 @@ unsafe impl ::windows::core::Abi for OLE_TM_CONFIG_PARAMS_V2 {
 }
 impl ::core::cmp::PartialEq for OLE_TM_CONFIG_PARAMS_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLE_TM_CONFIG_PARAMS_V2>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwcConcurrencyHint == other.dwcConcurrencyHint && self.applicationType == other.applicationType && self.clusterResourceId == other.clusterResourceId
     }
 }
 impl ::core::cmp::Eq for OLE_TM_CONFIG_PARAMS_V2 {}
@@ -4650,7 +4650,7 @@ unsafe impl ::windows::core::Abi for PROXY_CONFIG_PARAMS {
 }
 impl ::core::cmp::PartialEq for PROXY_CONFIG_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROXY_CONFIG_PARAMS>()) == 0 }
+        self.wcThreadsMax == other.wcThreadsMax
     }
 }
 impl ::core::cmp::Eq for PROXY_CONFIG_PARAMS {}
@@ -4681,7 +4681,7 @@ unsafe impl ::windows::core::Abi for XACTOPT {
 }
 impl ::core::cmp::PartialEq for XACTOPT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XACTOPT>()) == 0 }
+        self.ulTimeout == other.ulTimeout && self.szDescription == other.szDescription
     }
 }
 impl ::core::cmp::Eq for XACTOPT {}
@@ -4724,7 +4724,7 @@ unsafe impl ::windows::core::Abi for XACTSTATS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for XACTSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XACTSTATS>()) == 0 }
+        self.cOpen == other.cOpen && self.cCommitting == other.cCommitting && self.cCommitted == other.cCommitted && self.cAborting == other.cAborting && self.cAborted == other.cAborted && self.cInDoubt == other.cInDoubt && self.cHeuristicDecision == other.cHeuristicDecision && self.timeTransactionsUp == other.timeTransactionsUp
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4762,7 +4762,7 @@ unsafe impl ::windows::core::Abi for XACTTRANSINFO {
 }
 impl ::core::cmp::PartialEq for XACTTRANSINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XACTTRANSINFO>()) == 0 }
+        self.uow == other.uow && self.isoLevel == other.isoLevel && self.isoFlags == other.isoFlags && self.grfTCSupported == other.grfTCSupported && self.grfRMSupported == other.grfRMSupported && self.grfTCSupportedRetaining == other.grfTCSupportedRetaining && self.grfRMSupportedRetaining == other.grfRMSupportedRetaining
     }
 }
 impl ::core::cmp::Eq for XACTTRANSINFO {}
@@ -4801,7 +4801,7 @@ unsafe impl ::windows::core::Abi for XID {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for XID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XID>()) == 0 }
+        self.formatID == other.formatID && self.gtrid_length == other.gtrid_length && self.bqual_length == other.bqual_length && self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4865,7 +4865,7 @@ unsafe impl ::windows::core::Abi for xa_switch_t {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for xa_switch_t {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<xa_switch_t>()) == 0 }
+        self.name == other.name && self.flags == other.flags && self.version == other.version && self.xa_open_entry == other.xa_open_entry && self.xa_close_entry == other.xa_close_entry && self.xa_start_entry == other.xa_start_entry && self.xa_end_entry == other.xa_end_entry && self.xa_rollback_entry == other.xa_rollback_entry && self.xa_prepare_entry == other.xa_prepare_entry && self.xa_commit_entry == other.xa_commit_entry && self.xa_recover_entry == other.xa_recover_entry && self.xa_forget_entry == other.xa_forget_entry && self.xa_complete_entry == other.xa_complete_entry
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Environment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Environment/mod.rs
@@ -408,12 +408,6 @@ impl ::core::clone::Clone for ENCLAVE_IDENTITY {
 unsafe impl ::windows::core::Abi for ENCLAVE_IDENTITY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ENCLAVE_IDENTITY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCLAVE_IDENTITY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ENCLAVE_IDENTITY {}
 impl ::core::default::Default for ENCLAVE_IDENTITY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -437,12 +431,6 @@ impl ::core::clone::Clone for ENCLAVE_INFORMATION {
 unsafe impl ::windows::core::Abi for ENCLAVE_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ENCLAVE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCLAVE_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ENCLAVE_INFORMATION {}
 impl ::core::default::Default for ENCLAVE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -473,7 +461,7 @@ unsafe impl ::windows::core::Abi for ENCLAVE_VBS_BASIC_KEY_REQUEST {
 }
 impl ::core::cmp::PartialEq for ENCLAVE_VBS_BASIC_KEY_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCLAVE_VBS_BASIC_KEY_REQUEST>()) == 0 }
+        self.RequestSize == other.RequestSize && self.Flags == other.Flags && self.EnclaveSVN == other.EnclaveSVN && self.SystemKeyID == other.SystemKeyID && self.CurrentSystemKeyID == other.CurrentSystemKeyID
     }
 }
 impl ::core::cmp::Eq for ENCLAVE_VBS_BASIC_KEY_REQUEST {}
@@ -510,7 +498,7 @@ unsafe impl ::windows::core::Abi for VBS_BASIC_ENCLAVE_EXCEPTION_AMD64 {
 }
 impl ::core::cmp::PartialEq for VBS_BASIC_ENCLAVE_EXCEPTION_AMD64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_BASIC_ENCLAVE_EXCEPTION_AMD64>()) == 0 }
+        self.ExceptionCode == other.ExceptionCode && self.NumberParameters == other.NumberParameters && self.ExceptionInformation == other.ExceptionInformation && self.ExceptionRAX == other.ExceptionRAX && self.ExceptionRCX == other.ExceptionRCX && self.ExceptionRIP == other.ExceptionRIP && self.ExceptionRFLAGS == other.ExceptionRFLAGS && self.ExceptionRSP == other.ExceptionRSP
     }
 }
 impl ::core::cmp::Eq for VBS_BASIC_ENCLAVE_EXCEPTION_AMD64 {}
@@ -544,32 +532,12 @@ impl ::core::clone::Clone for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
 }
 impl ::core::fmt::Debug for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("VBS_BASIC_ENCLAVE_SYSCALL_PAGE")
-            .field("ReturnFromEnclave", &self.ReturnFromEnclave.map(|f| f as usize))
-            .field("ReturnFromException", &self.ReturnFromException.map(|f| f as usize))
-            .field("TerminateThread", &self.TerminateThread.map(|f| f as usize))
-            .field("InterruptThread", &self.InterruptThread.map(|f| f as usize))
-            .field("CommitPages", &self.CommitPages.map(|f| f as usize))
-            .field("DecommitPages", &self.DecommitPages.map(|f| f as usize))
-            .field("ProtectPages", &self.ProtectPages.map(|f| f as usize))
-            .field("CreateThread", &self.CreateThread.map(|f| f as usize))
-            .field("GetEnclaveInformation", &self.GetEnclaveInformation.map(|f| f as usize))
-            .field("GenerateKey", &self.GenerateKey.map(|f| f as usize))
-            .field("GenerateReport", &self.GenerateReport.map(|f| f as usize))
-            .field("VerifyReport", &self.VerifyReport.map(|f| f as usize))
-            .field("GenerateRandomData", &self.GenerateRandomData.map(|f| f as usize))
-            .finish()
+        f.debug_struct("VBS_BASIC_ENCLAVE_SYSCALL_PAGE").finish()
     }
 }
 unsafe impl ::windows::core::Abi for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_BASIC_ENCLAVE_SYSCALL_PAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {}
 impl ::core::default::Default for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -601,7 +569,7 @@ unsafe impl ::windows::core::Abi for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {
 }
 impl ::core::cmp::PartialEq for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32>()) == 0 }
+        self.ThreadContext == other.ThreadContext && self.EntryPoint == other.EntryPoint && self.StackPointer == other.StackPointer && self.ExceptionEntryPoint == other.ExceptionEntryPoint && self.ExceptionStack == other.ExceptionStack && self.ExceptionActive == other.ExceptionActive
     }
 }
 impl ::core::cmp::Eq for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {}
@@ -636,7 +604,7 @@ unsafe impl ::windows::core::Abi for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64 {
 }
 impl ::core::cmp::PartialEq for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64>()) == 0 }
+        self.ThreadContext == other.ThreadContext && self.EntryPoint == other.EntryPoint && self.StackPointer == other.StackPointer && self.ExceptionEntryPoint == other.ExceptionEntryPoint && self.ExceptionStack == other.ExceptionStack && self.ExceptionActive == other.ExceptionActive
     }
 }
 impl ::core::cmp::Eq for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64 {}
@@ -662,12 +630,6 @@ impl ::core::clone::Clone for VBS_ENCLAVE_REPORT {
 unsafe impl ::windows::core::Abi for VBS_ENCLAVE_REPORT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBS_ENCLAVE_REPORT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_ENCLAVE_REPORT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBS_ENCLAVE_REPORT {}
 impl ::core::default::Default for VBS_ENCLAVE_REPORT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -693,12 +655,6 @@ impl ::core::clone::Clone for VBS_ENCLAVE_REPORT_MODULE {
 unsafe impl ::windows::core::Abi for VBS_ENCLAVE_REPORT_MODULE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBS_ENCLAVE_REPORT_MODULE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_ENCLAVE_REPORT_MODULE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBS_ENCLAVE_REPORT_MODULE {}
 impl ::core::default::Default for VBS_ENCLAVE_REPORT_MODULE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -723,12 +679,6 @@ impl ::core::clone::Clone for VBS_ENCLAVE_REPORT_PKG_HEADER {
 unsafe impl ::windows::core::Abi for VBS_ENCLAVE_REPORT_PKG_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBS_ENCLAVE_REPORT_PKG_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_ENCLAVE_REPORT_PKG_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBS_ENCLAVE_REPORT_PKG_HEADER {}
 impl ::core::default::Default for VBS_ENCLAVE_REPORT_PKG_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -749,12 +699,6 @@ impl ::core::clone::Clone for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
 unsafe impl ::windows::core::Abi for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VBS_ENCLAVE_REPORT_VARDATA_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VBS_ENCLAVE_REPORT_VARDATA_HEADER {}
 impl ::core::default::Default for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
@@ -1117,7 +1117,7 @@ unsafe impl ::windows::core::Abi for WER_DUMP_CUSTOM_OPTIONS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_DUMP_CUSTOM_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_DUMP_CUSTOM_OPTIONS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMask == other.dwMask && self.dwDumpFlags == other.dwDumpFlags && self.bOnlyThisThread == other.bOnlyThisThread && self.dwExceptionThreadFlags == other.dwExceptionThreadFlags && self.dwOtherThreadFlags == other.dwOtherThreadFlags && self.dwExceptionThreadExFlags == other.dwExceptionThreadExFlags && self.dwOtherThreadExFlags == other.dwOtherThreadExFlags && self.dwPreferredModuleFlags == other.dwPreferredModuleFlags && self.dwOtherModuleFlags == other.dwOtherModuleFlags && self.wzPreferredModuleList == other.wzPreferredModuleList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1181,7 +1181,7 @@ unsafe impl ::windows::core::Abi for WER_DUMP_CUSTOM_OPTIONS_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_DUMP_CUSTOM_OPTIONS_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_DUMP_CUSTOM_OPTIONS_V2>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMask == other.dwMask && self.dwDumpFlags == other.dwDumpFlags && self.bOnlyThisThread == other.bOnlyThisThread && self.dwExceptionThreadFlags == other.dwExceptionThreadFlags && self.dwOtherThreadFlags == other.dwOtherThreadFlags && self.dwExceptionThreadExFlags == other.dwExceptionThreadExFlags && self.dwOtherThreadExFlags == other.dwOtherThreadExFlags && self.dwPreferredModuleFlags == other.dwPreferredModuleFlags && self.dwOtherModuleFlags == other.dwOtherModuleFlags && self.wzPreferredModuleList == other.wzPreferredModuleList && self.dwPreferredModuleResetFlags == other.dwPreferredModuleResetFlags && self.dwOtherModuleResetFlags == other.dwOtherModuleResetFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1251,7 +1251,22 @@ unsafe impl ::windows::core::Abi for WER_DUMP_CUSTOM_OPTIONS_V3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_DUMP_CUSTOM_OPTIONS_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_DUMP_CUSTOM_OPTIONS_V3>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwMask == other.dwMask
+            && self.dwDumpFlags == other.dwDumpFlags
+            && self.bOnlyThisThread == other.bOnlyThisThread
+            && self.dwExceptionThreadFlags == other.dwExceptionThreadFlags
+            && self.dwOtherThreadFlags == other.dwOtherThreadFlags
+            && self.dwExceptionThreadExFlags == other.dwExceptionThreadExFlags
+            && self.dwOtherThreadExFlags == other.dwOtherThreadExFlags
+            && self.dwPreferredModuleFlags == other.dwPreferredModuleFlags
+            && self.dwOtherModuleFlags == other.dwOtherModuleFlags
+            && self.wzPreferredModuleList == other.wzPreferredModuleList
+            && self.dwPreferredModuleResetFlags == other.dwPreferredModuleResetFlags
+            && self.dwOtherModuleResetFlags == other.dwOtherModuleResetFlags
+            && self.pvDumpKey == other.pvDumpKey
+            && self.hSnapshot == other.hSnapshot
+            && self.dwThreadID == other.dwThreadID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1290,7 +1305,7 @@ unsafe impl ::windows::core::Abi for WER_EXCEPTION_INFORMATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for WER_EXCEPTION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_EXCEPTION_INFORMATION>()) == 0 }
+        self.pExceptionPointers == other.pExceptionPointers && self.bClientPointers == other.bClientPointers
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
@@ -1335,7 +1350,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_INFORMATION>()) == 0 }
+        self.dwSize == other.dwSize && self.hProcess == other.hProcess && self.wzConsentKey == other.wzConsentKey && self.wzFriendlyEventName == other.wzFriendlyEventName && self.wzApplicationName == other.wzApplicationName && self.wzApplicationPath == other.wzApplicationPath && self.wzDescription == other.wzDescription && self.hwndParent == other.hwndParent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1393,7 +1408,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_INFORMATION_V3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_INFORMATION_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_INFORMATION_V3>()) == 0 }
+        self.dwSize == other.dwSize && self.hProcess == other.hProcess && self.wzConsentKey == other.wzConsentKey && self.wzFriendlyEventName == other.wzFriendlyEventName && self.wzApplicationName == other.wzApplicationName && self.wzApplicationPath == other.wzApplicationPath && self.wzDescription == other.wzDescription && self.hwndParent == other.hwndParent && self.wzNamespacePartner == other.wzNamespacePartner && self.wzNamespaceGroup == other.wzNamespaceGroup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1457,7 +1472,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_INFORMATION_V4 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_INFORMATION_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_INFORMATION_V4>()) == 0 }
+        self.dwSize == other.dwSize && self.hProcess == other.hProcess && self.wzConsentKey == other.wzConsentKey && self.wzFriendlyEventName == other.wzFriendlyEventName && self.wzApplicationName == other.wzApplicationName && self.wzApplicationPath == other.wzApplicationPath && self.wzDescription == other.wzDescription && self.hwndParent == other.hwndParent && self.wzNamespacePartner == other.wzNamespacePartner && self.wzNamespaceGroup == other.wzNamespaceGroup && self.rgbApplicationIdentity == other.rgbApplicationIdentity && self.hSnapshot == other.hSnapshot && self.hDeleteFilesImpersonationToken == other.hDeleteFilesImpersonationToken
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1523,7 +1538,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_INFORMATION_V5 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_INFORMATION_V5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_INFORMATION_V5>()) == 0 }
+        self.dwSize == other.dwSize && self.hProcess == other.hProcess && self.wzConsentKey == other.wzConsentKey && self.wzFriendlyEventName == other.wzFriendlyEventName && self.wzApplicationName == other.wzApplicationName && self.wzApplicationPath == other.wzApplicationPath && self.wzDescription == other.wzDescription && self.hwndParent == other.hwndParent && self.wzNamespacePartner == other.wzNamespacePartner && self.wzNamespaceGroup == other.wzNamespaceGroup && self.rgbApplicationIdentity == other.rgbApplicationIdentity && self.hSnapshot == other.hSnapshot && self.hDeleteFilesImpersonationToken == other.hDeleteFilesImpersonationToken && self.submitResultMax == other.submitResultMax
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1565,7 +1580,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_METADATA_V1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_METADATA_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_METADATA_V1>()) == 0 }
+        self.Signature == other.Signature && self.BucketId == other.BucketId && self.ReportId == other.ReportId && self.CreationTime == other.CreationTime && self.SizeInBytes == other.SizeInBytes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1625,7 +1640,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_METADATA_V2 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_METADATA_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_METADATA_V2>()) == 0 }
+        self.Signature == other.Signature && self.BucketId == other.BucketId && self.ReportId == other.ReportId && self.CreationTime == other.CreationTime && self.SizeInBytes == other.SizeInBytes && self.CabId == other.CabId && self.ReportStatus == other.ReportStatus && self.ReportIntegratorId == other.ReportIntegratorId && self.NumberOfFiles == other.NumberOfFiles && self.SizeOfFileNames == other.SizeOfFileNames && self.FileNames == other.FileNames
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1697,7 +1712,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_METADATA_V3 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WER_REPORT_METADATA_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_METADATA_V3>()) == 0 }
+        self.Signature == other.Signature && self.BucketId == other.BucketId && self.ReportId == other.ReportId && self.CreationTime == other.CreationTime && self.SizeInBytes == other.SizeInBytes && self.CabId == other.CabId && self.ReportStatus == other.ReportStatus && self.ReportIntegratorId == other.ReportIntegratorId && self.NumberOfFiles == other.NumberOfFiles && self.SizeOfFileNames == other.SizeOfFileNames && self.FileNames == other.FileNames && self.FriendlyEventName == other.FriendlyEventName && self.ApplicationName == other.ApplicationName && self.ApplicationPath == other.ApplicationPath && self.Description == other.Description && self.BucketIdString == other.BucketIdString && self.LegacyBucketId == other.LegacyBucketId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1730,7 +1745,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_PARAMETER {
 }
 impl ::core::cmp::PartialEq for WER_REPORT_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_PARAMETER>()) == 0 }
+        self.Name == other.Name && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for WER_REPORT_PARAMETER {}
@@ -1761,7 +1776,7 @@ unsafe impl ::windows::core::Abi for WER_REPORT_SIGNATURE {
 }
 impl ::core::cmp::PartialEq for WER_REPORT_SIGNATURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_REPORT_SIGNATURE>()) == 0 }
+        self.EventName == other.EventName && self.Parameters == other.Parameters
     }
 }
 impl ::core::cmp::Eq for WER_REPORT_SIGNATURE {}
@@ -1795,14 +1810,6 @@ impl ::core::clone::Clone for WER_RUNTIME_EXCEPTION_INFORMATION {
 unsafe impl ::windows::core::Abi for WER_RUNTIME_EXCEPTION_INFORMATION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for WER_RUNTIME_EXCEPTION_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WER_RUNTIME_EXCEPTION_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for WER_RUNTIME_EXCEPTION_INFORMATION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for WER_RUNTIME_EXCEPTION_INFORMATION {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/EventCollector/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventCollector/mod.rs
@@ -489,14 +489,6 @@ unsafe impl ::windows::core::Abi for EC_VARIANT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EC_VARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EC_VARIANT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EC_VARIANT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EC_VARIANT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -528,14 +520,6 @@ impl ::core::clone::Clone for EC_VARIANT_0 {
 unsafe impl ::windows::core::Abi for EC_VARIANT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EC_VARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EC_VARIANT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EC_VARIANT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EC_VARIANT_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
@@ -1597,7 +1597,7 @@ unsafe impl ::windows::core::Abi for EVENTLOGRECORD {
 }
 impl ::core::cmp::PartialEq for EVENTLOGRECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENTLOGRECORD>()) == 0 }
+        self.Length == other.Length && self.Reserved == other.Reserved && self.RecordNumber == other.RecordNumber && self.TimeGenerated == other.TimeGenerated && self.TimeWritten == other.TimeWritten && self.EventID == other.EventID && self.EventType == other.EventType && self.NumStrings == other.NumStrings && self.EventCategory == other.EventCategory && self.ReservedFlags == other.ReservedFlags && self.ClosingRecordNumber == other.ClosingRecordNumber && self.StringOffset == other.StringOffset && self.UserSidLength == other.UserSidLength && self.UserSidOffset == other.UserSidOffset && self.DataLength == other.DataLength && self.DataOffset == other.DataOffset
     }
 }
 impl ::core::cmp::Eq for EVENTLOGRECORD {}
@@ -1627,7 +1627,7 @@ unsafe impl ::windows::core::Abi for EVENTLOG_FULL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for EVENTLOG_FULL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENTLOG_FULL_INFORMATION>()) == 0 }
+        self.dwFull == other.dwFull
     }
 }
 impl ::core::cmp::Eq for EVENTLOG_FULL_INFORMATION {}
@@ -1660,7 +1660,7 @@ unsafe impl ::windows::core::Abi for EVENTSFORLOGFILE {
 }
 impl ::core::cmp::PartialEq for EVENTSFORLOGFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENTSFORLOGFILE>()) == 0 }
+        self.ulSize == other.ulSize && self.szLogicalLogFile == other.szLogicalLogFile && self.ulNumRecords == other.ulNumRecords && self.pEventLogRecords == other.pEventLogRecords
     }
 }
 impl ::core::cmp::Eq for EVENTSFORLOGFILE {}
@@ -1726,7 +1726,7 @@ unsafe impl ::windows::core::Abi for EVT_RPC_LOGIN {
 }
 impl ::core::cmp::PartialEq for EVT_RPC_LOGIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVT_RPC_LOGIN>()) == 0 }
+        self.Server == other.Server && self.User == other.User && self.Domain == other.Domain && self.Password == other.Password && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for EVT_RPC_LOGIN {}
@@ -1755,14 +1755,6 @@ impl ::core::clone::Clone for EVT_VARIANT {
 unsafe impl ::windows::core::Abi for EVT_VARIANT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVT_VARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVT_VARIANT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVT_VARIANT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVT_VARIANT {
     fn default() -> Self {
@@ -1826,14 +1818,6 @@ impl ::core::clone::Clone for EVT_VARIANT_0 {
 unsafe impl ::windows::core::Abi for EVT_VARIANT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EVT_VARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVT_VARIANT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EVT_VARIANT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EVT_VARIANT_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
@@ -346,7 +346,7 @@ unsafe impl ::windows::core::Abi for QOCINFO {
 }
 impl ::core::cmp::PartialEq for QOCINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QOCINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwInSpeed == other.dwInSpeed && self.dwOutSpeed == other.dwOutSpeed
     }
 }
 impl ::core::cmp::Eq for QOCINFO {}
@@ -379,7 +379,7 @@ unsafe impl ::windows::core::Abi for SENS_QOCINFO {
 }
 impl ::core::cmp::PartialEq for SENS_QOCINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENS_QOCINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.dwOutSpeed == other.dwOutSpeed && self.dwInSpeed == other.dwInSpeed
     }
 }
 impl ::core::cmp::Eq for SENS_QOCINFO {}

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -6344,7 +6344,7 @@ unsafe impl ::windows::core::Abi for GPOBROWSEINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GPOBROWSEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GPOBROWSEINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.hwndOwner == other.hwndOwner && self.lpTitle == other.lpTitle && self.lpInitialOU == other.lpInitialOU && self.lpDSPath == other.lpDSPath && self.dwDSPathSize == other.dwDSPathSize && self.lpName == other.lpName && self.dwNameSize == other.dwNameSize && self.gpoType == other.gpoType && self.gpoHint == other.gpoHint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6408,7 +6408,7 @@ unsafe impl ::windows::core::Abi for GROUP_POLICY_OBJECTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_POLICY_OBJECTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_POLICY_OBJECTA>()) == 0 }
+        self.dwOptions == other.dwOptions && self.dwVersion == other.dwVersion && self.lpDSPath == other.lpDSPath && self.lpFileSysPath == other.lpFileSysPath && self.lpDisplayName == other.lpDisplayName && self.szGPOName == other.szGPOName && self.GPOLink == other.GPOLink && self.lParam == other.lParam && self.pNext == other.pNext && self.pPrev == other.pPrev && self.lpExtensions == other.lpExtensions && self.lParam2 == other.lParam2 && self.lpLink == other.lpLink
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6472,7 +6472,7 @@ unsafe impl ::windows::core::Abi for GROUP_POLICY_OBJECTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GROUP_POLICY_OBJECTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_POLICY_OBJECTW>()) == 0 }
+        self.dwOptions == other.dwOptions && self.dwVersion == other.dwVersion && self.lpDSPath == other.lpDSPath && self.lpFileSysPath == other.lpFileSysPath && self.lpDisplayName == other.lpDisplayName && self.szGPOName == other.szGPOName && self.GPOLink == other.GPOLink && self.lParam == other.lParam && self.pNext == other.pNext && self.pPrev == other.pPrev && self.lpExtensions == other.lpExtensions && self.lParam2 == other.lParam2 && self.lpLink == other.lpLink
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6498,12 +6498,6 @@ impl ::core::clone::Clone for INSTALLDATA {
 unsafe impl ::windows::core::Abi for INSTALLDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INSTALLDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTALLDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INSTALLDATA {}
 impl ::core::default::Default for INSTALLDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6526,12 +6520,6 @@ impl ::core::clone::Clone for INSTALLSPEC {
 unsafe impl ::windows::core::Abi for INSTALLSPEC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INSTALLSPEC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTALLSPEC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INSTALLSPEC {}
 impl ::core::default::Default for INSTALLSPEC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6559,7 +6547,7 @@ unsafe impl ::windows::core::Abi for INSTALLSPEC_0 {
 }
 impl ::core::cmp::PartialEq for INSTALLSPEC_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTALLSPEC_0>()) == 0 }
+        self.Name == other.Name && self.GPOId == other.GPOId
     }
 }
 impl ::core::cmp::Eq for INSTALLSPEC_0 {}
@@ -6590,7 +6578,7 @@ unsafe impl ::windows::core::Abi for INSTALLSPEC_1 {
 }
 impl ::core::cmp::PartialEq for INSTALLSPEC_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INSTALLSPEC_1>()) == 0 }
+        self.Clsid == other.Clsid && self.ClsCtx == other.ClsCtx
     }
 }
 impl ::core::cmp::Eq for INSTALLSPEC_1 {}
@@ -6623,7 +6611,7 @@ unsafe impl ::windows::core::Abi for LOCALMANAGEDAPPLICATION {
 }
 impl ::core::cmp::PartialEq for LOCALMANAGEDAPPLICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOCALMANAGEDAPPLICATION>()) == 0 }
+        self.pszDeploymentName == other.pszDeploymentName && self.pszPolicyName == other.pszPolicyName && self.pszProductId == other.pszProductId && self.dwState == other.dwState
     }
 }
 impl ::core::cmp::Eq for LOCALMANAGEDAPPLICATION {}
@@ -6691,7 +6679,7 @@ unsafe impl ::windows::core::Abi for MANAGEDAPPLICATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MANAGEDAPPLICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MANAGEDAPPLICATION>()) == 0 }
+        self.pszPackageName == other.pszPackageName && self.pszPublisher == other.pszPublisher && self.dwVersionHi == other.dwVersionHi && self.dwVersionLo == other.dwVersionLo && self.dwRevision == other.dwRevision && self.GpoId == other.GpoId && self.pszPolicyName == other.pszPolicyName && self.ProductId == other.ProductId && self.Language == other.Language && self.pszOwner == other.pszOwner && self.pszCompany == other.pszCompany && self.pszComments == other.pszComments && self.pszContact == other.pszContact && self.pszSupportUrl == other.pszSupportUrl && self.dwPathType == other.dwPathType && self.bInstalled == other.bInstalled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6735,7 +6723,7 @@ unsafe impl ::windows::core::Abi for POLICYSETTINGSTATUSINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POLICYSETTINGSTATUSINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POLICYSETTINGSTATUSINFO>()) == 0 }
+        self.szKey == other.szKey && self.szEventSource == other.szEventSource && self.szEventLogName == other.szEventLogName && self.dwEventID == other.dwEventID && self.dwErrorCode == other.dwErrorCode && self.status == other.status && self.timeLogged == other.timeLogged
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeNetwork/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeNetwork/mod.rs
@@ -453,7 +453,7 @@ unsafe impl ::windows::core::Abi for HCN_PORT_RANGE_ENTRY {
 }
 impl ::core::cmp::PartialEq for HCN_PORT_RANGE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HCN_PORT_RANGE_ENTRY>()) == 0 }
+        self.OwningPartitionId == other.OwningPartitionId && self.TargetPartitionId == other.TargetPartitionId && self.Protocol == other.Protocol && self.Priority == other.Priority && self.ReservationType == other.ReservationType && self.SharingFlags == other.SharingFlags && self.DeliveryMode == other.DeliveryMode && self.StartingPort == other.StartingPort && self.EndingPort == other.EndingPort
     }
 }
 impl ::core::cmp::Eq for HCN_PORT_RANGE_ENTRY {}
@@ -484,7 +484,7 @@ unsafe impl ::windows::core::Abi for HCN_PORT_RANGE_RESERVATION {
 }
 impl ::core::cmp::PartialEq for HCN_PORT_RANGE_RESERVATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HCN_PORT_RANGE_RESERVATION>()) == 0 }
+        self.startingPort == other.startingPort && self.endingPort == other.endingPort
     }
 }
 impl ::core::cmp::Eq for HCN_PORT_RANGE_RESERVATION {}

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
@@ -946,21 +946,13 @@ impl ::core::clone::Clone for HCS_CREATE_OPTIONS_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::fmt::Debug for HCS_CREATE_OPTIONS_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("HCS_CREATE_OPTIONS_1").field("Version", &self.Version).field("UserToken", &self.UserToken).field("SecurityDescriptor", &self.SecurityDescriptor).field("CallbackOptions", &self.CallbackOptions).field("CallbackContext", &self.CallbackContext).field("Callback", &self.Callback.map(|f| f as usize)).finish()
+        f.debug_struct("HCS_CREATE_OPTIONS_1").field("Version", &self.Version).field("UserToken", &self.UserToken).field("SecurityDescriptor", &self.SecurityDescriptor).field("CallbackOptions", &self.CallbackOptions).field("CallbackContext", &self.CallbackContext).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 unsafe impl ::windows::core::Abi for HCS_CREATE_OPTIONS_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for HCS_CREATE_OPTIONS_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HCS_CREATE_OPTIONS_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for HCS_CREATE_OPTIONS_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for HCS_CREATE_OPTIONS_1 {
     fn default() -> Self {
@@ -990,7 +982,7 @@ unsafe impl ::windows::core::Abi for HCS_EVENT {
 }
 impl ::core::cmp::PartialEq for HCS_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HCS_EVENT>()) == 0 }
+        self.Type == other.Type && self.EventData == other.EventData && self.Operation == other.Operation
     }
 }
 impl ::core::cmp::Eq for HCS_EVENT {}
@@ -1094,7 +1086,7 @@ unsafe impl ::windows::core::Abi for HCS_PROCESS_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HCS_PROCESS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HCS_PROCESS_INFORMATION>()) == 0 }
+        self.ProcessId == other.ProcessId && self.Reserved == other.Reserved && self.StdInput == other.StdInput && self.StdOutput == other.StdOutput && self.StdError == other.StdError
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -3696,7 +3696,7 @@ unsafe impl ::windows::core::Abi for DOS_IMAGE_INFO {
 }
 impl ::core::cmp::PartialEq for DOS_IMAGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DOS_IMAGE_INFO>()) == 0 }
+        self.PdbName == other.PdbName && self.ImageBaseAddress == other.ImageBaseAddress && self.ImageSize == other.ImageSize && self.Timestamp == other.Timestamp
     }
 }
 impl ::core::cmp::Eq for DOS_IMAGE_INFO {}
@@ -3727,7 +3727,7 @@ unsafe impl ::windows::core::Abi for GPA_MEMORY_CHUNK {
 }
 impl ::core::cmp::PartialEq for GPA_MEMORY_CHUNK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GPA_MEMORY_CHUNK>()) == 0 }
+        self.GuestPhysicalStartPageIndex == other.GuestPhysicalStartPageIndex && self.PageCount == other.PageCount
     }
 }
 impl ::core::cmp::Eq for GPA_MEMORY_CHUNK {}
@@ -3752,12 +3752,6 @@ impl ::core::clone::Clone for GUEST_OS_INFO {
 unsafe impl ::windows::core::Abi for GUEST_OS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GUEST_OS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUEST_OS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GUEST_OS_INFO {}
 impl ::core::default::Default for GUEST_OS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3784,7 +3778,7 @@ unsafe impl ::windows::core::Abi for GUEST_OS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for GUEST_OS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUEST_OS_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for GUEST_OS_INFO_0 {}
@@ -3814,7 +3808,7 @@ unsafe impl ::windows::core::Abi for GUEST_OS_INFO_1 {
 }
 impl ::core::cmp::PartialEq for GUEST_OS_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUEST_OS_INFO_1>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for GUEST_OS_INFO_1 {}
@@ -3846,30 +3840,12 @@ impl ::core::clone::Clone for HDV_PCI_DEVICE_INTERFACE {
 }
 impl ::core::fmt::Debug for HDV_PCI_DEVICE_INTERFACE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("HDV_PCI_DEVICE_INTERFACE")
-            .field("Version", &self.Version)
-            .field("Initialize", &self.Initialize.map(|f| f as usize))
-            .field("Teardown", &self.Teardown.map(|f| f as usize))
-            .field("SetConfiguration", &self.SetConfiguration.map(|f| f as usize))
-            .field("GetDetails", &self.GetDetails.map(|f| f as usize))
-            .field("Start", &self.Start.map(|f| f as usize))
-            .field("Stop", &self.Stop.map(|f| f as usize))
-            .field("ReadConfigSpace", &self.ReadConfigSpace.map(|f| f as usize))
-            .field("WriteConfigSpace", &self.WriteConfigSpace.map(|f| f as usize))
-            .field("ReadInterceptedMemory", &self.ReadInterceptedMemory.map(|f| f as usize))
-            .field("WriteInterceptedMemory", &self.WriteInterceptedMemory.map(|f| f as usize))
-            .finish()
+        f.debug_struct("HDV_PCI_DEVICE_INTERFACE").field("Version", &self.Version).finish()
     }
 }
 unsafe impl ::windows::core::Abi for HDV_PCI_DEVICE_INTERFACE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HDV_PCI_DEVICE_INTERFACE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDV_PCI_DEVICE_INTERFACE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HDV_PCI_DEVICE_INTERFACE {}
 impl ::core::default::Default for HDV_PCI_DEVICE_INTERFACE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3903,7 +3879,7 @@ unsafe impl ::windows::core::Abi for HDV_PCI_PNP_ID {
 }
 impl ::core::cmp::PartialEq for HDV_PCI_PNP_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDV_PCI_PNP_ID>()) == 0 }
+        self.VendorID == other.VendorID && self.DeviceID == other.DeviceID && self.RevisionID == other.RevisionID && self.ProgIf == other.ProgIf && self.SubClass == other.SubClass && self.BaseClass == other.BaseClass && self.SubVendorID == other.SubVendorID && self.SubSystemID == other.SubSystemID
     }
 }
 impl ::core::cmp::Eq for HDV_PCI_PNP_ID {}
@@ -3936,7 +3912,7 @@ unsafe impl ::windows::core::Abi for HVSOCKET_ADDRESS_INFO {
 }
 impl ::core::cmp::PartialEq for HVSOCKET_ADDRESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HVSOCKET_ADDRESS_INFO>()) == 0 }
+        self.SystemId == other.SystemId && self.VirtualMachineId == other.VirtualMachineId && self.SiloId == other.SiloId && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for HVSOCKET_ADDRESS_INFO {}
@@ -3967,7 +3943,7 @@ unsafe impl ::windows::core::Abi for MODULE_INFO {
 }
 impl ::core::cmp::PartialEq for MODULE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULE_INFO>()) == 0 }
+        self.ProcessImageName == other.ProcessImageName && self.Image == other.Image
     }
 }
 impl ::core::cmp::Eq for MODULE_INFO {}
@@ -4000,7 +3976,7 @@ unsafe impl ::windows::core::Abi for SOCKADDR_HV {
 }
 impl ::core::cmp::PartialEq for SOCKADDR_HV {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOCKADDR_HV>()) == 0 }
+        self.Family == other.Family && self.Reserved == other.Reserved && self.VmId == other.VmId && self.ServiceId == other.ServiceId
     }
 }
 impl ::core::cmp::Eq for SOCKADDR_HV {}
@@ -4028,12 +4004,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4061,7 +4031,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_0 {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_0>()) == 0 }
+        self.Low64 == other.Low64 && self.High64 == other.High64
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_0 {}
@@ -4087,12 +4057,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4117,12 +4081,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_0 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_0 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4143,12 +4101,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4176,7 +4128,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_0_0_0>()) == 0 }
+        self.LastFpEip == other.LastFpEip && self.LastFpCs == other.LastFpCs
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {}
@@ -4202,12 +4154,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_1 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_1 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4228,12 +4174,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_1_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4260,7 +4200,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_1_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {}
@@ -4291,7 +4231,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_2 {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_2>()) == 0 }
+        self.Limit == other.Limit && self.Base == other.Base
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_2 {}
@@ -4316,12 +4256,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_3 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_3 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4342,12 +4276,6 @@ impl ::core::clone::Clone for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
 unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_3_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {}
 impl ::core::default::Default for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4375,7 +4303,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_PROCESSOR_REGISTER_1_3_0_0>()) == 0 }
+        self.LastFpDp == other.LastFpDp && self.LastFpDs == other.LastFpDs
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {}
@@ -4406,7 +4334,7 @@ unsafe impl ::windows::core::Abi for VM_GENCOUNTER {
 }
 impl ::core::cmp::PartialEq for VM_GENCOUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VM_GENCOUNTER>()) == 0 }
+        self.GenerationCount == other.GenerationCount && self.GenerationCountHigh == other.GenerationCountHigh
     }
 }
 impl ::core::cmp::Eq for VM_GENCOUNTER {}
@@ -4430,12 +4358,6 @@ impl ::core::clone::Clone for WHV_ACCESS_GPA_CONTROLS {
 unsafe impl ::windows::core::Abi for WHV_ACCESS_GPA_CONTROLS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_ACCESS_GPA_CONTROLS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ACCESS_GPA_CONTROLS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_ACCESS_GPA_CONTROLS {}
 impl ::core::default::Default for WHV_ACCESS_GPA_CONTROLS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4463,7 +4385,7 @@ unsafe impl ::windows::core::Abi for WHV_ACCESS_GPA_CONTROLS_0 {
 }
 impl ::core::cmp::PartialEq for WHV_ACCESS_GPA_CONTROLS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ACCESS_GPA_CONTROLS_0>()) == 0 }
+        self.CacheType == other.CacheType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WHV_ACCESS_GPA_CONTROLS_0 {}
@@ -4486,12 +4408,6 @@ impl ::core::clone::Clone for WHV_ADVISE_GPA_RANGE {
 unsafe impl ::windows::core::Abi for WHV_ADVISE_GPA_RANGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_ADVISE_GPA_RANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ADVISE_GPA_RANGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_ADVISE_GPA_RANGE {}
 impl ::core::default::Default for WHV_ADVISE_GPA_RANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4512,12 +4428,6 @@ impl ::core::clone::Clone for WHV_ADVISE_GPA_RANGE_POPULATE {
 unsafe impl ::windows::core::Abi for WHV_ADVISE_GPA_RANGE_POPULATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_ADVISE_GPA_RANGE_POPULATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ADVISE_GPA_RANGE_POPULATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_ADVISE_GPA_RANGE_POPULATE {}
 impl ::core::default::Default for WHV_ADVISE_GPA_RANGE_POPULATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4538,12 +4448,6 @@ impl ::core::clone::Clone for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
 unsafe impl ::windows::core::Abi for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {}
 impl ::core::default::Default for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4570,7 +4474,7 @@ unsafe impl ::windows::core::Abi for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {
 }
 impl ::core::cmp::PartialEq for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {}
@@ -4614,14 +4518,6 @@ unsafe impl ::windows::core::Abi for WHV_CAPABILITY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHV_CAPABILITY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_CAPABILITY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHV_CAPABILITY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHV_CAPABILITY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4642,12 +4538,6 @@ impl ::core::clone::Clone for WHV_CAPABILITY_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_CAPABILITY_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_CAPABILITY_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_CAPABILITY_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_CAPABILITY_FEATURES {}
 impl ::core::default::Default for WHV_CAPABILITY_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4674,7 +4564,7 @@ unsafe impl ::windows::core::Abi for WHV_CAPABILITY_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_CAPABILITY_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_CAPABILITY_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_CAPABILITY_FEATURES_0 {}
@@ -4708,7 +4598,7 @@ unsafe impl ::windows::core::Abi for WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP {
 }
 impl ::core::cmp::PartialEq for WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP>()) == 0 }
+        self._bitfield == other._bitfield && self.HighestFrequencyMhz == other.HighestFrequencyMhz && self.NominalFrequencyMhz == other.NominalFrequencyMhz && self.LowestFrequencyMhz == other.LowestFrequencyMhz && self.FrequencyStepMhz == other.FrequencyStepMhz
     }
 }
 impl ::core::cmp::Eq for WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP {}
@@ -4741,7 +4631,7 @@ unsafe impl ::windows::core::Abi for WHV_CPUID_OUTPUT {
 }
 impl ::core::cmp::PartialEq for WHV_CPUID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_CPUID_OUTPUT>()) == 0 }
+        self.Eax == other.Eax && self.Ebx == other.Ebx && self.Ecx == other.Ecx && self.Edx == other.Edx
     }
 }
 impl ::core::cmp::Eq for WHV_CPUID_OUTPUT {}
@@ -4774,7 +4664,7 @@ unsafe impl ::windows::core::Abi for WHV_DOORBELL_MATCH_DATA {
 }
 impl ::core::cmp::PartialEq for WHV_DOORBELL_MATCH_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_DOORBELL_MATCH_DATA>()) == 0 }
+        self.GuestAddress == other.GuestAddress && self.Value == other.Value && self.Length == other.Length && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_DOORBELL_MATCH_DATA {}
@@ -4802,26 +4692,12 @@ impl ::core::clone::Clone for WHV_EMULATOR_CALLBACKS {
 }
 impl ::core::fmt::Debug for WHV_EMULATOR_CALLBACKS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WHV_EMULATOR_CALLBACKS")
-            .field("Size", &self.Size)
-            .field("Reserved", &self.Reserved)
-            .field("WHvEmulatorIoPortCallback", &self.WHvEmulatorIoPortCallback.map(|f| f as usize))
-            .field("WHvEmulatorMemoryCallback", &self.WHvEmulatorMemoryCallback.map(|f| f as usize))
-            .field("WHvEmulatorGetVirtualProcessorRegisters", &self.WHvEmulatorGetVirtualProcessorRegisters.map(|f| f as usize))
-            .field("WHvEmulatorSetVirtualProcessorRegisters", &self.WHvEmulatorSetVirtualProcessorRegisters.map(|f| f as usize))
-            .field("WHvEmulatorTranslateGvaPage", &self.WHvEmulatorTranslateGvaPage.map(|f| f as usize))
-            .finish()
+        f.debug_struct("WHV_EMULATOR_CALLBACKS").field("Size", &self.Size).field("Reserved", &self.Reserved).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WHV_EMULATOR_CALLBACKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_EMULATOR_CALLBACKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EMULATOR_CALLBACKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_EMULATOR_CALLBACKS {}
 impl ::core::default::Default for WHV_EMULATOR_CALLBACKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4851,7 +4727,7 @@ unsafe impl ::windows::core::Abi for WHV_EMULATOR_IO_ACCESS_INFO {
 }
 impl ::core::cmp::PartialEq for WHV_EMULATOR_IO_ACCESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EMULATOR_IO_ACCESS_INFO>()) == 0 }
+        self.Direction == other.Direction && self.Port == other.Port && self.AccessSize == other.AccessSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WHV_EMULATOR_IO_ACCESS_INFO {}
@@ -4884,7 +4760,7 @@ unsafe impl ::windows::core::Abi for WHV_EMULATOR_MEMORY_ACCESS_INFO {
 }
 impl ::core::cmp::PartialEq for WHV_EMULATOR_MEMORY_ACCESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EMULATOR_MEMORY_ACCESS_INFO>()) == 0 }
+        self.GpaAddress == other.GpaAddress && self.Direction == other.Direction && self.AccessSize == other.AccessSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WHV_EMULATOR_MEMORY_ACCESS_INFO {}
@@ -4908,12 +4784,6 @@ impl ::core::clone::Clone for WHV_EMULATOR_STATUS {
 unsafe impl ::windows::core::Abi for WHV_EMULATOR_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_EMULATOR_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EMULATOR_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_EMULATOR_STATUS {}
 impl ::core::default::Default for WHV_EMULATOR_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4940,7 +4810,7 @@ unsafe impl ::windows::core::Abi for WHV_EMULATOR_STATUS_0 {
 }
 impl ::core::cmp::PartialEq for WHV_EMULATOR_STATUS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EMULATOR_STATUS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_EMULATOR_STATUS_0 {}
@@ -4964,12 +4834,6 @@ impl ::core::clone::Clone for WHV_EXTENDED_VM_EXITS {
 unsafe impl ::windows::core::Abi for WHV_EXTENDED_VM_EXITS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_EXTENDED_VM_EXITS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EXTENDED_VM_EXITS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_EXTENDED_VM_EXITS {}
 impl ::core::default::Default for WHV_EXTENDED_VM_EXITS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4996,7 +4860,7 @@ unsafe impl ::windows::core::Abi for WHV_EXTENDED_VM_EXITS_0 {
 }
 impl ::core::cmp::PartialEq for WHV_EXTENDED_VM_EXITS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_EXTENDED_VM_EXITS_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_EXTENDED_VM_EXITS_0 {}
@@ -5028,12 +4892,6 @@ impl ::core::clone::Clone for WHV_HYPERCALL_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_HYPERCALL_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_HYPERCALL_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_HYPERCALL_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_HYPERCALL_CONTEXT {}
 impl ::core::default::Default for WHV_HYPERCALL_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5054,12 +4912,6 @@ impl ::core::clone::Clone for WHV_INTERNAL_ACTIVITY_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_INTERNAL_ACTIVITY_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_INTERNAL_ACTIVITY_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_INTERNAL_ACTIVITY_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_INTERNAL_ACTIVITY_REGISTER {}
 impl ::core::default::Default for WHV_INTERNAL_ACTIVITY_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5086,7 +4938,7 @@ unsafe impl ::windows::core::Abi for WHV_INTERNAL_ACTIVITY_REGISTER_0 {
 }
 impl ::core::cmp::PartialEq for WHV_INTERNAL_ACTIVITY_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_INTERNAL_ACTIVITY_REGISTER_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_INTERNAL_ACTIVITY_REGISTER_0 {}
@@ -5118,7 +4970,7 @@ unsafe impl ::windows::core::Abi for WHV_INTERRUPT_CONTROL {
 }
 impl ::core::cmp::PartialEq for WHV_INTERRUPT_CONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_INTERRUPT_CONTROL>()) == 0 }
+        self._bitfield == other._bitfield && self.Destination == other.Destination && self.Vector == other.Vector
     }
 }
 impl ::core::cmp::Eq for WHV_INTERRUPT_CONTROL {}
@@ -5146,12 +4998,6 @@ impl ::core::clone::Clone for WHV_MEMORY_ACCESS_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_MEMORY_ACCESS_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_MEMORY_ACCESS_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_MEMORY_ACCESS_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_MEMORY_ACCESS_CONTEXT {}
 impl ::core::default::Default for WHV_MEMORY_ACCESS_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5172,12 +5018,6 @@ impl ::core::clone::Clone for WHV_MEMORY_ACCESS_INFO {
 unsafe impl ::windows::core::Abi for WHV_MEMORY_ACCESS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_MEMORY_ACCESS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_MEMORY_ACCESS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_MEMORY_ACCESS_INFO {}
 impl ::core::default::Default for WHV_MEMORY_ACCESS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5204,7 +5044,7 @@ unsafe impl ::windows::core::Abi for WHV_MEMORY_ACCESS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WHV_MEMORY_ACCESS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_MEMORY_ACCESS_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_MEMORY_ACCESS_INFO_0 {}
@@ -5235,7 +5075,7 @@ unsafe impl ::windows::core::Abi for WHV_MEMORY_RANGE_ENTRY {
 }
 impl ::core::cmp::PartialEq for WHV_MEMORY_RANGE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_MEMORY_RANGE_ENTRY>()) == 0 }
+        self.GuestAddress == other.GuestAddress && self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for WHV_MEMORY_RANGE_ENTRY {}
@@ -5268,7 +5108,7 @@ unsafe impl ::windows::core::Abi for WHV_MSR_ACTION_ENTRY {
 }
 impl ::core::cmp::PartialEq for WHV_MSR_ACTION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_MSR_ACTION_ENTRY>()) == 0 }
+        self.Index == other.Index && self.ReadAction == other.ReadAction && self.WriteAction == other.WriteAction && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WHV_MSR_ACTION_ENTRY {}
@@ -5293,12 +5133,6 @@ impl ::core::clone::Clone for WHV_NOTIFICATION_PORT_PARAMETERS {
 unsafe impl ::windows::core::Abi for WHV_NOTIFICATION_PORT_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_NOTIFICATION_PORT_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_NOTIFICATION_PORT_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_NOTIFICATION_PORT_PARAMETERS {}
 impl ::core::default::Default for WHV_NOTIFICATION_PORT_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5319,12 +5153,6 @@ impl ::core::clone::Clone for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_NOTIFICATION_PORT_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_NOTIFICATION_PORT_PARAMETERS_0 {}
 impl ::core::default::Default for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5351,7 +5179,7 @@ unsafe impl ::windows::core::Abi for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_NOTIFICATION_PORT_PARAMETERS_0_0>()) == 0 }
+        self.ConnectionId == other.ConnectionId
     }
 }
 impl ::core::cmp::Eq for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {}
@@ -5415,7 +5243,7 @@ unsafe impl ::windows::core::Abi for WHV_PARTITION_MEMORY_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PARTITION_MEMORY_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PARTITION_MEMORY_COUNTERS>()) == 0 }
+        self.Mapped4KPageCount == other.Mapped4KPageCount && self.Mapped2MPageCount == other.Mapped2MPageCount && self.Mapped1GPageCount == other.Mapped1GPageCount
     }
 }
 impl ::core::cmp::Eq for WHV_PARTITION_MEMORY_COUNTERS {}
@@ -5472,14 +5300,6 @@ unsafe impl ::windows::core::Abi for WHV_PARTITION_PROPERTY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WHV_PARTITION_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PARTITION_PROPERTY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WHV_PARTITION_PROPERTY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WHV_PARTITION_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5510,7 +5330,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_APIC_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_APIC_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_APIC_COUNTERS>()) == 0 }
+        self.MmioAccessCount == other.MmioAccessCount && self.EoiAccessCount == other.EoiAccessCount && self.TprAccessCount == other.TprAccessCount && self.SentIpiCount == other.SentIpiCount && self.SelfIpiCount == other.SelfIpiCount
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_APIC_COUNTERS {}
@@ -5542,7 +5362,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_EVENT_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_EVENT_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_EVENT_COUNTERS>()) == 0 }
+        self.PageFaultCount == other.PageFaultCount && self.ExceptionCount == other.ExceptionCount && self.InterruptCount == other.InterruptCount
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_EVENT_COUNTERS {}
@@ -5566,12 +5386,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES {}
 impl ::core::default::Default for WHV_PROCESSOR_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5598,7 +5412,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES_0 {}
@@ -5622,12 +5436,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_FEATURES1 {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES1 {}
 impl ::core::default::Default for WHV_PROCESSOR_FEATURES1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5654,7 +5462,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES1_0 {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES1_0 {}
@@ -5679,12 +5487,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_FEATURES_BANKS {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES_BANKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES_BANKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES_BANKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES_BANKS {}
 impl ::core::default::Default for WHV_PROCESSOR_FEATURES_BANKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5705,12 +5507,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_FEATURES_BANKS_0 {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES_BANKS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES_BANKS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES_BANKS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES_BANKS_0 {}
 impl ::core::default::Default for WHV_PROCESSOR_FEATURES_BANKS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5731,12 +5527,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_FEATURES_BANKS_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_FEATURES_BANKS_0_0 {}
 impl ::core::default::Default for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5764,7 +5554,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_INTERCEPT_COUNTER {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_INTERCEPT_COUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_INTERCEPT_COUNTER>()) == 0 }
+        self.Count == other.Count && self.Time100ns == other.Time100ns
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_INTERCEPT_COUNTER {}
@@ -5822,7 +5612,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_INTERCEPT_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_INTERCEPT_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_INTERCEPT_COUNTERS>()) == 0 }
+        self.PageInvalidations == other.PageInvalidations && self.ControlRegisterAccesses == other.ControlRegisterAccesses && self.IoInstructions == other.IoInstructions && self.HaltInstructions == other.HaltInstructions && self.CpuidInstructions == other.CpuidInstructions && self.MsrAccesses == other.MsrAccesses && self.OtherIntercepts == other.OtherIntercepts && self.PendingInterrupts == other.PendingInterrupts && self.EmulatedInstructions == other.EmulatedInstructions && self.DebugRegisterAccesses == other.DebugRegisterAccesses && self.PageFaultIntercepts == other.PageFaultIntercepts && self.NestedPageFaultIntercepts == other.NestedPageFaultIntercepts && self.Hypercalls == other.Hypercalls && self.RdpmcInstructions == other.RdpmcInstructions
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_INTERCEPT_COUNTERS {}
@@ -5846,12 +5636,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_PERFMON_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_PERFMON_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_PERFMON_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_PERFMON_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_PERFMON_FEATURES {}
 impl ::core::default::Default for WHV_PROCESSOR_PERFMON_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5878,7 +5662,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_PERFMON_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_PERFMON_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_PERFMON_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_PERFMON_FEATURES_0 {}
@@ -5909,7 +5693,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_RUNTIME_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_RUNTIME_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_RUNTIME_COUNTERS>()) == 0 }
+        self.TotalRuntime100ns == other.TotalRuntime100ns && self.HypervisorRuntime100ns == other.HypervisorRuntime100ns
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_RUNTIME_COUNTERS {}
@@ -5951,7 +5735,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS>()) == 0 }
+        self.SyntheticInterruptsCount == other.SyntheticInterruptsCount && self.LongSpinWaitHypercallsCount == other.LongSpinWaitHypercallsCount && self.OtherHypercallsCount == other.OtherHypercallsCount && self.SyntheticInterruptHypercallsCount == other.SyntheticInterruptHypercallsCount && self.VirtualInterruptHypercallsCount == other.VirtualInterruptHypercallsCount && self.VirtualMmuHypercallsCount == other.VirtualMmuHypercallsCount
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS {}
@@ -5975,12 +5759,6 @@ impl ::core::clone::Clone for WHV_PROCESSOR_XSAVE_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_PROCESSOR_XSAVE_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_PROCESSOR_XSAVE_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_XSAVE_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_PROCESSOR_XSAVE_FEATURES {}
 impl ::core::default::Default for WHV_PROCESSOR_XSAVE_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6007,7 +5785,7 @@ unsafe impl ::windows::core::Abi for WHV_PROCESSOR_XSAVE_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_PROCESSOR_XSAVE_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_PROCESSOR_XSAVE_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_PROCESSOR_XSAVE_FEATURES_0 {}
@@ -6046,12 +5824,6 @@ impl ::core::clone::Clone for WHV_REGISTER_VALUE {
 unsafe impl ::windows::core::Abi for WHV_REGISTER_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_REGISTER_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_REGISTER_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_REGISTER_VALUE {}
 impl ::core::default::Default for WHV_REGISTER_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6078,7 +5850,7 @@ unsafe impl ::windows::core::Abi for WHV_RUN_VP_CANCELED_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_RUN_VP_CANCELED_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_RUN_VP_CANCELED_CONTEXT>()) == 0 }
+        self.CancelReason == other.CancelReason
     }
 }
 impl ::core::cmp::Eq for WHV_RUN_VP_CANCELED_CONTEXT {}
@@ -6104,12 +5876,6 @@ impl ::core::clone::Clone for WHV_RUN_VP_EXIT_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_RUN_VP_EXIT_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_RUN_VP_EXIT_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_RUN_VP_EXIT_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_RUN_VP_EXIT_CONTEXT {}
 impl ::core::default::Default for WHV_RUN_VP_EXIT_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6143,12 +5909,6 @@ impl ::core::clone::Clone for WHV_RUN_VP_EXIT_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for WHV_RUN_VP_EXIT_CONTEXT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_RUN_VP_EXIT_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_RUN_VP_EXIT_CONTEXT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_RUN_VP_EXIT_CONTEXT_0 {}
 impl ::core::default::Default for WHV_RUN_VP_EXIT_CONTEXT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6169,12 +5929,6 @@ impl ::core::clone::Clone for WHV_SCHEDULER_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_SCHEDULER_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_SCHEDULER_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SCHEDULER_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_SCHEDULER_FEATURES {}
 impl ::core::default::Default for WHV_SCHEDULER_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6201,7 +5955,7 @@ unsafe impl ::windows::core::Abi for WHV_SCHEDULER_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_SCHEDULER_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SCHEDULER_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_SCHEDULER_FEATURES_0 {}
@@ -6240,7 +5994,7 @@ unsafe impl ::windows::core::Abi for WHV_SRIOV_RESOURCE_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WHV_SRIOV_RESOURCE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SRIOV_RESOURCE_DESCRIPTOR>()) == 0 }
+        self.PnpInstanceId == other.PnpInstanceId && self.VirtualFunctionId == other.VirtualFunctionId && self.VirtualFunctionIndex == other.VirtualFunctionIndex && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6275,7 +6029,7 @@ unsafe impl ::windows::core::Abi for WHV_SYNIC_EVENT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for WHV_SYNIC_EVENT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNIC_EVENT_PARAMETERS>()) == 0 }
+        self.VpIndex == other.VpIndex && self.TargetSint == other.TargetSint && self.Reserved == other.Reserved && self.FlagNumber == other.FlagNumber
     }
 }
 impl ::core::cmp::Eq for WHV_SYNIC_EVENT_PARAMETERS {}
@@ -6307,7 +6061,7 @@ unsafe impl ::windows::core::Abi for WHV_SYNIC_SINT_DELIVERABLE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_SYNIC_SINT_DELIVERABLE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNIC_SINT_DELIVERABLE_CONTEXT>()) == 0 }
+        self.DeliverableSints == other.DeliverableSints && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for WHV_SYNIC_SINT_DELIVERABLE_CONTEXT {}
@@ -6331,12 +6085,6 @@ impl ::core::clone::Clone for WHV_SYNTHETIC_PROCESSOR_FEATURES {
 unsafe impl ::windows::core::Abi for WHV_SYNTHETIC_PROCESSOR_FEATURES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_SYNTHETIC_PROCESSOR_FEATURES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNTHETIC_PROCESSOR_FEATURES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_SYNTHETIC_PROCESSOR_FEATURES {}
 impl ::core::default::Default for WHV_SYNTHETIC_PROCESSOR_FEATURES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6363,7 +6111,7 @@ unsafe impl ::windows::core::Abi for WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {
 }
 impl ::core::cmp::PartialEq for WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNTHETIC_PROCESSOR_FEATURES_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {}
@@ -6388,12 +6136,6 @@ impl ::core::clone::Clone for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
 unsafe impl ::windows::core::Abi for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {}
 impl ::core::default::Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6414,12 +6156,6 @@ impl ::core::clone::Clone for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
 unsafe impl ::windows::core::Abi for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {}
 impl ::core::default::Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6439,12 +6175,6 @@ impl ::core::clone::Clone for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
 unsafe impl ::windows::core::Abi for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {}
 impl ::core::default::Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6472,7 +6202,7 @@ unsafe impl ::windows::core::Abi for WHV_TRANSLATE_GVA_RESULT {
 }
 impl ::core::cmp::PartialEq for WHV_TRANSLATE_GVA_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_TRANSLATE_GVA_RESULT>()) == 0 }
+        self.ResultCode == other.ResultCode && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WHV_TRANSLATE_GVA_RESULT {}
@@ -6497,12 +6227,6 @@ impl ::core::clone::Clone for WHV_TRIGGER_PARAMETERS {
 unsafe impl ::windows::core::Abi for WHV_TRIGGER_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_TRIGGER_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_TRIGGER_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_TRIGGER_PARAMETERS {}
 impl ::core::default::Default for WHV_TRIGGER_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6524,12 +6248,6 @@ impl ::core::clone::Clone for WHV_TRIGGER_PARAMETERS_0 {
 unsafe impl ::windows::core::Abi for WHV_TRIGGER_PARAMETERS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_TRIGGER_PARAMETERS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_TRIGGER_PARAMETERS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_TRIGGER_PARAMETERS_0 {}
 impl ::core::default::Default for WHV_TRIGGER_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6559,7 +6277,7 @@ unsafe impl ::windows::core::Abi for WHV_TRIGGER_PARAMETERS_0_0 {
 }
 impl ::core::cmp::PartialEq for WHV_TRIGGER_PARAMETERS_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_TRIGGER_PARAMETERS_0_0>()) == 0 }
+        self.LogicalDeviceId == other.LogicalDeviceId && self.MsiAddress == other.MsiAddress && self.MsiData == other.MsiData && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WHV_TRIGGER_PARAMETERS_0_0 {}
@@ -6583,12 +6301,6 @@ impl ::core::clone::Clone for WHV_UINT128 {
 unsafe impl ::windows::core::Abi for WHV_UINT128 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_UINT128 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_UINT128>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_UINT128 {}
 impl ::core::default::Default for WHV_UINT128 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6616,7 +6328,7 @@ unsafe impl ::windows::core::Abi for WHV_UINT128_0 {
 }
 impl ::core::cmp::PartialEq for WHV_UINT128_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_UINT128_0>()) == 0 }
+        self.Low64 == other.Low64 && self.High64 == other.High64
     }
 }
 impl ::core::cmp::Eq for WHV_UINT128_0 {}
@@ -6641,12 +6353,6 @@ impl ::core::clone::Clone for WHV_VIRTUAL_PROCESSOR_PROPERTY {
 unsafe impl ::windows::core::Abi for WHV_VIRTUAL_PROCESSOR_PROPERTY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VIRTUAL_PROCESSOR_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VIRTUAL_PROCESSOR_PROPERTY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VIRTUAL_PROCESSOR_PROPERTY {}
 impl ::core::default::Default for WHV_VIRTUAL_PROCESSOR_PROPERTY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6667,12 +6373,6 @@ impl ::core::clone::Clone for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
 unsafe impl ::windows::core::Abi for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VIRTUAL_PROCESSOR_PROPERTY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {}
 impl ::core::default::Default for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6694,12 +6394,6 @@ impl ::core::clone::Clone for WHV_VPCI_DEVICE_NOTIFICATION {
 unsafe impl ::windows::core::Abi for WHV_VPCI_DEVICE_NOTIFICATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VPCI_DEVICE_NOTIFICATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_DEVICE_NOTIFICATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VPCI_DEVICE_NOTIFICATION {}
 impl ::core::default::Default for WHV_VPCI_DEVICE_NOTIFICATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6719,12 +6413,6 @@ impl ::core::clone::Clone for WHV_VPCI_DEVICE_NOTIFICATION_0 {
 unsafe impl ::windows::core::Abi for WHV_VPCI_DEVICE_NOTIFICATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VPCI_DEVICE_NOTIFICATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_DEVICE_NOTIFICATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VPCI_DEVICE_NOTIFICATION_0 {}
 impl ::core::default::Default for WHV_VPCI_DEVICE_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6753,7 +6441,7 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_DEVICE_REGISTER {
 }
 impl ::core::cmp::PartialEq for WHV_VPCI_DEVICE_REGISTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_DEVICE_REGISTER>()) == 0 }
+        self.Location == other.Location && self.SizeInBytes == other.SizeInBytes && self.OffsetInBytes == other.OffsetInBytes
     }
 }
 impl ::core::cmp::Eq for WHV_VPCI_DEVICE_REGISTER {}
@@ -6790,7 +6478,7 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_HARDWARE_IDS {
 }
 impl ::core::cmp::PartialEq for WHV_VPCI_HARDWARE_IDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_HARDWARE_IDS>()) == 0 }
+        self.VendorID == other.VendorID && self.DeviceID == other.DeviceID && self.RevisionID == other.RevisionID && self.ProgIf == other.ProgIf && self.SubClass == other.SubClass && self.BaseClass == other.BaseClass && self.SubVendorID == other.SubVendorID && self.SubSystemID == other.SubSystemID
     }
 }
 impl ::core::cmp::Eq for WHV_VPCI_HARDWARE_IDS {}
@@ -6823,7 +6511,7 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_INTERRUPT_TARGET {
 }
 impl ::core::cmp::PartialEq for WHV_VPCI_INTERRUPT_TARGET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_INTERRUPT_TARGET>()) == 0 }
+        self.Vector == other.Vector && self.Flags == other.Flags && self.ProcessorCount == other.ProcessorCount && self.Processors == other.Processors
     }
 }
 impl ::core::cmp::Eq for WHV_VPCI_INTERRUPT_TARGET {}
@@ -6857,7 +6545,7 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_MMIO_MAPPING {
 }
 impl ::core::cmp::PartialEq for WHV_VPCI_MMIO_MAPPING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_MMIO_MAPPING>()) == 0 }
+        self.Location == other.Location && self.Flags == other.Flags && self.SizeInBytes == other.SizeInBytes && self.OffsetInBytes == other.OffsetInBytes && self.VirtualAddress == other.VirtualAddress
     }
 }
 impl ::core::cmp::Eq for WHV_VPCI_MMIO_MAPPING {}
@@ -6887,7 +6575,7 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_PROBED_BARS {
 }
 impl ::core::cmp::PartialEq for WHV_VPCI_PROBED_BARS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VPCI_PROBED_BARS>()) == 0 }
+        self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for WHV_VPCI_PROBED_BARS {}
@@ -6917,12 +6605,6 @@ impl ::core::clone::Clone for WHV_VP_EXCEPTION_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_VP_EXCEPTION_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VP_EXCEPTION_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VP_EXCEPTION_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VP_EXCEPTION_CONTEXT {}
 impl ::core::default::Default for WHV_VP_EXCEPTION_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6943,12 +6625,6 @@ impl ::core::clone::Clone for WHV_VP_EXCEPTION_INFO {
 unsafe impl ::windows::core::Abi for WHV_VP_EXCEPTION_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VP_EXCEPTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VP_EXCEPTION_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VP_EXCEPTION_INFO {}
 impl ::core::default::Default for WHV_VP_EXCEPTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6975,7 +6651,7 @@ unsafe impl ::windows::core::Abi for WHV_VP_EXCEPTION_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WHV_VP_EXCEPTION_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VP_EXCEPTION_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_VP_EXCEPTION_INFO_0 {}
@@ -7004,12 +6680,6 @@ impl ::core::clone::Clone for WHV_VP_EXIT_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_VP_EXIT_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_VP_EXIT_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_VP_EXIT_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_VP_EXIT_CONTEXT {}
 impl ::core::default::Default for WHV_VP_EXIT_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7036,7 +6706,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_APIC_EOI_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_APIC_EOI_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_APIC_EOI_CONTEXT>()) == 0 }
+        self.InterruptVector == other.InterruptVector
     }
 }
 impl ::core::cmp::Eq for WHV_X64_APIC_EOI_CONTEXT {}
@@ -7066,7 +6736,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_APIC_INIT_SIPI_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_APIC_INIT_SIPI_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_APIC_INIT_SIPI_CONTEXT>()) == 0 }
+        self.ApicIcr == other.ApicIcr
     }
 }
 impl ::core::cmp::Eq for WHV_X64_APIC_INIT_SIPI_CONTEXT {}
@@ -7096,7 +6766,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_APIC_SMI_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_APIC_SMI_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_APIC_SMI_CONTEXT>()) == 0 }
+        self.ApicIcr == other.ApicIcr
     }
 }
 impl ::core::cmp::Eq for WHV_X64_APIC_SMI_CONTEXT {}
@@ -7128,7 +6798,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_APIC_WRITE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_APIC_WRITE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_APIC_WRITE_CONTEXT>()) == 0 }
+        self.Type == other.Type && self.Reserved == other.Reserved && self.WriteValue == other.WriteValue
     }
 }
 impl ::core::cmp::Eq for WHV_X64_APIC_WRITE_CONTEXT {}
@@ -7165,7 +6835,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_CPUID_ACCESS_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_CPUID_ACCESS_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_CPUID_ACCESS_CONTEXT>()) == 0 }
+        self.Rax == other.Rax && self.Rcx == other.Rcx && self.Rdx == other.Rdx && self.Rbx == other.Rbx && self.DefaultResultRax == other.DefaultResultRax && self.DefaultResultRcx == other.DefaultResultRcx && self.DefaultResultRdx == other.DefaultResultRdx && self.DefaultResultRbx == other.DefaultResultRbx
     }
 }
 impl ::core::cmp::Eq for WHV_X64_CPUID_ACCESS_CONTEXT {}
@@ -7200,7 +6870,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_CPUID_RESULT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_CPUID_RESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_CPUID_RESULT>()) == 0 }
+        self.Function == other.Function && self.Reserved == other.Reserved && self.Eax == other.Eax && self.Ebx == other.Ebx && self.Ecx == other.Ecx && self.Edx == other.Edx
     }
 }
 impl ::core::cmp::Eq for WHV_X64_CPUID_RESULT {}
@@ -7235,7 +6905,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_CPUID_RESULT2 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_CPUID_RESULT2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_CPUID_RESULT2>()) == 0 }
+        self.Function == other.Function && self.Index == other.Index && self.VpIndex == other.VpIndex && self.Flags == other.Flags && self.Output == other.Output && self.Mask == other.Mask
     }
 }
 impl ::core::cmp::Eq for WHV_X64_CPUID_RESULT2 {}
@@ -7259,12 +6929,6 @@ impl ::core::clone::Clone for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {}
 impl ::core::default::Default for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7291,7 +6955,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGIST
 }
 impl ::core::cmp::PartialEq for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0 {}
@@ -7315,12 +6979,6 @@ impl ::core::clone::Clone for WHV_X64_FP_CONTROL_STATUS_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_FP_CONTROL_STATUS_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_FP_CONTROL_STATUS_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_CONTROL_STATUS_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_FP_CONTROL_STATUS_REGISTER {}
 impl ::core::default::Default for WHV_X64_FP_CONTROL_STATUS_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7345,12 +7003,6 @@ impl ::core::clone::Clone for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
 unsafe impl ::windows::core::Abi for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_CONTROL_STATUS_REGISTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {}
 impl ::core::default::Default for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7371,12 +7023,6 @@ impl ::core::clone::Clone for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
 unsafe impl ::windows::core::Abi for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {}
 impl ::core::default::Default for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7405,7 +7051,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0>()) == 0 }
+        self.LastFpEip == other.LastFpEip && self.LastFpCs == other.LastFpCs && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0 {}
@@ -7429,12 +7075,6 @@ impl ::core::clone::Clone for WHV_X64_FP_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_FP_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_FP_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_FP_REGISTER {}
 impl ::core::default::Default for WHV_X64_FP_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7462,7 +7102,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_FP_REGISTER_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_FP_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_FP_REGISTER_0>()) == 0 }
+        self.Mantissa == other.Mantissa && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_FP_REGISTER_0 {}
@@ -7492,7 +7132,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT>()) == 0 }
+        self.DeliverableType == other.DeliverableType
     }
 }
 impl ::core::cmp::Eq for WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {}
@@ -7516,12 +7156,6 @@ impl ::core::clone::Clone for WHV_X64_INTERRUPT_STATE_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_INTERRUPT_STATE_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_INTERRUPT_STATE_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_INTERRUPT_STATE_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_INTERRUPT_STATE_REGISTER {}
 impl ::core::default::Default for WHV_X64_INTERRUPT_STATE_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7548,7 +7182,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_INTERRUPT_STATE_REGISTER_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_INTERRUPT_STATE_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_INTERRUPT_STATE_REGISTER_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_INTERRUPT_STATE_REGISTER_0 {}
@@ -7582,12 +7216,6 @@ impl ::core::clone::Clone for WHV_X64_IO_PORT_ACCESS_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_X64_IO_PORT_ACCESS_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_IO_PORT_ACCESS_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_IO_PORT_ACCESS_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_IO_PORT_ACCESS_CONTEXT {}
 impl ::core::default::Default for WHV_X64_IO_PORT_ACCESS_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7608,12 +7236,6 @@ impl ::core::clone::Clone for WHV_X64_IO_PORT_ACCESS_INFO {
 unsafe impl ::windows::core::Abi for WHV_X64_IO_PORT_ACCESS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_IO_PORT_ACCESS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_IO_PORT_ACCESS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_IO_PORT_ACCESS_INFO {}
 impl ::core::default::Default for WHV_X64_IO_PORT_ACCESS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7640,7 +7262,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_IO_PORT_ACCESS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_IO_PORT_ACCESS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_IO_PORT_ACCESS_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_IO_PORT_ACCESS_INFO_0 {}
@@ -7666,12 +7288,6 @@ impl ::core::clone::Clone for WHV_X64_MSR_ACCESS_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_X64_MSR_ACCESS_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_MSR_ACCESS_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_MSR_ACCESS_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_MSR_ACCESS_CONTEXT {}
 impl ::core::default::Default for WHV_X64_MSR_ACCESS_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7692,12 +7308,6 @@ impl ::core::clone::Clone for WHV_X64_MSR_ACCESS_INFO {
 unsafe impl ::windows::core::Abi for WHV_X64_MSR_ACCESS_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_MSR_ACCESS_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_MSR_ACCESS_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_MSR_ACCESS_INFO {}
 impl ::core::default::Default for WHV_X64_MSR_ACCESS_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7724,7 +7334,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_MSR_ACCESS_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_MSR_ACCESS_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_MSR_ACCESS_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_MSR_ACCESS_INFO_0 {}
@@ -7748,12 +7358,6 @@ impl ::core::clone::Clone for WHV_X64_MSR_EXIT_BITMAP {
 unsafe impl ::windows::core::Abi for WHV_X64_MSR_EXIT_BITMAP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_MSR_EXIT_BITMAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_MSR_EXIT_BITMAP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_MSR_EXIT_BITMAP {}
 impl ::core::default::Default for WHV_X64_MSR_EXIT_BITMAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7780,7 +7384,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_MSR_EXIT_BITMAP_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_MSR_EXIT_BITMAP_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_MSR_EXIT_BITMAP_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_MSR_EXIT_BITMAP_0 {}
@@ -7804,12 +7408,6 @@ impl ::core::clone::Clone for WHV_X64_PENDING_DEBUG_EXCEPTION {
 unsafe impl ::windows::core::Abi for WHV_X64_PENDING_DEBUG_EXCEPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_PENDING_DEBUG_EXCEPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_DEBUG_EXCEPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_PENDING_DEBUG_EXCEPTION {}
 impl ::core::default::Default for WHV_X64_PENDING_DEBUG_EXCEPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7836,7 +7434,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_PENDING_DEBUG_EXCEPTION_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_PENDING_DEBUG_EXCEPTION_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_DEBUG_EXCEPTION_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_PENDING_DEBUG_EXCEPTION_0 {}
@@ -7860,12 +7458,6 @@ impl ::core::clone::Clone for WHV_X64_PENDING_EXCEPTION_EVENT {
 unsafe impl ::windows::core::Abi for WHV_X64_PENDING_EXCEPTION_EVENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_PENDING_EXCEPTION_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_EXCEPTION_EVENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_PENDING_EXCEPTION_EVENT {}
 impl ::core::default::Default for WHV_X64_PENDING_EXCEPTION_EVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7894,7 +7486,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_PENDING_EXCEPTION_EVENT_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_PENDING_EXCEPTION_EVENT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_EXCEPTION_EVENT_0>()) == 0 }
+        self._bitfield == other._bitfield && self.ErrorCode == other.ErrorCode && self.ExceptionParameter == other.ExceptionParameter
     }
 }
 impl ::core::cmp::Eq for WHV_X64_PENDING_EXCEPTION_EVENT_0 {}
@@ -7918,12 +7510,6 @@ impl ::core::clone::Clone for WHV_X64_PENDING_EXT_INT_EVENT {
 unsafe impl ::windows::core::Abi for WHV_X64_PENDING_EXT_INT_EVENT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_PENDING_EXT_INT_EVENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_EXT_INT_EVENT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_PENDING_EXT_INT_EVENT {}
 impl ::core::default::Default for WHV_X64_PENDING_EXT_INT_EVENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7951,7 +7537,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_PENDING_EXT_INT_EVENT_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_PENDING_EXT_INT_EVENT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_EXT_INT_EVENT_0>()) == 0 }
+        self._bitfield == other._bitfield && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for WHV_X64_PENDING_EXT_INT_EVENT_0 {}
@@ -7975,12 +7561,6 @@ impl ::core::clone::Clone for WHV_X64_PENDING_INTERRUPTION_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_PENDING_INTERRUPTION_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_PENDING_INTERRUPTION_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_INTERRUPTION_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_PENDING_INTERRUPTION_REGISTER {}
 impl ::core::default::Default for WHV_X64_PENDING_INTERRUPTION_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8008,7 +7588,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_PENDING_INTERRUPTION_REGISTER_0>()) == 0 }
+        self._bitfield == other._bitfield && self.ErrorCode == other.ErrorCode
     }
 }
 impl ::core::cmp::Eq for WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {}
@@ -8035,12 +7615,6 @@ impl ::core::clone::Clone for WHV_X64_RDTSC_CONTEXT {
 unsafe impl ::windows::core::Abi for WHV_X64_RDTSC_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_RDTSC_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_RDTSC_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_RDTSC_CONTEXT {}
 impl ::core::default::Default for WHV_X64_RDTSC_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8061,12 +7635,6 @@ impl ::core::clone::Clone for WHV_X64_RDTSC_INFO {
 unsafe impl ::windows::core::Abi for WHV_X64_RDTSC_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_RDTSC_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_RDTSC_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_RDTSC_INFO {}
 impl ::core::default::Default for WHV_X64_RDTSC_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8093,7 +7661,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_RDTSC_INFO_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_RDTSC_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_RDTSC_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_RDTSC_INFO_0 {}
@@ -8119,12 +7687,6 @@ impl ::core::clone::Clone for WHV_X64_SEGMENT_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_SEGMENT_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_SEGMENT_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_SEGMENT_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_SEGMENT_REGISTER {}
 impl ::core::default::Default for WHV_X64_SEGMENT_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8145,12 +7707,6 @@ impl ::core::clone::Clone for WHV_X64_SEGMENT_REGISTER_0 {
 unsafe impl ::windows::core::Abi for WHV_X64_SEGMENT_REGISTER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_SEGMENT_REGISTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_SEGMENT_REGISTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_SEGMENT_REGISTER_0 {}
 impl ::core::default::Default for WHV_X64_SEGMENT_REGISTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8177,7 +7733,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_SEGMENT_REGISTER_0_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_SEGMENT_REGISTER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_SEGMENT_REGISTER_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_SEGMENT_REGISTER_0_0 {}
@@ -8209,7 +7765,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_TABLE_REGISTER {
 }
 impl ::core::cmp::PartialEq for WHV_X64_TABLE_REGISTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_TABLE_REGISTER>()) == 0 }
+        self.Pad == other.Pad && self.Limit == other.Limit && self.Base == other.Base
     }
 }
 impl ::core::cmp::Eq for WHV_X64_TABLE_REGISTER {}
@@ -8241,7 +7797,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_UNSUPPORTED_FEATURE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for WHV_X64_UNSUPPORTED_FEATURE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_UNSUPPORTED_FEATURE_CONTEXT>()) == 0 }
+        self.FeatureCode == other.FeatureCode && self.Reserved == other.Reserved && self.FeatureParameter == other.FeatureParameter
     }
 }
 impl ::core::cmp::Eq for WHV_X64_UNSUPPORTED_FEATURE_CONTEXT {}
@@ -8265,12 +7821,6 @@ impl ::core::clone::Clone for WHV_X64_VP_EXECUTION_STATE {
 unsafe impl ::windows::core::Abi for WHV_X64_VP_EXECUTION_STATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_VP_EXECUTION_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_VP_EXECUTION_STATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_VP_EXECUTION_STATE {}
 impl ::core::default::Default for WHV_X64_VP_EXECUTION_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8297,7 +7847,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_VP_EXECUTION_STATE_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_VP_EXECUTION_STATE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_VP_EXECUTION_STATE_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WHV_X64_VP_EXECUTION_STATE_0 {}
@@ -8321,12 +7871,6 @@ impl ::core::clone::Clone for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
 unsafe impl ::windows::core::Abi for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_XMM_CONTROL_STATUS_REGISTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_XMM_CONTROL_STATUS_REGISTER {}
 impl ::core::default::Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8348,12 +7892,6 @@ impl ::core::clone::Clone for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
 unsafe impl ::windows::core::Abi for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_XMM_CONTROL_STATUS_REGISTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {}
 impl ::core::default::Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8374,12 +7912,6 @@ impl ::core::clone::Clone for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
 unsafe impl ::windows::core::Abi for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {}
 impl ::core::default::Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8408,7 +7940,7 @@ unsafe impl ::windows::core::Abi for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0 {
 }
 impl ::core::cmp::PartialEq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0>()) == 0 }
+        self.LastFpDp == other.LastFpDp && self.LastFpDs == other.LastFpDs && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0 {}

--- a/crates/libs/windows/src/Windows/Win32/System/IO/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/IO/mod.rs
@@ -135,14 +135,6 @@ unsafe impl ::windows::core::Abi for OVERLAPPED {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OVERLAPPED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OVERLAPPED>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OVERLAPPED {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OVERLAPPED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -167,14 +159,6 @@ impl ::core::clone::Clone for OVERLAPPED_0 {
 unsafe impl ::windows::core::Abi for OVERLAPPED_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OVERLAPPED_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OVERLAPPED_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OVERLAPPED_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OVERLAPPED_0 {
     fn default() -> Self {
@@ -209,7 +193,7 @@ unsafe impl ::windows::core::Abi for OVERLAPPED_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OVERLAPPED_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OVERLAPPED_0_0>()) == 0 }
+        self.Offset == other.Offset && self.OffsetHigh == other.OffsetHigh
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -250,7 +234,7 @@ unsafe impl ::windows::core::Abi for OVERLAPPED_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OVERLAPPED_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OVERLAPPED_ENTRY>()) == 0 }
+        self.lpCompletionKey == other.lpCompletionKey && self.lpOverlapped == other.lpOverlapped && self.Internal == other.Internal && self.dwNumberOfBytesTransferred == other.dwNumberOfBytesTransferred
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -3786,7 +3786,7 @@ unsafe impl ::windows::core::Abi for CERT_CONTEXT_EX {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl ::core::cmp::PartialEq for CERT_CONTEXT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CERT_CONTEXT_EX>()) == 0 }
+        self.CertContext == other.CertContext && self.cbAllocated == other.cbAllocated && self.dwCertificateFlags == other.dwCertificateFlags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
@@ -3888,7 +3888,7 @@ unsafe impl ::windows::core::Abi for EXTENSION_CONTROL_BLOCK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EXTENSION_CONTROL_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTENSION_CONTROL_BLOCK>()) == 0 }
+        self.cbSize == other.cbSize && self.dwVersion == other.dwVersion && self.ConnID == other.ConnID && self.dwHttpStatusCode == other.dwHttpStatusCode && self.lpszLogData == other.lpszLogData && self.lpszMethod == other.lpszMethod && self.lpszQueryString == other.lpszQueryString && self.lpszPathInfo == other.lpszPathInfo && self.lpszPathTranslated == other.lpszPathTranslated && self.cbTotalBytes == other.cbTotalBytes && self.cbAvailable == other.cbAvailable && self.lpbData == other.lpbData && self.lpszContentType == other.lpszContentType && self.GetServerVariable == other.GetServerVariable && self.WriteClient == other.WriteClient && self.ReadClient == other.ReadClient && self.ServerSupportFunction == other.ServerSupportFunction
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3928,7 +3928,7 @@ unsafe impl ::windows::core::Abi for HSE_CUSTOM_ERROR_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_CUSTOM_ERROR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_CUSTOM_ERROR_INFO>()) == 0 }
+        self.pszStatus == other.pszStatus && self.uHttpSubError == other.uHttpSubError && self.fAsync == other.fAsync
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3971,7 +3971,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_UNICODE_URL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_EXEC_UNICODE_URL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_UNICODE_URL_INFO>()) == 0 }
+        self.pszUrl == other.pszUrl && self.pszMethod == other.pszMethod && self.pszChildHeaders == other.pszChildHeaders && self.pUserInfo == other.pUserInfo && self.pEntity == other.pEntity && self.dwExecUrlFlags == other.dwExecUrlFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4011,7 +4011,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_UNICODE_URL_USER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_EXEC_UNICODE_URL_USER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_UNICODE_URL_USER_INFO>()) == 0 }
+        self.hImpersonationToken == other.hImpersonationToken && self.pszCustomUserName == other.pszCustomUserName && self.pszCustomAuthType == other.pszCustomAuthType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4044,7 +4044,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_URL_ENTITY_INFO {
 }
 impl ::core::cmp::PartialEq for HSE_EXEC_URL_ENTITY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_URL_ENTITY_INFO>()) == 0 }
+        self.cbAvailable == other.cbAvailable && self.lpbData == other.lpbData
     }
 }
 impl ::core::cmp::Eq for HSE_EXEC_URL_ENTITY_INFO {}
@@ -4085,7 +4085,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_URL_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_EXEC_URL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_URL_INFO>()) == 0 }
+        self.pszUrl == other.pszUrl && self.pszMethod == other.pszMethod && self.pszChildHeaders == other.pszChildHeaders && self.pUserInfo == other.pUserInfo && self.pEntity == other.pEntity && self.dwExecUrlFlags == other.dwExecUrlFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4119,7 +4119,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_URL_STATUS {
 }
 impl ::core::cmp::PartialEq for HSE_EXEC_URL_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_URL_STATUS>()) == 0 }
+        self.uHttpStatusCode == other.uHttpStatusCode && self.uHttpSubStatus == other.uHttpSubStatus && self.dwWin32Error == other.dwWin32Error
     }
 }
 impl ::core::cmp::Eq for HSE_EXEC_URL_STATUS {}
@@ -4157,7 +4157,7 @@ unsafe impl ::windows::core::Abi for HSE_EXEC_URL_USER_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_EXEC_URL_USER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_EXEC_URL_USER_INFO>()) == 0 }
+        self.hImpersonationToken == other.hImpersonationToken && self.pszCustomUserName == other.pszCustomUserName && self.pszCustomAuthType == other.pszCustomAuthType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4193,7 +4193,7 @@ unsafe impl ::windows::core::Abi for HSE_RESPONSE_VECTOR {
 }
 impl ::core::cmp::PartialEq for HSE_RESPONSE_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_RESPONSE_VECTOR>()) == 0 }
+        self.dwFlags == other.dwFlags && self.pszStatus == other.pszStatus && self.pszHeaders == other.pszHeaders && self.nElementCount == other.nElementCount && self.lpElementArray == other.lpElementArray
     }
 }
 impl ::core::cmp::Eq for HSE_RESPONSE_VECTOR {}
@@ -4233,7 +4233,7 @@ unsafe impl ::windows::core::Abi for HSE_SEND_HEADER_EX_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_SEND_HEADER_EX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_SEND_HEADER_EX_INFO>()) == 0 }
+        self.pszStatus == other.pszStatus && self.pszHeader == other.pszHeader && self.cchStatus == other.cchStatus && self.cchHeader == other.cchHeader && self.fKeepConn == other.fKeepConn
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4271,21 +4271,13 @@ impl ::core::clone::Clone for HSE_TF_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for HSE_TF_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("HSE_TF_INFO").field("pfnHseIO", &self.pfnHseIO.map(|f| f as usize)).field("pContext", &self.pContext).field("hFile", &self.hFile).field("pszStatusCode", &self.pszStatusCode).field("BytesToWrite", &self.BytesToWrite).field("Offset", &self.Offset).field("pHead", &self.pHead).field("HeadLength", &self.HeadLength).field("pTail", &self.pTail).field("TailLength", &self.TailLength).field("dwFlags", &self.dwFlags).finish()
+        f.debug_struct("HSE_TF_INFO").field("pContext", &self.pContext).field("hFile", &self.hFile).field("pszStatusCode", &self.pszStatusCode).field("BytesToWrite", &self.BytesToWrite).field("Offset", &self.Offset).field("pHead", &self.pHead).field("HeadLength", &self.HeadLength).field("pTail", &self.pTail).field("TailLength", &self.TailLength).field("dwFlags", &self.dwFlags).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for HSE_TF_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for HSE_TF_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_TF_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for HSE_TF_INFO {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for HSE_TF_INFO {
     fn default() -> Self {
@@ -4322,7 +4314,7 @@ unsafe impl ::windows::core::Abi for HSE_TRACE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_TRACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_TRACE_INFO>()) == 0 }
+        self.fTraceRequest == other.fTraceRequest && self.TraceContextId == other.TraceContextId && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4357,7 +4349,7 @@ unsafe impl ::windows::core::Abi for HSE_UNICODE_URL_MAPEX_INFO {
 }
 impl ::core::cmp::PartialEq for HSE_UNICODE_URL_MAPEX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_UNICODE_URL_MAPEX_INFO>()) == 0 }
+        self.lpszPath == other.lpszPath && self.dwFlags == other.dwFlags && self.cchMatchingPath == other.cchMatchingPath && self.cchMatchingURL == other.cchMatchingURL
     }
 }
 impl ::core::cmp::Eq for HSE_UNICODE_URL_MAPEX_INFO {}
@@ -4398,7 +4390,7 @@ unsafe impl ::windows::core::Abi for HSE_URL_MAPEX_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_URL_MAPEX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_URL_MAPEX_INFO>()) == 0 }
+        self.lpszPath == other.lpszPath && self.dwFlags == other.dwFlags && self.cchMatchingPath == other.cchMatchingPath && self.cchMatchingURL == other.cchMatchingURL && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4433,7 +4425,7 @@ unsafe impl ::windows::core::Abi for HSE_VECTOR_ELEMENT {
 }
 impl ::core::cmp::PartialEq for HSE_VECTOR_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_VECTOR_ELEMENT>()) == 0 }
+        self.ElementType == other.ElementType && self.pvContext == other.pvContext && self.cbOffset == other.cbOffset && self.cbSize == other.cbSize
     }
 }
 impl ::core::cmp::Eq for HSE_VECTOR_ELEMENT {}
@@ -4470,7 +4462,7 @@ unsafe impl ::windows::core::Abi for HSE_VERSION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HSE_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSE_VERSION_INFO>()) == 0 }
+        self.dwExtensionVersion == other.dwExtensionVersion && self.lpszExtensionDesc == other.lpszExtensionDesc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4504,7 +4496,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_ACCESS_DENIED {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_ACCESS_DENIED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_ACCESS_DENIED>()) == 0 }
+        self.pszURL == other.pszURL && self.pszPhysicalPath == other.pszPhysicalPath && self.dwReason == other.dwReason
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_ACCESS_DENIED {}
@@ -4537,7 +4529,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_AUTHENT {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_AUTHENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_AUTHENT>()) == 0 }
+        self.pszUser == other.pszUser && self.cbUserBuff == other.cbUserBuff && self.pszPassword == other.pszPassword && self.cbPasswordBuff == other.cbPasswordBuff
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_AUTHENT {}
@@ -4579,7 +4571,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_AUTH_COMPLETE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_FILTER_AUTH_COMPLETE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_AUTH_COMPLETE_INFO>()) == 0 }
+        self.GetHeader == other.GetHeader && self.SetHeader == other.SetHeader && self.AddHeader == other.AddHeader && self.GetUserToken == other.GetUserToken && self.HttpStatus == other.HttpStatus && self.fResetAuth == other.fResetAuth && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4639,7 +4631,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_CONTEXT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_FILTER_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_CONTEXT>()) == 0 }
+        self.cbSize == other.cbSize && self.Revision == other.Revision && self.ServerContext == other.ServerContext && self.ulReserved == other.ulReserved && self.fIsSecurePort == other.fIsSecurePort && self.pFilterContext == other.pFilterContext && self.GetServerVariable == other.GetServerVariable && self.AddResponseHeaders == other.AddResponseHeaders && self.WriteClient == other.WriteClient && self.AllocMem == other.AllocMem && self.ServerSupportFunction == other.ServerSupportFunction
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4693,7 +4685,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_LOG {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_LOG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_LOG>()) == 0 }
+        self.pszClientHostName == other.pszClientHostName && self.pszClientUserName == other.pszClientUserName && self.pszServerName == other.pszServerName && self.pszOperation == other.pszOperation && self.pszTarget == other.pszTarget && self.pszParameters == other.pszParameters && self.dwHttpStatus == other.dwHttpStatus && self.dwWin32Status == other.dwWin32Status && self.dwBytesSent == other.dwBytesSent && self.dwBytesRecvd == other.dwBytesRecvd && self.msTimeForProcessing == other.msTimeForProcessing
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_LOG {}
@@ -4727,7 +4719,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_PREPROC_HEADERS {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_PREPROC_HEADERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_PREPROC_HEADERS>()) == 0 }
+        self.GetHeader == other.GetHeader && self.SetHeader == other.SetHeader && self.AddHeader == other.AddHeader && self.HttpStatus == other.HttpStatus && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_PREPROC_HEADERS {}
@@ -4760,7 +4752,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_RAW_DATA {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_RAW_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_RAW_DATA>()) == 0 }
+        self.pvInData == other.pvInData && self.cbInData == other.cbInData && self.cbInBuffer == other.cbInBuffer && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_RAW_DATA {}
@@ -4792,7 +4784,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_URL_MAP {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_URL_MAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_URL_MAP>()) == 0 }
+        self.pszURL == other.pszURL && self.pszPhysicalPath == other.pszPhysicalPath && self.cbPathBuff == other.cbPathBuff
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_URL_MAP {}
@@ -4828,7 +4820,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_URL_MAP_EX {
 }
 impl ::core::cmp::PartialEq for HTTP_FILTER_URL_MAP_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_URL_MAP_EX>()) == 0 }
+        self.pszURL == other.pszURL && self.pszPhysicalPath == other.pszPhysicalPath && self.cbPathBuff == other.cbPathBuff && self.dwFlags == other.dwFlags && self.cchMatchingPath == other.cchMatchingPath && self.cchMatchingURL == other.cchMatchingURL && self.pszScriptMapEntry == other.pszScriptMapEntry
     }
 }
 impl ::core::cmp::Eq for HTTP_FILTER_URL_MAP_EX {}
@@ -4867,7 +4859,7 @@ unsafe impl ::windows::core::Abi for HTTP_FILTER_VERSION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_FILTER_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_FILTER_VERSION>()) == 0 }
+        self.dwServerFilterVersion == other.dwServerFilterVersion && self.dwFilterVersion == other.dwFilterVersion && self.lpszFilterDesc == other.lpszFilterDesc && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4908,7 +4900,7 @@ unsafe impl ::windows::core::Abi for HTTP_TRACE_CONFIGURATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HTTP_TRACE_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TRACE_CONFIGURATION>()) == 0 }
+        self.pProviderGuid == other.pProviderGuid && self.dwAreas == other.dwAreas && self.dwVerbosity == other.dwVerbosity && self.fProviderEnabled == other.fProviderEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4966,7 +4958,7 @@ unsafe impl ::windows::core::Abi for HTTP_TRACE_EVENT {
 }
 impl ::core::cmp::PartialEq for HTTP_TRACE_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TRACE_EVENT>()) == 0 }
+        self.pProviderGuid == other.pProviderGuid && self.dwArea == other.dwArea && self.pAreaGuid == other.pAreaGuid && self.dwEvent == other.dwEvent && self.pszEventName == other.pszEventName && self.dwEventVersion == other.dwEventVersion && self.dwVerbosity == other.dwVerbosity && self.pActivityGuid == other.pActivityGuid && self.pRelatedActivityGuid == other.pRelatedActivityGuid && self.dwTimeStamp == other.dwTimeStamp && self.dwFlags == other.dwFlags && self.cEventItems == other.cEventItems && self.pEventItems == other.pEventItems
     }
 }
 impl ::core::cmp::Eq for HTTP_TRACE_EVENT {}
@@ -5000,7 +4992,7 @@ unsafe impl ::windows::core::Abi for HTTP_TRACE_EVENT_ITEM {
 }
 impl ::core::cmp::PartialEq for HTTP_TRACE_EVENT_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HTTP_TRACE_EVENT_ITEM>()) == 0 }
+        self.pszName == other.pszName && self.dwDataType == other.dwDataType && self.pbData == other.pbData && self.cbData == other.cbData && self.pszDataDescription == other.pszDataDescription
     }
 }
 impl ::core::cmp::Eq for HTTP_TRACE_EVENT_ITEM {}
@@ -5066,7 +5058,24 @@ unsafe impl ::windows::core::Abi for LOGGING_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for LOGGING_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGGING_PARAMETERS>()) == 0 }
+        self.pszSessionId == other.pszSessionId
+            && self.pszSiteName == other.pszSiteName
+            && self.pszUserName == other.pszUserName
+            && self.pszHostName == other.pszHostName
+            && self.pszRemoteIpAddress == other.pszRemoteIpAddress
+            && self.dwRemoteIpPort == other.dwRemoteIpPort
+            && self.pszLocalIpAddress == other.pszLocalIpAddress
+            && self.dwLocalIpPort == other.dwLocalIpPort
+            && self.BytesSent == other.BytesSent
+            && self.BytesReceived == other.BytesReceived
+            && self.pszCommand == other.pszCommand
+            && self.pszCommandParameters == other.pszCommandParameters
+            && self.pszFullPath == other.pszFullPath
+            && self.dwElapsedMilliseconds == other.dwElapsedMilliseconds
+            && self.FtpStatus == other.FtpStatus
+            && self.FtpSubStatus == other.FtpSubStatus
+            && self.hrStatus == other.hrStatus
+            && self.pszInformation == other.pszInformation
     }
 }
 impl ::core::cmp::Eq for LOGGING_PARAMETERS {}
@@ -5099,7 +5108,7 @@ unsafe impl ::windows::core::Abi for MD_CHANGE_OBJECT_W {
 }
 impl ::core::cmp::PartialEq for MD_CHANGE_OBJECT_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MD_CHANGE_OBJECT_W>()) == 0 }
+        self.pszMDPath == other.pszMDPath && self.dwMDChangeType == other.dwMDChangeType && self.dwMDNumDataIDs == other.dwMDNumDataIDs && self.pdwMDDataIDs == other.pdwMDDataIDs
     }
 }
 impl ::core::cmp::Eq for MD_CHANGE_OBJECT_W {}
@@ -5128,12 +5137,6 @@ impl ::core::clone::Clone for METADATA_GETALL_INTERNAL_RECORD {
 unsafe impl ::windows::core::Abi for METADATA_GETALL_INTERNAL_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for METADATA_GETALL_INTERNAL_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METADATA_GETALL_INTERNAL_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for METADATA_GETALL_INTERNAL_RECORD {}
 impl ::core::default::Default for METADATA_GETALL_INTERNAL_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5154,12 +5157,6 @@ impl ::core::clone::Clone for METADATA_GETALL_INTERNAL_RECORD_0 {
 unsafe impl ::windows::core::Abi for METADATA_GETALL_INTERNAL_RECORD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for METADATA_GETALL_INTERNAL_RECORD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METADATA_GETALL_INTERNAL_RECORD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for METADATA_GETALL_INTERNAL_RECORD_0 {}
 impl ::core::default::Default for METADATA_GETALL_INTERNAL_RECORD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5192,7 +5189,7 @@ unsafe impl ::windows::core::Abi for METADATA_GETALL_RECORD {
 }
 impl ::core::cmp::PartialEq for METADATA_GETALL_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METADATA_GETALL_RECORD>()) == 0 }
+        self.dwMDIdentifier == other.dwMDIdentifier && self.dwMDAttributes == other.dwMDAttributes && self.dwMDUserType == other.dwMDUserType && self.dwMDDataType == other.dwMDDataType && self.dwMDDataLen == other.dwMDDataLen && self.dwMDDataOffset == other.dwMDDataOffset && self.dwMDDataTag == other.dwMDDataTag
     }
 }
 impl ::core::cmp::Eq for METADATA_GETALL_RECORD {}
@@ -5223,7 +5220,7 @@ unsafe impl ::windows::core::Abi for METADATA_HANDLE_INFO {
 }
 impl ::core::cmp::PartialEq for METADATA_HANDLE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METADATA_HANDLE_INFO>()) == 0 }
+        self.dwMDPermissions == other.dwMDPermissions && self.dwMDSystemChangeNumber == other.dwMDSystemChangeNumber
     }
 }
 impl ::core::cmp::Eq for METADATA_HANDLE_INFO {}
@@ -5259,7 +5256,7 @@ unsafe impl ::windows::core::Abi for METADATA_RECORD {
 }
 impl ::core::cmp::PartialEq for METADATA_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METADATA_RECORD>()) == 0 }
+        self.dwMDIdentifier == other.dwMDIdentifier && self.dwMDAttributes == other.dwMDAttributes && self.dwMDUserType == other.dwMDUserType && self.dwMDDataType == other.dwMDDataType && self.dwMDDataLen == other.dwMDDataLen && self.pbMDData == other.pbMDData && self.dwMDDataTag == other.dwMDDataTag
     }
 }
 impl ::core::cmp::Eq for METADATA_RECORD {}
@@ -5335,7 +5332,26 @@ unsafe impl ::windows::core::Abi for POST_PROCESS_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POST_PROCESS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POST_PROCESS_PARAMETERS>()) == 0 }
+        self.pszSessionId == other.pszSessionId
+            && self.pszSiteName == other.pszSiteName
+            && self.pszUserName == other.pszUserName
+            && self.pszHostName == other.pszHostName
+            && self.pszRemoteIpAddress == other.pszRemoteIpAddress
+            && self.dwRemoteIpPort == other.dwRemoteIpPort
+            && self.pszLocalIpAddress == other.pszLocalIpAddress
+            && self.dwLocalIpPort == other.dwLocalIpPort
+            && self.BytesSent == other.BytesSent
+            && self.BytesReceived == other.BytesReceived
+            && self.pszCommand == other.pszCommand
+            && self.pszCommandParameters == other.pszCommandParameters
+            && self.pszFullPath == other.pszFullPath
+            && self.pszPhysicalPath == other.pszPhysicalPath
+            && self.FtpStatus == other.FtpStatus
+            && self.FtpSubStatus == other.FtpSubStatus
+            && self.hrStatus == other.hrStatus
+            && self.SessionStartTime == other.SessionStartTime
+            && self.BytesSentPerSession == other.BytesSentPerSession
+            && self.BytesReceivedPerSession == other.BytesReceivedPerSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5399,7 +5415,7 @@ unsafe impl ::windows::core::Abi for PRE_PROCESS_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRE_PROCESS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRE_PROCESS_PARAMETERS>()) == 0 }
+        self.pszSessionId == other.pszSessionId && self.pszSiteName == other.pszSiteName && self.pszUserName == other.pszUserName && self.pszHostName == other.pszHostName && self.pszRemoteIpAddress == other.pszRemoteIpAddress && self.dwRemoteIpPort == other.dwRemoteIpPort && self.pszLocalIpAddress == other.pszLocalIpAddress && self.dwLocalIpPort == other.dwLocalIpPort && self.pszCommand == other.pszCommand && self.pszCommandParameters == other.pszCommandParameters && self.SessionStartTime == other.SessionStartTime && self.BytesSentPerSession == other.BytesSentPerSession && self.BytesReceivedPerSession == other.BytesReceivedPerSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -5495,7 +5495,7 @@ unsafe impl ::windows::core::Abi for ASYNC_DUPLICATE_EXTENTS_STATUS {
 }
 impl ::core::cmp::PartialEq for ASYNC_DUPLICATE_EXTENTS_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASYNC_DUPLICATE_EXTENTS_STATUS>()) == 0 }
+        self.Version == other.Version && self.State == other.State && self.SourceFileOffset == other.SourceFileOffset && self.TargetFileOffset == other.TargetFileOffset && self.ByteCount == other.ByteCount && self.BytesDuplicated == other.BytesDuplicated
     }
 }
 impl ::core::cmp::Eq for ASYNC_DUPLICATE_EXTENTS_STATUS {}
@@ -5526,7 +5526,7 @@ unsafe impl ::windows::core::Abi for BIN_COUNT {
 }
 impl ::core::cmp::PartialEq for BIN_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIN_COUNT>()) == 0 }
+        self.BinRange == other.BinRange && self.BinCount == other.BinCount
     }
 }
 impl ::core::cmp::Eq for BIN_COUNT {}
@@ -5557,7 +5557,7 @@ unsafe impl ::windows::core::Abi for BIN_RANGE {
 }
 impl ::core::cmp::PartialEq for BIN_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIN_RANGE>()) == 0 }
+        self.StartValue == other.StartValue && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for BIN_RANGE {}
@@ -5588,7 +5588,7 @@ unsafe impl ::windows::core::Abi for BIN_RESULTS {
 }
 impl ::core::cmp::PartialEq for BIN_RESULTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIN_RESULTS>()) == 0 }
+        self.NumberOfBins == other.NumberOfBins && self.BinCounts == other.BinCounts
     }
 }
 impl ::core::cmp::Eq for BIN_RESULTS {}
@@ -5619,7 +5619,7 @@ unsafe impl ::windows::core::Abi for BOOT_AREA_INFO {
 }
 impl ::core::cmp::PartialEq for BOOT_AREA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BOOT_AREA_INFO>()) == 0 }
+        self.BootSectorCount == other.BootSectorCount && self.BootSectors == other.BootSectors
     }
 }
 impl ::core::cmp::Eq for BOOT_AREA_INFO {}
@@ -5649,7 +5649,7 @@ unsafe impl ::windows::core::Abi for BOOT_AREA_INFO_0 {
 }
 impl ::core::cmp::PartialEq for BOOT_AREA_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BOOT_AREA_INFO_0>()) == 0 }
+        self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for BOOT_AREA_INFO_0 {}
@@ -5680,7 +5680,7 @@ unsafe impl ::windows::core::Abi for BULK_SECURITY_TEST_DATA {
 }
 impl ::core::cmp::PartialEq for BULK_SECURITY_TEST_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BULK_SECURITY_TEST_DATA>()) == 0 }
+        self.DesiredAccess == other.DesiredAccess && self.SecurityIds == other.SecurityIds
     }
 }
 impl ::core::cmp::Eq for BULK_SECURITY_TEST_DATA {}
@@ -5711,7 +5711,7 @@ unsafe impl ::windows::core::Abi for CHANGER_ELEMENT {
 }
 impl ::core::cmp::PartialEq for CHANGER_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_ELEMENT>()) == 0 }
+        self.ElementType == other.ElementType && self.ElementAddress == other.ElementAddress
     }
 }
 impl ::core::cmp::Eq for CHANGER_ELEMENT {}
@@ -5742,7 +5742,7 @@ unsafe impl ::windows::core::Abi for CHANGER_ELEMENT_LIST {
 }
 impl ::core::cmp::PartialEq for CHANGER_ELEMENT_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_ELEMENT_LIST>()) == 0 }
+        self.Element == other.Element && self.NumberOfElements == other.NumberOfElements
     }
 }
 impl ::core::cmp::Eq for CHANGER_ELEMENT_LIST {}
@@ -5780,7 +5780,7 @@ unsafe impl ::windows::core::Abi for CHANGER_ELEMENT_STATUS {
 }
 impl ::core::cmp::PartialEq for CHANGER_ELEMENT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_ELEMENT_STATUS>()) == 0 }
+        self.Element == other.Element && self.SrcElementAddress == other.SrcElementAddress && self.Flags == other.Flags && self.ExceptionCode == other.ExceptionCode && self.TargetId == other.TargetId && self.Lun == other.Lun && self.Reserved == other.Reserved && self.PrimaryVolumeID == other.PrimaryVolumeID && self.AlternateVolumeID == other.AlternateVolumeID
     }
 }
 impl ::core::cmp::Eq for CHANGER_ELEMENT_STATUS {}
@@ -5834,7 +5834,7 @@ unsafe impl ::windows::core::Abi for CHANGER_ELEMENT_STATUS_EX {
 }
 impl ::core::cmp::PartialEq for CHANGER_ELEMENT_STATUS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_ELEMENT_STATUS_EX>()) == 0 }
+        self.Element == other.Element && self.SrcElementAddress == other.SrcElementAddress && self.Flags == other.Flags && self.ExceptionCode == other.ExceptionCode && self.TargetId == other.TargetId && self.Lun == other.Lun && self.Reserved == other.Reserved && self.PrimaryVolumeID == other.PrimaryVolumeID && self.AlternateVolumeID == other.AlternateVolumeID && self.VendorIdentification == other.VendorIdentification && self.ProductIdentification == other.ProductIdentification && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for CHANGER_ELEMENT_STATUS_EX {}
@@ -5875,7 +5875,7 @@ unsafe impl ::windows::core::Abi for CHANGER_EXCHANGE_MEDIUM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CHANGER_EXCHANGE_MEDIUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_EXCHANGE_MEDIUM>()) == 0 }
+        self.Transport == other.Transport && self.Source == other.Source && self.Destination1 == other.Destination1 && self.Destination2 == other.Destination2 && self.Flip1 == other.Flip1 && self.Flip2 == other.Flip2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5914,7 +5914,7 @@ unsafe impl ::windows::core::Abi for CHANGER_INITIALIZE_ELEMENT_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CHANGER_INITIALIZE_ELEMENT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_INITIALIZE_ELEMENT_STATUS>()) == 0 }
+        self.ElementList == other.ElementList && self.BarCodeScan == other.BarCodeScan
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5955,7 +5955,7 @@ unsafe impl ::windows::core::Abi for CHANGER_MOVE_MEDIUM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CHANGER_MOVE_MEDIUM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_MOVE_MEDIUM>()) == 0 }
+        self.Transport == other.Transport && self.Source == other.Source && self.Destination == other.Destination && self.Flip == other.Flip
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5991,7 +5991,7 @@ unsafe impl ::windows::core::Abi for CHANGER_PRODUCT_DATA {
 }
 impl ::core::cmp::PartialEq for CHANGER_PRODUCT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_PRODUCT_DATA>()) == 0 }
+        self.VendorId == other.VendorId && self.ProductId == other.ProductId && self.Revision == other.Revision && self.SerialNumber == other.SerialNumber && self.DeviceType == other.DeviceType
     }
 }
 impl ::core::cmp::Eq for CHANGER_PRODUCT_DATA {}
@@ -6028,7 +6028,7 @@ unsafe impl ::windows::core::Abi for CHANGER_READ_ELEMENT_STATUS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CHANGER_READ_ELEMENT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_READ_ELEMENT_STATUS>()) == 0 }
+        self.ElementList == other.ElementList && self.VolumeTagInfo == other.VolumeTagInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6062,7 +6062,7 @@ unsafe impl ::windows::core::Abi for CHANGER_SEND_VOLUME_TAG_INFORMATION {
 }
 impl ::core::cmp::PartialEq for CHANGER_SEND_VOLUME_TAG_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_SEND_VOLUME_TAG_INFORMATION>()) == 0 }
+        self.StartingElement == other.StartingElement && self.ActionCode == other.ActionCode && self.VolumeIDTemplate == other.VolumeIDTemplate
     }
 }
 impl ::core::cmp::Eq for CHANGER_SEND_VOLUME_TAG_INFORMATION {}
@@ -6093,7 +6093,7 @@ unsafe impl ::windows::core::Abi for CHANGER_SET_ACCESS {
 }
 impl ::core::cmp::PartialEq for CHANGER_SET_ACCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_SET_ACCESS>()) == 0 }
+        self.Element == other.Element && self.Control == other.Control
     }
 }
 impl ::core::cmp::Eq for CHANGER_SET_ACCESS {}
@@ -6131,7 +6131,7 @@ unsafe impl ::windows::core::Abi for CHANGER_SET_POSITION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CHANGER_SET_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGER_SET_POSITION>()) == 0 }
+        self.Transport == other.Transport && self.Destination == other.Destination && self.Flip == other.Flip
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6164,7 +6164,7 @@ unsafe impl ::windows::core::Abi for CLASS_MEDIA_CHANGE_CONTEXT {
 }
 impl ::core::cmp::PartialEq for CLASS_MEDIA_CHANGE_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLASS_MEDIA_CHANGE_CONTEXT>()) == 0 }
+        self.MediaChangeCount == other.MediaChangeCount && self.NewState == other.NewState
     }
 }
 impl ::core::cmp::Eq for CLASS_MEDIA_CHANGE_CONTEXT {}
@@ -6195,7 +6195,7 @@ unsafe impl ::windows::core::Abi for CLUSTER_RANGE {
 }
 impl ::core::cmp::PartialEq for CLUSTER_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLUSTER_RANGE>()) == 0 }
+        self.StartingCluster == other.StartingCluster && self.ClusterCount == other.ClusterCount
     }
 }
 impl ::core::cmp::Eq for CLUSTER_RANGE {}
@@ -6225,7 +6225,7 @@ unsafe impl ::windows::core::Abi for CONTAINER_ROOT_INFO_INPUT {
 }
 impl ::core::cmp::PartialEq for CONTAINER_ROOT_INFO_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTAINER_ROOT_INFO_INPUT>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CONTAINER_ROOT_INFO_INPUT {}
@@ -6256,7 +6256,7 @@ unsafe impl ::windows::core::Abi for CONTAINER_ROOT_INFO_OUTPUT {
 }
 impl ::core::cmp::PartialEq for CONTAINER_ROOT_INFO_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTAINER_ROOT_INFO_OUTPUT>()) == 0 }
+        self.ContainerRootIdLength == other.ContainerRootIdLength && self.ContainerRootId == other.ContainerRootId
     }
 }
 impl ::core::cmp::Eq for CONTAINER_ROOT_INFO_OUTPUT {}
@@ -6286,7 +6286,7 @@ unsafe impl ::windows::core::Abi for CONTAINER_VOLUME_STATE {
 }
 impl ::core::cmp::PartialEq for CONTAINER_VOLUME_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTAINER_VOLUME_STATE>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CONTAINER_VOLUME_STATE {}
@@ -6310,12 +6310,6 @@ impl ::core::clone::Clone for CREATE_DISK {
 unsafe impl ::windows::core::Abi for CREATE_DISK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CREATE_DISK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_DISK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CREATE_DISK {}
 impl ::core::default::Default for CREATE_DISK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6336,12 +6330,6 @@ impl ::core::clone::Clone for CREATE_DISK_0 {
 unsafe impl ::windows::core::Abi for CREATE_DISK_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CREATE_DISK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_DISK_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CREATE_DISK_0 {}
 impl ::core::default::Default for CREATE_DISK_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6369,7 +6357,7 @@ unsafe impl ::windows::core::Abi for CREATE_DISK_GPT {
 }
 impl ::core::cmp::PartialEq for CREATE_DISK_GPT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_DISK_GPT>()) == 0 }
+        self.DiskId == other.DiskId && self.MaxPartitionCount == other.MaxPartitionCount
     }
 }
 impl ::core::cmp::Eq for CREATE_DISK_GPT {}
@@ -6399,7 +6387,7 @@ unsafe impl ::windows::core::Abi for CREATE_DISK_MBR {
 }
 impl ::core::cmp::PartialEq for CREATE_DISK_MBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_DISK_MBR>()) == 0 }
+        self.Signature == other.Signature
     }
 }
 impl ::core::cmp::Eq for CREATE_DISK_MBR {}
@@ -6430,7 +6418,7 @@ unsafe impl ::windows::core::Abi for CREATE_USN_JOURNAL_DATA {
 }
 impl ::core::cmp::PartialEq for CREATE_USN_JOURNAL_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATE_USN_JOURNAL_DATA>()) == 0 }
+        self.MaximumSize == other.MaximumSize && self.AllocationDelta == other.AllocationDelta
     }
 }
 impl ::core::cmp::Eq for CREATE_USN_JOURNAL_DATA {}
@@ -6461,7 +6449,7 @@ unsafe impl ::windows::core::Abi for CSV_CONTROL_PARAM {
 }
 impl ::core::cmp::PartialEq for CSV_CONTROL_PARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_CONTROL_PARAM>()) == 0 }
+        self.Operation == other.Operation && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for CSV_CONTROL_PARAM {}
@@ -6497,7 +6485,7 @@ unsafe impl ::windows::core::Abi for CSV_IS_OWNED_BY_CSVFS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CSV_IS_OWNED_BY_CSVFS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_IS_OWNED_BY_CSVFS>()) == 0 }
+        self.OwnedByCSVFS == other.OwnedByCSVFS
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6529,7 +6517,7 @@ unsafe impl ::windows::core::Abi for CSV_MGMT_LOCK {
 }
 impl ::core::cmp::PartialEq for CSV_MGMT_LOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_MGMT_LOCK>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CSV_MGMT_LOCK {}
@@ -6562,7 +6550,7 @@ unsafe impl ::windows::core::Abi for CSV_NAMESPACE_INFO {
 }
 impl ::core::cmp::PartialEq for CSV_NAMESPACE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_NAMESPACE_INFO>()) == 0 }
+        self.Version == other.Version && self.DeviceNumber == other.DeviceNumber && self.StartingOffset == other.StartingOffset && self.SectorSize == other.SectorSize
     }
 }
 impl ::core::cmp::Eq for CSV_NAMESPACE_INFO {}
@@ -6593,7 +6581,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_FILE_REVISION {
 }
 impl ::core::cmp::PartialEq for CSV_QUERY_FILE_REVISION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_FILE_REVISION>()) == 0 }
+        self.FileId == other.FileId && self.FileRevision == other.FileRevision
     }
 }
 impl ::core::cmp::Eq for CSV_QUERY_FILE_REVISION {}
@@ -6630,7 +6618,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_FILE_REVISION_FILE_ID_128 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for CSV_QUERY_FILE_REVISION_FILE_ID_128 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_FILE_REVISION_FILE_ID_128>()) == 0 }
+        self.FileId == other.FileId && self.FileRevision == other.FileRevision
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -6665,7 +6653,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_MDS_PATH {
 }
 impl ::core::cmp::PartialEq for CSV_QUERY_MDS_PATH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_MDS_PATH>()) == 0 }
+        self.MdsNodeId == other.MdsNodeId && self.DsNodeId == other.DsNodeId && self.PathLength == other.PathLength && self.Path == other.Path
     }
 }
 impl ::core::cmp::Eq for CSV_QUERY_MDS_PATH {}
@@ -6705,7 +6693,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_MDS_PATH_V2 {
 }
 impl ::core::cmp::PartialEq for CSV_QUERY_MDS_PATH_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_MDS_PATH_V2>()) == 0 }
+        self.Version == other.Version && self.RequiredSize == other.RequiredSize && self.MdsNodeId == other.MdsNodeId && self.DsNodeId == other.DsNodeId && self.Flags == other.Flags && self.DiskConnectivity == other.DiskConnectivity && self.VolumeId == other.VolumeId && self.IpAddressOffset == other.IpAddressOffset && self.IpAddressLength == other.IpAddressLength && self.PathOffset == other.PathOffset && self.PathLength == other.PathLength
     }
 }
 impl ::core::cmp::Eq for CSV_QUERY_MDS_PATH_V2 {}
@@ -6743,7 +6731,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_REDIRECT_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CSV_QUERY_REDIRECT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_REDIRECT_STATE>()) == 0 }
+        self.MdsNodeId == other.MdsNodeId && self.DsNodeId == other.DsNodeId && self.FileRedirected == other.FileRedirected
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6777,7 +6765,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {
 }
 impl ::core::cmp::PartialEq for CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT>()) == 0 }
+        self.VetoedFromAltitudeIntegral == other.VetoedFromAltitudeIntegral && self.VetoedFromAltitudeDecimal == other.VetoedFromAltitudeDecimal && self.Reason == other.Reason
     }
 }
 impl ::core::cmp::Eq for CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {}
@@ -6807,7 +6795,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_VOLUME_ID {
 }
 impl ::core::cmp::PartialEq for CSV_QUERY_VOLUME_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_VOLUME_ID>()) == 0 }
+        self.VolumeId == other.VolumeId
     }
 }
 impl ::core::cmp::Eq for CSV_QUERY_VOLUME_ID {}
@@ -6847,7 +6835,7 @@ unsafe impl ::windows::core::Abi for CSV_QUERY_VOLUME_REDIRECT_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CSV_QUERY_VOLUME_REDIRECT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_QUERY_VOLUME_REDIRECT_STATE>()) == 0 }
+        self.MdsNodeId == other.MdsNodeId && self.DsNodeId == other.DsNodeId && self.IsDiskConnected == other.IsDiskConnected && self.ClusterEnableDirectIo == other.ClusterEnableDirectIo && self.DiskConnectivity == other.DiskConnectivity
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6879,7 +6867,7 @@ unsafe impl ::windows::core::Abi for CSV_SET_VOLUME_ID {
 }
 impl ::core::cmp::PartialEq for CSV_SET_VOLUME_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSV_SET_VOLUME_ID>()) == 0 }
+        self.VolumeId == other.VolumeId
     }
 }
 impl ::core::cmp::Eq for CSV_SET_VOLUME_ID {}
@@ -6915,7 +6903,7 @@ unsafe impl ::windows::core::Abi for DECRYPTION_STATUS_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DECRYPTION_STATUS_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DECRYPTION_STATUS_BUFFER>()) == 0 }
+        self.NoEncryptedStreams == other.NoEncryptedStreams
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6948,7 +6936,7 @@ unsafe impl ::windows::core::Abi for DELETE_USN_JOURNAL_DATA {
 }
 impl ::core::cmp::PartialEq for DELETE_USN_JOURNAL_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETE_USN_JOURNAL_DATA>()) == 0 }
+        self.UsnJournalID == other.UsnJournalID && self.DeleteFlags == other.DeleteFlags
     }
 }
 impl ::core::cmp::Eq for DELETE_USN_JOURNAL_DATA {}
@@ -6973,12 +6961,6 @@ impl ::core::clone::Clone for DEVICEDUMP_PRIVATE_SUBSECTION {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_PRIVATE_SUBSECTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_PRIVATE_SUBSECTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_PRIVATE_SUBSECTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_PRIVATE_SUBSECTION {}
 impl ::core::default::Default for DEVICEDUMP_PRIVATE_SUBSECTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7006,14 +6988,6 @@ unsafe impl ::windows::core::Abi for DEVICEDUMP_PUBLIC_SUBSECTION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DEVICEDUMP_PUBLIC_SUBSECTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_PUBLIC_SUBSECTION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DEVICEDUMP_PUBLIC_SUBSECTION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DEVICEDUMP_PUBLIC_SUBSECTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7040,7 +7014,7 @@ unsafe impl ::windows::core::Abi for DEVICEDUMP_RESTRICTED_SUBSECTION {
 }
 impl ::core::cmp::PartialEq for DEVICEDUMP_RESTRICTED_SUBSECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_RESTRICTED_SUBSECTION>()) == 0 }
+        self.bData == other.bData
     }
 }
 impl ::core::cmp::Eq for DEVICEDUMP_RESTRICTED_SUBSECTION {}
@@ -7071,12 +7045,6 @@ impl ::core::clone::Clone for DEVICEDUMP_SECTION_HEADER {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_SECTION_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_SECTION_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_SECTION_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_SECTION_HEADER {}
 impl ::core::default::Default for DEVICEDUMP_SECTION_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7102,12 +7070,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGEDEVICE_DATA {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGEDEVICE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGEDEVICE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGEDEVICE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGEDEVICE_DATA {}
 impl ::core::default::Default for DEVICEDUMP_STORAGEDEVICE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7131,12 +7093,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7162,12 +7118,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7189,12 +7139,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7214,12 +7158,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7239,12 +7177,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7264,12 +7196,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {}
 impl ::core::default::Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7291,12 +7217,6 @@ impl ::core::clone::Clone for DEVICEDUMP_STRUCTURE_VERSION {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_STRUCTURE_VERSION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_STRUCTURE_VERSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_STRUCTURE_VERSION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_STRUCTURE_VERSION {}
 impl ::core::default::Default for DEVICEDUMP_STRUCTURE_VERSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7318,12 +7238,6 @@ impl ::core::clone::Clone for DEVICEDUMP_SUBSECTION_POINTER {
 unsafe impl ::windows::core::Abi for DEVICEDUMP_SUBSECTION_POINTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICEDUMP_SUBSECTION_POINTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICEDUMP_SUBSECTION_POINTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICEDUMP_SUBSECTION_POINTER {}
 impl ::core::default::Default for DEVICEDUMP_SUBSECTION_POINTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7372,7 +7286,7 @@ unsafe impl ::windows::core::Abi for DEVICE_COPY_OFFLOAD_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for DEVICE_COPY_OFFLOAD_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_COPY_OFFLOAD_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.MaximumTokenLifetime == other.MaximumTokenLifetime && self.DefaultTokenLifetime == other.DefaultTokenLifetime && self.MaximumTransferSize == other.MaximumTransferSize && self.OptimalTransferCount == other.OptimalTransferCount && self.MaximumDataDescriptors == other.MaximumDataDescriptors && self.MaximumTransferLengthPerDescriptor == other.MaximumTransferLengthPerDescriptor && self.OptimalTransferLengthPerDescriptor == other.OptimalTransferLengthPerDescriptor && self.OptimalTransferLengthGranularity == other.OptimalTransferLengthGranularity && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEVICE_COPY_OFFLOAD_DESCRIPTOR {}
@@ -7405,7 +7319,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_LBP_STATE_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_LBP_STATE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_LBP_STATE_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.OutputVersion == other.OutputVersion
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_LBP_STATE_PARAMETERS {}
@@ -7441,7 +7355,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_LB_PROVISIONING_STATE {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_LB_PROVISIONING_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_LB_PROVISIONING_STATE>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.SlabSizeInBytes == other.SlabSizeInBytes && self.SlabOffsetDeltaInBytes == other.SlabOffsetDeltaInBytes && self.SlabAllocationBitMapBitCount == other.SlabAllocationBitMapBitCount && self.SlabAllocationBitMapLength == other.SlabAllocationBitMapLength && self.SlabAllocationBitMap == other.SlabAllocationBitMap
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_LB_PROVISIONING_STATE {}
@@ -7477,7 +7391,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.SlabSizeInBytes == other.SlabSizeInBytes && self.SlabOffsetDeltaInBytes == other.SlabOffsetDeltaInBytes && self.SlabAllocationBitMapBitCount == other.SlabAllocationBitMapBitCount && self.SlabAllocationBitMapLength == other.SlabAllocationBitMapLength && self.SlabAllocationBitMap == other.SlabAllocationBitMap
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {}
@@ -7508,7 +7422,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_RANGE {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_RANGE>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_RANGE {}
@@ -7538,7 +7452,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_REPAIR_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_REPAIR_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_REPAIR_OUTPUT>()) == 0 }
+        self.ParityExtent == other.ParityExtent
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_REPAIR_OUTPUT {}
@@ -7570,7 +7484,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_REPAIR_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_REPAIR_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_REPAIR_PARAMETERS>()) == 0 }
+        self.NumberOfRepairCopies == other.NumberOfRepairCopies && self.SourceCopy == other.SourceCopy && self.RepairCopies == other.RepairCopies
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_REPAIR_PARAMETERS {}
@@ -7604,7 +7518,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_SCRUB_EX_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_SCRUB_EX_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_SCRUB_EX_OUTPUT>()) == 0 }
+        self.BytesProcessed == other.BytesProcessed && self.BytesRepaired == other.BytesRepaired && self.BytesFailed == other.BytesFailed && self.ParityExtent == other.ParityExtent && self.BytesScrubbed == other.BytesScrubbed
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_SCRUB_EX_OUTPUT {}
@@ -7636,7 +7550,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_SCRUB_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_SCRUB_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_SCRUB_OUTPUT>()) == 0 }
+        self.BytesProcessed == other.BytesProcessed && self.BytesRepaired == other.BytesRepaired && self.BytesFailed == other.BytesFailed
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_SCRUB_OUTPUT {}
@@ -7667,7 +7581,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT>()) == 0 }
+        self.TopologyRangeBytes == other.TopologyRangeBytes && self.TopologyId == other.TopologyId
     }
 }
 impl ::core::cmp::Eq for DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {}
@@ -7698,7 +7612,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_CONVERSION_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_CONVERSION_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_CONVERSION_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Source == other.Source
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_CONVERSION_OUTPUT {}
@@ -7740,7 +7654,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_DEFINITION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_DSM_DEFINITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_DEFINITION>()) == 0 }
+        self.Action == other.Action && self.SingleRange == other.SingleRange && self.ParameterBlockAlignment == other.ParameterBlockAlignment && self.ParameterBlockLength == other.ParameterBlockLength && self.HasOutput == other.HasOutput && self.OutputBlockAlignment == other.OutputBlockAlignment && self.OutputBlockLength == other.OutputBlockLength
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7773,7 +7687,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_FREE_SPACE_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_FREE_SPACE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_FREE_SPACE_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.FreeSpace == other.FreeSpace
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_FREE_SPACE_OUTPUT {}
@@ -7807,7 +7721,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_LOST_QUERY_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_LOST_QUERY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_LOST_QUERY_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Alignment == other.Alignment && self.NumberOfBits == other.NumberOfBits && self.BitMap == other.BitMap
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_LOST_QUERY_OUTPUT {}
@@ -7838,7 +7752,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_LOST_QUERY_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_LOST_QUERY_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_LOST_QUERY_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.Granularity == other.Granularity
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_LOST_QUERY_PARAMETERS {}
@@ -7871,7 +7785,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_NOTIFICATION_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_NOTIFICATION_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_NOTIFICATION_PARAMETERS>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.NumFileTypeIDs == other.NumFileTypeIDs && self.FileTypeID == other.FileTypeID
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_NOTIFICATION_PARAMETERS {}
@@ -7903,7 +7817,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETE
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETERS>()) == 0 }
+        self.Size == other.Size && self.TargetPriority == other.TargetPriority && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETERS {}
@@ -7935,7 +7849,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_OFFLOAD_READ_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_OFFLOAD_READ_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_OFFLOAD_READ_PARAMETERS>()) == 0 }
+        self.Flags == other.Flags && self.TimeToLive == other.TimeToLive && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_OFFLOAD_READ_PARAMETERS {}
@@ -7961,12 +7875,6 @@ impl ::core::clone::Clone for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
 unsafe impl ::windows::core::Abi for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {}
 impl ::core::default::Default for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7997,7 +7905,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.TotalNumberOfRanges == other.TotalNumberOfRanges && self.NumberOfRangesReturned == other.NumberOfRangesReturned && self.Ranges == other.Ranges
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT {}
@@ -8024,12 +7932,6 @@ impl ::core::clone::Clone for DEVICE_DSM_RANGE_ERROR_INFO {
 unsafe impl ::windows::core::Abi for DEVICE_DSM_RANGE_ERROR_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_DSM_RANGE_ERROR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_RANGE_ERROR_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_DSM_RANGE_ERROR_INFO {}
 impl ::core::default::Default for DEVICE_DSM_RANGE_ERROR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8066,7 +7968,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_REPORT_ZONES_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_DSM_REPORT_ZONES_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_REPORT_ZONES_DATA>()) == 0 }
+        self.Size == other.Size && self.ZoneCount == other.ZoneCount && self.Attributes == other.Attributes && self.Reserved0 == other.Reserved0 && self.ZoneDescriptors == other.ZoneDescriptors
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8101,7 +8003,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_REPORT_ZONES_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_REPORT_ZONES_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_REPORT_ZONES_PARAMETERS>()) == 0 }
+        self.Size == other.Size && self.ReportOption == other.ReportOption && self.Partial == other.Partial && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_REPORT_ZONES_PARAMETERS {}
@@ -8135,7 +8037,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_TIERING_QUERY_INPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_TIERING_QUERY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_TIERING_QUERY_INPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.NumberOfTierIds == other.NumberOfTierIds && self.TierIds == other.TierIds
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_TIERING_QUERY_INPUT {}
@@ -8172,7 +8074,7 @@ unsafe impl ::windows::core::Abi for DEVICE_DSM_TIERING_QUERY_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_DSM_TIERING_QUERY_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_DSM_TIERING_QUERY_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Alignment == other.Alignment && self.TotalNumberOfRegions == other.TotalNumberOfRegions && self.NumberOfRegionsReturned == other.NumberOfRegionsReturned && self.Regions == other.Regions
     }
 }
 impl ::core::cmp::Eq for DEVICE_DSM_TIERING_QUERY_OUTPUT {}
@@ -8226,7 +8128,7 @@ unsafe impl ::windows::core::Abi for DEVICE_INTERNAL_STATUS_DATA {
 }
 impl ::core::cmp::PartialEq for DEVICE_INTERNAL_STATUS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_INTERNAL_STATUS_DATA>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.T10VendorId == other.T10VendorId && self.DataSet1Length == other.DataSet1Length && self.DataSet2Length == other.DataSet2Length && self.DataSet3Length == other.DataSet3Length && self.DataSet4Length == other.DataSet4Length && self.StatusDataVersion == other.StatusDataVersion && self.Reserved == other.Reserved && self.ReasonIdentifier == other.ReasonIdentifier && self.StatusDataLength == other.StatusDataLength && self.StatusData == other.StatusData
     }
 }
 impl ::core::cmp::Eq for DEVICE_INTERNAL_STATUS_DATA {}
@@ -8263,7 +8165,7 @@ unsafe impl ::windows::core::Abi for DEVICE_LB_PROVISIONING_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for DEVICE_LB_PROVISIONING_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_LB_PROVISIONING_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self._bitfield == other._bitfield && self.Reserved1 == other.Reserved1 && self.OptimalUnmapGranularity == other.OptimalUnmapGranularity && self.UnmapGranularityAlignment == other.UnmapGranularityAlignment && self.MaxUnmapLbaCount == other.MaxUnmapLbaCount && self.MaxUnmapBlockDescriptorCount == other.MaxUnmapBlockDescriptorCount
     }
 }
 impl ::core::cmp::Eq for DEVICE_LB_PROVISIONING_DESCRIPTOR {}
@@ -8290,12 +8192,6 @@ impl ::core::clone::Clone for DEVICE_LOCATION {
 unsafe impl ::windows::core::Abi for DEVICE_LOCATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_LOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_LOCATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_LOCATION {}
 impl ::core::default::Default for DEVICE_LOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8316,12 +8212,6 @@ impl ::core::clone::Clone for DEVICE_LOCATION_0 {
 unsafe impl ::windows::core::Abi for DEVICE_LOCATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_LOCATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_LOCATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_LOCATION_0 {}
 impl ::core::default::Default for DEVICE_LOCATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8349,7 +8239,7 @@ unsafe impl ::windows::core::Abi for DEVICE_LOCATION_0_0 {
 }
 impl ::core::cmp::PartialEq for DEVICE_LOCATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_LOCATION_0_0>()) == 0 }
+        self.Channel == other.Channel && self.Device == other.Device
     }
 }
 impl ::core::cmp::Eq for DEVICE_LOCATION_0_0 {}
@@ -8380,7 +8270,7 @@ unsafe impl ::windows::core::Abi for DEVICE_LOCATION_0_1 {
 }
 impl ::core::cmp::PartialEq for DEVICE_LOCATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_LOCATION_0_1>()) == 0 }
+        self.Target == other.Target && self.Lun == other.Lun
     }
 }
 impl ::core::cmp::Eq for DEVICE_LOCATION_0_1 {}
@@ -8416,7 +8306,7 @@ unsafe impl ::windows::core::Abi for DEVICE_MANAGE_DATA_SET_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for DEVICE_MANAGE_DATA_SET_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MANAGE_DATA_SET_ATTRIBUTES>()) == 0 }
+        self.Size == other.Size && self.Action == other.Action && self.Flags == other.Flags && self.ParameterBlockOffset == other.ParameterBlockOffset && self.ParameterBlockLength == other.ParameterBlockLength && self.DataSetRangesOffset == other.DataSetRangesOffset && self.DataSetRangesLength == other.DataSetRangesLength
     }
 }
 impl ::core::cmp::Eq for DEVICE_MANAGE_DATA_SET_ATTRIBUTES {}
@@ -8454,7 +8344,7 @@ unsafe impl ::windows::core::Abi for DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT>()) == 0 }
+        self.Size == other.Size && self.Action == other.Action && self.Flags == other.Flags && self.OperationStatus == other.OperationStatus && self.ExtendedError == other.ExtendedError && self.TargetDetailedError == other.TargetDetailedError && self.ReservedStatus == other.ReservedStatus && self.OutputBlockOffset == other.OutputBlockOffset && self.OutputBlockLength == other.OutputBlockLength
     }
 }
 impl ::core::cmp::Eq for DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT {}
@@ -8482,14 +8372,6 @@ unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for DEVICE_MEDIA_INFO {}
-#[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for DEVICE_MEDIA_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8515,14 +8397,6 @@ impl ::core::clone::Clone for DEVICE_MEDIA_INFO_0 {
 unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for DEVICE_MEDIA_INFO_0 {}
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for DEVICE_MEDIA_INFO_0 {
     fn default() -> Self {
@@ -8562,7 +8436,7 @@ unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0_0 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0_0>()) == 0 }
+        self.Cylinders == other.Cylinders && self.MediaType == other.MediaType && self.TracksPerCylinder == other.TracksPerCylinder && self.SectorsPerTrack == other.SectorsPerTrack && self.BytesPerSector == other.BytesPerSector && self.NumberMediaSides == other.NumberMediaSides && self.MediaCharacteristics == other.MediaCharacteristics
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -8606,7 +8480,7 @@ unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0_1 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0_1>()) == 0 }
+        self.Cylinders == other.Cylinders && self.MediaType == other.MediaType && self.TracksPerCylinder == other.TracksPerCylinder && self.SectorsPerTrack == other.SectorsPerTrack && self.BytesPerSector == other.BytesPerSector && self.NumberMediaSides == other.NumberMediaSides && self.MediaCharacteristics == other.MediaCharacteristics
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -8640,14 +8514,6 @@ unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0_2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0_2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for DEVICE_MEDIA_INFO_0_2 {}
-#[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for DEVICE_MEDIA_INFO_0_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8671,14 +8537,6 @@ impl ::core::clone::Clone for DEVICE_MEDIA_INFO_0_2_0 {
 unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0_2_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0_2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0_2_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for DEVICE_MEDIA_INFO_0_2_0 {}
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for DEVICE_MEDIA_INFO_0_2_0 {
     fn default() -> Self {
@@ -8713,7 +8571,7 @@ unsafe impl ::windows::core::Abi for DEVICE_MEDIA_INFO_0_2_0_0 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for DEVICE_MEDIA_INFO_0_2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_MEDIA_INFO_0_2_0_0>()) == 0 }
+        self.MediumType == other.MediumType && self.DensityCode == other.DensityCode
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -8771,7 +8629,7 @@ unsafe impl ::windows::core::Abi for DEVICE_POWER_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_POWER_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_POWER_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceAttentionSupported == other.DeviceAttentionSupported && self.AsynchronousNotificationSupported == other.AsynchronousNotificationSupported && self.IdlePowerManagementEnabled == other.IdlePowerManagementEnabled && self.D3ColdEnabled == other.D3ColdEnabled && self.D3ColdSupported == other.D3ColdSupported && self.NoVerifyDuringIdlePower == other.NoVerifyDuringIdlePower && self.Reserved == other.Reserved && self.IdleTimeoutInMS == other.IdleTimeoutInMS
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8811,7 +8669,7 @@ unsafe impl ::windows::core::Abi for DEVICE_SEEK_PENALTY_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_SEEK_PENALTY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_SEEK_PENALTY_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.IncursSeekPenalty == other.IncursSeekPenalty
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8844,7 +8702,7 @@ unsafe impl ::windows::core::Abi for DEVICE_STORAGE_ADDRESS_RANGE {
 }
 impl ::core::cmp::PartialEq for DEVICE_STORAGE_ADDRESS_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_STORAGE_ADDRESS_RANGE>()) == 0 }
+        self.StartAddress == other.StartAddress && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for DEVICE_STORAGE_ADDRESS_RANGE {}
@@ -8869,12 +8727,6 @@ impl ::core::clone::Clone for DEVICE_STORAGE_RANGE_ATTRIBUTES {
 unsafe impl ::windows::core::Abi for DEVICE_STORAGE_RANGE_ATTRIBUTES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_STORAGE_RANGE_ATTRIBUTES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_STORAGE_RANGE_ATTRIBUTES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_STORAGE_RANGE_ATTRIBUTES {}
 impl ::core::default::Default for DEVICE_STORAGE_RANGE_ATTRIBUTES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8895,12 +8747,6 @@ impl ::core::clone::Clone for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
 unsafe impl ::windows::core::Abi for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_STORAGE_RANGE_ATTRIBUTES_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {}
 impl ::core::default::Default for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8927,7 +8773,7 @@ unsafe impl ::windows::core::Abi for DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {
 }
 impl ::core::cmp::PartialEq for DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {}
@@ -8965,7 +8811,7 @@ unsafe impl ::windows::core::Abi for DEVICE_TRIM_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_TRIM_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_TRIM_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.TrimEnabled == other.TrimEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9005,7 +8851,7 @@ unsafe impl ::windows::core::Abi for DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_WRITE_AGGREGATION_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.BenefitsFromWriteAggregation == other.BenefitsFromWriteAggregation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9042,14 +8888,6 @@ unsafe impl ::windows::core::Abi for DISK_CACHE_INFORMATION {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISK_CACHE_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_CACHE_INFORMATION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISK_CACHE_INFORMATION {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISK_CACHE_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9074,14 +8912,6 @@ impl ::core::clone::Clone for DISK_CACHE_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for DISK_CACHE_INFORMATION_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DISK_CACHE_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_CACHE_INFORMATION_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DISK_CACHE_INFORMATION_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DISK_CACHE_INFORMATION_0 {
     fn default() -> Self {
@@ -9116,7 +8946,7 @@ unsafe impl ::windows::core::Abi for DISK_CACHE_INFORMATION_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISK_CACHE_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_CACHE_INFORMATION_0_0>()) == 0 }
+        self.Minimum == other.Minimum && self.Maximum == other.Maximum
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9156,7 +8986,7 @@ unsafe impl ::windows::core::Abi for DISK_CACHE_INFORMATION_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISK_CACHE_INFORMATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_CACHE_INFORMATION_0_1>()) == 0 }
+        self.Minimum == other.Minimum && self.Maximum == other.Maximum && self.MaximumBlocks == other.MaximumBlocks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9189,7 +9019,7 @@ unsafe impl ::windows::core::Abi for DISK_CONTROLLER_NUMBER {
 }
 impl ::core::cmp::PartialEq for DISK_CONTROLLER_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_CONTROLLER_NUMBER>()) == 0 }
+        self.ControllerNumber == other.ControllerNumber && self.DiskNumber == other.DiskNumber
     }
 }
 impl ::core::cmp::Eq for DISK_CONTROLLER_NUMBER {}
@@ -9214,12 +9044,6 @@ impl ::core::clone::Clone for DISK_DETECTION_INFO {
 unsafe impl ::windows::core::Abi for DISK_DETECTION_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISK_DETECTION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_DETECTION_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISK_DETECTION_INFO {}
 impl ::core::default::Default for DISK_DETECTION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9239,12 +9063,6 @@ impl ::core::clone::Clone for DISK_DETECTION_INFO_0 {
 unsafe impl ::windows::core::Abi for DISK_DETECTION_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISK_DETECTION_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_DETECTION_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISK_DETECTION_INFO_0 {}
 impl ::core::default::Default for DISK_DETECTION_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9272,7 +9090,7 @@ unsafe impl ::windows::core::Abi for DISK_DETECTION_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for DISK_DETECTION_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_DETECTION_INFO_0_0>()) == 0 }
+        self.Int13 == other.Int13 && self.ExInt13 == other.ExInt13
     }
 }
 impl ::core::cmp::Eq for DISK_DETECTION_INFO_0_0 {}
@@ -9304,7 +9122,7 @@ unsafe impl ::windows::core::Abi for DISK_EXTENT {
 }
 impl ::core::cmp::PartialEq for DISK_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_EXTENT>()) == 0 }
+        self.DiskNumber == other.DiskNumber && self.StartingOffset == other.StartingOffset && self.ExtentLength == other.ExtentLength
     }
 }
 impl ::core::cmp::Eq for DISK_EXTENT {}
@@ -9341,7 +9159,7 @@ unsafe impl ::windows::core::Abi for DISK_EX_INT13_INFO {
 }
 impl ::core::cmp::PartialEq for DISK_EX_INT13_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_EX_INT13_INFO>()) == 0 }
+        self.ExBufferSize == other.ExBufferSize && self.ExFlags == other.ExFlags && self.ExCylinders == other.ExCylinders && self.ExHeads == other.ExHeads && self.ExSectorsPerTrack == other.ExSectorsPerTrack && self.ExSectorsPerDrive == other.ExSectorsPerDrive && self.ExSectorSize == other.ExSectorSize && self.ExReserved == other.ExReserved
     }
 }
 impl ::core::cmp::Eq for DISK_EX_INT13_INFO {}
@@ -9375,7 +9193,7 @@ unsafe impl ::windows::core::Abi for DISK_GEOMETRY {
 }
 impl ::core::cmp::PartialEq for DISK_GEOMETRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_GEOMETRY>()) == 0 }
+        self.Cylinders == other.Cylinders && self.MediaType == other.MediaType && self.TracksPerCylinder == other.TracksPerCylinder && self.SectorsPerTrack == other.SectorsPerTrack && self.BytesPerSector == other.BytesPerSector
     }
 }
 impl ::core::cmp::Eq for DISK_GEOMETRY {}
@@ -9407,7 +9225,7 @@ unsafe impl ::windows::core::Abi for DISK_GEOMETRY_EX {
 }
 impl ::core::cmp::PartialEq for DISK_GEOMETRY_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_GEOMETRY_EX>()) == 0 }
+        self.Geometry == other.Geometry && self.DiskSize == other.DiskSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for DISK_GEOMETRY_EX {}
@@ -9438,7 +9256,7 @@ unsafe impl ::windows::core::Abi for DISK_GROW_PARTITION {
 }
 impl ::core::cmp::PartialEq for DISK_GROW_PARTITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_GROW_PARTITION>()) == 0 }
+        self.PartitionNumber == other.PartitionNumber && self.BytesToGrow == other.BytesToGrow
     }
 }
 impl ::core::cmp::Eq for DISK_GROW_PARTITION {}
@@ -9478,7 +9296,7 @@ unsafe impl ::windows::core::Abi for DISK_HISTOGRAM {
 }
 impl ::core::cmp::PartialEq for DISK_HISTOGRAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_HISTOGRAM>()) == 0 }
+        self.DiskSize == other.DiskSize && self.Start == other.Start && self.End == other.End && self.Average == other.Average && self.AverageRead == other.AverageRead && self.AverageWrite == other.AverageWrite && self.Granularity == other.Granularity && self.Size == other.Size && self.ReadCount == other.ReadCount && self.WriteCount == other.WriteCount && self.Histogram == other.Histogram
     }
 }
 impl ::core::cmp::Eq for DISK_HISTOGRAM {}
@@ -9512,7 +9330,7 @@ unsafe impl ::windows::core::Abi for DISK_INT13_INFO {
 }
 impl ::core::cmp::PartialEq for DISK_INT13_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_INT13_INFO>()) == 0 }
+        self.DriveSelect == other.DriveSelect && self.MaxCylinders == other.MaxCylinders && self.SectorsPerTrack == other.SectorsPerTrack && self.MaxHeads == other.MaxHeads && self.NumberDrives == other.NumberDrives
     }
 }
 impl ::core::cmp::Eq for DISK_INT13_INFO {}
@@ -9544,7 +9362,7 @@ unsafe impl ::windows::core::Abi for DISK_LOGGING {
 }
 impl ::core::cmp::PartialEq for DISK_LOGGING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_LOGGING>()) == 0 }
+        self.Function == other.Function && self.BufferAddress == other.BufferAddress && self.BufferSize == other.BufferSize
     }
 }
 impl ::core::cmp::Eq for DISK_LOGGING {}
@@ -9569,12 +9387,6 @@ impl ::core::clone::Clone for DISK_PARTITION_INFO {
 unsafe impl ::windows::core::Abi for DISK_PARTITION_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISK_PARTITION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_PARTITION_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISK_PARTITION_INFO {}
 impl ::core::default::Default for DISK_PARTITION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9595,12 +9407,6 @@ impl ::core::clone::Clone for DISK_PARTITION_INFO_0 {
 unsafe impl ::windows::core::Abi for DISK_PARTITION_INFO_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISK_PARTITION_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_PARTITION_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISK_PARTITION_INFO_0 {}
 impl ::core::default::Default for DISK_PARTITION_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9627,7 +9433,7 @@ unsafe impl ::windows::core::Abi for DISK_PARTITION_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for DISK_PARTITION_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_PARTITION_INFO_0_0>()) == 0 }
+        self.DiskId == other.DiskId
     }
 }
 impl ::core::cmp::Eq for DISK_PARTITION_INFO_0_0 {}
@@ -9658,7 +9464,7 @@ unsafe impl ::windows::core::Abi for DISK_PARTITION_INFO_0_1 {
 }
 impl ::core::cmp::PartialEq for DISK_PARTITION_INFO_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_PARTITION_INFO_0_1>()) == 0 }
+        self.Signature == other.Signature && self.CheckSum == other.CheckSum
     }
 }
 impl ::core::cmp::Eq for DISK_PARTITION_INFO_0_1 {}
@@ -9712,7 +9518,7 @@ unsafe impl ::windows::core::Abi for DISK_PERFORMANCE {
 }
 impl ::core::cmp::PartialEq for DISK_PERFORMANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_PERFORMANCE>()) == 0 }
+        self.BytesRead == other.BytesRead && self.BytesWritten == other.BytesWritten && self.ReadTime == other.ReadTime && self.WriteTime == other.WriteTime && self.IdleTime == other.IdleTime && self.ReadCount == other.ReadCount && self.WriteCount == other.WriteCount && self.QueueDepth == other.QueueDepth && self.SplitCount == other.SplitCount && self.QueryTime == other.QueryTime && self.StorageDeviceNumber == other.StorageDeviceNumber && self.StorageManagerName == other.StorageManagerName
     }
 }
 impl ::core::cmp::Eq for DISK_PERFORMANCE {}
@@ -9754,7 +9560,7 @@ unsafe impl ::windows::core::Abi for DISK_RECORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DISK_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_RECORD>()) == 0 }
+        self.ByteOffset == other.ByteOffset && self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.VirtualAddress == other.VirtualAddress && self.NumberOfBytes == other.NumberOfBytes && self.DeviceNumber == other.DeviceNumber && self.ReadRequest == other.ReadRequest
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9782,12 +9588,6 @@ impl ::core::clone::Clone for DRIVERSTATUS {
 unsafe impl ::windows::core::Abi for DRIVERSTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DRIVERSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVERSTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DRIVERSTATUS {}
 impl ::core::default::Default for DRIVERSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9822,7 +9622,7 @@ unsafe impl ::windows::core::Abi for DRIVE_LAYOUT_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRIVE_LAYOUT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVE_LAYOUT_INFORMATION>()) == 0 }
+        self.PartitionCount == other.PartitionCount && self.Signature == other.Signature && self.PartitionEntry == other.PartitionEntry
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9855,14 +9655,6 @@ unsafe impl ::windows::core::Abi for DRIVE_LAYOUT_INFORMATION_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRIVE_LAYOUT_INFORMATION_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVE_LAYOUT_INFORMATION_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRIVE_LAYOUT_INFORMATION_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRIVE_LAYOUT_INFORMATION_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9887,14 +9679,6 @@ impl ::core::clone::Clone for DRIVE_LAYOUT_INFORMATION_EX_0 {
 unsafe impl ::windows::core::Abi for DRIVE_LAYOUT_INFORMATION_EX_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRIVE_LAYOUT_INFORMATION_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVE_LAYOUT_INFORMATION_EX_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRIVE_LAYOUT_INFORMATION_EX_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRIVE_LAYOUT_INFORMATION_EX_0 {
     fn default() -> Self {
@@ -9925,7 +9709,7 @@ unsafe impl ::windows::core::Abi for DRIVE_LAYOUT_INFORMATION_GPT {
 }
 impl ::core::cmp::PartialEq for DRIVE_LAYOUT_INFORMATION_GPT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVE_LAYOUT_INFORMATION_GPT>()) == 0 }
+        self.DiskId == other.DiskId && self.StartingUsableOffset == other.StartingUsableOffset && self.UsableLength == other.UsableLength && self.MaxPartitionCount == other.MaxPartitionCount
     }
 }
 impl ::core::cmp::Eq for DRIVE_LAYOUT_INFORMATION_GPT {}
@@ -9956,7 +9740,7 @@ unsafe impl ::windows::core::Abi for DRIVE_LAYOUT_INFORMATION_MBR {
 }
 impl ::core::cmp::PartialEq for DRIVE_LAYOUT_INFORMATION_MBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRIVE_LAYOUT_INFORMATION_MBR>()) == 0 }
+        self.Signature == other.Signature && self.CheckSum == other.CheckSum
     }
 }
 impl ::core::cmp::Eq for DRIVE_LAYOUT_INFORMATION_MBR {}
@@ -9995,7 +9779,7 @@ unsafe impl ::windows::core::Abi for DUPLICATE_EXTENTS_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DUPLICATE_EXTENTS_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUPLICATE_EXTENTS_DATA>()) == 0 }
+        self.FileHandle == other.FileHandle && self.SourceFileOffset == other.SourceFileOffset && self.TargetFileOffset == other.TargetFileOffset && self.ByteCount == other.ByteCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10036,7 +9820,7 @@ unsafe impl ::windows::core::Abi for DUPLICATE_EXTENTS_DATA32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DUPLICATE_EXTENTS_DATA32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUPLICATE_EXTENTS_DATA32>()) == 0 }
+        self.FileHandle == other.FileHandle && self.SourceFileOffset == other.SourceFileOffset && self.TargetFileOffset == other.TargetFileOffset && self.ByteCount == other.ByteCount
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -10079,7 +9863,7 @@ unsafe impl ::windows::core::Abi for DUPLICATE_EXTENTS_DATA_EX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DUPLICATE_EXTENTS_DATA_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUPLICATE_EXTENTS_DATA_EX>()) == 0 }
+        self.Size == other.Size && self.FileHandle == other.FileHandle && self.SourceFileOffset == other.SourceFileOffset && self.TargetFileOffset == other.TargetFileOffset && self.ByteCount == other.ByteCount && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10122,7 +9906,7 @@ unsafe impl ::windows::core::Abi for DUPLICATE_EXTENTS_DATA_EX32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for DUPLICATE_EXTENTS_DATA_EX32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DUPLICATE_EXTENTS_DATA_EX32>()) == 0 }
+        self.Size == other.Size && self.FileHandle == other.FileHandle && self.SourceFileOffset == other.SourceFileOffset && self.TargetFileOffset == other.TargetFileOffset && self.ByteCount == other.ByteCount && self.Flags == other.Flags
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -10176,7 +9960,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTED_DATA_INFO {
 }
 impl ::core::cmp::PartialEq for ENCRYPTED_DATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTED_DATA_INFO>()) == 0 }
+        self.StartingFileOffset == other.StartingFileOffset && self.OutputBufferOffset == other.OutputBufferOffset && self.BytesWithinFileSize == other.BytesWithinFileSize && self.BytesWithinValidDataLength == other.BytesWithinValidDataLength && self.CompressionFormat == other.CompressionFormat && self.DataUnitShift == other.DataUnitShift && self.ChunkShift == other.ChunkShift && self.ClusterShift == other.ClusterShift && self.EncryptionFormat == other.EncryptionFormat && self.NumberOfDataBlocks == other.NumberOfDataBlocks && self.DataBlockSize == other.DataBlockSize
     }
 }
 impl ::core::cmp::Eq for ENCRYPTED_DATA_INFO {}
@@ -10207,7 +9991,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_BUFFER {
 }
 impl ::core::cmp::PartialEq for ENCRYPTION_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_BUFFER>()) == 0 }
+        self.EncryptionOperation == other.EncryptionOperation && self.Private == other.Private
     }
 }
 impl ::core::cmp::Eq for ENCRYPTION_BUFFER {}
@@ -10243,7 +10027,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTION_KEY_CTRL_INPUT {
 }
 impl ::core::cmp::PartialEq for ENCRYPTION_KEY_CTRL_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTION_KEY_CTRL_INPUT>()) == 0 }
+        self.HeaderSize == other.HeaderSize && self.StructureSize == other.StructureSize && self.KeyOffset == other.KeyOffset && self.KeySize == other.KeySize && self.DplLock == other.DplLock && self.DplUserId == other.DplUserId && self.DplCredentialId == other.DplCredentialId
     }
 }
 impl ::core::cmp::Eq for ENCRYPTION_KEY_CTRL_INPUT {}
@@ -10291,7 +10075,7 @@ unsafe impl ::windows::core::Abi for EXFAT_STATISTICS {
 }
 impl ::core::cmp::PartialEq for EXFAT_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXFAT_STATISTICS>()) == 0 }
+        self.CreateHits == other.CreateHits && self.SuccessfulCreates == other.SuccessfulCreates && self.FailedCreates == other.FailedCreates && self.NonCachedReads == other.NonCachedReads && self.NonCachedReadBytes == other.NonCachedReadBytes && self.NonCachedWrites == other.NonCachedWrites && self.NonCachedWriteBytes == other.NonCachedWriteBytes && self.NonCachedDiskReads == other.NonCachedDiskReads && self.NonCachedDiskWrites == other.NonCachedDiskWrites
     }
 }
 impl ::core::cmp::Eq for EXFAT_STATISTICS {}
@@ -10324,7 +10108,7 @@ unsafe impl ::windows::core::Abi for EXTENDED_ENCRYPTED_DATA_INFO {
 }
 impl ::core::cmp::PartialEq for EXTENDED_ENCRYPTED_DATA_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTENDED_ENCRYPTED_DATA_INFO>()) == 0 }
+        self.ExtendedCode == other.ExtendedCode && self.Length == other.Length && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for EXTENDED_ENCRYPTED_DATA_INFO {}
@@ -10372,7 +10156,7 @@ unsafe impl ::windows::core::Abi for FAT_STATISTICS {
 }
 impl ::core::cmp::PartialEq for FAT_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FAT_STATISTICS>()) == 0 }
+        self.CreateHits == other.CreateHits && self.SuccessfulCreates == other.SuccessfulCreates && self.FailedCreates == other.FailedCreates && self.NonCachedReads == other.NonCachedReads && self.NonCachedReadBytes == other.NonCachedReadBytes && self.NonCachedWrites == other.NonCachedWrites && self.NonCachedWriteBytes == other.NonCachedWriteBytes && self.NonCachedDiskReads == other.NonCachedDiskReads && self.NonCachedDiskWrites == other.NonCachedDiskWrites
     }
 }
 impl ::core::cmp::Eq for FAT_STATISTICS {}
@@ -10432,7 +10216,7 @@ unsafe impl ::windows::core::Abi for FILESYSTEM_STATISTICS {
 }
 impl ::core::cmp::PartialEq for FILESYSTEM_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILESYSTEM_STATISTICS>()) == 0 }
+        self.FileSystemType == other.FileSystemType && self.Version == other.Version && self.SizeOfCompleteStructure == other.SizeOfCompleteStructure && self.UserFileReads == other.UserFileReads && self.UserFileReadBytes == other.UserFileReadBytes && self.UserDiskReads == other.UserDiskReads && self.UserFileWrites == other.UserFileWrites && self.UserFileWriteBytes == other.UserFileWriteBytes && self.UserDiskWrites == other.UserDiskWrites && self.MetaDataReads == other.MetaDataReads && self.MetaDataReadBytes == other.MetaDataReadBytes && self.MetaDataDiskReads == other.MetaDataDiskReads && self.MetaDataWrites == other.MetaDataWrites && self.MetaDataWriteBytes == other.MetaDataWriteBytes && self.MetaDataDiskWrites == other.MetaDataDiskWrites
     }
 }
 impl ::core::cmp::Eq for FILESYSTEM_STATISTICS {}
@@ -10492,7 +10276,7 @@ unsafe impl ::windows::core::Abi for FILESYSTEM_STATISTICS_EX {
 }
 impl ::core::cmp::PartialEq for FILESYSTEM_STATISTICS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILESYSTEM_STATISTICS_EX>()) == 0 }
+        self.FileSystemType == other.FileSystemType && self.Version == other.Version && self.SizeOfCompleteStructure == other.SizeOfCompleteStructure && self.UserFileReads == other.UserFileReads && self.UserFileReadBytes == other.UserFileReadBytes && self.UserDiskReads == other.UserDiskReads && self.UserFileWrites == other.UserFileWrites && self.UserFileWriteBytes == other.UserFileWriteBytes && self.UserDiskWrites == other.UserDiskWrites && self.MetaDataReads == other.MetaDataReads && self.MetaDataReadBytes == other.MetaDataReadBytes && self.MetaDataDiskReads == other.MetaDataDiskReads && self.MetaDataWrites == other.MetaDataWrites && self.MetaDataWriteBytes == other.MetaDataWriteBytes && self.MetaDataDiskWrites == other.MetaDataDiskWrites
     }
 }
 impl ::core::cmp::Eq for FILESYSTEM_STATISTICS_EX {}
@@ -10523,7 +10307,7 @@ unsafe impl ::windows::core::Abi for FILE_ALLOCATED_RANGE_BUFFER {
 }
 impl ::core::cmp::PartialEq for FILE_ALLOCATED_RANGE_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ALLOCATED_RANGE_BUFFER>()) == 0 }
+        self.FileOffset == other.FileOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for FILE_ALLOCATED_RANGE_BUFFER {}
@@ -10554,7 +10338,7 @@ unsafe impl ::windows::core::Abi for FILE_DESIRED_STORAGE_CLASS_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILE_DESIRED_STORAGE_CLASS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_DESIRED_STORAGE_CLASS_INFORMATION>()) == 0 }
+        self.Class == other.Class && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FILE_DESIRED_STORAGE_CLASS_INFORMATION {}
@@ -10587,7 +10371,7 @@ unsafe impl ::windows::core::Abi for FILE_FS_PERSISTENT_VOLUME_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILE_FS_PERSISTENT_VOLUME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_FS_PERSISTENT_VOLUME_INFORMATION>()) == 0 }
+        self.VolumeFlags == other.VolumeFlags && self.FlagMask == other.FlagMask && self.Version == other.Version && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FILE_FS_PERSISTENT_VOLUME_INFORMATION {}
@@ -10620,7 +10404,7 @@ unsafe impl ::windows::core::Abi for FILE_INITIATE_REPAIR_OUTPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for FILE_INITIATE_REPAIR_OUTPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_INITIATE_REPAIR_OUTPUT_BUFFER>()) == 0 }
+        self.Hint1 == other.Hint1 && self.Hint2 == other.Hint2 && self.Clsn == other.Clsn && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for FILE_INITIATE_REPAIR_OUTPUT_BUFFER {}
@@ -10658,7 +10442,7 @@ unsafe impl ::windows::core::Abi for FILE_LAYOUT_ENTRY {
 }
 impl ::core::cmp::PartialEq for FILE_LAYOUT_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LAYOUT_ENTRY>()) == 0 }
+        self.Version == other.Version && self.NextFileOffset == other.NextFileOffset && self.Flags == other.Flags && self.FileAttributes == other.FileAttributes && self.FileReferenceNumber == other.FileReferenceNumber && self.FirstNameOffset == other.FirstNameOffset && self.FirstStreamOffset == other.FirstStreamOffset && self.ExtraInfoOffset == other.ExtraInfoOffset && self.ExtraInfoLength == other.ExtraInfoLength
     }
 }
 impl ::core::cmp::Eq for FILE_LAYOUT_ENTRY {}
@@ -10692,7 +10476,7 @@ unsafe impl ::windows::core::Abi for FILE_LAYOUT_INFO_ENTRY {
 }
 impl ::core::cmp::PartialEq for FILE_LAYOUT_INFO_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LAYOUT_INFO_ENTRY>()) == 0 }
+        self.BasicInformation == other.BasicInformation && self.OwnerId == other.OwnerId && self.SecurityId == other.SecurityId && self.Usn == other.Usn && self.StorageReserveId == other.StorageReserveId
     }
 }
 impl ::core::cmp::Eq for FILE_LAYOUT_INFO_ENTRY {}
@@ -10726,7 +10510,7 @@ unsafe impl ::windows::core::Abi for FILE_LAYOUT_INFO_ENTRY_0 {
 }
 impl ::core::cmp::PartialEq for FILE_LAYOUT_INFO_ENTRY_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LAYOUT_INFO_ENTRY_0>()) == 0 }
+        self.CreationTime == other.CreationTime && self.LastAccessTime == other.LastAccessTime && self.LastWriteTime == other.LastWriteTime && self.ChangeTime == other.ChangeTime && self.FileAttributes == other.FileAttributes
     }
 }
 impl ::core::cmp::Eq for FILE_LAYOUT_INFO_ENTRY_0 {}
@@ -10761,7 +10545,7 @@ unsafe impl ::windows::core::Abi for FILE_LAYOUT_NAME_ENTRY {
 }
 impl ::core::cmp::PartialEq for FILE_LAYOUT_NAME_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LAYOUT_NAME_ENTRY>()) == 0 }
+        self.NextNameOffset == other.NextNameOffset && self.Flags == other.Flags && self.ParentFileReferenceNumber == other.ParentFileReferenceNumber && self.FileNameLength == other.FileNameLength && self.Reserved == other.Reserved && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FILE_LAYOUT_NAME_ENTRY {}
@@ -10793,7 +10577,7 @@ unsafe impl ::windows::core::Abi for FILE_LEVEL_TRIM {
 }
 impl ::core::cmp::PartialEq for FILE_LEVEL_TRIM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LEVEL_TRIM>()) == 0 }
+        self.Key == other.Key && self.NumRanges == other.NumRanges && self.Ranges == other.Ranges
     }
 }
 impl ::core::cmp::Eq for FILE_LEVEL_TRIM {}
@@ -10823,7 +10607,7 @@ unsafe impl ::windows::core::Abi for FILE_LEVEL_TRIM_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FILE_LEVEL_TRIM_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LEVEL_TRIM_OUTPUT>()) == 0 }
+        self.NumRangesProcessed == other.NumRangesProcessed
     }
 }
 impl ::core::cmp::Eq for FILE_LEVEL_TRIM_OUTPUT {}
@@ -10854,7 +10638,7 @@ unsafe impl ::windows::core::Abi for FILE_LEVEL_TRIM_RANGE {
 }
 impl ::core::cmp::PartialEq for FILE_LEVEL_TRIM_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_LEVEL_TRIM_RANGE>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for FILE_LEVEL_TRIM_RANGE {}
@@ -10890,7 +10674,7 @@ unsafe impl ::windows::core::Abi for FILE_MAKE_COMPATIBLE_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_MAKE_COMPATIBLE_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_MAKE_COMPATIBLE_BUFFER>()) == 0 }
+        self.CloseDisc == other.CloseDisc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10916,12 +10700,6 @@ impl ::core::clone::Clone for FILE_OBJECTID_BUFFER {
 unsafe impl ::windows::core::Abi for FILE_OBJECTID_BUFFER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_OBJECTID_BUFFER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_OBJECTID_BUFFER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_OBJECTID_BUFFER {}
 impl ::core::default::Default for FILE_OBJECTID_BUFFER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10942,12 +10720,6 @@ impl ::core::clone::Clone for FILE_OBJECTID_BUFFER_0 {
 unsafe impl ::windows::core::Abi for FILE_OBJECTID_BUFFER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_OBJECTID_BUFFER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_OBJECTID_BUFFER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_OBJECTID_BUFFER_0 {}
 impl ::core::default::Default for FILE_OBJECTID_BUFFER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10976,7 +10748,7 @@ unsafe impl ::windows::core::Abi for FILE_OBJECTID_BUFFER_0_0 {
 }
 impl ::core::cmp::PartialEq for FILE_OBJECTID_BUFFER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_OBJECTID_BUFFER_0_0>()) == 0 }
+        self.BirthVolumeId == other.BirthVolumeId && self.BirthObjectId == other.BirthObjectId && self.DomainId == other.DomainId
     }
 }
 impl ::core::cmp::Eq for FILE_OBJECTID_BUFFER_0_0 {}
@@ -11008,7 +10780,7 @@ unsafe impl ::windows::core::Abi for FILE_PREFETCH {
 }
 impl ::core::cmp::PartialEq for FILE_PREFETCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_PREFETCH>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.Prefetch == other.Prefetch
     }
 }
 impl ::core::cmp::Eq for FILE_PREFETCH {}
@@ -11041,7 +10813,7 @@ unsafe impl ::windows::core::Abi for FILE_PREFETCH_EX {
 }
 impl ::core::cmp::PartialEq for FILE_PREFETCH_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_PREFETCH_EX>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.Context == other.Context && self.Prefetch == other.Prefetch
     }
 }
 impl ::core::cmp::Eq for FILE_PREFETCH_EX {}
@@ -11072,7 +10844,7 @@ unsafe impl ::windows::core::Abi for FILE_PROVIDER_EXTERNAL_INFO_V0 {
 }
 impl ::core::cmp::PartialEq for FILE_PROVIDER_EXTERNAL_INFO_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_PROVIDER_EXTERNAL_INFO_V0>()) == 0 }
+        self.Version == other.Version && self.Algorithm == other.Algorithm
     }
 }
 impl ::core::cmp::Eq for FILE_PROVIDER_EXTERNAL_INFO_V0 {}
@@ -11104,7 +10876,7 @@ unsafe impl ::windows::core::Abi for FILE_PROVIDER_EXTERNAL_INFO_V1 {
 }
 impl ::core::cmp::PartialEq for FILE_PROVIDER_EXTERNAL_INFO_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_PROVIDER_EXTERNAL_INFO_V1>()) == 0 }
+        self.Version == other.Version && self.Algorithm == other.Algorithm && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FILE_PROVIDER_EXTERNAL_INFO_V1 {}
@@ -11156,7 +10928,7 @@ unsafe impl ::windows::core::Abi for FILE_QUERY_ON_DISK_VOL_INFO_BUFFER {
 }
 impl ::core::cmp::PartialEq for FILE_QUERY_ON_DISK_VOL_INFO_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_QUERY_ON_DISK_VOL_INFO_BUFFER>()) == 0 }
+        self.DirectoryCount == other.DirectoryCount && self.FileCount == other.FileCount && self.FsFormatMajVersion == other.FsFormatMajVersion && self.FsFormatMinVersion == other.FsFormatMinVersion && self.FsFormatName == other.FsFormatName && self.FormatTime == other.FormatTime && self.LastUpdateTime == other.LastUpdateTime && self.CopyrightInfo == other.CopyrightInfo && self.AbstractInfo == other.AbstractInfo && self.FormattingImplementationInfo == other.FormattingImplementationInfo && self.LastModifyingImplementationInfo == other.LastModifyingImplementationInfo
     }
 }
 impl ::core::cmp::Eq for FILE_QUERY_ON_DISK_VOL_INFO_BUFFER {}
@@ -11195,7 +10967,7 @@ unsafe impl ::windows::core::Abi for FILE_QUERY_SPARING_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_QUERY_SPARING_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_QUERY_SPARING_BUFFER>()) == 0 }
+        self.SparingUnitBytes == other.SparingUnitBytes && self.SoftwareSparing == other.SoftwareSparing && self.TotalSpareBlocks == other.TotalSpareBlocks && self.FreeSpareBlocks == other.FreeSpareBlocks
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11228,7 +11000,7 @@ unsafe impl ::windows::core::Abi for FILE_REFERENCE_RANGE {
 }
 impl ::core::cmp::PartialEq for FILE_REFERENCE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REFERENCE_RANGE>()) == 0 }
+        self.StartingFileReferenceNumber == other.StartingFileReferenceNumber && self.EndingFileReferenceNumber == other.EndingFileReferenceNumber
     }
 }
 impl ::core::cmp::Eq for FILE_REFERENCE_RANGE {}
@@ -11261,7 +11033,7 @@ unsafe impl ::windows::core::Abi for FILE_REGION_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_REGION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REGION_INFO>()) == 0 }
+        self.FileOffset == other.FileOffset && self.Length == other.Length && self.Usage == other.Usage && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for FILE_REGION_INFO {}
@@ -11293,7 +11065,7 @@ unsafe impl ::windows::core::Abi for FILE_REGION_INPUT {
 }
 impl ::core::cmp::PartialEq for FILE_REGION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REGION_INPUT>()) == 0 }
+        self.FileOffset == other.FileOffset && self.Length == other.Length && self.DesiredUsage == other.DesiredUsage
     }
 }
 impl ::core::cmp::Eq for FILE_REGION_INPUT {}
@@ -11327,7 +11099,7 @@ unsafe impl ::windows::core::Abi for FILE_REGION_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FILE_REGION_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_REGION_OUTPUT>()) == 0 }
+        self.Flags == other.Flags && self.TotalRegionEntryCount == other.TotalRegionEntryCount && self.RegionEntryCount == other.RegionEntryCount && self.Reserved == other.Reserved && self.Region == other.Region
     }
 }
 impl ::core::cmp::Eq for FILE_REGION_OUTPUT {}
@@ -11363,7 +11135,7 @@ unsafe impl ::windows::core::Abi for FILE_SET_DEFECT_MGMT_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_SET_DEFECT_MGMT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_SET_DEFECT_MGMT_BUFFER>()) == 0 }
+        self.Disable == other.Disable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11401,7 +11173,7 @@ unsafe impl ::windows::core::Abi for FILE_SET_SPARSE_BUFFER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_SET_SPARSE_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_SET_SPARSE_BUFFER>()) == 0 }
+        self.SetSparse == other.SetSparse
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11439,7 +11211,7 @@ unsafe impl ::windows::core::Abi for FILE_STORAGE_TIER {
 }
 impl ::core::cmp::PartialEq for FILE_STORAGE_TIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_STORAGE_TIER>()) == 0 }
+        self.Id == other.Id && self.Name == other.Name && self.Description == other.Description && self.Flags == other.Flags && self.ProvisionedCapacity == other.ProvisionedCapacity && self.MediaType == other.MediaType && self.Class == other.Class
     }
 }
 impl ::core::cmp::Eq for FILE_STORAGE_TIER {}
@@ -11471,7 +11243,7 @@ unsafe impl ::windows::core::Abi for FILE_STORAGE_TIER_REGION {
 }
 impl ::core::cmp::PartialEq for FILE_STORAGE_TIER_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_STORAGE_TIER_REGION>()) == 0 }
+        self.TierId == other.TierId && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for FILE_STORAGE_TIER_REGION {}
@@ -11507,7 +11279,7 @@ unsafe impl ::windows::core::Abi for FILE_SYSTEM_RECOGNITION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FILE_SYSTEM_RECOGNITION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_SYSTEM_RECOGNITION_INFORMATION>()) == 0 }
+        self.FileSystem == other.FileSystem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11541,7 +11313,7 @@ unsafe impl ::windows::core::Abi for FILE_TYPE_NOTIFICATION_INPUT {
 }
 impl ::core::cmp::PartialEq for FILE_TYPE_NOTIFICATION_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_TYPE_NOTIFICATION_INPUT>()) == 0 }
+        self.Flags == other.Flags && self.NumFileTypeIDs == other.NumFileTypeIDs && self.FileTypeID == other.FileTypeID
     }
 }
 impl ::core::cmp::Eq for FILE_TYPE_NOTIFICATION_INPUT {}
@@ -11572,7 +11344,7 @@ unsafe impl ::windows::core::Abi for FILE_ZERO_DATA_INFORMATION {
 }
 impl ::core::cmp::PartialEq for FILE_ZERO_DATA_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ZERO_DATA_INFORMATION>()) == 0 }
+        self.FileOffset == other.FileOffset && self.BeyondFinalZero == other.BeyondFinalZero
     }
 }
 impl ::core::cmp::Eq for FILE_ZERO_DATA_INFORMATION {}
@@ -11604,7 +11376,7 @@ unsafe impl ::windows::core::Abi for FILE_ZERO_DATA_INFORMATION_EX {
 }
 impl ::core::cmp::PartialEq for FILE_ZERO_DATA_INFORMATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ZERO_DATA_INFORMATION_EX>()) == 0 }
+        self.FileOffset == other.FileOffset && self.BeyondFinalZero == other.BeyondFinalZero && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FILE_ZERO_DATA_INFORMATION_EX {}
@@ -11641,7 +11413,7 @@ unsafe impl ::windows::core::Abi for FIND_BY_SID_DATA {
 #[cfg(feature = "Win32_Security")]
 impl ::core::cmp::PartialEq for FIND_BY_SID_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIND_BY_SID_DATA>()) == 0 }
+        self.Restart == other.Restart && self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Security")]
@@ -11676,7 +11448,7 @@ unsafe impl ::windows::core::Abi for FIND_BY_SID_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FIND_BY_SID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FIND_BY_SID_OUTPUT>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.FileIndex == other.FileIndex && self.FileNameLength == other.FileNameLength && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for FIND_BY_SID_OUTPUT {}
@@ -11713,7 +11485,7 @@ unsafe impl ::windows::core::Abi for FORMAT_EX_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for FORMAT_EX_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORMAT_EX_PARAMETERS>()) == 0 }
+        self.MediaType == other.MediaType && self.StartCylinderNumber == other.StartCylinderNumber && self.EndCylinderNumber == other.EndCylinderNumber && self.StartHeadNumber == other.StartHeadNumber && self.EndHeadNumber == other.EndHeadNumber && self.FormatGapLength == other.FormatGapLength && self.SectorsPerTrack == other.SectorsPerTrack && self.SectorNumber == other.SectorNumber
     }
 }
 impl ::core::cmp::Eq for FORMAT_EX_PARAMETERS {}
@@ -11747,7 +11519,7 @@ unsafe impl ::windows::core::Abi for FORMAT_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for FORMAT_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORMAT_PARAMETERS>()) == 0 }
+        self.MediaType == other.MediaType && self.StartCylinderNumber == other.StartCylinderNumber && self.EndCylinderNumber == other.EndCylinderNumber && self.StartHeadNumber == other.StartHeadNumber && self.EndHeadNumber == other.EndHeadNumber
     }
 }
 impl ::core::cmp::Eq for FORMAT_PARAMETERS {}
@@ -11781,7 +11553,7 @@ unsafe impl ::windows::core::Abi for FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {
 }
 impl ::core::cmp::PartialEq for FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_GET_INTEGRITY_INFORMATION_BUFFER>()) == 0 }
+        self.ChecksumAlgorithm == other.ChecksumAlgorithm && self.Reserved == other.Reserved && self.Flags == other.Flags && self.ChecksumChunkSizeInBytes == other.ChecksumChunkSizeInBytes && self.ClusterSizeInBytes == other.ClusterSizeInBytes
     }
 }
 impl ::core::cmp::Eq for FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {}
@@ -11816,7 +11588,7 @@ unsafe impl ::windows::core::Abi for FSCTL_OFFLOAD_READ_INPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_OFFLOAD_READ_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_OFFLOAD_READ_INPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.TokenTimeToLive == other.TokenTimeToLive && self.Reserved == other.Reserved && self.FileOffset == other.FileOffset && self.CopyLength == other.CopyLength
     }
 }
 impl ::core::cmp::Eq for FSCTL_OFFLOAD_READ_INPUT {}
@@ -11849,7 +11621,7 @@ unsafe impl ::windows::core::Abi for FSCTL_OFFLOAD_READ_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_OFFLOAD_READ_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_OFFLOAD_READ_OUTPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.TransferLength == other.TransferLength && self.Token == other.Token
     }
 }
 impl ::core::cmp::Eq for FSCTL_OFFLOAD_READ_OUTPUT {}
@@ -11884,7 +11656,7 @@ unsafe impl ::windows::core::Abi for FSCTL_OFFLOAD_WRITE_INPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_OFFLOAD_WRITE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_OFFLOAD_WRITE_INPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.FileOffset == other.FileOffset && self.CopyLength == other.CopyLength && self.TransferOffset == other.TransferOffset && self.Token == other.Token
     }
 }
 impl ::core::cmp::Eq for FSCTL_OFFLOAD_WRITE_INPUT {}
@@ -11916,7 +11688,7 @@ unsafe impl ::windows::core::Abi for FSCTL_OFFLOAD_WRITE_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_OFFLOAD_WRITE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_OFFLOAD_WRITE_OUTPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.LengthWritten == other.LengthWritten
     }
 }
 impl ::core::cmp::Eq for FSCTL_OFFLOAD_WRITE_OUTPUT {}
@@ -11946,7 +11718,7 @@ unsafe impl ::windows::core::Abi for FSCTL_QUERY_FAT_BPB_BUFFER {
 }
 impl ::core::cmp::PartialEq for FSCTL_QUERY_FAT_BPB_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_QUERY_FAT_BPB_BUFFER>()) == 0 }
+        self.First0x24BytesOfBootSector == other.First0x24BytesOfBootSector
     }
 }
 impl ::core::cmp::Eq for FSCTL_QUERY_FAT_BPB_BUFFER {}
@@ -11980,7 +11752,7 @@ unsafe impl ::windows::core::Abi for FSCTL_QUERY_REGION_INFO_INPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_QUERY_REGION_INFO_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_QUERY_REGION_INFO_INPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.NumberOfTierIds == other.NumberOfTierIds && self.TierIds == other.TierIds
     }
 }
 impl ::core::cmp::Eq for FSCTL_QUERY_REGION_INFO_INPUT {}
@@ -12017,7 +11789,7 @@ unsafe impl ::windows::core::Abi for FSCTL_QUERY_REGION_INFO_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_QUERY_REGION_INFO_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_QUERY_REGION_INFO_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Alignment == other.Alignment && self.TotalNumberOfRegions == other.TotalNumberOfRegions && self.NumberOfRegionsReturned == other.NumberOfRegionsReturned && self.Regions == other.Regions
     }
 }
 impl ::core::cmp::Eq for FSCTL_QUERY_REGION_INFO_OUTPUT {}
@@ -12052,7 +11824,7 @@ unsafe impl ::windows::core::Abi for FSCTL_QUERY_STORAGE_CLASSES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for FSCTL_QUERY_STORAGE_CLASSES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_QUERY_STORAGE_CLASSES_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.TotalNumberOfTiers == other.TotalNumberOfTiers && self.NumberOfTiersReturned == other.NumberOfTiersReturned && self.Tiers == other.Tiers
     }
 }
 impl ::core::cmp::Eq for FSCTL_QUERY_STORAGE_CLASSES_OUTPUT {}
@@ -12084,7 +11856,7 @@ unsafe impl ::windows::core::Abi for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {
 }
 impl ::core::cmp::PartialEq for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_SET_INTEGRITY_INFORMATION_BUFFER>()) == 0 }
+        self.ChecksumAlgorithm == other.ChecksumAlgorithm && self.Reserved == other.Reserved && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {}
@@ -12119,7 +11891,7 @@ unsafe impl ::windows::core::Abi for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {
 }
 impl ::core::cmp::PartialEq for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX>()) == 0 }
+        self.EnableIntegrity == other.EnableIntegrity && self.KeepIntegrityStateUnchanged == other.KeepIntegrityStateUnchanged && self.Reserved == other.Reserved && self.Flags == other.Flags && self.Version == other.Version && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {}
@@ -12151,7 +11923,7 @@ unsafe impl ::windows::core::Abi for FS_BPIO_INFO {
 }
 impl ::core::cmp::PartialEq for FS_BPIO_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FS_BPIO_INFO>()) == 0 }
+        self.ActiveBypassIoCount == other.ActiveBypassIoCount && self.StorageDriverNameLen == other.StorageDriverNameLen && self.StorageDriverName == other.StorageDriverName
     }
 }
 impl ::core::cmp::Eq for FS_BPIO_INFO {}
@@ -12184,7 +11956,7 @@ unsafe impl ::windows::core::Abi for FS_BPIO_INPUT {
 }
 impl ::core::cmp::PartialEq for FS_BPIO_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FS_BPIO_INPUT>()) == 0 }
+        self.Operation == other.Operation && self.InFlags == other.InFlags && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for FS_BPIO_INPUT {}
@@ -12211,12 +11983,6 @@ impl ::core::clone::Clone for FS_BPIO_OUTPUT {
 unsafe impl ::windows::core::Abi for FS_BPIO_OUTPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FS_BPIO_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FS_BPIO_OUTPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FS_BPIO_OUTPUT {}
 impl ::core::default::Default for FS_BPIO_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12240,12 +12006,6 @@ impl ::core::clone::Clone for FS_BPIO_OUTPUT_0 {
 unsafe impl ::windows::core::Abi for FS_BPIO_OUTPUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FS_BPIO_OUTPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FS_BPIO_OUTPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FS_BPIO_OUTPUT_0 {}
 impl ::core::default::Default for FS_BPIO_OUTPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12276,7 +12036,7 @@ unsafe impl ::windows::core::Abi for FS_BPIO_RESULTS {
 }
 impl ::core::cmp::PartialEq for FS_BPIO_RESULTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FS_BPIO_RESULTS>()) == 0 }
+        self.OpStatus == other.OpStatus && self.FailingDriverNameLen == other.FailingDriverNameLen && self.FailingDriverName == other.FailingDriverName && self.FailureReasonLen == other.FailureReasonLen && self.FailureReason == other.FailureReason
     }
 }
 impl ::core::cmp::Eq for FS_BPIO_RESULTS {}
@@ -12304,12 +12064,6 @@ impl ::core::clone::Clone for GETVERSIONINPARAMS {
 unsafe impl ::windows::core::Abi for GETVERSIONINPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GETVERSIONINPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GETVERSIONINPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GETVERSIONINPARAMS {}
 impl ::core::default::Default for GETVERSIONINPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12392,7 +12146,34 @@ unsafe impl ::windows::core::Abi for GET_CHANGER_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for GET_CHANGER_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_CHANGER_PARAMETERS>()) == 0 }
+        self.Size == other.Size
+            && self.NumberTransportElements == other.NumberTransportElements
+            && self.NumberStorageElements == other.NumberStorageElements
+            && self.NumberCleanerSlots == other.NumberCleanerSlots
+            && self.NumberIEElements == other.NumberIEElements
+            && self.NumberDataTransferElements == other.NumberDataTransferElements
+            && self.NumberOfDoors == other.NumberOfDoors
+            && self.FirstSlotNumber == other.FirstSlotNumber
+            && self.FirstDriveNumber == other.FirstDriveNumber
+            && self.FirstTransportNumber == other.FirstTransportNumber
+            && self.FirstIEPortNumber == other.FirstIEPortNumber
+            && self.FirstCleanerSlotAddress == other.FirstCleanerSlotAddress
+            && self.MagazineSize == other.MagazineSize
+            && self.DriveCleanTimeout == other.DriveCleanTimeout
+            && self.Features0 == other.Features0
+            && self.Features1 == other.Features1
+            && self.MoveFromTransport == other.MoveFromTransport
+            && self.MoveFromSlot == other.MoveFromSlot
+            && self.MoveFromIePort == other.MoveFromIePort
+            && self.MoveFromDrive == other.MoveFromDrive
+            && self.ExchangeFromTransport == other.ExchangeFromTransport
+            && self.ExchangeFromSlot == other.ExchangeFromSlot
+            && self.ExchangeFromIePort == other.ExchangeFromIePort
+            && self.ExchangeFromDrive == other.ExchangeFromDrive
+            && self.LockUnlockCapabilities == other.LockUnlockCapabilities
+            && self.PositionCapabilities == other.PositionCapabilities
+            && self.Reserved1 == other.Reserved1
+            && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for GET_CHANGER_PARAMETERS {}
@@ -12425,7 +12206,7 @@ unsafe impl ::windows::core::Abi for GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST {
 }
 impl ::core::cmp::PartialEq for GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.RequestDataType == other.RequestDataType && self.RequestDataSet == other.RequestDataSet
     }
 }
 impl ::core::cmp::Eq for GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST {}
@@ -12457,7 +12238,7 @@ unsafe impl ::windows::core::Abi for GET_DISK_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for GET_DISK_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_DISK_ATTRIBUTES>()) == 0 }
+        self.Version == other.Version && self.Reserved1 == other.Reserved1 && self.Attributes == other.Attributes
     }
 }
 impl ::core::cmp::Eq for GET_DISK_ATTRIBUTES {}
@@ -12488,7 +12269,7 @@ unsafe impl ::windows::core::Abi for GET_FILTER_FILE_IDENTIFIER_INPUT {
 }
 impl ::core::cmp::PartialEq for GET_FILTER_FILE_IDENTIFIER_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_FILTER_FILE_IDENTIFIER_INPUT>()) == 0 }
+        self.AltitudeLength == other.AltitudeLength && self.Altitude == other.Altitude
     }
 }
 impl ::core::cmp::Eq for GET_FILTER_FILE_IDENTIFIER_INPUT {}
@@ -12519,7 +12300,7 @@ unsafe impl ::windows::core::Abi for GET_FILTER_FILE_IDENTIFIER_OUTPUT {
 }
 impl ::core::cmp::PartialEq for GET_FILTER_FILE_IDENTIFIER_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_FILTER_FILE_IDENTIFIER_OUTPUT>()) == 0 }
+        self.FilterFileIdentifierLength == other.FilterFileIdentifierLength && self.FilterFileIdentifier == other.FilterFileIdentifier
     }
 }
 impl ::core::cmp::Eq for GET_FILTER_FILE_IDENTIFIER_OUTPUT {}
@@ -12549,7 +12330,7 @@ unsafe impl ::windows::core::Abi for GET_LENGTH_INFORMATION {
 }
 impl ::core::cmp::PartialEq for GET_LENGTH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_LENGTH_INFORMATION>()) == 0 }
+        self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for GET_LENGTH_INFORMATION {}
@@ -12579,14 +12360,6 @@ unsafe impl ::windows::core::Abi for GET_MEDIA_TYPES {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for GET_MEDIA_TYPES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GET_MEDIA_TYPES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for GET_MEDIA_TYPES {}
-#[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for GET_MEDIA_TYPES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12607,12 +12380,6 @@ impl ::core::clone::Clone for GP_LOG_PAGE_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for GP_LOG_PAGE_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GP_LOG_PAGE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GP_LOG_PAGE_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GP_LOG_PAGE_DESCRIPTOR {}
 impl ::core::default::Default for GP_LOG_PAGE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12640,7 +12407,7 @@ unsafe impl ::windows::core::Abi for HISTOGRAM_BUCKET {
 }
 impl ::core::cmp::PartialEq for HISTOGRAM_BUCKET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HISTOGRAM_BUCKET>()) == 0 }
+        self.Reads == other.Reads && self.Writes == other.Writes
     }
 }
 impl ::core::cmp::Eq for HISTOGRAM_BUCKET {}
@@ -12677,7 +12444,7 @@ unsafe impl ::windows::core::Abi for IDEREGS {
 }
 impl ::core::cmp::PartialEq for IDEREGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IDEREGS>()) == 0 }
+        self.bFeaturesReg == other.bFeaturesReg && self.bSectorCountReg == other.bSectorCountReg && self.bSectorNumberReg == other.bSectorNumberReg && self.bCylLowReg == other.bCylLowReg && self.bCylHighReg == other.bCylHighReg && self.bDriveHeadReg == other.bDriveHeadReg && self.bCommandReg == other.bCommandReg && self.bReserved == other.bReserved
     }
 }
 impl ::core::cmp::Eq for IDEREGS {}
@@ -12701,18 +12468,12 @@ impl ::core::clone::Clone for IO_IRP_EXT_TRACK_OFFSET_HEADER {
 }
 impl ::core::fmt::Debug for IO_IRP_EXT_TRACK_OFFSET_HEADER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("IO_IRP_EXT_TRACK_OFFSET_HEADER").field("Validation", &self.Validation).field("Flags", &self.Flags).field("TrackedOffsetCallback", &self.TrackedOffsetCallback.map(|f| f as usize)).finish()
+        f.debug_struct("IO_IRP_EXT_TRACK_OFFSET_HEADER").field("Validation", &self.Validation).field("Flags", &self.Flags).finish()
     }
 }
 unsafe impl ::windows::core::Abi for IO_IRP_EXT_TRACK_OFFSET_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IO_IRP_EXT_TRACK_OFFSET_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_IRP_EXT_TRACK_OFFSET_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IO_IRP_EXT_TRACK_OFFSET_HEADER {}
 impl ::core::default::Default for IO_IRP_EXT_TRACK_OFFSET_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12743,7 +12504,7 @@ unsafe impl ::windows::core::Abi for LOOKUP_STREAM_FROM_CLUSTER_ENTRY {
 }
 impl ::core::cmp::PartialEq for LOOKUP_STREAM_FROM_CLUSTER_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOOKUP_STREAM_FROM_CLUSTER_ENTRY>()) == 0 }
+        self.OffsetToNext == other.OffsetToNext && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Cluster == other.Cluster && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for LOOKUP_STREAM_FROM_CLUSTER_ENTRY {}
@@ -12775,7 +12536,7 @@ unsafe impl ::windows::core::Abi for LOOKUP_STREAM_FROM_CLUSTER_INPUT {
 }
 impl ::core::cmp::PartialEq for LOOKUP_STREAM_FROM_CLUSTER_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOOKUP_STREAM_FROM_CLUSTER_INPUT>()) == 0 }
+        self.Flags == other.Flags && self.NumberOfClusters == other.NumberOfClusters && self.Cluster == other.Cluster
     }
 }
 impl ::core::cmp::Eq for LOOKUP_STREAM_FROM_CLUSTER_INPUT {}
@@ -12807,7 +12568,7 @@ unsafe impl ::windows::core::Abi for LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {
 }
 impl ::core::cmp::PartialEq for LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOOKUP_STREAM_FROM_CLUSTER_OUTPUT>()) == 0 }
+        self.Offset == other.Offset && self.NumberOfMatches == other.NumberOfMatches && self.BufferSizeRequired == other.BufferSizeRequired
     }
 }
 impl ::core::cmp::Eq for LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {}
@@ -12837,14 +12598,6 @@ unsafe impl ::windows::core::Abi for MARK_HANDLE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MARK_HANDLE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MARK_HANDLE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MARK_HANDLE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MARK_HANDLE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12869,14 +12622,6 @@ impl ::core::clone::Clone for MARK_HANDLE_INFO_0 {
 unsafe impl ::windows::core::Abi for MARK_HANDLE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MARK_HANDLE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MARK_HANDLE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MARK_HANDLE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MARK_HANDLE_INFO_0 {
     fn default() -> Self {
@@ -12904,14 +12649,6 @@ unsafe impl ::windows::core::Abi for MARK_HANDLE_INFO32 {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for MARK_HANDLE_INFO32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MARK_HANDLE_INFO32>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for MARK_HANDLE_INFO32 {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for MARK_HANDLE_INFO32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12936,14 +12673,6 @@ impl ::core::clone::Clone for MARK_HANDLE_INFO32_0 {
 unsafe impl ::windows::core::Abi for MARK_HANDLE_INFO32_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for MARK_HANDLE_INFO32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MARK_HANDLE_INFO32_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for MARK_HANDLE_INFO32_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for MARK_HANDLE_INFO32_0 {
     fn default() -> Self {
@@ -12973,7 +12702,7 @@ unsafe impl ::windows::core::Abi for MFT_ENUM_DATA_V0 {
 }
 impl ::core::cmp::PartialEq for MFT_ENUM_DATA_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_ENUM_DATA_V0>()) == 0 }
+        self.StartFileReferenceNumber == other.StartFileReferenceNumber && self.LowUsn == other.LowUsn && self.HighUsn == other.HighUsn
     }
 }
 impl ::core::cmp::Eq for MFT_ENUM_DATA_V0 {}
@@ -13007,7 +12736,7 @@ unsafe impl ::windows::core::Abi for MFT_ENUM_DATA_V1 {
 }
 impl ::core::cmp::PartialEq for MFT_ENUM_DATA_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MFT_ENUM_DATA_V1>()) == 0 }
+        self.StartFileReferenceNumber == other.StartFileReferenceNumber && self.LowUsn == other.LowUsn && self.HighUsn == other.HighUsn && self.MinMajorVersion == other.MinMajorVersion && self.MaxMajorVersion == other.MaxMajorVersion
     }
 }
 impl ::core::cmp::Eq for MFT_ENUM_DATA_V1 {}
@@ -13046,7 +12775,7 @@ unsafe impl ::windows::core::Abi for MOVE_FILE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOVE_FILE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOVE_FILE_DATA>()) == 0 }
+        self.FileHandle == other.FileHandle && self.StartingVcn == other.StartingVcn && self.StartingLcn == other.StartingLcn && self.ClusterCount == other.ClusterCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13087,7 +12816,7 @@ unsafe impl ::windows::core::Abi for MOVE_FILE_DATA32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MOVE_FILE_DATA32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOVE_FILE_DATA32>()) == 0 }
+        self.FileHandle == other.FileHandle && self.StartingVcn == other.StartingVcn && self.StartingLcn == other.StartingLcn && self.ClusterCount == other.ClusterCount
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -13127,7 +12856,7 @@ unsafe impl ::windows::core::Abi for MOVE_FILE_RECORD_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOVE_FILE_RECORD_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOVE_FILE_RECORD_DATA>()) == 0 }
+        self.FileHandle == other.FileHandle && self.SourceFileRecord == other.SourceFileRecord && self.TargetFileRecord == other.TargetFileRecord
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13179,7 +12908,7 @@ unsafe impl ::windows::core::Abi for NTFS_EXTENDED_VOLUME_DATA {
 }
 impl ::core::cmp::PartialEq for NTFS_EXTENDED_VOLUME_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_EXTENDED_VOLUME_DATA>()) == 0 }
+        self.ByteCount == other.ByteCount && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.BytesPerPhysicalSector == other.BytesPerPhysicalSector && self.LfsMajorVersion == other.LfsMajorVersion && self.LfsMinorVersion == other.LfsMinorVersion && self.MaxDeviceTrimExtentCount == other.MaxDeviceTrimExtentCount && self.MaxDeviceTrimByteCount == other.MaxDeviceTrimByteCount && self.MaxVolumeTrimExtentCount == other.MaxVolumeTrimExtentCount && self.MaxVolumeTrimByteCount == other.MaxVolumeTrimByteCount
     }
 }
 impl ::core::cmp::Eq for NTFS_EXTENDED_VOLUME_DATA {}
@@ -13209,7 +12938,7 @@ unsafe impl ::windows::core::Abi for NTFS_FILE_RECORD_INPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for NTFS_FILE_RECORD_INPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_FILE_RECORD_INPUT_BUFFER>()) == 0 }
+        self.FileReferenceNumber == other.FileReferenceNumber
     }
 }
 impl ::core::cmp::Eq for NTFS_FILE_RECORD_INPUT_BUFFER {}
@@ -13241,7 +12970,7 @@ unsafe impl ::windows::core::Abi for NTFS_FILE_RECORD_OUTPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for NTFS_FILE_RECORD_OUTPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_FILE_RECORD_OUTPUT_BUFFER>()) == 0 }
+        self.FileReferenceNumber == other.FileReferenceNumber && self.FileRecordLength == other.FileRecordLength && self.FileRecordBuffer == other.FileRecordBuffer
     }
 }
 impl ::core::cmp::Eq for NTFS_FILE_RECORD_OUTPUT_BUFFER {}
@@ -13363,7 +13092,52 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS>()) == 0 }
+        self.LogFileFullExceptions == other.LogFileFullExceptions
+            && self.OtherExceptions == other.OtherExceptions
+            && self.MftReads == other.MftReads
+            && self.MftReadBytes == other.MftReadBytes
+            && self.MftWrites == other.MftWrites
+            && self.MftWriteBytes == other.MftWriteBytes
+            && self.MftWritesUserLevel == other.MftWritesUserLevel
+            && self.MftWritesFlushForLogFileFull == other.MftWritesFlushForLogFileFull
+            && self.MftWritesLazyWriter == other.MftWritesLazyWriter
+            && self.MftWritesUserRequest == other.MftWritesUserRequest
+            && self.Mft2Writes == other.Mft2Writes
+            && self.Mft2WriteBytes == other.Mft2WriteBytes
+            && self.Mft2WritesUserLevel == other.Mft2WritesUserLevel
+            && self.Mft2WritesFlushForLogFileFull == other.Mft2WritesFlushForLogFileFull
+            && self.Mft2WritesLazyWriter == other.Mft2WritesLazyWriter
+            && self.Mft2WritesUserRequest == other.Mft2WritesUserRequest
+            && self.RootIndexReads == other.RootIndexReads
+            && self.RootIndexReadBytes == other.RootIndexReadBytes
+            && self.RootIndexWrites == other.RootIndexWrites
+            && self.RootIndexWriteBytes == other.RootIndexWriteBytes
+            && self.BitmapReads == other.BitmapReads
+            && self.BitmapReadBytes == other.BitmapReadBytes
+            && self.BitmapWrites == other.BitmapWrites
+            && self.BitmapWriteBytes == other.BitmapWriteBytes
+            && self.BitmapWritesFlushForLogFileFull == other.BitmapWritesFlushForLogFileFull
+            && self.BitmapWritesLazyWriter == other.BitmapWritesLazyWriter
+            && self.BitmapWritesUserRequest == other.BitmapWritesUserRequest
+            && self.BitmapWritesUserLevel == other.BitmapWritesUserLevel
+            && self.MftBitmapReads == other.MftBitmapReads
+            && self.MftBitmapReadBytes == other.MftBitmapReadBytes
+            && self.MftBitmapWrites == other.MftBitmapWrites
+            && self.MftBitmapWriteBytes == other.MftBitmapWriteBytes
+            && self.MftBitmapWritesFlushForLogFileFull == other.MftBitmapWritesFlushForLogFileFull
+            && self.MftBitmapWritesLazyWriter == other.MftBitmapWritesLazyWriter
+            && self.MftBitmapWritesUserRequest == other.MftBitmapWritesUserRequest
+            && self.MftBitmapWritesUserLevel == other.MftBitmapWritesUserLevel
+            && self.UserIndexReads == other.UserIndexReads
+            && self.UserIndexReadBytes == other.UserIndexReadBytes
+            && self.UserIndexWrites == other.UserIndexWrites
+            && self.UserIndexWriteBytes == other.UserIndexWriteBytes
+            && self.LogFileReads == other.LogFileReads
+            && self.LogFileReadBytes == other.LogFileReadBytes
+            && self.LogFileWrites == other.LogFileWrites
+            && self.LogFileWriteBytes == other.LogFileWriteBytes
+            && self.Allocate == other.Allocate
+            && self.DiskResourcesExhausted == other.DiskResourcesExhausted
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS {}
@@ -13402,7 +13176,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_0 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_0>()) == 0 }
+        self.Calls == other.Calls && self.Clusters == other.Clusters && self.Hints == other.Hints && self.RunsReturned == other.RunsReturned && self.HintsHonored == other.HintsHonored && self.HintsClusters == other.HintsClusters && self.Cache == other.Cache && self.CacheClusters == other.CacheClusters && self.CacheMiss == other.CacheMiss && self.CacheMissClusters == other.CacheMissClusters
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_0 {}
@@ -13434,7 +13208,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_1 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_1>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_1 {}
@@ -13467,7 +13241,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_2 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_2>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_2 {}
@@ -13500,7 +13274,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_3 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_3>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_3 {}
@@ -13533,7 +13307,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_4 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_4>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_4 {}
@@ -13677,7 +13451,63 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX>()) == 0 }
+        self.LogFileFullExceptions == other.LogFileFullExceptions
+            && self.OtherExceptions == other.OtherExceptions
+            && self.MftReads == other.MftReads
+            && self.MftReadBytes == other.MftReadBytes
+            && self.MftWrites == other.MftWrites
+            && self.MftWriteBytes == other.MftWriteBytes
+            && self.MftWritesUserLevel == other.MftWritesUserLevel
+            && self.MftWritesFlushForLogFileFull == other.MftWritesFlushForLogFileFull
+            && self.MftWritesLazyWriter == other.MftWritesLazyWriter
+            && self.MftWritesUserRequest == other.MftWritesUserRequest
+            && self.Mft2Writes == other.Mft2Writes
+            && self.Mft2WriteBytes == other.Mft2WriteBytes
+            && self.Mft2WritesUserLevel == other.Mft2WritesUserLevel
+            && self.Mft2WritesFlushForLogFileFull == other.Mft2WritesFlushForLogFileFull
+            && self.Mft2WritesLazyWriter == other.Mft2WritesLazyWriter
+            && self.Mft2WritesUserRequest == other.Mft2WritesUserRequest
+            && self.RootIndexReads == other.RootIndexReads
+            && self.RootIndexReadBytes == other.RootIndexReadBytes
+            && self.RootIndexWrites == other.RootIndexWrites
+            && self.RootIndexWriteBytes == other.RootIndexWriteBytes
+            && self.BitmapReads == other.BitmapReads
+            && self.BitmapReadBytes == other.BitmapReadBytes
+            && self.BitmapWrites == other.BitmapWrites
+            && self.BitmapWriteBytes == other.BitmapWriteBytes
+            && self.BitmapWritesFlushForLogFileFull == other.BitmapWritesFlushForLogFileFull
+            && self.BitmapWritesLazyWriter == other.BitmapWritesLazyWriter
+            && self.BitmapWritesUserRequest == other.BitmapWritesUserRequest
+            && self.BitmapWritesUserLevel == other.BitmapWritesUserLevel
+            && self.MftBitmapReads == other.MftBitmapReads
+            && self.MftBitmapReadBytes == other.MftBitmapReadBytes
+            && self.MftBitmapWrites == other.MftBitmapWrites
+            && self.MftBitmapWriteBytes == other.MftBitmapWriteBytes
+            && self.MftBitmapWritesFlushForLogFileFull == other.MftBitmapWritesFlushForLogFileFull
+            && self.MftBitmapWritesLazyWriter == other.MftBitmapWritesLazyWriter
+            && self.MftBitmapWritesUserRequest == other.MftBitmapWritesUserRequest
+            && self.MftBitmapWritesUserLevel == other.MftBitmapWritesUserLevel
+            && self.UserIndexReads == other.UserIndexReads
+            && self.UserIndexReadBytes == other.UserIndexReadBytes
+            && self.UserIndexWrites == other.UserIndexWrites
+            && self.UserIndexWriteBytes == other.UserIndexWriteBytes
+            && self.LogFileReads == other.LogFileReads
+            && self.LogFileReadBytes == other.LogFileReadBytes
+            && self.LogFileWrites == other.LogFileWrites
+            && self.LogFileWriteBytes == other.LogFileWriteBytes
+            && self.Allocate == other.Allocate
+            && self.DiskResourcesExhausted == other.DiskResourcesExhausted
+            && self.VolumeTrimCount == other.VolumeTrimCount
+            && self.VolumeTrimTime == other.VolumeTrimTime
+            && self.VolumeTrimByteCount == other.VolumeTrimByteCount
+            && self.FileLevelTrimCount == other.FileLevelTrimCount
+            && self.FileLevelTrimTime == other.FileLevelTrimTime
+            && self.FileLevelTrimByteCount == other.FileLevelTrimByteCount
+            && self.VolumeTrimSkippedCount == other.VolumeTrimSkippedCount
+            && self.VolumeTrimSkippedByteCount == other.VolumeTrimSkippedByteCount
+            && self.NtfsFillStatInfoFromMftRecordCalledCount == other.NtfsFillStatInfoFromMftRecordCalledCount
+            && self.NtfsFillStatInfoFromMftRecordBailedBecauseOfAttributeListCount == other.NtfsFillStatInfoFromMftRecordBailedBecauseOfAttributeListCount
+            && self.NtfsFillStatInfoFromMftRecordBailedBecauseOfNonResReparsePointCount == other.NtfsFillStatInfoFromMftRecordBailedBecauseOfNonResReparsePointCount
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX {}
@@ -13716,7 +13546,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX_0 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX_0>()) == 0 }
+        self.Calls == other.Calls && self.RunsReturned == other.RunsReturned && self.Hints == other.Hints && self.HintsHonored == other.HintsHonored && self.Cache == other.Cache && self.CacheMiss == other.CacheMiss && self.Clusters == other.Clusters && self.HintsClusters == other.HintsClusters && self.CacheClusters == other.CacheClusters && self.CacheMissClusters == other.CacheMissClusters
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX_0 {}
@@ -13749,7 +13579,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX_1 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX_1>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX_1 {}
@@ -13782,7 +13612,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX_2 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX_2>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX_2 {}
@@ -13815,7 +13645,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX_3 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX_3>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX_3 {}
@@ -13848,7 +13678,7 @@ unsafe impl ::windows::core::Abi for NTFS_STATISTICS_EX_4 {
 }
 impl ::core::cmp::PartialEq for NTFS_STATISTICS_EX_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_STATISTICS_EX_4>()) == 0 }
+        self.Write == other.Write && self.Create == other.Create && self.SetInfo == other.SetInfo && self.Flush == other.Flush
     }
 }
 impl ::core::cmp::Eq for NTFS_STATISTICS_EX_4 {}
@@ -13906,7 +13736,7 @@ unsafe impl ::windows::core::Abi for NTFS_VOLUME_DATA_BUFFER {
 }
 impl ::core::cmp::PartialEq for NTFS_VOLUME_DATA_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NTFS_VOLUME_DATA_BUFFER>()) == 0 }
+        self.VolumeSerialNumber == other.VolumeSerialNumber && self.NumberSectors == other.NumberSectors && self.TotalClusters == other.TotalClusters && self.FreeClusters == other.FreeClusters && self.TotalReserved == other.TotalReserved && self.BytesPerSector == other.BytesPerSector && self.BytesPerCluster == other.BytesPerCluster && self.BytesPerFileRecordSegment == other.BytesPerFileRecordSegment && self.ClustersPerFileRecordSegment == other.ClustersPerFileRecordSegment && self.MftValidDataLength == other.MftValidDataLength && self.MftStartLcn == other.MftStartLcn && self.Mft2StartLcn == other.Mft2StartLcn && self.MftZoneStart == other.MftZoneStart && self.MftZoneEnd == other.MftZoneEnd
     }
 }
 impl ::core::cmp::Eq for NTFS_VOLUME_DATA_BUFFER {}
@@ -13949,7 +13779,7 @@ unsafe impl ::windows::core::Abi for PARTITION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PARTITION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARTITION_INFORMATION>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.PartitionLength == other.PartitionLength && self.HiddenSectors == other.HiddenSectors && self.PartitionNumber == other.PartitionNumber && self.PartitionType == other.PartitionType && self.BootIndicator == other.BootIndicator && self.RecognizedPartition == other.RecognizedPartition && self.RewritePartition == other.RewritePartition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13985,14 +13815,6 @@ unsafe impl ::windows::core::Abi for PARTITION_INFORMATION_EX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PARTITION_INFORMATION_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARTITION_INFORMATION_EX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PARTITION_INFORMATION_EX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PARTITION_INFORMATION_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14017,14 +13839,6 @@ impl ::core::clone::Clone for PARTITION_INFORMATION_EX_0 {
 unsafe impl ::windows::core::Abi for PARTITION_INFORMATION_EX_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PARTITION_INFORMATION_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARTITION_INFORMATION_EX_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PARTITION_INFORMATION_EX_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
@@ -14055,7 +13869,7 @@ unsafe impl ::windows::core::Abi for PARTITION_INFORMATION_GPT {
 }
 impl ::core::cmp::PartialEq for PARTITION_INFORMATION_GPT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARTITION_INFORMATION_GPT>()) == 0 }
+        self.PartitionType == other.PartitionType && self.PartitionId == other.PartitionId && self.Attributes == other.Attributes && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for PARTITION_INFORMATION_GPT {}
@@ -14095,7 +13909,7 @@ unsafe impl ::windows::core::Abi for PARTITION_INFORMATION_MBR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PARTITION_INFORMATION_MBR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARTITION_INFORMATION_MBR>()) == 0 }
+        self.PartitionType == other.PartitionType && self.BootIndicator == other.BootIndicator && self.RecognizedPartition == other.RecognizedPartition && self.HiddenSectors == other.HiddenSectors && self.PartitionId == other.PartitionId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14128,7 +13942,7 @@ unsafe impl ::windows::core::Abi for PATHNAME_BUFFER {
 }
 impl ::core::cmp::PartialEq for PATHNAME_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PATHNAME_BUFFER>()) == 0 }
+        self.PathNameLength == other.PathNameLength && self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for PATHNAME_BUFFER {}
@@ -14160,7 +13974,7 @@ unsafe impl ::windows::core::Abi for PERF_BIN {
 }
 impl ::core::cmp::PartialEq for PERF_BIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_BIN>()) == 0 }
+        self.NumberOfBins == other.NumberOfBins && self.TypeOfBin == other.TypeOfBin && self.BinsRanges == other.BinsRanges
     }
 }
 impl ::core::cmp::Eq for PERF_BIN {}
@@ -14185,12 +13999,6 @@ impl ::core::clone::Clone for PERSISTENT_RESERVE_COMMAND {
 unsafe impl ::windows::core::Abi for PERSISTENT_RESERVE_COMMAND {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PERSISTENT_RESERVE_COMMAND {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_RESERVE_COMMAND>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PERSISTENT_RESERVE_COMMAND {}
 impl ::core::default::Default for PERSISTENT_RESERVE_COMMAND {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14211,12 +14019,6 @@ impl ::core::clone::Clone for PERSISTENT_RESERVE_COMMAND_0 {
 unsafe impl ::windows::core::Abi for PERSISTENT_RESERVE_COMMAND_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PERSISTENT_RESERVE_COMMAND_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_RESERVE_COMMAND_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PERSISTENT_RESERVE_COMMAND_0 {}
 impl ::core::default::Default for PERSISTENT_RESERVE_COMMAND_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14244,7 +14046,7 @@ unsafe impl ::windows::core::Abi for PERSISTENT_RESERVE_COMMAND_0_0 {
 }
 impl ::core::cmp::PartialEq for PERSISTENT_RESERVE_COMMAND_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_RESERVE_COMMAND_0_0>()) == 0 }
+        self._bitfield == other._bitfield && self.AllocationLength == other.AllocationLength
     }
 }
 impl ::core::cmp::Eq for PERSISTENT_RESERVE_COMMAND_0_0 {}
@@ -14276,7 +14078,7 @@ unsafe impl ::windows::core::Abi for PERSISTENT_RESERVE_COMMAND_0_1 {
 }
 impl ::core::cmp::PartialEq for PERSISTENT_RESERVE_COMMAND_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSISTENT_RESERVE_COMMAND_0_1>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2 && self.ParameterList == other.ParameterList
     }
 }
 impl ::core::cmp::Eq for PERSISTENT_RESERVE_COMMAND_0_1 {}
@@ -14312,7 +14114,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_ELEMENT_STATUS {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_ELEMENT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_ELEMENT_STATUS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DescriptorCount == other.DescriptorCount && self.ReturnedDescriptorCount == other.ReturnedDescriptorCount && self.ElementIdentifierBeingDepoped == other.ElementIdentifierBeingDepoped && self.Reserved == other.Reserved && self.Descriptors == other.Descriptors
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_ELEMENT_STATUS {}
@@ -14349,7 +14151,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_ELEMENT_STATUS_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ElementIdentifier == other.ElementIdentifier && self.PhysicalElementType == other.PhysicalElementType && self.PhysicalElementHealth == other.PhysicalElementHealth && self.Reserved1 == other.Reserved1 && self.AssociatedCapacity == other.AssociatedCapacity && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {}
@@ -14384,7 +14186,7 @@ unsafe impl ::windows::core::Abi for PHYSICAL_ELEMENT_STATUS_REQUEST {
 }
 impl ::core::cmp::PartialEq for PHYSICAL_ELEMENT_STATUS_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PHYSICAL_ELEMENT_STATUS_REQUEST>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.StartingElement == other.StartingElement && self.Filter == other.Filter && self.ReportType == other.ReportType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PHYSICAL_ELEMENT_STATUS_REQUEST {}
@@ -14416,7 +14218,7 @@ unsafe impl ::windows::core::Abi for PLEX_READ_DATA_REQUEST {
 }
 impl ::core::cmp::PartialEq for PLEX_READ_DATA_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PLEX_READ_DATA_REQUEST>()) == 0 }
+        self.ByteOffset == other.ByteOffset && self.ByteLength == other.ByteLength && self.PlexNumber == other.PlexNumber
     }
 }
 impl ::core::cmp::Eq for PLEX_READ_DATA_REQUEST {}
@@ -14452,7 +14254,7 @@ unsafe impl ::windows::core::Abi for PREVENT_MEDIA_REMOVAL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PREVENT_MEDIA_REMOVAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PREVENT_MEDIA_REMOVAL>()) == 0 }
+        self.PreventMediaRemoval == other.PreventMediaRemoval
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14486,7 +14288,7 @@ unsafe impl ::windows::core::Abi for QUERY_BAD_RANGES_INPUT {
 }
 impl ::core::cmp::PartialEq for QUERY_BAD_RANGES_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_BAD_RANGES_INPUT>()) == 0 }
+        self.Flags == other.Flags && self.NumRanges == other.NumRanges && self.Ranges == other.Ranges
     }
 }
 impl ::core::cmp::Eq for QUERY_BAD_RANGES_INPUT {}
@@ -14517,7 +14319,7 @@ unsafe impl ::windows::core::Abi for QUERY_BAD_RANGES_INPUT_RANGE {
 }
 impl ::core::cmp::PartialEq for QUERY_BAD_RANGES_INPUT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_BAD_RANGES_INPUT_RANGE>()) == 0 }
+        self.StartOffset == other.StartOffset && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for QUERY_BAD_RANGES_INPUT_RANGE {}
@@ -14550,7 +14352,7 @@ unsafe impl ::windows::core::Abi for QUERY_BAD_RANGES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for QUERY_BAD_RANGES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_BAD_RANGES_OUTPUT>()) == 0 }
+        self.Flags == other.Flags && self.NumBadRanges == other.NumBadRanges && self.NextOffsetToLookUp == other.NextOffsetToLookUp && self.BadRanges == other.BadRanges
     }
 }
 impl ::core::cmp::Eq for QUERY_BAD_RANGES_OUTPUT {}
@@ -14583,7 +14385,7 @@ unsafe impl ::windows::core::Abi for QUERY_BAD_RANGES_OUTPUT_RANGE {
 }
 impl ::core::cmp::PartialEq for QUERY_BAD_RANGES_OUTPUT_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_BAD_RANGES_OUTPUT_RANGE>()) == 0 }
+        self.Flags == other.Flags && self.Reserved == other.Reserved && self.StartOffset == other.StartOffset && self.LengthInBytes == other.LengthInBytes
     }
 }
 impl ::core::cmp::Eq for QUERY_BAD_RANGES_OUTPUT_RANGE {}
@@ -14610,12 +14412,6 @@ impl ::core::clone::Clone for QUERY_FILE_LAYOUT_INPUT {
 unsafe impl ::windows::core::Abi for QUERY_FILE_LAYOUT_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUERY_FILE_LAYOUT_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_FILE_LAYOUT_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUERY_FILE_LAYOUT_INPUT {}
 impl ::core::default::Default for QUERY_FILE_LAYOUT_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14636,12 +14432,6 @@ impl ::core::clone::Clone for QUERY_FILE_LAYOUT_INPUT_0 {
 unsafe impl ::windows::core::Abi for QUERY_FILE_LAYOUT_INPUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUERY_FILE_LAYOUT_INPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_FILE_LAYOUT_INPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUERY_FILE_LAYOUT_INPUT_0 {}
 impl ::core::default::Default for QUERY_FILE_LAYOUT_INPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14663,12 +14453,6 @@ impl ::core::clone::Clone for QUERY_FILE_LAYOUT_INPUT_1 {
 unsafe impl ::windows::core::Abi for QUERY_FILE_LAYOUT_INPUT_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUERY_FILE_LAYOUT_INPUT_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_FILE_LAYOUT_INPUT_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUERY_FILE_LAYOUT_INPUT_1 {}
 impl ::core::default::Default for QUERY_FILE_LAYOUT_INPUT_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14698,7 +14482,7 @@ unsafe impl ::windows::core::Abi for QUERY_FILE_LAYOUT_OUTPUT {
 }
 impl ::core::cmp::PartialEq for QUERY_FILE_LAYOUT_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_FILE_LAYOUT_OUTPUT>()) == 0 }
+        self.FileEntryCount == other.FileEntryCount && self.FirstFileOffset == other.FirstFileOffset && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for QUERY_FILE_LAYOUT_OUTPUT {}
@@ -14729,7 +14513,7 @@ unsafe impl ::windows::core::Abi for READ_ELEMENT_ADDRESS_INFO {
 }
 impl ::core::cmp::PartialEq for READ_ELEMENT_ADDRESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READ_ELEMENT_ADDRESS_INFO>()) == 0 }
+        self.NumberOfElements == other.NumberOfElements && self.ElementStatus == other.ElementStatus
     }
 }
 impl ::core::cmp::Eq for READ_ELEMENT_ADDRESS_INFO {}
@@ -14760,7 +14544,7 @@ unsafe impl ::windows::core::Abi for READ_FILE_USN_DATA {
 }
 impl ::core::cmp::PartialEq for READ_FILE_USN_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READ_FILE_USN_DATA>()) == 0 }
+        self.MinMajorVersion == other.MinMajorVersion && self.MaxMajorVersion == other.MaxMajorVersion
     }
 }
 impl ::core::cmp::Eq for READ_FILE_USN_DATA {}
@@ -14795,7 +14579,7 @@ unsafe impl ::windows::core::Abi for READ_USN_JOURNAL_DATA_V0 {
 }
 impl ::core::cmp::PartialEq for READ_USN_JOURNAL_DATA_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READ_USN_JOURNAL_DATA_V0>()) == 0 }
+        self.StartUsn == other.StartUsn && self.ReasonMask == other.ReasonMask && self.ReturnOnlyOnClose == other.ReturnOnlyOnClose && self.Timeout == other.Timeout && self.BytesToWaitFor == other.BytesToWaitFor && self.UsnJournalID == other.UsnJournalID
     }
 }
 impl ::core::cmp::Eq for READ_USN_JOURNAL_DATA_V0 {}
@@ -14832,7 +14616,7 @@ unsafe impl ::windows::core::Abi for READ_USN_JOURNAL_DATA_V1 {
 }
 impl ::core::cmp::PartialEq for READ_USN_JOURNAL_DATA_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<READ_USN_JOURNAL_DATA_V1>()) == 0 }
+        self.StartUsn == other.StartUsn && self.ReasonMask == other.ReasonMask && self.ReturnOnlyOnClose == other.ReturnOnlyOnClose && self.Timeout == other.Timeout && self.BytesToWaitFor == other.BytesToWaitFor && self.UsnJournalID == other.UsnJournalID && self.MinMajorVersion == other.MinMajorVersion && self.MaxMajorVersion == other.MaxMajorVersion
     }
 }
 impl ::core::cmp::Eq for READ_USN_JOURNAL_DATA_V1 {}
@@ -14864,7 +14648,7 @@ unsafe impl ::windows::core::Abi for REASSIGN_BLOCKS {
 }
 impl ::core::cmp::PartialEq for REASSIGN_BLOCKS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REASSIGN_BLOCKS>()) == 0 }
+        self.Reserved == other.Reserved && self.Count == other.Count && self.BlockNumber == other.BlockNumber
     }
 }
 impl ::core::cmp::Eq for REASSIGN_BLOCKS {}
@@ -14889,12 +14673,6 @@ impl ::core::clone::Clone for REASSIGN_BLOCKS_EX {
 unsafe impl ::windows::core::Abi for REASSIGN_BLOCKS_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for REASSIGN_BLOCKS_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REASSIGN_BLOCKS_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for REASSIGN_BLOCKS_EX {}
 impl ::core::default::Default for REASSIGN_BLOCKS_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14927,7 +14705,7 @@ unsafe impl ::windows::core::Abi for REFS_SMR_VOLUME_GC_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for REFS_SMR_VOLUME_GC_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REFS_SMR_VOLUME_GC_PARAMETERS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Action == other.Action && self.Method == other.Method && self.IoGranularity == other.IoGranularity && self.CompressionFormat == other.CompressionFormat && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for REFS_SMR_VOLUME_GC_PARAMETERS {}
@@ -14979,7 +14757,7 @@ unsafe impl ::windows::core::Abi for REFS_SMR_VOLUME_INFO_OUTPUT {
 }
 impl ::core::cmp::PartialEq for REFS_SMR_VOLUME_INFO_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REFS_SMR_VOLUME_INFO_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.SizeOfRandomlyWritableTier == other.SizeOfRandomlyWritableTier && self.FreeSpaceInRandomlyWritableTier == other.FreeSpaceInRandomlyWritableTier && self.SizeofSMRTier == other.SizeofSMRTier && self.FreeSpaceInSMRTier == other.FreeSpaceInSMRTier && self.UsableFreeSpaceInSMRTier == other.UsableFreeSpaceInSMRTier && self.VolumeGcState == other.VolumeGcState && self.VolumeGcLastStatus == other.VolumeGcLastStatus && self.CurrentGcBandFillPercentage == other.CurrentGcBandFillPercentage && self.Unused == other.Unused
     }
 }
 impl ::core::cmp::Eq for REFS_SMR_VOLUME_INFO_OUTPUT {}
@@ -15041,7 +14819,22 @@ unsafe impl ::windows::core::Abi for REFS_VOLUME_DATA_BUFFER {
 }
 impl ::core::cmp::PartialEq for REFS_VOLUME_DATA_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REFS_VOLUME_DATA_BUFFER>()) == 0 }
+        self.ByteCount == other.ByteCount
+            && self.MajorVersion == other.MajorVersion
+            && self.MinorVersion == other.MinorVersion
+            && self.BytesPerPhysicalSector == other.BytesPerPhysicalSector
+            && self.VolumeSerialNumber == other.VolumeSerialNumber
+            && self.NumberSectors == other.NumberSectors
+            && self.TotalClusters == other.TotalClusters
+            && self.FreeClusters == other.FreeClusters
+            && self.TotalReserved == other.TotalReserved
+            && self.BytesPerSector == other.BytesPerSector
+            && self.BytesPerCluster == other.BytesPerCluster
+            && self.MaximumSizeOfResidentFile == other.MaximumSizeOfResidentFile
+            && self.FastTierDataFillRatio == other.FastTierDataFillRatio
+            && self.SlowTierDataFillRatio == other.SlowTierDataFillRatio
+            && self.DestagesFastTierToSlowTierRate == other.DestagesFastTierToSlowTierRate
+            && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for REFS_VOLUME_DATA_BUFFER {}
@@ -15075,7 +14868,7 @@ unsafe impl ::windows::core::Abi for REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {
 }
 impl ::core::cmp::PartialEq for REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REMOVE_ELEMENT_AND_TRUNCATE_REQUEST>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.RequestCapacity == other.RequestCapacity && self.ElementIdentifier == other.ElementIdentifier && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {}
@@ -15111,7 +14904,7 @@ unsafe impl ::windows::core::Abi for REPAIR_COPIES_INPUT {
 }
 impl ::core::cmp::PartialEq for REPAIR_COPIES_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPAIR_COPIES_INPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.FileOffset == other.FileOffset && self.Length == other.Length && self.SourceCopy == other.SourceCopy && self.NumberOfRepairCopies == other.NumberOfRepairCopies && self.RepairCopies == other.RepairCopies
     }
 }
 impl ::core::cmp::Eq for REPAIR_COPIES_INPUT {}
@@ -15143,7 +14936,7 @@ unsafe impl ::windows::core::Abi for REPAIR_COPIES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for REPAIR_COPIES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPAIR_COPIES_OUTPUT>()) == 0 }
+        self.Size == other.Size && self.Status == other.Status && self.ResumeFileOffset == other.ResumeFileOffset
     }
 }
 impl ::core::cmp::Eq for REPAIR_COPIES_OUTPUT {}
@@ -15176,7 +14969,7 @@ unsafe impl ::windows::core::Abi for REQUEST_OPLOCK_INPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for REQUEST_OPLOCK_INPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUEST_OPLOCK_INPUT_BUFFER>()) == 0 }
+        self.StructureVersion == other.StructureVersion && self.StructureLength == other.StructureLength && self.RequestedOplockLevel == other.RequestedOplockLevel && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for REQUEST_OPLOCK_INPUT_BUFFER {}
@@ -15212,7 +15005,7 @@ unsafe impl ::windows::core::Abi for REQUEST_OPLOCK_OUTPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for REQUEST_OPLOCK_OUTPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUEST_OPLOCK_OUTPUT_BUFFER>()) == 0 }
+        self.StructureVersion == other.StructureVersion && self.StructureLength == other.StructureLength && self.OriginalOplockLevel == other.OriginalOplockLevel && self.NewOplockLevel == other.NewOplockLevel && self.Flags == other.Flags && self.AccessMode == other.AccessMode && self.ShareMode == other.ShareMode
     }
 }
 impl ::core::cmp::Eq for REQUEST_OPLOCK_OUTPUT_BUFFER {}
@@ -15243,7 +15036,7 @@ unsafe impl ::windows::core::Abi for REQUEST_RAW_ENCRYPTED_DATA {
 }
 impl ::core::cmp::PartialEq for REQUEST_RAW_ENCRYPTED_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQUEST_RAW_ENCRYPTED_DATA>()) == 0 }
+        self.FileOffset == other.FileOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for REQUEST_RAW_ENCRYPTED_DATA {}
@@ -15275,7 +15068,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER>()) == 0 }
+        self.ExtentCount == other.ExtentCount && self.StartingVcn == other.StartingVcn && self.Extents == other.Extents
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {}
@@ -15307,7 +15100,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0>()) == 0 }
+        self.NextVcn == other.NextVcn && self.Lcn == other.Lcn && self.ReferenceCount == other.ReferenceCount
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {}
@@ -15339,7 +15132,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTERS_BUFFER {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTERS_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTERS_BUFFER>()) == 0 }
+        self.ExtentCount == other.ExtentCount && self.StartingVcn == other.StartingVcn && self.Extents == other.Extents
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTERS_BUFFER {}
@@ -15370,7 +15163,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTERS_BUFFER_0 {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTERS_BUFFER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTERS_BUFFER_0>()) == 0 }
+        self.NextVcn == other.NextVcn && self.Lcn == other.Lcn
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTERS_BUFFER_0 {}
@@ -15400,7 +15193,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTER_BASE {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTER_BASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTER_BASE>()) == 0 }
+        self.FileAreaOffset == other.FileAreaOffset
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTER_BASE {}
@@ -15430,7 +15223,7 @@ unsafe impl ::windows::core::Abi for RETRIEVAL_POINTER_COUNT {
 }
 impl ::core::cmp::PartialEq for RETRIEVAL_POINTER_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RETRIEVAL_POINTER_COUNT>()) == 0 }
+        self.ExtentCount == other.ExtentCount
     }
 }
 impl ::core::cmp::Eq for RETRIEVAL_POINTER_COUNT {}
@@ -15463,7 +15256,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceCount == other.DeviceCount && self.Devices == other.Devices
     }
 }
 impl ::core::cmp::Eq for SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO {}
@@ -15496,7 +15289,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO>()) == 0 }
+        self.DeviceGuid == other.DeviceGuid && self.DeviceNumber == other.DeviceNumber && self.Flags == other.Flags && self.DeviceSize == other.DeviceSize
     }
 }
 impl ::core::cmp::Eq for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {}
@@ -15526,7 +15319,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {}
@@ -15562,7 +15355,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_DEDICATED_MEMORY_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCM_BUS_DEDICATED_MEMORY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_DEDICATED_MEMORY_STATE>()) == 0 }
+        self.ActivateState == other.ActivateState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15598,7 +15391,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_PROPERTY_QUERY {
 }
 impl ::core::cmp::PartialEq for SCM_BUS_PROPERTY_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_PROPERTY_QUERY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.PropertyId == other.PropertyId && self.QueryType == other.QueryType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for SCM_BUS_PROPERTY_QUERY {}
@@ -15632,7 +15425,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_PROPERTY_SET {
 }
 impl ::core::cmp::PartialEq for SCM_BUS_PROPERTY_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_PROPERTY_SET>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.PropertyId == other.PropertyId && self.SetType == other.SetType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for SCM_BUS_PROPERTY_SET {}
@@ -15686,7 +15479,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_RUNTIME_FW_ACTIVATION_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.RuntimeFwActivationSupported == other.RuntimeFwActivationSupported && self.FirmwareActivationState == other.FirmwareActivationState && self.FirmwareActivationCapability == other.FirmwareActivationCapability && self.EstimatedFirmwareActivationTimeInUSecs == other.EstimatedFirmwareActivationTimeInUSecs && self.EstimatedProcessorAccessQuiesceTimeInUSecs == other.EstimatedProcessorAccessQuiesceTimeInUSecs && self.EstimatedIOAccessQuiesceTimeInUSecs == other.EstimatedIOAccessQuiesceTimeInUSecs && self.PlatformSupportedMaxIOAccessQuiesceTimeInUSecs == other.PlatformSupportedMaxIOAccessQuiesceTimeInUSecs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15724,7 +15517,7 @@ unsafe impl ::windows::core::Abi for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15757,7 +15550,7 @@ unsafe impl ::windows::core::Abi for SCM_INTERLEAVED_PD_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_INTERLEAVED_PD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_INTERLEAVED_PD_INFO>()) == 0 }
+        self.DeviceHandle == other.DeviceHandle && self.DeviceGuid == other.DeviceGuid
     }
 }
 impl ::core::cmp::Eq for SCM_INTERLEAVED_PD_INFO {}
@@ -15790,7 +15583,7 @@ unsafe impl ::windows::core::Abi for SCM_LD_INTERLEAVE_SET_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_LD_INTERLEAVE_SET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_LD_INTERLEAVE_SET_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.InterleaveSetSize == other.InterleaveSetSize && self.InterleaveSet == other.InterleaveSet
     }
 }
 impl ::core::cmp::Eq for SCM_LD_INTERLEAVE_SET_INFO {}
@@ -15823,7 +15616,7 @@ unsafe impl ::windows::core::Abi for SCM_LOGICAL_DEVICES {
 }
 impl ::core::cmp::PartialEq for SCM_LOGICAL_DEVICES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_LOGICAL_DEVICES>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceCount == other.DeviceCount && self.Devices == other.Devices
     }
 }
 impl ::core::cmp::Eq for SCM_LOGICAL_DEVICES {}
@@ -15856,7 +15649,7 @@ unsafe impl ::windows::core::Abi for SCM_LOGICAL_DEVICE_INSTANCE {
 }
 impl ::core::cmp::PartialEq for SCM_LOGICAL_DEVICE_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_LOGICAL_DEVICE_INSTANCE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceGuid == other.DeviceGuid && self.SymbolicLink == other.SymbolicLink
     }
 }
 impl ::core::cmp::Eq for SCM_LOGICAL_DEVICE_INSTANCE {}
@@ -15887,7 +15680,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_DESCRIPTOR_HEADER {
 }
 impl ::core::cmp::PartialEq for SCM_PD_DESCRIPTOR_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_DESCRIPTOR_HEADER>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for SCM_PD_DESCRIPTOR_HEADER {}
@@ -15920,7 +15713,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_DEVICE_HANDLE {
 }
 impl ::core::cmp::PartialEq for SCM_PD_DEVICE_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_DEVICE_HANDLE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceGuid == other.DeviceGuid && self.DeviceHandle == other.DeviceHandle
     }
 }
 impl ::core::cmp::Eq for SCM_PD_DEVICE_HANDLE {}
@@ -16000,7 +15793,28 @@ unsafe impl ::windows::core::Abi for SCM_PD_DEVICE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCM_PD_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_DEVICE_INFO>()) == 0 }
+        self.Version == other.Version
+            && self.Size == other.Size
+            && self.DeviceGuid == other.DeviceGuid
+            && self.UnsafeShutdownCount == other.UnsafeShutdownCount
+            && self.PersistentMemorySizeInBytes == other.PersistentMemorySizeInBytes
+            && self.VolatileMemorySizeInBytes == other.VolatileMemorySizeInBytes
+            && self.TotalMemorySizeInBytes == other.TotalMemorySizeInBytes
+            && self.SlotNumber == other.SlotNumber
+            && self.DeviceHandle == other.DeviceHandle
+            && self.PhysicalId == other.PhysicalId
+            && self.NumberOfFormatInterfaceCodes == other.NumberOfFormatInterfaceCodes
+            && self.FormatInterfaceCodes == other.FormatInterfaceCodes
+            && self.VendorId == other.VendorId
+            && self.ProductId == other.ProductId
+            && self.SubsystemDeviceId == other.SubsystemDeviceId
+            && self.SubsystemVendorId == other.SubsystemVendorId
+            && self.ManufacturingLocation == other.ManufacturingLocation
+            && self.ManufacturingWeek == other.ManufacturingWeek
+            && self.ManufacturingYear == other.ManufacturingYear
+            && self.SerialNumber4Byte == other.SerialNumber4Byte
+            && self.SerialNumberLengthInChars == other.SerialNumberLengthInChars
+            && self.SerialNumber == other.SerialNumber
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16035,7 +15849,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_DEVICE_SPECIFIC_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_PD_DEVICE_SPECIFIC_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_DEVICE_SPECIFIC_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumberOfProperties == other.NumberOfProperties && self.DeviceSpecificProperties == other.DeviceSpecificProperties
     }
 }
 impl ::core::cmp::Eq for SCM_PD_DEVICE_SPECIFIC_INFO {}
@@ -16066,7 +15880,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_DEVICE_SPECIFIC_PROPERTY {
 }
 impl ::core::cmp::PartialEq for SCM_PD_DEVICE_SPECIFIC_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_DEVICE_SPECIFIC_PROPERTY>()) == 0 }
+        self.Name == other.Name && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for SCM_PD_DEVICE_SPECIFIC_PROPERTY {}
@@ -16099,7 +15913,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_FIRMWARE_ACTIVATE {
 }
 impl ::core::cmp::PartialEq for SCM_PD_FIRMWARE_ACTIVATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_FIRMWARE_ACTIVATE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Slot == other.Slot
     }
 }
 impl ::core::cmp::Eq for SCM_PD_FIRMWARE_ACTIVATE {}
@@ -16136,7 +15950,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_FIRMWARE_DOWNLOAD {
 }
 impl ::core::cmp::PartialEq for SCM_PD_FIRMWARE_DOWNLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_FIRMWARE_DOWNLOAD>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Slot == other.Slot && self.Reserved == other.Reserved && self.Offset == other.Offset && self.FirmwareImageSizeInBytes == other.FirmwareImageSizeInBytes && self.FirmwareImage == other.FirmwareImage
     }
 }
 impl ::core::cmp::Eq for SCM_PD_FIRMWARE_DOWNLOAD {}
@@ -16171,7 +15985,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_FIRMWARE_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_PD_FIRMWARE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_FIRMWARE_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ActiveSlot == other.ActiveSlot && self.NextActiveSlot == other.NextActiveSlot && self.SlotCount == other.SlotCount && self.Slots == other.Slots
     }
 }
 impl ::core::cmp::Eq for SCM_PD_FIRMWARE_INFO {}
@@ -16206,7 +16020,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_FIRMWARE_SLOT_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_PD_FIRMWARE_SLOT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_FIRMWARE_SLOT_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SlotNumber == other.SlotNumber && self._bitfield == other._bitfield && self.Reserved1 == other.Reserved1 && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for SCM_PD_FIRMWARE_SLOT_INFO {}
@@ -16239,7 +16053,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_FRU_ID_STRING {
 }
 impl ::core::cmp::PartialEq for SCM_PD_FRU_ID_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_FRU_ID_STRING>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.IdentifierSize == other.IdentifierSize && self.Identifier == other.Identifier
     }
 }
 impl ::core::cmp::Eq for SCM_PD_FRU_ID_STRING {}
@@ -16269,7 +16083,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_HEALTH_NOTIFICATION_DATA {
 }
 impl ::core::cmp::PartialEq for SCM_PD_HEALTH_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_HEALTH_NOTIFICATION_DATA>()) == 0 }
+        self.DeviceGuid == other.DeviceGuid
     }
 }
 impl ::core::cmp::Eq for SCM_PD_HEALTH_NOTIFICATION_DATA {}
@@ -16301,7 +16115,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_LOCATION_STRING {
 }
 impl ::core::cmp::PartialEq for SCM_PD_LOCATION_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_LOCATION_STRING>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Location == other.Location
     }
 }
 impl ::core::cmp::Eq for SCM_PD_LOCATION_STRING {}
@@ -16337,7 +16151,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_MANAGEMENT_STATUS {
 }
 impl ::core::cmp::PartialEq for SCM_PD_MANAGEMENT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_MANAGEMENT_STATUS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Health == other.Health && self.NumberOfOperationalStatus == other.NumberOfOperationalStatus && self.NumberOfAdditionalReasons == other.NumberOfAdditionalReasons && self.OperationalStatus == other.OperationalStatus && self.AdditionalReasons == other.AdditionalReasons
     }
 }
 impl ::core::cmp::Eq for SCM_PD_MANAGEMENT_STATUS {}
@@ -16371,7 +16185,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PASSTHROUGH_INPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PASSTHROUGH_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PASSTHROUGH_INPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ProtocolGuid == other.ProtocolGuid && self.DataSize == other.DataSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PASSTHROUGH_INPUT {}
@@ -16403,7 +16217,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PASSTHROUGH_INVDIMM_INPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PASSTHROUGH_INVDIMM_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PASSTHROUGH_INVDIMM_INPUT>()) == 0 }
+        self.Opcode == other.Opcode && self.OpcodeParametersLength == other.OpcodeParametersLength && self.OpcodeParameters == other.OpcodeParameters
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PASSTHROUGH_INVDIMM_INPUT {}
@@ -16436,7 +16250,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT>()) == 0 }
+        self.GeneralStatus == other.GeneralStatus && self.ExtendedStatus == other.ExtendedStatus && self.OutputDataLength == other.OutputDataLength && self.OutputData == other.OutputData
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT {}
@@ -16470,7 +16284,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PASSTHROUGH_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PASSTHROUGH_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PASSTHROUGH_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ProtocolGuid == other.ProtocolGuid && self.DataSize == other.DataSize && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PASSTHROUGH_OUTPUT {}
@@ -16504,7 +16318,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PROPERTY_QUERY {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PROPERTY_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PROPERTY_QUERY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.PropertyId == other.PropertyId && self.QueryType == other.QueryType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PROPERTY_QUERY {}
@@ -16538,7 +16352,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_PROPERTY_SET {
 }
 impl ::core::cmp::PartialEq for SCM_PD_PROPERTY_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_PROPERTY_SET>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.PropertyId == other.PropertyId && self.SetType == other.SetType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for SCM_PD_PROPERTY_SET {}
@@ -16570,7 +16384,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_REINITIALIZE_MEDIA_INPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_REINITIALIZE_MEDIA_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_REINITIALIZE_MEDIA_INPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Options == other.Options
     }
 }
 impl ::core::cmp::Eq for SCM_PD_REINITIALIZE_MEDIA_INPUT {}
@@ -16600,7 +16414,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {
 }
 impl ::core::cmp::PartialEq for SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_REINITIALIZE_MEDIA_INPUT_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {}
@@ -16632,7 +16446,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_REINITIALIZE_MEDIA_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SCM_PD_REINITIALIZE_MEDIA_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_REINITIALIZE_MEDIA_OUTPUT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Status == other.Status
     }
 }
 impl ::core::cmp::Eq for SCM_PD_REINITIALIZE_MEDIA_OUTPUT {}
@@ -16668,7 +16482,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE>()) == 0 }
+        self.ArmState == other.ArmState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16703,7 +16517,7 @@ unsafe impl ::windows::core::Abi for SCM_PD_RUNTIME_FW_ACTIVATION_INFO {
 }
 impl ::core::cmp::PartialEq for SCM_PD_RUNTIME_FW_ACTIVATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PD_RUNTIME_FW_ACTIVATION_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.LastFirmwareActivationStatus == other.LastFirmwareActivationStatus && self.FirmwareActivationState == other.FirmwareActivationState
     }
 }
 impl ::core::cmp::Eq for SCM_PD_RUNTIME_FW_ACTIVATION_INFO {}
@@ -16736,7 +16550,7 @@ unsafe impl ::windows::core::Abi for SCM_PHYSICAL_DEVICES {
 }
 impl ::core::cmp::PartialEq for SCM_PHYSICAL_DEVICES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PHYSICAL_DEVICES>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceCount == other.DeviceCount && self.Devices == other.Devices
     }
 }
 impl ::core::cmp::Eq for SCM_PHYSICAL_DEVICES {}
@@ -16769,7 +16583,7 @@ unsafe impl ::windows::core::Abi for SCM_PHYSICAL_DEVICE_INSTANCE {
 }
 impl ::core::cmp::PartialEq for SCM_PHYSICAL_DEVICE_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_PHYSICAL_DEVICE_INSTANCE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NfitHandle == other.NfitHandle && self.SymbolicLink == other.SymbolicLink
     }
 }
 impl ::core::cmp::Eq for SCM_PHYSICAL_DEVICE_INSTANCE {}
@@ -16823,7 +16637,7 @@ unsafe impl ::windows::core::Abi for SCM_REGION {
 }
 impl ::core::cmp::PartialEq for SCM_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_REGION>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.NfitHandle == other.NfitHandle && self.LogicalDeviceGuid == other.LogicalDeviceGuid && self.AddressRangeType == other.AddressRangeType && self.AssociatedId == other.AssociatedId && self.Length == other.Length && self.StartingDPA == other.StartingDPA && self.BaseSPA == other.BaseSPA && self.SPAOffset == other.SPAOffset && self.RegionOffset == other.RegionOffset
     }
 }
 impl ::core::cmp::Eq for SCM_REGION {}
@@ -16856,7 +16670,7 @@ unsafe impl ::windows::core::Abi for SCM_REGIONS {
 }
 impl ::core::cmp::PartialEq for SCM_REGIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCM_REGIONS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.RegionCount == other.RegionCount && self.Regions == other.Regions
     }
 }
 impl ::core::cmp::Eq for SCM_REGIONS {}
@@ -16889,7 +16703,7 @@ unsafe impl ::windows::core::Abi for SD_CHANGE_MACHINE_SID_INPUT {
 }
 impl ::core::cmp::PartialEq for SD_CHANGE_MACHINE_SID_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_CHANGE_MACHINE_SID_INPUT>()) == 0 }
+        self.CurrentMachineSIDOffset == other.CurrentMachineSIDOffset && self.CurrentMachineSIDLength == other.CurrentMachineSIDLength && self.NewMachineSIDOffset == other.NewMachineSIDOffset && self.NewMachineSIDLength == other.NewMachineSIDLength
     }
 }
 impl ::core::cmp::Eq for SD_CHANGE_MACHINE_SID_INPUT {}
@@ -16925,7 +16739,7 @@ unsafe impl ::windows::core::Abi for SD_CHANGE_MACHINE_SID_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SD_CHANGE_MACHINE_SID_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_CHANGE_MACHINE_SID_OUTPUT>()) == 0 }
+        self.NumSDChangedSuccess == other.NumSDChangedSuccess && self.NumSDChangedFail == other.NumSDChangedFail && self.NumSDUnused == other.NumSDUnused && self.NumSDTotal == other.NumSDTotal && self.NumMftSDChangedSuccess == other.NumMftSDChangedSuccess && self.NumMftSDChangedFail == other.NumMftSDChangedFail && self.NumMftSDTotal == other.NumMftSDTotal
     }
 }
 impl ::core::cmp::Eq for SD_CHANGE_MACHINE_SID_OUTPUT {}
@@ -16959,7 +16773,7 @@ unsafe impl ::windows::core::Abi for SD_ENUM_SDS_ENTRY {
 }
 impl ::core::cmp::PartialEq for SD_ENUM_SDS_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_ENUM_SDS_ENTRY>()) == 0 }
+        self.Hash == other.Hash && self.SecurityId == other.SecurityId && self.Offset == other.Offset && self.Length == other.Length && self.Descriptor == other.Descriptor
     }
 }
 impl ::core::cmp::Eq for SD_ENUM_SDS_ENTRY {}
@@ -16990,7 +16804,7 @@ unsafe impl ::windows::core::Abi for SD_ENUM_SDS_INPUT {
 }
 impl ::core::cmp::PartialEq for SD_ENUM_SDS_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_ENUM_SDS_INPUT>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.MaxSDEntriesToReturn == other.MaxSDEntriesToReturn
     }
 }
 impl ::core::cmp::Eq for SD_ENUM_SDS_INPUT {}
@@ -17023,7 +16837,7 @@ unsafe impl ::windows::core::Abi for SD_ENUM_SDS_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SD_ENUM_SDS_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_ENUM_SDS_OUTPUT>()) == 0 }
+        self.NextOffset == other.NextOffset && self.NumSDEntriesReturned == other.NumSDEntriesReturned && self.NumSDBytesReturned == other.NumSDBytesReturned && self.SDEntry == other.SDEntry
     }
 }
 impl ::core::cmp::Eq for SD_ENUM_SDS_OUTPUT {}
@@ -17048,12 +16862,6 @@ impl ::core::clone::Clone for SD_GLOBAL_CHANGE_INPUT {
 unsafe impl ::windows::core::Abi for SD_GLOBAL_CHANGE_INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SD_GLOBAL_CHANGE_INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_GLOBAL_CHANGE_INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SD_GLOBAL_CHANGE_INPUT {}
 impl ::core::default::Default for SD_GLOBAL_CHANGE_INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17075,12 +16883,6 @@ impl ::core::clone::Clone for SD_GLOBAL_CHANGE_INPUT_0 {
 unsafe impl ::windows::core::Abi for SD_GLOBAL_CHANGE_INPUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SD_GLOBAL_CHANGE_INPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_GLOBAL_CHANGE_INPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SD_GLOBAL_CHANGE_INPUT_0 {}
 impl ::core::default::Default for SD_GLOBAL_CHANGE_INPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17102,12 +16904,6 @@ impl ::core::clone::Clone for SD_GLOBAL_CHANGE_OUTPUT {
 unsafe impl ::windows::core::Abi for SD_GLOBAL_CHANGE_OUTPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SD_GLOBAL_CHANGE_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_GLOBAL_CHANGE_OUTPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SD_GLOBAL_CHANGE_OUTPUT {}
 impl ::core::default::Default for SD_GLOBAL_CHANGE_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17129,12 +16925,6 @@ impl ::core::clone::Clone for SD_GLOBAL_CHANGE_OUTPUT_0 {
 unsafe impl ::windows::core::Abi for SD_GLOBAL_CHANGE_OUTPUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SD_GLOBAL_CHANGE_OUTPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_GLOBAL_CHANGE_OUTPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SD_GLOBAL_CHANGE_OUTPUT_0 {}
 impl ::core::default::Default for SD_GLOBAL_CHANGE_OUTPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17161,7 +16951,7 @@ unsafe impl ::windows::core::Abi for SD_QUERY_STATS_INPUT {
 }
 impl ::core::cmp::PartialEq for SD_QUERY_STATS_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_QUERY_STATS_INPUT>()) == 0 }
+        self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for SD_QUERY_STATS_INPUT {}
@@ -17198,7 +16988,7 @@ unsafe impl ::windows::core::Abi for SD_QUERY_STATS_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SD_QUERY_STATS_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SD_QUERY_STATS_OUTPUT>()) == 0 }
+        self.SdsStreamSize == other.SdsStreamSize && self.SdsAllocationSize == other.SdsAllocationSize && self.SiiStreamSize == other.SiiStreamSize && self.SiiAllocationSize == other.SiiAllocationSize && self.SdhStreamSize == other.SdhStreamSize && self.SdhAllocationSize == other.SdhAllocationSize && self.NumSDTotal == other.NumSDTotal && self.NumSDUnused == other.NumSDUnused
     }
 }
 impl ::core::cmp::Eq for SD_QUERY_STATS_OUTPUT {}
@@ -17226,12 +17016,6 @@ impl ::core::clone::Clone for SENDCMDINPARAMS {
 unsafe impl ::windows::core::Abi for SENDCMDINPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SENDCMDINPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENDCMDINPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SENDCMDINPARAMS {}
 impl ::core::default::Default for SENDCMDINPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17253,12 +17037,6 @@ impl ::core::clone::Clone for SENDCMDOUTPARAMS {
 unsafe impl ::windows::core::Abi for SENDCMDOUTPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SENDCMDOUTPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SENDCMDOUTPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SENDCMDOUTPARAMS {}
 impl ::core::default::Default for SENDCMDOUTPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17288,7 +17066,7 @@ unsafe impl ::windows::core::Abi for SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT {
 }
 impl ::core::cmp::PartialEq for SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT>()) == 0 }
+        self.Flags == other.Flags && self.AlignmentShift == other.AlignmentShift && self.FileOffsetToAlign == other.FileOffsetToAlign && self.FallbackAlignmentShift == other.FallbackAlignmentShift
     }
 }
 impl ::core::cmp::Eq for SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT {}
@@ -17329,7 +17107,7 @@ unsafe impl ::windows::core::Abi for SET_DISK_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SET_DISK_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_DISK_ATTRIBUTES>()) == 0 }
+        self.Version == other.Version && self.Persist == other.Persist && self.Reserved1 == other.Reserved1 && self.Attributes == other.Attributes && self.AttributesMask == other.AttributesMask && self.Reserved2 == other.Reserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17361,7 +17139,7 @@ unsafe impl ::windows::core::Abi for SET_PARTITION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SET_PARTITION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_PARTITION_INFORMATION>()) == 0 }
+        self.PartitionType == other.PartitionType
     }
 }
 impl ::core::cmp::Eq for SET_PARTITION_INFORMATION {}
@@ -17385,12 +17163,6 @@ impl ::core::clone::Clone for SET_PARTITION_INFORMATION_EX {
 unsafe impl ::windows::core::Abi for SET_PARTITION_INFORMATION_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SET_PARTITION_INFORMATION_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_PARTITION_INFORMATION_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SET_PARTITION_INFORMATION_EX {}
 impl ::core::default::Default for SET_PARTITION_INFORMATION_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17411,12 +17183,6 @@ impl ::core::clone::Clone for SET_PARTITION_INFORMATION_EX_0 {
 unsafe impl ::windows::core::Abi for SET_PARTITION_INFORMATION_EX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SET_PARTITION_INFORMATION_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_PARTITION_INFORMATION_EX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SET_PARTITION_INFORMATION_EX_0 {}
 impl ::core::default::Default for SET_PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17443,7 +17209,7 @@ unsafe impl ::windows::core::Abi for SET_PURGE_FAILURE_MODE_INPUT {
 }
 impl ::core::cmp::PartialEq for SET_PURGE_FAILURE_MODE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_PURGE_FAILURE_MODE_INPUT>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SET_PURGE_FAILURE_MODE_INPUT {}
@@ -17475,7 +17241,7 @@ unsafe impl ::windows::core::Abi for SHRINK_VOLUME_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SHRINK_VOLUME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHRINK_VOLUME_INFORMATION>()) == 0 }
+        self.ShrinkRequestType == other.ShrinkRequestType && self.Flags == other.Flags && self.NewNumberOfSectors == other.NewNumberOfSectors
     }
 }
 impl ::core::cmp::Eq for SHRINK_VOLUME_INFORMATION {}
@@ -17508,7 +17274,7 @@ unsafe impl ::windows::core::Abi for SI_COPYFILE {
 }
 impl ::core::cmp::PartialEq for SI_COPYFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SI_COPYFILE>()) == 0 }
+        self.SourceFileNameLength == other.SourceFileNameLength && self.DestinationFileNameLength == other.DestinationFileNameLength && self.Flags == other.Flags && self.FileNameBuffer == other.FileNameBuffer
     }
 }
 impl ::core::cmp::Eq for SI_COPYFILE {}
@@ -17538,7 +17304,7 @@ unsafe impl ::windows::core::Abi for SMB_SHARE_FLUSH_AND_PURGE_INPUT {
 }
 impl ::core::cmp::PartialEq for SMB_SHARE_FLUSH_AND_PURGE_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMB_SHARE_FLUSH_AND_PURGE_INPUT>()) == 0 }
+        self.Version == other.Version
     }
 }
 impl ::core::cmp::Eq for SMB_SHARE_FLUSH_AND_PURGE_INPUT {}
@@ -17568,7 +17334,7 @@ unsafe impl ::windows::core::Abi for SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMB_SHARE_FLUSH_AND_PURGE_OUTPUT>()) == 0 }
+        self.cEntriesPurged == other.cEntriesPurged
     }
 }
 impl ::core::cmp::Eq for SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {}
@@ -17598,7 +17364,7 @@ unsafe impl ::windows::core::Abi for STARTING_LCN_INPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for STARTING_LCN_INPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTING_LCN_INPUT_BUFFER>()) == 0 }
+        self.StartingLcn == other.StartingLcn
     }
 }
 impl ::core::cmp::Eq for STARTING_LCN_INPUT_BUFFER {}
@@ -17629,7 +17395,7 @@ unsafe impl ::windows::core::Abi for STARTING_LCN_INPUT_BUFFER_EX {
 }
 impl ::core::cmp::PartialEq for STARTING_LCN_INPUT_BUFFER_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTING_LCN_INPUT_BUFFER_EX>()) == 0 }
+        self.StartingLcn == other.StartingLcn && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for STARTING_LCN_INPUT_BUFFER_EX {}
@@ -17659,7 +17425,7 @@ unsafe impl ::windows::core::Abi for STARTING_VCN_INPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for STARTING_VCN_INPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTING_VCN_INPUT_BUFFER>()) == 0 }
+        self.StartingVcn == other.StartingVcn
     }
 }
 impl ::core::cmp::Eq for STARTING_VCN_INPUT_BUFFER {}
@@ -17695,7 +17461,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.BytesPerCacheLine == other.BytesPerCacheLine && self.BytesOffsetForCacheAlignment == other.BytesOffsetForCacheAlignment && self.BytesPerLogicalSector == other.BytesPerLogicalSector && self.BytesPerPhysicalSector == other.BytesPerPhysicalSector && self.BytesOffsetForSectorAlignment == other.BytesOffsetForSectorAlignment
     }
 }
 impl ::core::cmp::Eq for STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR {}
@@ -17759,7 +17525,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ADAPTER_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_ADAPTER_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ADAPTER_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.MaximumTransferLength == other.MaximumTransferLength && self.MaximumPhysicalPages == other.MaximumPhysicalPages && self.AlignmentMask == other.AlignmentMask && self.AdapterUsesPio == other.AdapterUsesPio && self.AdapterScansDown == other.AdapterScansDown && self.CommandQueueing == other.CommandQueueing && self.AcceleratedTransfer == other.AcceleratedTransfer && self.BusType == other.BusType && self.BusMajorVersion == other.BusMajorVersion && self.BusMinorVersion == other.BusMinorVersion && self.SrbType == other.SrbType && self.AddressType == other.AddressType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17793,7 +17559,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ADAPTER_SERIAL_NUMBER {
 }
 impl ::core::cmp::PartialEq for STORAGE_ADAPTER_SERIAL_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ADAPTER_SERIAL_NUMBER>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for STORAGE_ADAPTER_SERIAL_NUMBER {}
@@ -17836,7 +17602,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ALLOCATE_BC_STREAM_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_ALLOCATE_BC_STREAM_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ALLOCATE_BC_STREAM_INPUT>()) == 0 }
+        self.Version == other.Version && self.RequestsPerPeriod == other.RequestsPerPeriod && self.Period == other.Period && self.RetryFailures == other.RetryFailures && self.Discardable == other.Discardable && self.Reserved1 == other.Reserved1 && self.AccessType == other.AccessType && self.AccessMode == other.AccessMode
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17869,7 +17635,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ALLOCATE_BC_STREAM_OUTPUT {
 }
 impl ::core::cmp::PartialEq for STORAGE_ALLOCATE_BC_STREAM_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ALLOCATE_BC_STREAM_OUTPUT>()) == 0 }
+        self.RequestSize == other.RequestSize && self.NumOutStandingRequests == other.NumOutStandingRequests
     }
 }
 impl ::core::cmp::Eq for STORAGE_ALLOCATE_BC_STREAM_OUTPUT {}
@@ -17902,7 +17668,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ATTRIBUTE_MGMT {
 }
 impl ::core::cmp::PartialEq for STORAGE_ATTRIBUTE_MGMT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ATTRIBUTE_MGMT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Action == other.Action && self.Attribute == other.Attribute
     }
 }
 impl ::core::cmp::Eq for STORAGE_ATTRIBUTE_MGMT {}
@@ -17936,7 +17702,7 @@ unsafe impl ::windows::core::Abi for STORAGE_BREAK_RESERVATION_REQUEST {
 }
 impl ::core::cmp::PartialEq for STORAGE_BREAK_RESERVATION_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_BREAK_RESERVATION_REQUEST>()) == 0 }
+        self.Length == other.Length && self._unused == other._unused && self.PathId == other.PathId && self.TargetId == other.TargetId && self.Lun == other.Lun
     }
 }
 impl ::core::cmp::Eq for STORAGE_BREAK_RESERVATION_REQUEST {}
@@ -17966,7 +17732,7 @@ unsafe impl ::windows::core::Abi for STORAGE_BUS_RESET_REQUEST {
 }
 impl ::core::cmp::PartialEq for STORAGE_BUS_RESET_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_BUS_RESET_REQUEST>()) == 0 }
+        self.PathId == other.PathId
     }
 }
 impl ::core::cmp::Eq for STORAGE_BUS_RESET_REQUEST {}
@@ -17990,12 +17756,6 @@ impl ::core::clone::Clone for STORAGE_COUNTER {
 unsafe impl ::windows::core::Abi for STORAGE_COUNTER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_COUNTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_COUNTER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_COUNTER {}
 impl ::core::default::Default for STORAGE_COUNTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18016,12 +17776,6 @@ impl ::core::clone::Clone for STORAGE_COUNTER_0 {
 unsafe impl ::windows::core::Abi for STORAGE_COUNTER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_COUNTER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_COUNTER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_COUNTER_0 {}
 impl ::core::default::Default for STORAGE_COUNTER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18049,7 +17803,7 @@ unsafe impl ::windows::core::Abi for STORAGE_COUNTER_0_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_COUNTER_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_COUNTER_0_0>()) == 0 }
+        self.Week == other.Week && self.Year == other.Year
     }
 }
 impl ::core::cmp::Eq for STORAGE_COUNTER_0_0 {}
@@ -18075,12 +17829,6 @@ impl ::core::clone::Clone for STORAGE_COUNTERS {
 unsafe impl ::windows::core::Abi for STORAGE_COUNTERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_COUNTERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_COUNTERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_COUNTERS {}
 impl ::core::default::Default for STORAGE_COUNTERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18112,7 +17860,7 @@ unsafe impl ::windows::core::Abi for STORAGE_CRYPTO_CAPABILITY {
 }
 impl ::core::cmp::PartialEq for STORAGE_CRYPTO_CAPABILITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_CRYPTO_CAPABILITY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.CryptoCapabilityIndex == other.CryptoCapabilityIndex && self.AlgorithmId == other.AlgorithmId && self.KeySize == other.KeySize && self.DataUnitSizeBitmask == other.DataUnitSizeBitmask
     }
 }
 impl ::core::cmp::Eq for STORAGE_CRYPTO_CAPABILITY {}
@@ -18146,7 +17894,7 @@ unsafe impl ::windows::core::Abi for STORAGE_CRYPTO_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_CRYPTO_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_CRYPTO_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumKeysSupported == other.NumKeysSupported && self.NumCryptoCapabilities == other.NumCryptoCapabilities && self.CryptoCapabilities == other.CryptoCapabilities
     }
 }
 impl ::core::cmp::Eq for STORAGE_CRYPTO_DESCRIPTOR {}
@@ -18177,7 +17925,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DESCRIPTOR_HEADER {
 }
 impl ::core::cmp::PartialEq for STORAGE_DESCRIPTOR_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DESCRIPTOR_HEADER>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for STORAGE_DESCRIPTOR_HEADER {}
@@ -18209,7 +17957,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Attributes == other.Attributes
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {}
@@ -18271,7 +18019,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_DESCRIPTOR {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.DeviceType == other.DeviceType && self.DeviceTypeModifier == other.DeviceTypeModifier && self.RemovableMedia == other.RemovableMedia && self.CommandQueueing == other.CommandQueueing && self.VendorIdOffset == other.VendorIdOffset && self.ProductIdOffset == other.ProductIdOffset && self.ProductRevisionOffset == other.ProductRevisionOffset && self.SerialNumberOffset == other.SerialNumberOffset && self.BusType == other.BusType && self.RawPropertiesLength == other.RawPropertiesLength && self.RawDeviceProperties == other.RawDeviceProperties
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
@@ -18306,7 +18054,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumberOfFaultDomains == other.NumberOfFaultDomains && self.FaultDomainIds == other.FaultDomainIds
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {}
@@ -18339,7 +18087,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_ID_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_ID_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_ID_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumberOfIdentifiers == other.NumberOfIdentifiers && self.Identifiers == other.Identifiers
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_ID_DESCRIPTOR {}
@@ -18372,7 +18120,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.LunMaxIoCount == other.LunMaxIoCount && self.AdapterMaxIoCount == other.AdapterMaxIoCount
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {}
@@ -18404,7 +18152,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_LED_STATE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_LED_STATE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_LED_STATE_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_LED_STATE_DESCRIPTOR {}
@@ -18430,12 +18178,6 @@ impl ::core::clone::Clone for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_LOCATION_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_DEVICE_LOCATION_DESCRIPTOR {}
 impl ::core::default::Default for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18461,12 +18203,6 @@ impl ::core::clone::Clone for STORAGE_DEVICE_MANAGEMENT_STATUS {
 unsafe impl ::windows::core::Abi for STORAGE_DEVICE_MANAGEMENT_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_DEVICE_MANAGEMENT_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_MANAGEMENT_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_DEVICE_MANAGEMENT_STATUS {}
 impl ::core::default::Default for STORAGE_DEVICE_MANAGEMENT_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18495,7 +18231,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_NUMA_PROPERTY {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_NUMA_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_NUMA_PROPERTY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumaNode == other.NumaNode
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_NUMA_PROPERTY {}
@@ -18527,7 +18263,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_NUMBER {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_NUMBER>()) == 0 }
+        self.DeviceType == other.DeviceType && self.DeviceNumber == other.DeviceNumber && self.PartitionNumber == other.PartitionNumber
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_NUMBER {}
@@ -18560,7 +18296,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_NUMBERS {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_NUMBERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_NUMBERS>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NumberOfDevices == other.NumberOfDevices && self.Devices == other.Devices
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_NUMBERS {}
@@ -18596,7 +18332,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_NUMBER_EX {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_NUMBER_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_NUMBER_EX>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.DeviceType == other.DeviceType && self.DeviceNumber == other.DeviceNumber && self.DeviceGuid == other.DeviceGuid && self.PartitionNumber == other.PartitionNumber
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_NUMBER_EX {}
@@ -18629,7 +18365,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_POWER_CAP {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_POWER_CAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_POWER_CAP>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Units == other.Units && self.MaxPower == other.MaxPower
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_POWER_CAP {}
@@ -18666,7 +18402,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_RESILIENCY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_RESILIENCY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_RESILIENCY_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NameOffset == other.NameOffset && self.NumberOfLogicalCopies == other.NumberOfLogicalCopies && self.NumberOfPhysicalCopies == other.NumberOfPhysicalCopies && self.PhysicalDiskRedundancy == other.PhysicalDiskRedundancy && self.NumberOfColumns == other.NumberOfColumns && self.Interleave == other.Interleave
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_RESILIENCY_DESCRIPTOR {}
@@ -18704,7 +18440,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SupportsSelfEncryption == other.SupportsSelfEncryption
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18741,7 +18477,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_TIERING_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_TIERING_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_TIERING_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.TotalNumberOfTiers == other.TotalNumberOfTiers && self.NumberOfTiersReturned == other.NumberOfTiersReturned && self.Tiers == other.Tiers
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_TIERING_DESCRIPTOR {}
@@ -18773,7 +18509,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {
 }
 impl ::core::cmp::PartialEq for STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.UnsafeShutdownCount == other.UnsafeShutdownCount
     }
 }
 impl ::core::cmp::Eq for STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {}
@@ -18808,7 +18544,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DIAGNOSTIC_DATA {
 }
 impl ::core::cmp::PartialEq for STORAGE_DIAGNOSTIC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DIAGNOSTIC_DATA>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ProviderId == other.ProviderId && self.BufferSize == other.BufferSize && self.Reserved == other.Reserved && self.DiagnosticDataBuffer == other.DiagnosticDataBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_DIAGNOSTIC_DATA {}
@@ -18842,7 +18578,7 @@ unsafe impl ::windows::core::Abi for STORAGE_DIAGNOSTIC_REQUEST {
 }
 impl ::core::cmp::PartialEq for STORAGE_DIAGNOSTIC_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_DIAGNOSTIC_REQUEST>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.TargetType == other.TargetType && self.Level == other.Level
     }
 }
 impl ::core::cmp::Eq for STORAGE_DIAGNOSTIC_REQUEST {}
@@ -18874,7 +18610,7 @@ unsafe impl ::windows::core::Abi for STORAGE_EVENT_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for STORAGE_EVENT_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_EVENT_NOTIFICATION>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Events == other.Events
     }
 }
 impl ::core::cmp::Eq for STORAGE_EVENT_NOTIFICATION {}
@@ -18914,7 +18650,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FAILURE_PREDICTION_CONFIG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_FAILURE_PREDICTION_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FAILURE_PREDICTION_CONFIG>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Set == other.Set && self.Enabled == other.Enabled && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18949,7 +18685,7 @@ unsafe impl ::windows::core::Abi for STORAGE_FRU_ID_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_FRU_ID_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_FRU_ID_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.IdentifierSize == other.IdentifierSize && self.Identifier == other.Identifier
     }
 }
 impl ::core::cmp::Eq for STORAGE_FRU_ID_DESCRIPTOR {}
@@ -18984,7 +18720,7 @@ unsafe impl ::windows::core::Abi for STORAGE_GET_BC_PROPERTIES_OUTPUT {
 }
 impl ::core::cmp::PartialEq for STORAGE_GET_BC_PROPERTIES_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_GET_BC_PROPERTIES_OUTPUT>()) == 0 }
+        self.MaximumRequestsPerPeriod == other.MaximumRequestsPerPeriod && self.MinimumPeriod == other.MinimumPeriod && self.MaximumRequestSize == other.MaximumRequestSize && self.EstimatedTimePerRequest == other.EstimatedTimePerRequest && self.NumOutStandingRequests == other.NumOutStandingRequests && self.RequestSize == other.RequestSize
     }
 }
 impl ::core::cmp::Eq for STORAGE_GET_BC_PROPERTIES_OUTPUT {}
@@ -19024,7 +18760,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HOTPLUG_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_HOTPLUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HOTPLUG_INFO>()) == 0 }
+        self.Size == other.Size && self.MediaRemovable == other.MediaRemovable && self.MediaHotplug == other.MediaHotplug && self.DeviceHotplug == other.DeviceHotplug && self.WriteCacheEnableOverride == other.WriteCacheEnableOverride
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19058,7 +18794,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.EnduranceInfo == other.EnduranceInfo
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {}
@@ -19093,7 +18829,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_ENDURANCE_INFO {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_ENDURANCE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_ENDURANCE_INFO>()) == 0 }
+        self.ValidFields == other.ValidFields && self.GroupId == other.GroupId && self.Flags == other.Flags && self.LifePercentage == other.LifePercentage && self.BytesReadCount == other.BytesReadCount && self.ByteWriteCount == other.ByteWriteCount
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_ENDURANCE_INFO {}
@@ -19123,7 +18859,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_ENDURANCE_INFO_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_ENDURANCE_INFO_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_ENDURANCE_INFO_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_ENDURANCE_INFO_0 {}
@@ -19157,7 +18893,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_ACTIVATE {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_ACTIVATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_ACTIVATE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Slot == other.Slot && self.Reserved0 == other.Reserved0
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_FIRMWARE_ACTIVATE {}
@@ -19194,7 +18930,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_DOWNLOAD {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_DOWNLOAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_DOWNLOAD>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Slot == other.Slot && self.Reserved == other.Reserved && self.Offset == other.Offset && self.BufferSize == other.BufferSize && self.ImageBuffer == other.ImageBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_FIRMWARE_DOWNLOAD {}
@@ -19233,7 +18969,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_DOWNLOAD_V2 {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_DOWNLOAD_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_DOWNLOAD_V2>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Slot == other.Slot && self.Reserved == other.Reserved && self.Offset == other.Offset && self.BufferSize == other.BufferSize && self.ImageSize == other.ImageSize && self.Reserved2 == other.Reserved2 && self.ImageBuffer == other.ImageBuffer
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_FIRMWARE_DOWNLOAD_V2 {}
@@ -19291,7 +19027,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self._bitfield == other._bitfield && self.SlotCount == other.SlotCount && self.ActiveSlot == other.ActiveSlot && self.PendingActivateSlot == other.PendingActivateSlot && self.FirmwareShared == other.FirmwareShared && self.Reserved == other.Reserved && self.ImagePayloadAlignment == other.ImagePayloadAlignment && self.ImagePayloadMaxSize == other.ImagePayloadMaxSize && self.Slot == other.Slot
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19326,7 +19062,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_INFO_QUERY {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_INFO_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_INFO_QUERY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_FIRMWARE_INFO_QUERY {}
@@ -19361,7 +19097,7 @@ unsafe impl ::windows::core::Abi for STORAGE_HW_FIRMWARE_SLOT_INFO {
 }
 impl ::core::cmp::PartialEq for STORAGE_HW_FIRMWARE_SLOT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_HW_FIRMWARE_SLOT_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SlotNumber == other.SlotNumber && self._bitfield == other._bitfield && self.Reserved1 == other.Reserved1 && self.Revision == other.Revision
     }
 }
 impl ::core::cmp::Eq for STORAGE_HW_FIRMWARE_SLOT_INFO {}
@@ -19396,7 +19132,7 @@ unsafe impl ::windows::core::Abi for STORAGE_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for STORAGE_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_IDENTIFIER>()) == 0 }
+        self.CodeSet == other.CodeSet && self.Type == other.Type && self.IdentifierSize == other.IdentifierSize && self.NextOffset == other.NextOffset && self.Association == other.Association && self.Identifier == other.Identifier
     }
 }
 impl ::core::cmp::Eq for STORAGE_IDENTIFIER {}
@@ -19429,7 +19165,7 @@ unsafe impl ::windows::core::Abi for STORAGE_IDLE_POWER {
 }
 impl ::core::cmp::PartialEq for STORAGE_IDLE_POWER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_IDLE_POWER>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self._bitfield == other._bitfield && self.D3IdleTimeout == other.D3IdleTimeout
     }
 }
 impl ::core::cmp::Eq for STORAGE_IDLE_POWER {}
@@ -19461,7 +19197,7 @@ unsafe impl ::windows::core::Abi for STORAGE_IDLE_POWERUP_REASON {
 }
 impl ::core::cmp::PartialEq for STORAGE_IDLE_POWERUP_REASON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_IDLE_POWERUP_REASON>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.PowerupReason == other.PowerupReason
     }
 }
 impl ::core::cmp::Eq for STORAGE_IDLE_POWERUP_REASON {}
@@ -19498,7 +19234,7 @@ unsafe impl ::windows::core::Abi for STORAGE_LB_PROVISIONING_MAP_RESOURCES {
 }
 impl ::core::cmp::PartialEq for STORAGE_LB_PROVISIONING_MAP_RESOURCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_LB_PROVISIONING_MAP_RESOURCES>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self._bitfield1 == other._bitfield1 && self.Reserved1 == other.Reserved1 && self._bitfield2 == other._bitfield2 && self.Reserved3 == other.Reserved3 && self.AvailableMappingResources == other.AvailableMappingResources && self.UsedMappingResources == other.UsedMappingResources
     }
 }
 impl ::core::cmp::Eq for STORAGE_LB_PROVISIONING_MAP_RESOURCES {}
@@ -19530,7 +19266,7 @@ unsafe impl ::windows::core::Abi for STORAGE_MEDIA_SERIAL_NUMBER_DATA {
 }
 impl ::core::cmp::PartialEq for STORAGE_MEDIA_SERIAL_NUMBER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_MEDIA_SERIAL_NUMBER_DATA>()) == 0 }
+        self.Reserved == other.Reserved && self.SerialNumberLength == other.SerialNumberLength && self.SerialNumber == other.SerialNumber
     }
 }
 impl ::core::cmp::Eq for STORAGE_MEDIA_SERIAL_NUMBER_DATA {}
@@ -19562,7 +19298,7 @@ unsafe impl ::windows::core::Abi for STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.MediumProductType == other.MediumProductType
     }
 }
 impl ::core::cmp::Eq for STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR {}
@@ -19599,14 +19335,6 @@ unsafe impl ::windows::core::Abi for STORAGE_MINIPORT_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_MINIPORT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_MINIPORT_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_MINIPORT_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_MINIPORT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19631,14 +19359,6 @@ impl ::core::clone::Clone for STORAGE_MINIPORT_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for STORAGE_MINIPORT_DESCRIPTOR_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_MINIPORT_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_MINIPORT_DESCRIPTOR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_MINIPORT_DESCRIPTOR_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_MINIPORT_DESCRIPTOR_0 {
     fn default() -> Self {
@@ -19672,7 +19392,7 @@ unsafe impl ::windows::core::Abi for STORAGE_MINIPORT_DESCRIPTOR_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_MINIPORT_DESCRIPTOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_MINIPORT_DESCRIPTOR_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19701,12 +19421,6 @@ impl ::core::clone::Clone for STORAGE_OFFLOAD_READ_OUTPUT {
 unsafe impl ::windows::core::Abi for STORAGE_OFFLOAD_READ_OUTPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_OFFLOAD_READ_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OFFLOAD_READ_OUTPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_OFFLOAD_READ_OUTPUT {}
 impl ::core::default::Default for STORAGE_OFFLOAD_READ_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19729,12 +19443,6 @@ impl ::core::clone::Clone for STORAGE_OFFLOAD_TOKEN {
 unsafe impl ::windows::core::Abi for STORAGE_OFFLOAD_TOKEN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_OFFLOAD_TOKEN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OFFLOAD_TOKEN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_OFFLOAD_TOKEN {}
 impl ::core::default::Default for STORAGE_OFFLOAD_TOKEN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19755,12 +19463,6 @@ impl ::core::clone::Clone for STORAGE_OFFLOAD_TOKEN_0 {
 unsafe impl ::windows::core::Abi for STORAGE_OFFLOAD_TOKEN_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_OFFLOAD_TOKEN_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OFFLOAD_TOKEN_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_OFFLOAD_TOKEN_0 {}
 impl ::core::default::Default for STORAGE_OFFLOAD_TOKEN_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19787,7 +19489,7 @@ unsafe impl ::windows::core::Abi for STORAGE_OFFLOAD_TOKEN_0_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_OFFLOAD_TOKEN_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OFFLOAD_TOKEN_0_0>()) == 0 }
+        self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for STORAGE_OFFLOAD_TOKEN_0_0 {}
@@ -19819,7 +19521,7 @@ unsafe impl ::windows::core::Abi for STORAGE_OFFLOAD_WRITE_OUTPUT {
 }
 impl ::core::cmp::PartialEq for STORAGE_OFFLOAD_WRITE_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OFFLOAD_WRITE_OUTPUT>()) == 0 }
+        self.OffloadWriteFlags == other.OffloadWriteFlags && self.Reserved == other.Reserved && self.LengthCopied == other.LengthCopied
     }
 }
 impl ::core::cmp::Eq for STORAGE_OFFLOAD_WRITE_OUTPUT {}
@@ -19845,12 +19547,6 @@ impl ::core::clone::Clone for STORAGE_OPERATIONAL_REASON {
 unsafe impl ::windows::core::Abi for STORAGE_OPERATIONAL_REASON {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_OPERATIONAL_REASON {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OPERATIONAL_REASON>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_OPERATIONAL_REASON {}
 impl ::core::default::Default for STORAGE_OPERATIONAL_REASON {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19872,12 +19568,6 @@ impl ::core::clone::Clone for STORAGE_OPERATIONAL_REASON_0 {
 unsafe impl ::windows::core::Abi for STORAGE_OPERATIONAL_REASON_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_OPERATIONAL_REASON_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OPERATIONAL_REASON_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_OPERATIONAL_REASON_0 {}
 impl ::core::default::Default for STORAGE_OPERATIONAL_REASON_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -19906,7 +19596,7 @@ unsafe impl ::windows::core::Abi for STORAGE_OPERATIONAL_REASON_0_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_OPERATIONAL_REASON_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OPERATIONAL_REASON_0_0>()) == 0 }
+        self.CriticalHealth == other.CriticalHealth && self.ModuleHealth == other.ModuleHealth && self.ErrorThresholdStatus == other.ErrorThresholdStatus
     }
 }
 impl ::core::cmp::Eq for STORAGE_OPERATIONAL_REASON_0_0 {}
@@ -19939,7 +19629,7 @@ unsafe impl ::windows::core::Abi for STORAGE_OPERATIONAL_REASON_0_1 {
 }
 impl ::core::cmp::PartialEq for STORAGE_OPERATIONAL_REASON_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_OPERATIONAL_REASON_0_1>()) == 0 }
+        self.SenseKey == other.SenseKey && self.ASC == other.ASC && self.ASCQ == other.ASCQ && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for STORAGE_OPERATIONAL_REASON_0_1 {}
@@ -19977,14 +19667,6 @@ unsafe impl ::windows::core::Abi for STORAGE_PHYSICAL_ADAPTER_DATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_PHYSICAL_ADAPTER_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PHYSICAL_ADAPTER_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_PHYSICAL_ADAPTER_DATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_PHYSICAL_ADAPTER_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20015,12 +19697,6 @@ impl ::core::clone::Clone for STORAGE_PHYSICAL_DEVICE_DATA {
 unsafe impl ::windows::core::Abi for STORAGE_PHYSICAL_DEVICE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_PHYSICAL_DEVICE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PHYSICAL_DEVICE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_PHYSICAL_DEVICE_DATA {}
 impl ::core::default::Default for STORAGE_PHYSICAL_DEVICE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20054,7 +19730,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PHYSICAL_NODE_DATA {
 }
 impl ::core::cmp::PartialEq for STORAGE_PHYSICAL_NODE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PHYSICAL_NODE_DATA>()) == 0 }
+        self.NodeId == other.NodeId && self.AdapterCount == other.AdapterCount && self.AdapterDataLength == other.AdapterDataLength && self.AdapterDataOffset == other.AdapterDataOffset && self.DeviceCount == other.DeviceCount && self.DeviceDataLength == other.DeviceDataLength && self.DeviceDataOffset == other.DeviceDataOffset && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for STORAGE_PHYSICAL_NODE_DATA {}
@@ -20088,7 +19764,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.NodeCount == other.NodeCount && self.Reserved == other.Reserved && self.Node == other.Node
     }
 }
 impl ::core::cmp::Eq for STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {}
@@ -20119,7 +19795,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PREDICT_FAILURE {
 }
 impl ::core::cmp::PartialEq for STORAGE_PREDICT_FAILURE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PREDICT_FAILURE>()) == 0 }
+        self.PredictFailure == other.PredictFailure && self.VendorSpecific == other.VendorSpecific
     }
 }
 impl ::core::cmp::Eq for STORAGE_PREDICT_FAILURE {}
@@ -20149,7 +19825,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PRIORITY_HINT_SUPPORT {
 }
 impl ::core::cmp::PartialEq for STORAGE_PRIORITY_HINT_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PRIORITY_HINT_SUPPORT>()) == 0 }
+        self.SupportFlags == other.SupportFlags
     }
 }
 impl ::core::cmp::Eq for STORAGE_PRIORITY_HINT_SUPPORT {}
@@ -20181,7 +19857,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROPERTY_QUERY {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROPERTY_QUERY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROPERTY_QUERY>()) == 0 }
+        self.PropertyId == other.PropertyId && self.QueryType == other.QueryType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROPERTY_QUERY {}
@@ -20213,7 +19889,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROPERTY_SET {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROPERTY_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROPERTY_SET>()) == 0 }
+        self.PropertyId == other.PropertyId && self.SetType == other.SetType && self.AdditionalParameters == other.AdditionalParameters
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROPERTY_SET {}
@@ -20281,7 +19957,25 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_COMMAND {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_COMMAND>()) == 0 }
+        self.Version == other.Version
+            && self.Length == other.Length
+            && self.ProtocolType == other.ProtocolType
+            && self.Flags == other.Flags
+            && self.ReturnStatus == other.ReturnStatus
+            && self.ErrorCode == other.ErrorCode
+            && self.CommandLength == other.CommandLength
+            && self.ErrorInfoLength == other.ErrorInfoLength
+            && self.DataToDeviceTransferLength == other.DataToDeviceTransferLength
+            && self.DataFromDeviceTransferLength == other.DataFromDeviceTransferLength
+            && self.TimeOutValue == other.TimeOutValue
+            && self.ErrorInfoOffset == other.ErrorInfoOffset
+            && self.DataToDeviceBufferOffset == other.DataToDeviceBufferOffset
+            && self.DataFromDeviceBufferOffset == other.DataFromDeviceBufferOffset
+            && self.CommandSpecific == other.CommandSpecific
+            && self.Reserved0 == other.Reserved0
+            && self.FixedProtocolReturnData == other.FixedProtocolReturnData
+            && self.Reserved1 == other.Reserved1
+            && self.Command == other.Command
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_COMMAND {}
@@ -20313,7 +20007,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_DATA_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_DATA_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_DATA_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ProtocolSpecificData == other.ProtocolSpecificData
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_DATA_DESCRIPTOR {}
@@ -20345,7 +20039,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.ProtocolSpecificData == other.ProtocolSpecificData
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {}
@@ -20369,12 +20063,6 @@ impl ::core::clone::Clone for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
 unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {}
 impl ::core::default::Default for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20401,7 +20089,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0 {}
@@ -20451,7 +20139,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_SPECIFIC_DATA {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_SPECIFIC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_SPECIFIC_DATA>()) == 0 }
+        self.ProtocolType == other.ProtocolType && self.DataType == other.DataType && self.ProtocolDataRequestValue == other.ProtocolDataRequestValue && self.ProtocolDataRequestSubValue == other.ProtocolDataRequestSubValue && self.ProtocolDataOffset == other.ProtocolDataOffset && self.ProtocolDataLength == other.ProtocolDataLength && self.FixedProtocolReturnData == other.FixedProtocolReturnData && self.ProtocolDataRequestSubValue2 == other.ProtocolDataRequestSubValue2 && self.ProtocolDataRequestSubValue3 == other.ProtocolDataRequestSubValue3 && self.ProtocolDataRequestSubValue4 == other.ProtocolDataRequestSubValue4
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_SPECIFIC_DATA {}
@@ -20505,7 +20193,7 @@ unsafe impl ::windows::core::Abi for STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {
 }
 impl ::core::cmp::PartialEq for STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_PROTOCOL_SPECIFIC_DATA_EXT>()) == 0 }
+        self.ProtocolType == other.ProtocolType && self.DataType == other.DataType && self.ProtocolDataValue == other.ProtocolDataValue && self.ProtocolDataSubValue == other.ProtocolDataSubValue && self.ProtocolDataOffset == other.ProtocolDataOffset && self.ProtocolDataLength == other.ProtocolDataLength && self.FixedProtocolReturnData == other.FixedProtocolReturnData && self.ProtocolDataSubValue2 == other.ProtocolDataSubValue2 && self.ProtocolDataSubValue3 == other.ProtocolDataSubValue3 && self.ProtocolDataSubValue4 == other.ProtocolDataSubValue4 && self.ProtocolDataSubValue5 == other.ProtocolDataSubValue5 && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {}
@@ -20544,7 +20232,7 @@ unsafe impl ::windows::core::Abi for STORAGE_QUERY_DEPENDENT_VOLUME_LEV1_ENTRY {
 #[cfg(feature = "Win32_Storage_Vhd")]
 impl ::core::cmp::PartialEq for STORAGE_QUERY_DEPENDENT_VOLUME_LEV1_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_QUERY_DEPENDENT_VOLUME_LEV1_ENTRY>()) == 0 }
+        self.EntryLength == other.EntryLength && self.DependencyTypeFlags == other.DependencyTypeFlags && self.ProviderSpecificFlags == other.ProviderSpecificFlags && self.VirtualStorageType == other.VirtualStorageType
     }
 }
 #[cfg(feature = "Win32_Storage_Vhd")]
@@ -20608,7 +20296,7 @@ unsafe impl ::windows::core::Abi for STORAGE_QUERY_DEPENDENT_VOLUME_LEV2_ENTRY {
 #[cfg(feature = "Win32_Storage_Vhd")]
 impl ::core::cmp::PartialEq for STORAGE_QUERY_DEPENDENT_VOLUME_LEV2_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_QUERY_DEPENDENT_VOLUME_LEV2_ENTRY>()) == 0 }
+        self.EntryLength == other.EntryLength && self.DependencyTypeFlags == other.DependencyTypeFlags && self.ProviderSpecificFlags == other.ProviderSpecificFlags && self.VirtualStorageType == other.VirtualStorageType && self.AncestorLevel == other.AncestorLevel && self.HostVolumeNameOffset == other.HostVolumeNameOffset && self.HostVolumeNameSize == other.HostVolumeNameSize && self.DependentVolumeNameOffset == other.DependentVolumeNameOffset && self.DependentVolumeNameSize == other.DependentVolumeNameSize && self.RelativePathOffset == other.RelativePathOffset && self.RelativePathSize == other.RelativePathSize && self.DependentDeviceNameOffset == other.DependentDeviceNameOffset && self.DependentDeviceNameSize == other.DependentDeviceNameSize
     }
 }
 #[cfg(feature = "Win32_Storage_Vhd")]
@@ -20641,7 +20329,7 @@ unsafe impl ::windows::core::Abi for STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {
 }
 impl ::core::cmp::PartialEq for STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST>()) == 0 }
+        self.RequestLevel == other.RequestLevel && self.RequestFlags == other.RequestFlags
     }
 }
 impl ::core::cmp::Eq for STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {}
@@ -20671,14 +20359,6 @@ unsafe impl ::windows::core::Abi for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Storage_Vhd")]
-impl ::core::cmp::PartialEq for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl ::core::cmp::Eq for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {}
-#[cfg(feature = "Win32_Storage_Vhd")]
 impl ::core::default::Default for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20703,14 +20383,6 @@ impl ::core::clone::Clone for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
 unsafe impl ::windows::core::Abi for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl ::core::cmp::PartialEq for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl ::core::cmp::Eq for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {}
 #[cfg(feature = "Win32_Storage_Vhd")]
 impl ::core::default::Default for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
     fn default() -> Self {
@@ -20742,7 +20414,7 @@ unsafe impl ::windows::core::Abi for STORAGE_READ_CAPACITY {
 }
 impl ::core::cmp::PartialEq for STORAGE_READ_CAPACITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_READ_CAPACITY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.BlockLength == other.BlockLength && self.NumberOfBlocks == other.NumberOfBlocks && self.DiskLength == other.DiskLength
     }
 }
 impl ::core::cmp::Eq for STORAGE_READ_CAPACITY {}
@@ -20775,7 +20447,7 @@ unsafe impl ::windows::core::Abi for STORAGE_REINITIALIZE_MEDIA {
 }
 impl ::core::cmp::PartialEq for STORAGE_REINITIALIZE_MEDIA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_REINITIALIZE_MEDIA>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.TimeoutInSeconds == other.TimeoutInSeconds && self.SanitizeOption == other.SanitizeOption
     }
 }
 impl ::core::cmp::Eq for STORAGE_REINITIALIZE_MEDIA {}
@@ -20805,7 +20477,7 @@ unsafe impl ::windows::core::Abi for STORAGE_REINITIALIZE_MEDIA_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_REINITIALIZE_MEDIA_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_REINITIALIZE_MEDIA_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for STORAGE_REINITIALIZE_MEDIA_0 {}
@@ -20843,7 +20515,7 @@ unsafe impl ::windows::core::Abi for STORAGE_RPMB_DATA_FRAME {
 }
 impl ::core::cmp::PartialEq for STORAGE_RPMB_DATA_FRAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_RPMB_DATA_FRAME>()) == 0 }
+        self.Stuff == other.Stuff && self.KeyOrMAC == other.KeyOrMAC && self.Data == other.Data && self.Nonce == other.Nonce && self.WriteCounter == other.WriteCounter && self.Address == other.Address && self.BlockCount == other.BlockCount && self.OperationResult == other.OperationResult && self.RequestOrResponseType == other.RequestOrResponseType
     }
 }
 impl ::core::cmp::Eq for STORAGE_RPMB_DATA_FRAME {}
@@ -20877,7 +20549,7 @@ unsafe impl ::windows::core::Abi for STORAGE_RPMB_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for STORAGE_RPMB_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_RPMB_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SizeInBytes == other.SizeInBytes && self.MaxReliableWriteSizeInBytes == other.MaxReliableWriteSizeInBytes && self.FrameFormat == other.FrameFormat
     }
 }
 impl ::core::cmp::Eq for STORAGE_RPMB_DESCRIPTOR {}
@@ -20901,12 +20573,6 @@ impl ::core::clone::Clone for STORAGE_SPEC_VERSION {
 unsafe impl ::windows::core::Abi for STORAGE_SPEC_VERSION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_SPEC_VERSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_SPEC_VERSION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_SPEC_VERSION {}
 impl ::core::default::Default for STORAGE_SPEC_VERSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20927,12 +20593,6 @@ impl ::core::clone::Clone for STORAGE_SPEC_VERSION_0 {
 unsafe impl ::windows::core::Abi for STORAGE_SPEC_VERSION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_SPEC_VERSION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_SPEC_VERSION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_SPEC_VERSION_0 {}
 impl ::core::default::Default for STORAGE_SPEC_VERSION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20953,12 +20613,6 @@ impl ::core::clone::Clone for STORAGE_SPEC_VERSION_0_0 {
 unsafe impl ::windows::core::Abi for STORAGE_SPEC_VERSION_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STORAGE_SPEC_VERSION_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_SPEC_VERSION_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STORAGE_SPEC_VERSION_0_0 {}
 impl ::core::default::Default for STORAGE_SPEC_VERSION_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -20986,7 +20640,7 @@ unsafe impl ::windows::core::Abi for STORAGE_SPEC_VERSION_0_0_0 {
 }
 impl ::core::cmp::PartialEq for STORAGE_SPEC_VERSION_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_SPEC_VERSION_0_0_0>()) == 0 }
+        self.SubMinor == other.SubMinor && self.Minor == other.Minor
     }
 }
 impl ::core::cmp::Eq for STORAGE_SPEC_VERSION_0_0_0 {}
@@ -21029,7 +20683,7 @@ unsafe impl ::windows::core::Abi for STORAGE_TEMPERATURE_DATA_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_TEMPERATURE_DATA_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_TEMPERATURE_DATA_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.CriticalTemperature == other.CriticalTemperature && self.WarningTemperature == other.WarningTemperature && self.InfoCount == other.InfoCount && self.Reserved0 == other.Reserved0 && self.Reserved1 == other.Reserved1 && self.TemperatureInfo == other.TemperatureInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21075,7 +20729,7 @@ unsafe impl ::windows::core::Abi for STORAGE_TEMPERATURE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_TEMPERATURE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_TEMPERATURE_INFO>()) == 0 }
+        self.Index == other.Index && self.Temperature == other.Temperature && self.OverThreshold == other.OverThreshold && self.UnderThreshold == other.UnderThreshold && self.OverThresholdChangable == other.OverThresholdChangable && self.UnderThresholdChangable == other.UnderThresholdChangable && self.EventGenerated == other.EventGenerated && self.Reserved0 == other.Reserved0 && self.Reserved1 == other.Reserved1
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21119,7 +20773,7 @@ unsafe impl ::windows::core::Abi for STORAGE_TEMPERATURE_THRESHOLD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_TEMPERATURE_THRESHOLD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_TEMPERATURE_THRESHOLD>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Flags == other.Flags && self.Index == other.Index && self.Threshold == other.Threshold && self.OverThreshold == other.OverThreshold && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21157,7 +20811,7 @@ unsafe impl ::windows::core::Abi for STORAGE_TIER {
 }
 impl ::core::cmp::PartialEq for STORAGE_TIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_TIER>()) == 0 }
+        self.Id == other.Id && self.Name == other.Name && self.Description == other.Description && self.Flags == other.Flags && self.ProvisionedCapacity == other.ProvisionedCapacity && self.MediaType == other.MediaType && self.Class == other.Class
     }
 }
 impl ::core::cmp::Eq for STORAGE_TIER {}
@@ -21189,7 +20843,7 @@ unsafe impl ::windows::core::Abi for STORAGE_TIER_REGION {
 }
 impl ::core::cmp::PartialEq for STORAGE_TIER_REGION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_TIER_REGION>()) == 0 }
+        self.TierId == other.TierId && self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for STORAGE_TIER_REGION {}
@@ -21243,7 +20897,7 @@ unsafe impl ::windows::core::Abi for STORAGE_WRITE_CACHE_PROPERTY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_WRITE_CACHE_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_WRITE_CACHE_PROPERTY>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.WriteCacheType == other.WriteCacheType && self.WriteCacheEnabled == other.WriteCacheEnabled && self.WriteCacheChangeable == other.WriteCacheChangeable && self.WriteThroughSupported == other.WriteThroughSupported && self.FlushCacheSupported == other.FlushCacheSupported && self.UserDefinedPowerProtection == other.UserDefinedPowerProtection && self.NVCacheEnabled == other.NVCacheEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21279,14 +20933,6 @@ unsafe impl ::windows::core::Abi for STORAGE_ZONED_DEVICE_DESCRIPTOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_ZONED_DEVICE_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONED_DEVICE_DESCRIPTOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_ZONED_DEVICE_DESCRIPTOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_ZONED_DEVICE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21311,14 +20957,6 @@ impl ::core::clone::Clone for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONED_DEVICE_DESCRIPTOR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
     fn default() -> Self {
@@ -21353,7 +20991,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0>()) == 0 }
+        self.OptimalOpenZoneCount == other.OptimalOpenZoneCount && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21393,7 +21031,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1>()) == 0 }
+        self.MaxOpenZoneCount == other.MaxOpenZoneCount && self.UnrestrictedRead == other.UnrestrictedRead && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21437,7 +21075,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ZONE_DESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STORAGE_ZONE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONE_DESCRIPTOR>()) == 0 }
+        self.Size == other.Size && self.ZoneType == other.ZoneType && self.ZoneCondition == other.ZoneCondition && self.ResetWritePointerRecommend == other.ResetWritePointerRecommend && self.Reserved0 == other.Reserved0 && self.ZoneSize == other.ZoneSize && self.WritePointerOffset == other.WritePointerOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21471,7 +21109,7 @@ unsafe impl ::windows::core::Abi for STORAGE_ZONE_GROUP {
 }
 impl ::core::cmp::PartialEq for STORAGE_ZONE_GROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STORAGE_ZONE_GROUP>()) == 0 }
+        self.ZoneCount == other.ZoneCount && self.ZoneType == other.ZoneType && self.ZoneSize == other.ZoneSize
     }
 }
 impl ::core::cmp::Eq for STORAGE_ZONE_GROUP {}
@@ -21502,7 +21140,7 @@ unsafe impl ::windows::core::Abi for STREAMS_ASSOCIATE_ID_INPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for STREAMS_ASSOCIATE_ID_INPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAMS_ASSOCIATE_ID_INPUT_BUFFER>()) == 0 }
+        self.Flags == other.Flags && self.StreamId == other.StreamId
     }
 }
 impl ::core::cmp::Eq for STREAMS_ASSOCIATE_ID_INPUT_BUFFER {}
@@ -21532,7 +21170,7 @@ unsafe impl ::windows::core::Abi for STREAMS_QUERY_ID_OUTPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for STREAMS_QUERY_ID_OUTPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAMS_QUERY_ID_OUTPUT_BUFFER>()) == 0 }
+        self.StreamId == other.StreamId
     }
 }
 impl ::core::cmp::Eq for STREAMS_QUERY_ID_OUTPUT_BUFFER {}
@@ -21565,7 +21203,7 @@ unsafe impl ::windows::core::Abi for STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER {
 }
 impl ::core::cmp::PartialEq for STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER>()) == 0 }
+        self.OptimalWriteSize == other.OptimalWriteSize && self.StreamGranularitySize == other.StreamGranularitySize && self.StreamIdMin == other.StreamIdMin && self.StreamIdMax == other.StreamIdMax
     }
 }
 impl ::core::cmp::Eq for STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER {}
@@ -21589,12 +21227,6 @@ impl ::core::clone::Clone for STREAM_EXTENT_ENTRY {
 unsafe impl ::windows::core::Abi for STREAM_EXTENT_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STREAM_EXTENT_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_EXTENT_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STREAM_EXTENT_ENTRY {}
 impl ::core::default::Default for STREAM_EXTENT_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21614,12 +21246,6 @@ impl ::core::clone::Clone for STREAM_EXTENT_ENTRY_0 {
 unsafe impl ::windows::core::Abi for STREAM_EXTENT_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STREAM_EXTENT_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_EXTENT_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STREAM_EXTENT_ENTRY_0 {}
 impl ::core::default::Default for STREAM_EXTENT_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21641,12 +21267,6 @@ impl ::core::clone::Clone for STREAM_INFORMATION_ENTRY {
 unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY {}
 impl ::core::default::Default for STREAM_INFORMATION_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21669,12 +21289,6 @@ impl ::core::clone::Clone for STREAM_INFORMATION_ENTRY_0 {
 unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY_0 {}
 impl ::core::default::Default for STREAM_INFORMATION_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21704,7 +21318,7 @@ unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY_0_0>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Vdl == other.Vdl
     }
 }
 impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY_0_0 {}
@@ -21735,7 +21349,7 @@ unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY_0_1 {
 }
 impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY_0_1>()) == 0 }
+        self.Class == other.Class && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY_0_1 {}
@@ -21768,7 +21382,7 @@ unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY_0_2 {
 }
 impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY_0_2>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags && self.EaSize == other.EaSize && self.EaInformationOffset == other.EaInformationOffset
     }
 }
 impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY_0_2 {}
@@ -21801,7 +21415,7 @@ unsafe impl ::windows::core::Abi for STREAM_INFORMATION_ENTRY_0_3 {
 }
 impl ::core::cmp::PartialEq for STREAM_INFORMATION_ENTRY_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_INFORMATION_ENTRY_0_3>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags && self.ReparseDataSize == other.ReparseDataSize && self.ReparseDataOffset == other.ReparseDataOffset
     }
 }
 impl ::core::cmp::Eq for STREAM_INFORMATION_ENTRY_0_3 {}
@@ -21853,7 +21467,7 @@ unsafe impl ::windows::core::Abi for STREAM_LAYOUT_ENTRY {
 }
 impl ::core::cmp::PartialEq for STREAM_LAYOUT_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STREAM_LAYOUT_ENTRY>()) == 0 }
+        self.Version == other.Version && self.NextStreamOffset == other.NextStreamOffset && self.Flags == other.Flags && self.ExtentInformationOffset == other.ExtentInformationOffset && self.AllocationSize == other.AllocationSize && self.EndOfFile == other.EndOfFile && self.StreamInformationOffset == other.StreamInformationOffset && self.AttributeTypeCode == other.AttributeTypeCode && self.AttributeFlags == other.AttributeFlags && self.StreamIdentifierLength == other.StreamIdentifierLength && self.StreamIdentifier == other.StreamIdentifier
     }
 }
 impl ::core::cmp::Eq for STREAM_LAYOUT_ENTRY {}
@@ -21883,7 +21497,7 @@ unsafe impl ::windows::core::Abi for TAPE_GET_STATISTICS {
 }
 impl ::core::cmp::PartialEq for TAPE_GET_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_GET_STATISTICS>()) == 0 }
+        self.Operation == other.Operation
     }
 }
 impl ::core::cmp::Eq for TAPE_GET_STATISTICS {}
@@ -21920,7 +21534,7 @@ unsafe impl ::windows::core::Abi for TAPE_STATISTICS {
 }
 impl ::core::cmp::PartialEq for TAPE_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_STATISTICS>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.RecoveredWrites == other.RecoveredWrites && self.UnrecoveredWrites == other.UnrecoveredWrites && self.RecoveredReads == other.RecoveredReads && self.UnrecoveredReads == other.UnrecoveredReads && self.CompressionRatioReads == other.CompressionRatioReads && self.CompressionRatioWrites == other.CompressionRatioWrites
     }
 }
 impl ::core::cmp::Eq for TAPE_STATISTICS {}
@@ -21953,7 +21567,7 @@ unsafe impl ::windows::core::Abi for TXFS_CREATE_MINIVERSION_INFO {
 }
 impl ::core::cmp::PartialEq for TXFS_CREATE_MINIVERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_CREATE_MINIVERSION_INFO>()) == 0 }
+        self.StructureVersion == other.StructureVersion && self.StructureLength == other.StructureLength && self.BaseVersion == other.BaseVersion && self.MiniVersion == other.MiniVersion
     }
 }
 impl ::core::cmp::Eq for TXFS_CREATE_MINIVERSION_INFO {}
@@ -21986,7 +21600,7 @@ unsafe impl ::windows::core::Abi for TXFS_GET_METADATA_INFO_OUT {
 }
 impl ::core::cmp::PartialEq for TXFS_GET_METADATA_INFO_OUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_GET_METADATA_INFO_OUT>()) == 0 }
+        self.TxfFileId == other.TxfFileId && self.LockingTransaction == other.LockingTransaction && self.LastLsn == other.LastLsn && self.TransactionState == other.TransactionState
     }
 }
 impl ::core::cmp::Eq for TXFS_GET_METADATA_INFO_OUT {}
@@ -22017,7 +21631,7 @@ unsafe impl ::windows::core::Abi for TXFS_GET_METADATA_INFO_OUT_0 {
 }
 impl ::core::cmp::PartialEq for TXFS_GET_METADATA_INFO_OUT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_GET_METADATA_INFO_OUT_0>()) == 0 }
+        self.LowPart == other.LowPart && self.HighPart == other.HighPart
     }
 }
 impl ::core::cmp::Eq for TXFS_GET_METADATA_INFO_OUT_0 {}
@@ -22051,7 +21665,7 @@ unsafe impl ::windows::core::Abi for TXFS_GET_TRANSACTED_VERSION {
 }
 impl ::core::cmp::PartialEq for TXFS_GET_TRANSACTED_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_GET_TRANSACTED_VERSION>()) == 0 }
+        self.ThisBaseVersion == other.ThisBaseVersion && self.LatestVersion == other.LatestVersion && self.ThisMiniVersion == other.ThisMiniVersion && self.FirstMiniVersion == other.FirstMiniVersion && self.LatestMiniVersion == other.LatestMiniVersion
     }
 }
 impl ::core::cmp::Eq for TXFS_GET_TRANSACTED_VERSION {}
@@ -22082,7 +21696,7 @@ unsafe impl ::windows::core::Abi for TXFS_LIST_TRANSACTIONS {
 }
 impl ::core::cmp::PartialEq for TXFS_LIST_TRANSACTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_LIST_TRANSACTIONS>()) == 0 }
+        self.NumberOfTransactions == other.NumberOfTransactions && self.BufferSizeRequired == other.BufferSizeRequired
     }
 }
 impl ::core::cmp::Eq for TXFS_LIST_TRANSACTIONS {}
@@ -22116,7 +21730,7 @@ unsafe impl ::windows::core::Abi for TXFS_LIST_TRANSACTIONS_ENTRY {
 }
 impl ::core::cmp::PartialEq for TXFS_LIST_TRANSACTIONS_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_LIST_TRANSACTIONS_ENTRY>()) == 0 }
+        self.TransactionId == other.TransactionId && self.TransactionState == other.TransactionState && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3
     }
 }
 impl ::core::cmp::Eq for TXFS_LIST_TRANSACTIONS_ENTRY {}
@@ -22149,7 +21763,7 @@ unsafe impl ::windows::core::Abi for TXFS_LIST_TRANSACTION_LOCKED_FILES {
 }
 impl ::core::cmp::PartialEq for TXFS_LIST_TRANSACTION_LOCKED_FILES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_LIST_TRANSACTION_LOCKED_FILES>()) == 0 }
+        self.KtmTransaction == other.KtmTransaction && self.NumberOfFiles == other.NumberOfFiles && self.BufferSizeRequired == other.BufferSizeRequired && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for TXFS_LIST_TRANSACTION_LOCKED_FILES {}
@@ -22185,7 +21799,7 @@ unsafe impl ::windows::core::Abi for TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY {
 }
 impl ::core::cmp::PartialEq for TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY>()) == 0 }
+        self.Offset == other.Offset && self.NameFlags == other.NameFlags && self.FileId == other.FileId && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY {}
@@ -22222,7 +21836,7 @@ unsafe impl ::windows::core::Abi for TXFS_MODIFY_RM {
 }
 impl ::core::cmp::PartialEq for TXFS_MODIFY_RM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_MODIFY_RM>()) == 0 }
+        self.Flags == other.Flags && self.LogContainerCountMax == other.LogContainerCountMax && self.LogContainerCountMin == other.LogContainerCountMin && self.LogContainerCount == other.LogContainerCount && self.LogGrowthIncrement == other.LogGrowthIncrement && self.LogAutoShrinkPercentage == other.LogAutoShrinkPercentage && self.Reserved == other.Reserved && self.LoggingMode == other.LoggingMode
     }
 }
 impl ::core::cmp::Eq for TXFS_MODIFY_RM {}
@@ -22304,7 +21918,32 @@ unsafe impl ::windows::core::Abi for TXFS_QUERY_RM_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TXFS_QUERY_RM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_QUERY_RM_INFORMATION>()) == 0 }
+        self.BytesRequired == other.BytesRequired
+            && self.TailLsn == other.TailLsn
+            && self.CurrentLsn == other.CurrentLsn
+            && self.ArchiveTailLsn == other.ArchiveTailLsn
+            && self.LogContainerSize == other.LogContainerSize
+            && self.HighestVirtualClock == other.HighestVirtualClock
+            && self.LogContainerCount == other.LogContainerCount
+            && self.LogContainerCountMax == other.LogContainerCountMax
+            && self.LogContainerCountMin == other.LogContainerCountMin
+            && self.LogGrowthIncrement == other.LogGrowthIncrement
+            && self.LogAutoShrinkPercentage == other.LogAutoShrinkPercentage
+            && self.Flags == other.Flags
+            && self.LoggingMode == other.LoggingMode
+            && self.Reserved == other.Reserved
+            && self.RmState == other.RmState
+            && self.LogCapacity == other.LogCapacity
+            && self.LogFree == other.LogFree
+            && self.TopsSize == other.TopsSize
+            && self.TopsUsed == other.TopsUsed
+            && self.TransactionCount == other.TransactionCount
+            && self.OnePCCount == other.OnePCCount
+            && self.TwoPCCount == other.TwoPCCount
+            && self.NumberLogFileFull == other.NumberLogFileFull
+            && self.OldestTransactionAge == other.OldestTransactionAge
+            && self.RMName == other.RMName
+            && self.TmLogPathOffset == other.TmLogPathOffset
     }
 }
 impl ::core::cmp::Eq for TXFS_QUERY_RM_INFORMATION {}
@@ -22327,12 +21966,6 @@ impl ::core::clone::Clone for TXFS_READ_BACKUP_INFORMATION_OUT {
 unsafe impl ::windows::core::Abi for TXFS_READ_BACKUP_INFORMATION_OUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXFS_READ_BACKUP_INFORMATION_OUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_READ_BACKUP_INFORMATION_OUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXFS_READ_BACKUP_INFORMATION_OUT {}
 impl ::core::default::Default for TXFS_READ_BACKUP_INFORMATION_OUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22353,12 +21986,6 @@ impl ::core::clone::Clone for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
 unsafe impl ::windows::core::Abi for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_READ_BACKUP_INFORMATION_OUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TXFS_READ_BACKUP_INFORMATION_OUT_0 {}
 impl ::core::default::Default for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22388,7 +22015,7 @@ unsafe impl ::windows::core::Abi for TXFS_ROLLFORWARD_REDO_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TXFS_ROLLFORWARD_REDO_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_ROLLFORWARD_REDO_INFORMATION>()) == 0 }
+        self.LastVirtualClock == other.LastVirtualClock && self.LastRedoLsn == other.LastRedoLsn && self.HighestRecoveryLsn == other.HighestRecoveryLsn && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for TXFS_ROLLFORWARD_REDO_INFORMATION {}
@@ -22426,7 +22053,7 @@ unsafe impl ::windows::core::Abi for TXFS_SAVEPOINT_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TXFS_SAVEPOINT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_SAVEPOINT_INFORMATION>()) == 0 }
+        self.KtmTransaction == other.KtmTransaction && self.ActionCode == other.ActionCode && self.SavepointId == other.SavepointId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22482,7 +22109,7 @@ unsafe impl ::windows::core::Abi for TXFS_START_RM_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TXFS_START_RM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_START_RM_INFORMATION>()) == 0 }
+        self.Flags == other.Flags && self.LogContainerSize == other.LogContainerSize && self.LogContainerCountMin == other.LogContainerCountMin && self.LogContainerCountMax == other.LogContainerCountMax && self.LogGrowthIncrement == other.LogGrowthIncrement && self.LogAutoShrinkPercentage == other.LogAutoShrinkPercentage && self.TmLogPathOffset == other.TmLogPathOffset && self.TmLogPathLength == other.TmLogPathLength && self.LoggingMode == other.LoggingMode && self.LogPathLength == other.LogPathLength && self.Reserved == other.Reserved && self.LogPath == other.LogPath
     }
 }
 impl ::core::cmp::Eq for TXFS_START_RM_INFORMATION {}
@@ -22518,7 +22145,7 @@ unsafe impl ::windows::core::Abi for TXFS_TRANSACTION_ACTIVE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TXFS_TRANSACTION_ACTIVE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_TRANSACTION_ACTIVE_INFO>()) == 0 }
+        self.TransactionsActiveAtSnapshot == other.TransactionsActiveAtSnapshot
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22550,7 +22177,7 @@ unsafe impl ::windows::core::Abi for TXFS_WRITE_BACKUP_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TXFS_WRITE_BACKUP_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TXFS_WRITE_BACKUP_INFORMATION>()) == 0 }
+        self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for TXFS_WRITE_BACKUP_INFORMATION {}
@@ -22586,7 +22213,7 @@ unsafe impl ::windows::core::Abi for USN_JOURNAL_DATA_V0 {
 }
 impl ::core::cmp::PartialEq for USN_JOURNAL_DATA_V0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_JOURNAL_DATA_V0>()) == 0 }
+        self.UsnJournalID == other.UsnJournalID && self.FirstUsn == other.FirstUsn && self.NextUsn == other.NextUsn && self.LowestValidUsn == other.LowestValidUsn && self.MaxUsn == other.MaxUsn && self.MaximumSize == other.MaximumSize && self.AllocationDelta == other.AllocationDelta
     }
 }
 impl ::core::cmp::Eq for USN_JOURNAL_DATA_V0 {}
@@ -22624,7 +22251,7 @@ unsafe impl ::windows::core::Abi for USN_JOURNAL_DATA_V1 {
 }
 impl ::core::cmp::PartialEq for USN_JOURNAL_DATA_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_JOURNAL_DATA_V1>()) == 0 }
+        self.UsnJournalID == other.UsnJournalID && self.FirstUsn == other.FirstUsn && self.NextUsn == other.NextUsn && self.LowestValidUsn == other.LowestValidUsn && self.MaxUsn == other.MaxUsn && self.MaximumSize == other.MaximumSize && self.AllocationDelta == other.AllocationDelta && self.MinSupportedMajorVersion == other.MinSupportedMajorVersion && self.MaxSupportedMajorVersion == other.MaxSupportedMajorVersion
     }
 }
 impl ::core::cmp::Eq for USN_JOURNAL_DATA_V1 {}
@@ -22678,7 +22305,7 @@ unsafe impl ::windows::core::Abi for USN_JOURNAL_DATA_V2 {
 }
 impl ::core::cmp::PartialEq for USN_JOURNAL_DATA_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_JOURNAL_DATA_V2>()) == 0 }
+        self.UsnJournalID == other.UsnJournalID && self.FirstUsn == other.FirstUsn && self.NextUsn == other.NextUsn && self.LowestValidUsn == other.LowestValidUsn && self.MaxUsn == other.MaxUsn && self.MaximumSize == other.MaximumSize && self.AllocationDelta == other.AllocationDelta && self.MinSupportedMajorVersion == other.MinSupportedMajorVersion && self.MaxSupportedMajorVersion == other.MaxSupportedMajorVersion && self.Flags == other.Flags && self.RangeTrackChunkSize == other.RangeTrackChunkSize && self.RangeTrackFileSizeThreshold == other.RangeTrackFileSizeThreshold
     }
 }
 impl ::core::cmp::Eq for USN_JOURNAL_DATA_V2 {}
@@ -22708,7 +22335,7 @@ unsafe impl ::windows::core::Abi for USN_RANGE_TRACK_OUTPUT {
 }
 impl ::core::cmp::PartialEq for USN_RANGE_TRACK_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RANGE_TRACK_OUTPUT>()) == 0 }
+        self.Usn == other.Usn
     }
 }
 impl ::core::cmp::Eq for USN_RANGE_TRACK_OUTPUT {}
@@ -22740,7 +22367,7 @@ unsafe impl ::windows::core::Abi for USN_RECORD_COMMON_HEADER {
 }
 impl ::core::cmp::PartialEq for USN_RECORD_COMMON_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_COMMON_HEADER>()) == 0 }
+        self.RecordLength == other.RecordLength && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for USN_RECORD_COMMON_HEADER {}
@@ -22771,7 +22398,7 @@ unsafe impl ::windows::core::Abi for USN_RECORD_EXTENT {
 }
 impl ::core::cmp::PartialEq for USN_RECORD_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_EXTENT>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for USN_RECORD_EXTENT {}
@@ -22801,14 +22428,6 @@ impl ::core::clone::Clone for USN_RECORD_UNION {
 unsafe impl ::windows::core::Abi for USN_RECORD_UNION {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::PartialEq for USN_RECORD_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_UNION>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl ::core::cmp::Eq for USN_RECORD_UNION {}
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::default::Default for USN_RECORD_UNION {
     fn default() -> Self {
@@ -22864,7 +22483,7 @@ unsafe impl ::windows::core::Abi for USN_RECORD_V2 {
 }
 impl ::core::cmp::PartialEq for USN_RECORD_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_V2>()) == 0 }
+        self.RecordLength == other.RecordLength && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.FileReferenceNumber == other.FileReferenceNumber && self.ParentFileReferenceNumber == other.ParentFileReferenceNumber && self.Usn == other.Usn && self.TimeStamp == other.TimeStamp && self.Reason == other.Reason && self.SourceInfo == other.SourceInfo && self.SecurityId == other.SecurityId && self.FileAttributes == other.FileAttributes && self.FileNameLength == other.FileNameLength && self.FileNameOffset == other.FileNameOffset && self.FileName == other.FileName
     }
 }
 impl ::core::cmp::Eq for USN_RECORD_V2 {}
@@ -22928,7 +22547,7 @@ unsafe impl ::windows::core::Abi for USN_RECORD_V3 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for USN_RECORD_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_V3>()) == 0 }
+        self.RecordLength == other.RecordLength && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.FileReferenceNumber == other.FileReferenceNumber && self.ParentFileReferenceNumber == other.ParentFileReferenceNumber && self.Usn == other.Usn && self.TimeStamp == other.TimeStamp && self.Reason == other.Reason && self.SourceInfo == other.SourceInfo && self.SecurityId == other.SecurityId && self.FileAttributes == other.FileAttributes && self.FileNameLength == other.FileNameLength && self.FileNameOffset == other.FileNameOffset && self.FileName == other.FileName
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -22975,7 +22594,7 @@ unsafe impl ::windows::core::Abi for USN_RECORD_V4 {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for USN_RECORD_V4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_RECORD_V4>()) == 0 }
+        self.Header == other.Header && self.FileReferenceNumber == other.FileReferenceNumber && self.ParentFileReferenceNumber == other.ParentFileReferenceNumber && self.Usn == other.Usn && self.Reason == other.Reason && self.SourceInfo == other.SourceInfo && self.RemainingExtents == other.RemainingExtents && self.NumberOfExtents == other.NumberOfExtents && self.ExtentSize == other.ExtentSize && self.Extents == other.Extents
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -23010,7 +22629,7 @@ unsafe impl ::windows::core::Abi for USN_TRACK_MODIFIED_RANGES {
 }
 impl ::core::cmp::PartialEq for USN_TRACK_MODIFIED_RANGES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USN_TRACK_MODIFIED_RANGES>()) == 0 }
+        self.Flags == other.Flags && self.Unused == other.Unused && self.ChunkSize == other.ChunkSize && self.FileSizeThreshold == other.FileSizeThreshold
     }
 }
 impl ::core::cmp::Eq for USN_TRACK_MODIFIED_RANGES {}
@@ -23041,7 +22660,7 @@ unsafe impl ::windows::core::Abi for VERIFY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VERIFY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VERIFY_INFORMATION>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for VERIFY_INFORMATION {}
@@ -23072,7 +22691,7 @@ unsafe impl ::windows::core::Abi for VIRTUALIZATION_INSTANCE_INFO_INPUT {
 }
 impl ::core::cmp::PartialEq for VIRTUALIZATION_INSTANCE_INFO_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUALIZATION_INSTANCE_INFO_INPUT>()) == 0 }
+        self.NumberOfWorkerThreads == other.NumberOfWorkerThreads && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for VIRTUALIZATION_INSTANCE_INFO_INPUT {}
@@ -23106,7 +22725,7 @@ unsafe impl ::windows::core::Abi for VIRTUALIZATION_INSTANCE_INFO_INPUT_EX {
 }
 impl ::core::cmp::PartialEq for VIRTUALIZATION_INSTANCE_INFO_INPUT_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUALIZATION_INSTANCE_INFO_INPUT_EX>()) == 0 }
+        self.HeaderSize == other.HeaderSize && self.Flags == other.Flags && self.NotificationInfoSize == other.NotificationInfoSize && self.NotificationInfoOffset == other.NotificationInfoOffset && self.ProviderMajorVersion == other.ProviderMajorVersion
     }
 }
 impl ::core::cmp::Eq for VIRTUALIZATION_INSTANCE_INFO_INPUT_EX {}
@@ -23136,7 +22755,7 @@ unsafe impl ::windows::core::Abi for VIRTUALIZATION_INSTANCE_INFO_OUTPUT {
 }
 impl ::core::cmp::PartialEq for VIRTUALIZATION_INSTANCE_INFO_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUALIZATION_INSTANCE_INFO_OUTPUT>()) == 0 }
+        self.VirtualizationInstanceID == other.VirtualizationInstanceID
     }
 }
 impl ::core::cmp::Eq for VIRTUALIZATION_INSTANCE_INFO_OUTPUT {}
@@ -23167,7 +22786,7 @@ unsafe impl ::windows::core::Abi for VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT {
 }
 impl ::core::cmp::PartialEq for VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT>()) == 0 }
+        self.Size == other.Size && self.BehaviorCode == other.BehaviorCode
     }
 }
 impl ::core::cmp::Eq for VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT {}
@@ -23199,7 +22818,7 @@ unsafe impl ::windows::core::Abi for VOLUME_BITMAP_BUFFER {
 }
 impl ::core::cmp::PartialEq for VOLUME_BITMAP_BUFFER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_BITMAP_BUFFER>()) == 0 }
+        self.StartingLcn == other.StartingLcn && self.BitmapSize == other.BitmapSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for VOLUME_BITMAP_BUFFER {}
@@ -23230,7 +22849,7 @@ unsafe impl ::windows::core::Abi for VOLUME_DISK_EXTENTS {
 }
 impl ::core::cmp::PartialEq for VOLUME_DISK_EXTENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_DISK_EXTENTS>()) == 0 }
+        self.NumberOfDiskExtents == other.NumberOfDiskExtents && self.Extents == other.Extents
     }
 }
 impl ::core::cmp::Eq for VOLUME_DISK_EXTENTS {}
@@ -23260,7 +22879,7 @@ unsafe impl ::windows::core::Abi for VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {
 }
 impl ::core::cmp::PartialEq for VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VOLUME_GET_GPT_ATTRIBUTES_INFORMATION>()) == 0 }
+        self.GptAttributes == other.GptAttributes
     }
 }
 impl ::core::cmp::Eq for VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {}
@@ -23293,7 +22912,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_ADD_OVERLAY_INPUT {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_ADD_OVERLAY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_ADD_OVERLAY_INPUT>()) == 0 }
+        self.WimType == other.WimType && self.WimIndex == other.WimIndex && self.WimFileNameOffset == other.WimFileNameOffset && self.WimFileNameLength == other.WimFileNameLength
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_ADD_OVERLAY_INPUT {}
@@ -23326,7 +22945,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_EXTERNAL_INFO {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_EXTERNAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_EXTERNAL_INFO>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.DataSourceId == other.DataSourceId && self.ResourceHash == other.ResourceHash
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_EXTERNAL_INFO {}
@@ -23362,7 +22981,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_OVERLAY_ENTRY {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_OVERLAY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_OVERLAY_ENTRY>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.DataSourceId == other.DataSourceId && self.WimGuid == other.WimGuid && self.WimFileNameOffset == other.WimFileNameOffset && self.WimType == other.WimType && self.WimIndex == other.WimIndex && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_OVERLAY_ENTRY {}
@@ -23392,7 +23011,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_REMOVE_OVERLAY_INPUT {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_REMOVE_OVERLAY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_REMOVE_OVERLAY_INPUT>()) == 0 }
+        self.DataSourceId == other.DataSourceId
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_REMOVE_OVERLAY_INPUT {}
@@ -23422,7 +23041,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_SUSPEND_OVERLAY_INPUT>()) == 0 }
+        self.DataSourceId == other.DataSourceId
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {}
@@ -23454,7 +23073,7 @@ unsafe impl ::windows::core::Abi for WIM_PROVIDER_UPDATE_OVERLAY_INPUT {
 }
 impl ::core::cmp::PartialEq for WIM_PROVIDER_UPDATE_OVERLAY_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIM_PROVIDER_UPDATE_OVERLAY_INPUT>()) == 0 }
+        self.DataSourceId == other.DataSourceId && self.WimFileNameOffset == other.WimFileNameOffset && self.WimFileNameLength == other.WimFileNameLength
     }
 }
 impl ::core::cmp::Eq for WIM_PROVIDER_UPDATE_OVERLAY_INPUT {}
@@ -23490,7 +23109,7 @@ unsafe impl ::windows::core::Abi for WOF_EXTERNAL_FILE_ID {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl ::core::cmp::PartialEq for WOF_EXTERNAL_FILE_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOF_EXTERNAL_FILE_ID>()) == 0 }
+        self.FileId == other.FileId
     }
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -23523,7 +23142,7 @@ unsafe impl ::windows::core::Abi for WOF_EXTERNAL_INFO {
 }
 impl ::core::cmp::PartialEq for WOF_EXTERNAL_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOF_EXTERNAL_INFO>()) == 0 }
+        self.Version == other.Version && self.Provider == other.Provider
     }
 }
 impl ::core::cmp::Eq for WOF_EXTERNAL_INFO {}
@@ -23553,7 +23172,7 @@ unsafe impl ::windows::core::Abi for WOF_VERSION_INFO {
 }
 impl ::core::cmp::PartialEq for WOF_VERSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WOF_VERSION_INFO>()) == 0 }
+        self.WofVersion == other.WofVersion
     }
 }
 impl ::core::cmp::Eq for WOF_VERSION_INFO {}
@@ -23584,7 +23203,7 @@ unsafe impl ::windows::core::Abi for WRITE_USN_REASON_INPUT {
 }
 impl ::core::cmp::PartialEq for WRITE_USN_REASON_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRITE_USN_REASON_INPUT>()) == 0 }
+        self.Flags == other.Flags && self.UsnReasonToWrite == other.UsnReasonToWrite
     }
 }
 impl ::core::cmp::Eq for WRITE_USN_REASON_INPUT {}

--- a/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
@@ -793,7 +793,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_ASSOCIATE_COMPLETION_PORT>()) == 0 }
+        self.CompletionKey == other.CompletionKey && self.CompletionPort == other.CompletionPort
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -841,7 +841,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>()) == 0 }
+        self.TotalUserTime == other.TotalUserTime && self.TotalKernelTime == other.TotalKernelTime && self.ThisPeriodTotalUserTime == other.ThisPeriodTotalUserTime && self.ThisPeriodTotalKernelTime == other.ThisPeriodTotalKernelTime && self.TotalPageFaultCount == other.TotalPageFaultCount && self.TotalProcesses == other.TotalProcesses && self.ActiveProcesses == other.ActiveProcesses && self.TotalTerminatedProcesses == other.TotalTerminatedProcesses
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {}
@@ -878,7 +878,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATI
 #[cfg(feature = "Win32_System_Threading")]
 impl ::core::cmp::PartialEq for JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION>()) == 0 }
+        self.BasicInfo == other.BasicInfo && self.IoInfo == other.IoInfo
     }
 }
 #[cfg(feature = "Win32_System_Threading")]
@@ -928,7 +928,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_BASIC_LIMIT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_BASIC_LIMIT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_BASIC_LIMIT_INFORMATION>()) == 0 }
+        self.PerProcessUserTimeLimit == other.PerProcessUserTimeLimit && self.PerJobUserTimeLimit == other.PerJobUserTimeLimit && self.LimitFlags == other.LimitFlags && self.MinimumWorkingSetSize == other.MinimumWorkingSetSize && self.MaximumWorkingSetSize == other.MaximumWorkingSetSize && self.ActiveProcessLimit == other.ActiveProcessLimit && self.Affinity == other.Affinity && self.PriorityClass == other.PriorityClass && self.SchedulingClass == other.SchedulingClass
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_BASIC_LIMIT_INFORMATION {}
@@ -960,7 +960,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_BASIC_PROCESS_ID_LIST {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_BASIC_PROCESS_ID_LIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_BASIC_PROCESS_ID_LIST>()) == 0 }
+        self.NumberOfAssignedProcesses == other.NumberOfAssignedProcesses && self.NumberOfProcessIdsInList == other.NumberOfProcessIdsInList && self.ProcessIdList == other.ProcessIdList
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_BASIC_PROCESS_ID_LIST {}
@@ -990,7 +990,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_BASIC_UI_RESTRICTIONS {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_BASIC_UI_RESTRICTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_BASIC_UI_RESTRICTIONS>()) == 0 }
+        self.UIRestrictionsClass == other.UIRestrictionsClass
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_BASIC_UI_RESTRICTIONS {}
@@ -1014,12 +1014,6 @@ impl ::core::clone::Clone for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
 unsafe impl ::windows::core::Abi for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {}
 impl ::core::default::Default for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1041,12 +1035,6 @@ impl ::core::clone::Clone for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {}
 impl ::core::default::Default for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1074,7 +1062,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0>()) == 0 }
+        self.MinRate == other.MinRate && self.MaxRate == other.MaxRate
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 {}
@@ -1104,7 +1092,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_END_OF_JOB_TIME_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_END_OF_JOB_TIME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_END_OF_JOB_TIME_INFORMATION>()) == 0 }
+        self.EndOfJobTimeAction == other.EndOfJobTimeAction
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_END_OF_JOB_TIME_INFORMATION {}
@@ -1145,7 +1133,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
 #[cfg(feature = "Win32_System_Threading")]
 impl ::core::cmp::PartialEq for JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>()) == 0 }
+        self.BasicLimitInformation == other.BasicLimitInformation && self.IoInfo == other.IoInfo && self.ProcessMemoryLimit == other.ProcessMemoryLimit && self.JobMemoryLimit == other.JobMemoryLimit && self.PeakProcessMemoryUsed == other.PeakProcessMemoryUsed && self.PeakJobMemoryUsed == other.PeakJobMemoryUsed
     }
 }
 #[cfg(feature = "Win32_System_Threading")]
@@ -1179,7 +1167,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_ATTRIBUTION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_ATTRIBUTION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_ATTRIBUTION_INFORMATION>()) == 0 }
+        self.ControlFlags == other.ControlFlags && self.ReadStats == other.ReadStats && self.WriteStats == other.WriteStats
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_IO_ATTRIBUTION_INFORMATION {}
@@ -1212,7 +1200,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_ATTRIBUTION_STATS {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_ATTRIBUTION_STATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_ATTRIBUTION_STATS>()) == 0 }
+        self.IoCount == other.IoCount && self.TotalNonOverlappedQueueTime == other.TotalNonOverlappedQueueTime && self.TotalNonOverlappedServiceTime == other.TotalNonOverlappedServiceTime && self.TotalSize == other.TotalSize
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_IO_ATTRIBUTION_STATS {}
@@ -1247,7 +1235,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_RATE_CONTROL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_RATE_CONTROL_INFORMATION>()) == 0 }
+        self.MaxIops == other.MaxIops && self.MaxBandwidth == other.MaxBandwidth && self.ReservationIops == other.ReservationIops && self.VolumeName == other.VolumeName && self.BaseIoSize == other.BaseIoSize && self.ControlFlags == other.ControlFlags
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION {}
@@ -1303,7 +1291,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIV
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V2>()) == 0 }
+        self.MaxIops == other.MaxIops && self.MaxBandwidth == other.MaxBandwidth && self.ReservationIops == other.ReservationIops && self.VolumeName == other.VolumeName && self.BaseIoSize == other.BaseIoSize && self.ControlFlags == other.ControlFlags && self.VolumeNameLength == other.VolumeNameLength && self.CriticalReservationIops == other.CriticalReservationIops && self.ReservationBandwidth == other.ReservationBandwidth && self.CriticalReservationBandwidth == other.CriticalReservationBandwidth && self.MaxTimePercent == other.MaxTimePercent && self.ReservationTimePercent == other.ReservationTimePercent && self.CriticalReservationTimePercent == other.CriticalReservationTimePercent
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V2 {}
@@ -1371,7 +1359,25 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIV
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V3>()) == 0 }
+        self.MaxIops == other.MaxIops
+            && self.MaxBandwidth == other.MaxBandwidth
+            && self.ReservationIops == other.ReservationIops
+            && self.VolumeName == other.VolumeName
+            && self.BaseIoSize == other.BaseIoSize
+            && self.ControlFlags == other.ControlFlags
+            && self.VolumeNameLength == other.VolumeNameLength
+            && self.CriticalReservationIops == other.CriticalReservationIops
+            && self.ReservationBandwidth == other.ReservationBandwidth
+            && self.CriticalReservationBandwidth == other.CriticalReservationBandwidth
+            && self.MaxTimePercent == other.MaxTimePercent
+            && self.ReservationTimePercent == other.ReservationTimePercent
+            && self.CriticalReservationTimePercent == other.CriticalReservationTimePercent
+            && self.SoftMaxIops == other.SoftMaxIops
+            && self.SoftMaxBandwidth == other.SoftMaxBandwidth
+            && self.SoftMaxTimePercent == other.SoftMaxTimePercent
+            && self.LimitExcessNotifyIops == other.LimitExcessNotifyIops
+            && self.LimitExcessNotifyBandwidth == other.LimitExcessNotifyBandwidth
+            && self.LimitExcessNotifyTimePercent == other.LimitExcessNotifyTimePercent
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V3 {}
@@ -1401,7 +1407,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_JOBSET_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_JOBSET_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_JOBSET_INFORMATION>()) == 0 }
+        self.MemberLevel == other.MemberLevel
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_JOBSET_INFORMATION {}
@@ -1455,7 +1461,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_LIMIT_VIOLATION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_LIMIT_VIOLATION_INFORMATION>()) == 0 }
+        self.LimitFlags == other.LimitFlags && self.ViolationLimitFlags == other.ViolationLimitFlags && self.IoReadBytes == other.IoReadBytes && self.IoReadBytesLimit == other.IoReadBytesLimit && self.IoWriteBytes == other.IoWriteBytes && self.IoWriteBytesLimit == other.IoWriteBytesLimit && self.PerJobUserTime == other.PerJobUserTime && self.PerJobUserTimeLimit == other.PerJobUserTimeLimit && self.JobMemory == other.JobMemory && self.JobMemoryLimit == other.JobMemoryLimit && self.RateControlTolerance == other.RateControlTolerance && self.RateControlToleranceLimit == other.RateControlToleranceLimit
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION {}
@@ -1494,12 +1500,6 @@ impl ::core::clone::Clone for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {}
 impl ::core::default::Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1520,12 +1520,6 @@ impl ::core::clone::Clone for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {}
 impl ::core::default::Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1546,12 +1540,6 @@ impl ::core::clone::Clone for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {}
 impl ::core::default::Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1572,12 +1560,6 @@ impl ::core::clone::Clone for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {}
 impl ::core::default::Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1606,7 +1588,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_NET_RATE_CONTROL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_NET_RATE_CONTROL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NET_RATE_CONTROL_INFORMATION>()) == 0 }
+        self.MaxBandwidth == other.MaxBandwidth && self.ControlFlags == other.ControlFlags && self.DscpTag == other.DscpTag
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_NET_RATE_CONTROL_INFORMATION {}
@@ -1642,7 +1624,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION>()) == 0 }
+        self.IoReadBytesLimit == other.IoReadBytesLimit && self.IoWriteBytesLimit == other.IoWriteBytesLimit && self.PerJobUserTimeLimit == other.PerJobUserTimeLimit && self.JobMemoryLimit == other.JobMemoryLimit && self.RateControlTolerance == other.RateControlTolerance && self.RateControlToleranceInterval == other.RateControlToleranceInterval && self.LimitFlags == other.LimitFlags
     }
 }
 impl ::core::cmp::Eq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION {}
@@ -1676,12 +1658,6 @@ impl ::core::clone::Clone for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {}
 impl ::core::default::Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1702,12 +1678,6 @@ impl ::core::clone::Clone for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {}
 impl ::core::default::Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1728,12 +1698,6 @@ impl ::core::clone::Clone for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {}
 impl ::core::default::Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1754,12 +1718,6 @@ impl ::core::clone::Clone for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
 unsafe impl ::windows::core::Abi for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {}
 impl ::core::default::Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1796,7 +1754,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_SECURITY_LIMIT_INFORMATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::cmp::PartialEq for JOBOBJECT_SECURITY_LIMIT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_SECURITY_LIMIT_INFORMATION>()) == 0 }
+        self.SecurityLimitFlags == other.SecurityLimitFlags && self.JobToken == other.JobToken && self.SidsToDisable == other.SidsToDisable && self.PrivilegesToDelete == other.PrivilegesToDelete && self.RestrictedSids == other.RestrictedSids
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -1836,7 +1794,7 @@ unsafe impl ::windows::core::Abi for JOB_SET_ARRAY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JOB_SET_ARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOB_SET_ARRAY>()) == 0 }
+        self.JobHandle == other.JobHandle && self.MemberLevel == other.MemberLevel && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Kernel/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Kernel/mod.rs
@@ -332,7 +332,7 @@ unsafe impl ::windows::core::Abi for CSTRING {
 }
 impl ::core::cmp::PartialEq for CSTRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CSTRING>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for CSTRING {}
@@ -359,21 +359,13 @@ impl ::core::clone::Clone for EXCEPTION_REGISTRATION_RECORD {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
 impl ::core::fmt::Debug for EXCEPTION_REGISTRATION_RECORD {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("EXCEPTION_REGISTRATION_RECORD").field("Next", &self.Next).field("Handler", &self.Handler.map(|f| f as usize)).finish()
+        f.debug_struct("EXCEPTION_REGISTRATION_RECORD").field("Next", &self.Next).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
 unsafe impl ::windows::core::Abi for EXCEPTION_REGISTRATION_RECORD {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::PartialEq for EXCEPTION_REGISTRATION_RECORD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXCEPTION_REGISTRATION_RECORD>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::Eq for EXCEPTION_REGISTRATION_RECORD {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
 impl ::core::default::Default for EXCEPTION_REGISTRATION_RECORD {
     fn default() -> Self {
@@ -415,7 +407,7 @@ unsafe impl ::windows::core::Abi for FLOATING_SAVE_AREA {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for FLOATING_SAVE_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOATING_SAVE_AREA>()) == 0 }
+        self.ControlWord == other.ControlWord && self.StatusWord == other.StatusWord && self.TagWord == other.TagWord && self.ErrorOffset == other.ErrorOffset && self.ErrorSelector == other.ErrorSelector && self.DataOffset == other.DataOffset && self.DataSelector == other.DataSelector && self.RegisterArea == other.RegisterArea && self.Cr0NpxState == other.Cr0NpxState
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -461,7 +453,7 @@ unsafe impl ::windows::core::Abi for FLOATING_SAVE_AREA {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for FLOATING_SAVE_AREA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLOATING_SAVE_AREA>()) == 0 }
+        self.ControlWord == other.ControlWord && self.StatusWord == other.StatusWord && self.TagWord == other.TagWord && self.ErrorOffset == other.ErrorOffset && self.ErrorSelector == other.ErrorSelector && self.DataOffset == other.DataOffset && self.DataSelector == other.DataSelector && self.RegisterArea == other.RegisterArea && self.Spare0 == other.Spare0
     }
 }
 #[cfg(target_arch = "x86")]
@@ -494,7 +486,7 @@ unsafe impl ::windows::core::Abi for LIST_ENTRY {
 }
 impl ::core::cmp::PartialEq for LIST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIST_ENTRY>()) == 0 }
+        self.Flink == other.Flink && self.Blink == other.Blink
     }
 }
 impl ::core::cmp::Eq for LIST_ENTRY {}
@@ -525,7 +517,7 @@ unsafe impl ::windows::core::Abi for LIST_ENTRY32 {
 }
 impl ::core::cmp::PartialEq for LIST_ENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIST_ENTRY32>()) == 0 }
+        self.Flink == other.Flink && self.Blink == other.Blink
     }
 }
 impl ::core::cmp::Eq for LIST_ENTRY32 {}
@@ -556,7 +548,7 @@ unsafe impl ::windows::core::Abi for LIST_ENTRY64 {
 }
 impl ::core::cmp::PartialEq for LIST_ENTRY64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIST_ENTRY64>()) == 0 }
+        self.Flink == other.Flink && self.Blink == other.Blink
     }
 }
 impl ::core::cmp::Eq for LIST_ENTRY64 {}
@@ -590,14 +582,6 @@ unsafe impl ::windows::core::Abi for NT_TIB {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::PartialEq for NT_TIB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::Eq for NT_TIB {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
 impl ::core::default::Default for NT_TIB {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -622,14 +606,6 @@ impl ::core::clone::Clone for NT_TIB_0 {
 unsafe impl ::windows::core::Abi for NT_TIB_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::PartialEq for NT_TIB_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
-impl ::core::cmp::Eq for NT_TIB_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Diagnostics_Debug"))]
 impl ::core::default::Default for NT_TIB_0 {
     fn default() -> Self {
@@ -658,7 +634,7 @@ unsafe impl ::windows::core::Abi for OBJECTID {
 }
 impl ::core::cmp::PartialEq for OBJECTID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTID>()) == 0 }
+        self.Lineage == other.Lineage && self.Uniquifier == other.Uniquifier
     }
 }
 impl ::core::cmp::Eq for OBJECTID {}
@@ -693,7 +669,7 @@ unsafe impl ::windows::core::Abi for OBJECT_ATTRIBUTES32 {
 }
 impl ::core::cmp::PartialEq for OBJECT_ATTRIBUTES32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECT_ATTRIBUTES32>()) == 0 }
+        self.Length == other.Length && self.RootDirectory == other.RootDirectory && self.ObjectName == other.ObjectName && self.Attributes == other.Attributes && self.SecurityDescriptor == other.SecurityDescriptor && self.SecurityQualityOfService == other.SecurityQualityOfService
     }
 }
 impl ::core::cmp::Eq for OBJECT_ATTRIBUTES32 {}
@@ -728,7 +704,7 @@ unsafe impl ::windows::core::Abi for OBJECT_ATTRIBUTES64 {
 }
 impl ::core::cmp::PartialEq for OBJECT_ATTRIBUTES64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECT_ATTRIBUTES64>()) == 0 }
+        self.Length == other.Length && self.RootDirectory == other.RootDirectory && self.ObjectName == other.ObjectName && self.Attributes == other.Attributes && self.SecurityDescriptor == other.SecurityDescriptor && self.SecurityQualityOfService == other.SecurityQualityOfService
     }
 }
 impl ::core::cmp::Eq for OBJECT_ATTRIBUTES64 {}
@@ -760,7 +736,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_NUMBER {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_NUMBER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_NUMBER>()) == 0 }
+        self.Group == other.Group && self.Number == other.Number && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_NUMBER {}
@@ -783,12 +759,6 @@ impl ::core::clone::Clone for QUAD {
 unsafe impl ::windows::core::Abi for QUAD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUAD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUAD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUAD {}
 impl ::core::default::Default for QUAD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -809,12 +779,6 @@ impl ::core::clone::Clone for QUAD_0 {
 unsafe impl ::windows::core::Abi for QUAD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUAD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUAD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUAD_0 {}
 impl ::core::default::Default for QUAD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -835,12 +799,6 @@ impl ::core::clone::Clone for RTL_BALANCED_NODE {
 unsafe impl ::windows::core::Abi for RTL_BALANCED_NODE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTL_BALANCED_NODE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_BALANCED_NODE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTL_BALANCED_NODE {}
 impl ::core::default::Default for RTL_BALANCED_NODE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -861,12 +819,6 @@ impl ::core::clone::Clone for RTL_BALANCED_NODE_0 {
 unsafe impl ::windows::core::Abi for RTL_BALANCED_NODE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTL_BALANCED_NODE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_BALANCED_NODE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTL_BALANCED_NODE_0 {}
 impl ::core::default::Default for RTL_BALANCED_NODE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -894,7 +846,7 @@ unsafe impl ::windows::core::Abi for RTL_BALANCED_NODE_0_0 {
 }
 impl ::core::cmp::PartialEq for RTL_BALANCED_NODE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_BALANCED_NODE_0_0>()) == 0 }
+        self.Left == other.Left && self.Right == other.Right
     }
 }
 impl ::core::cmp::Eq for RTL_BALANCED_NODE_0_0 {}
@@ -918,12 +870,6 @@ impl ::core::clone::Clone for RTL_BALANCED_NODE_1 {
 unsafe impl ::windows::core::Abi for RTL_BALANCED_NODE_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTL_BALANCED_NODE_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_BALANCED_NODE_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTL_BALANCED_NODE_1 {}
 impl ::core::default::Default for RTL_BALANCED_NODE_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -950,7 +896,7 @@ unsafe impl ::windows::core::Abi for SINGLE_LIST_ENTRY {
 }
 impl ::core::cmp::PartialEq for SINGLE_LIST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SINGLE_LIST_ENTRY>()) == 0 }
+        self.Next == other.Next
     }
 }
 impl ::core::cmp::Eq for SINGLE_LIST_ENTRY {}
@@ -980,7 +926,7 @@ unsafe impl ::windows::core::Abi for SINGLE_LIST_ENTRY32 {
 }
 impl ::core::cmp::PartialEq for SINGLE_LIST_ENTRY32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SINGLE_LIST_ENTRY32>()) == 0 }
+        self.Next == other.Next
     }
 }
 impl ::core::cmp::Eq for SINGLE_LIST_ENTRY32 {}
@@ -1010,7 +956,7 @@ unsafe impl ::windows::core::Abi for SLIST_ENTRY {
 }
 impl ::core::cmp::PartialEq for SLIST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_ENTRY>()) == 0 }
+        self.Next == other.Next
     }
 }
 impl ::core::cmp::Eq for SLIST_ENTRY {}
@@ -1038,14 +984,6 @@ impl ::core::clone::Clone for SLIST_HEADER {
 unsafe impl ::windows::core::Abi for SLIST_HEADER {
     type Abi = Self;
 }
-#[cfg(target_arch = "aarch64")]
-impl ::core::cmp::PartialEq for SLIST_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "aarch64")]
-impl ::core::cmp::Eq for SLIST_HEADER {}
 #[cfg(target_arch = "aarch64")]
 impl ::core::default::Default for SLIST_HEADER {
     fn default() -> Self {
@@ -1080,7 +1018,7 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER_0 {
 #[cfg(target_arch = "aarch64")]
 impl ::core::cmp::PartialEq for SLIST_HEADER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER_0>()) == 0 }
+        self.Alignment == other.Alignment && self.Region == other.Region
     }
 }
 #[cfg(target_arch = "aarch64")]
@@ -1119,7 +1057,7 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER_1 {
 #[cfg(target_arch = "aarch64")]
 impl ::core::cmp::PartialEq for SLIST_HEADER_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER_1>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2
     }
 }
 #[cfg(target_arch = "aarch64")]
@@ -1150,14 +1088,6 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86_64")]
-impl ::core::cmp::PartialEq for SLIST_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86_64")]
-impl ::core::cmp::Eq for SLIST_HEADER {}
-#[cfg(target_arch = "x86_64")]
 impl ::core::default::Default for SLIST_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1191,7 +1121,7 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER_0 {
 #[cfg(target_arch = "x86_64")]
 impl ::core::cmp::PartialEq for SLIST_HEADER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER_0>()) == 0 }
+        self.Alignment == other.Alignment && self.Region == other.Region
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -1230,7 +1160,7 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER_1 {
 #[cfg(target_arch = "x86_64")]
 impl ::core::cmp::PartialEq for SLIST_HEADER_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER_1>()) == 0 }
+        self._bitfield1 == other._bitfield1 && self._bitfield2 == other._bitfield2
     }
 }
 #[cfg(target_arch = "x86_64")]
@@ -1260,14 +1190,6 @@ impl ::core::clone::Clone for SLIST_HEADER {
 unsafe impl ::windows::core::Abi for SLIST_HEADER {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SLIST_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SLIST_HEADER {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SLIST_HEADER {
     fn default() -> Self {
@@ -1303,7 +1225,7 @@ unsafe impl ::windows::core::Abi for SLIST_HEADER_0 {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for SLIST_HEADER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLIST_HEADER_0>()) == 0 }
+        self.Next == other.Next && self.Depth == other.Depth && self.CpuId == other.CpuId
     }
 }
 #[cfg(target_arch = "x86")]
@@ -1337,7 +1259,7 @@ unsafe impl ::windows::core::Abi for STRING {
 }
 impl ::core::cmp::PartialEq for STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRING>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for STRING {}
@@ -1369,7 +1291,7 @@ unsafe impl ::windows::core::Abi for STRING32 {
 }
 impl ::core::cmp::PartialEq for STRING32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRING32>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for STRING32 {}
@@ -1401,7 +1323,7 @@ unsafe impl ::windows::core::Abi for STRING64 {
 }
 impl ::core::cmp::PartialEq for STRING64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRING64>()) == 0 }
+        self.Length == other.Length && self.MaximumLength == other.MaximumLength && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for STRING64 {}
@@ -1431,7 +1353,7 @@ unsafe impl ::windows::core::Abi for WNF_STATE_NAME {
 }
 impl ::core::cmp::PartialEq for WNF_STATE_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNF_STATE_NAME>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for WNF_STATE_NAME {}

--- a/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
@@ -639,7 +639,7 @@ unsafe impl ::windows::core::Abi for ENUMUILANG {
 }
 impl ::core::cmp::PartialEq for ENUMUILANG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMUILANG>()) == 0 }
+        self.NumOfEnumUILang == other.NumOfEnumUILang && self.SizeOfEnumUIBuffer == other.SizeOfEnumUIBuffer && self.pEnumUIBuffer == other.pEnumUIBuffer
     }
 }
 impl ::core::cmp::Eq for ENUMUILANG {}
@@ -671,7 +671,7 @@ unsafe impl ::windows::core::Abi for REDIRECTION_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for REDIRECTION_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REDIRECTION_DESCRIPTOR>()) == 0 }
+        self.Version == other.Version && self.FunctionCount == other.FunctionCount && self.Redirections == other.Redirections
     }
 }
 impl ::core::cmp::Eq for REDIRECTION_DESCRIPTOR {}
@@ -703,7 +703,7 @@ unsafe impl ::windows::core::Abi for REDIRECTION_FUNCTION_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for REDIRECTION_FUNCTION_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REDIRECTION_FUNCTION_DESCRIPTOR>()) == 0 }
+        self.DllName == other.DllName && self.FunctionName == other.FunctionName && self.RedirectionTarget == other.RedirectionTarget
     }
 }
 impl ::core::cmp::Eq for REDIRECTION_FUNCTION_DESCRIPTOR {}

--- a/crates/libs/windows/src/Windows/Win32/System/Mapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mapi/mod.rs
@@ -140,7 +140,7 @@ unsafe impl ::windows::core::Abi for MapiFileDesc {
 }
 impl ::core::cmp::PartialEq for MapiFileDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiFileDesc>()) == 0 }
+        self.ulReserved == other.ulReserved && self.flFlags == other.flFlags && self.nPosition == other.nPosition && self.lpszPathName == other.lpszPathName && self.lpszFileName == other.lpszFileName && self.lpFileType == other.lpFileType
     }
 }
 impl ::core::cmp::Eq for MapiFileDesc {}
@@ -175,7 +175,7 @@ unsafe impl ::windows::core::Abi for MapiFileDescW {
 }
 impl ::core::cmp::PartialEq for MapiFileDescW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiFileDescW>()) == 0 }
+        self.ulReserved == other.ulReserved && self.flFlags == other.flFlags && self.nPosition == other.nPosition && self.lpszPathName == other.lpszPathName && self.lpszFileName == other.lpszFileName && self.lpFileType == other.lpFileType
     }
 }
 impl ::core::cmp::Eq for MapiFileDescW {}
@@ -209,7 +209,7 @@ unsafe impl ::windows::core::Abi for MapiFileTagExt {
 }
 impl ::core::cmp::PartialEq for MapiFileTagExt {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiFileTagExt>()) == 0 }
+        self.ulReserved == other.ulReserved && self.cbTag == other.cbTag && self.lpTag == other.lpTag && self.cbEncoding == other.cbEncoding && self.lpEncoding == other.lpEncoding
     }
 }
 impl ::core::cmp::Eq for MapiFileTagExt {}
@@ -263,7 +263,7 @@ unsafe impl ::windows::core::Abi for MapiMessage {
 }
 impl ::core::cmp::PartialEq for MapiMessage {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiMessage>()) == 0 }
+        self.ulReserved == other.ulReserved && self.lpszSubject == other.lpszSubject && self.lpszNoteText == other.lpszNoteText && self.lpszMessageType == other.lpszMessageType && self.lpszDateReceived == other.lpszDateReceived && self.lpszConversationID == other.lpszConversationID && self.flFlags == other.flFlags && self.lpOriginator == other.lpOriginator && self.nRecipCount == other.nRecipCount && self.lpRecips == other.lpRecips && self.nFileCount == other.nFileCount && self.lpFiles == other.lpFiles
     }
 }
 impl ::core::cmp::Eq for MapiMessage {}
@@ -317,7 +317,7 @@ unsafe impl ::windows::core::Abi for MapiMessageW {
 }
 impl ::core::cmp::PartialEq for MapiMessageW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiMessageW>()) == 0 }
+        self.ulReserved == other.ulReserved && self.lpszSubject == other.lpszSubject && self.lpszNoteText == other.lpszNoteText && self.lpszMessageType == other.lpszMessageType && self.lpszDateReceived == other.lpszDateReceived && self.lpszConversationID == other.lpszConversationID && self.flFlags == other.flFlags && self.lpOriginator == other.lpOriginator && self.nRecipCount == other.nRecipCount && self.lpRecips == other.lpRecips && self.nFileCount == other.nFileCount && self.lpFiles == other.lpFiles
     }
 }
 impl ::core::cmp::Eq for MapiMessageW {}
@@ -352,7 +352,7 @@ unsafe impl ::windows::core::Abi for MapiRecipDesc {
 }
 impl ::core::cmp::PartialEq for MapiRecipDesc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiRecipDesc>()) == 0 }
+        self.ulReserved == other.ulReserved && self.ulRecipClass == other.ulRecipClass && self.lpszName == other.lpszName && self.lpszAddress == other.lpszAddress && self.ulEIDSize == other.ulEIDSize && self.lpEntryID == other.lpEntryID
     }
 }
 impl ::core::cmp::Eq for MapiRecipDesc {}
@@ -387,7 +387,7 @@ unsafe impl ::windows::core::Abi for MapiRecipDescW {
 }
 impl ::core::cmp::PartialEq for MapiRecipDescW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MapiRecipDescW>()) == 0 }
+        self.ulReserved == other.ulReserved && self.ulRecipClass == other.ulRecipClass && self.lpszName == other.lpszName && self.lpszAddress == other.lpszAddress && self.ulEIDSize == other.ulEIDSize && self.lpEntryID == other.lpEntryID
     }
 }
 impl ::core::cmp::Eq for MapiRecipDescW {}

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/NonVolatile/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/NonVolatile/mod.rs
@@ -69,7 +69,7 @@ unsafe impl ::windows::core::Abi for NV_MEMORY_RANGE {
 }
 impl ::core::cmp::PartialEq for NV_MEMORY_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NV_MEMORY_RANGE>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for NV_MEMORY_RANGE {}

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
@@ -1692,7 +1692,7 @@ unsafe impl ::windows::core::Abi for CFG_CALL_TARGET_INFO {
 }
 impl ::core::cmp::PartialEq for CFG_CALL_TARGET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CFG_CALL_TARGET_INFO>()) == 0 }
+        self.Offset == other.Offset && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for CFG_CALL_TARGET_INFO {}
@@ -1726,7 +1726,7 @@ unsafe impl ::windows::core::Abi for HEAP_SUMMARY {
 }
 impl ::core::cmp::PartialEq for HEAP_SUMMARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAP_SUMMARY>()) == 0 }
+        self.cb == other.cb && self.cbAllocated == other.cbAllocated && self.cbCommitted == other.cbCommitted && self.cbReserved == other.cbReserved && self.cbMaxReserve == other.cbMaxReserve
     }
 }
 impl ::core::cmp::Eq for HEAP_SUMMARY {}
@@ -1801,7 +1801,7 @@ unsafe impl ::windows::core::Abi for MEMORY_BASIC_INFORMATION {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for MEMORY_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_BASIC_INFORMATION>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationBase == other.AllocationBase && self.AllocationProtect == other.AllocationProtect && self.PartitionId == other.PartitionId && self.RegionSize == other.RegionSize && self.State == other.State && self.Protect == other.Protect && self.Type == other.Type
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -1845,7 +1845,7 @@ unsafe impl ::windows::core::Abi for MEMORY_BASIC_INFORMATION {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for MEMORY_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_BASIC_INFORMATION>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationBase == other.AllocationBase && self.AllocationProtect == other.AllocationProtect && self.RegionSize == other.RegionSize && self.State == other.State && self.Protect == other.Protect && self.Type == other.Type
     }
 }
 #[cfg(target_arch = "x86")]
@@ -1883,7 +1883,7 @@ unsafe impl ::windows::core::Abi for MEMORY_BASIC_INFORMATION32 {
 }
 impl ::core::cmp::PartialEq for MEMORY_BASIC_INFORMATION32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_BASIC_INFORMATION32>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationBase == other.AllocationBase && self.AllocationProtect == other.AllocationProtect && self.RegionSize == other.RegionSize && self.State == other.State && self.Protect == other.Protect && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for MEMORY_BASIC_INFORMATION32 {}
@@ -1921,7 +1921,7 @@ unsafe impl ::windows::core::Abi for MEMORY_BASIC_INFORMATION64 {
 }
 impl ::core::cmp::PartialEq for MEMORY_BASIC_INFORMATION64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_BASIC_INFORMATION64>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.AllocationBase == other.AllocationBase && self.AllocationProtect == other.AllocationProtect && self.__alignment1 == other.__alignment1 && self.RegionSize == other.RegionSize && self.State == other.State && self.Protect == other.Protect && self.Type == other.Type && self.__alignment2 == other.__alignment2
     }
 }
 impl ::core::cmp::Eq for MEMORY_BASIC_INFORMATION64 {}
@@ -1953,7 +1953,7 @@ unsafe impl ::windows::core::Abi for MEM_ADDRESS_REQUIREMENTS {
 }
 impl ::core::cmp::PartialEq for MEM_ADDRESS_REQUIREMENTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_ADDRESS_REQUIREMENTS>()) == 0 }
+        self.LowestStartingAddress == other.LowestStartingAddress && self.HighestEndingAddress == other.HighestEndingAddress && self.Alignment == other.Alignment
     }
 }
 impl ::core::cmp::Eq for MEM_ADDRESS_REQUIREMENTS {}
@@ -1981,14 +1981,6 @@ impl ::core::clone::Clone for MEM_EXTENDED_PARAMETER {
 unsafe impl ::windows::core::Abi for MEM_EXTENDED_PARAMETER {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MEM_EXTENDED_PARAMETER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_EXTENDED_PARAMETER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MEM_EXTENDED_PARAMETER {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MEM_EXTENDED_PARAMETER {
     fn default() -> Self {
@@ -2022,7 +2014,7 @@ unsafe impl ::windows::core::Abi for MEM_EXTENDED_PARAMETER_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MEM_EXTENDED_PARAMETER_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_EXTENDED_PARAMETER_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2056,14 +2048,6 @@ unsafe impl ::windows::core::Abi for MEM_EXTENDED_PARAMETER_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MEM_EXTENDED_PARAMETER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEM_EXTENDED_PARAMETER_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MEM_EXTENDED_PARAMETER_1 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MEM_EXTENDED_PARAMETER_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2093,14 +2077,6 @@ unsafe impl ::windows::core::Abi for PROCESS_HEAP_ENTRY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROCESS_HEAP_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_HEAP_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROCESS_HEAP_ENTRY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROCESS_HEAP_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2125,14 +2101,6 @@ impl ::core::clone::Clone for PROCESS_HEAP_ENTRY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_HEAP_ENTRY_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROCESS_HEAP_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_HEAP_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROCESS_HEAP_ENTRY_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROCESS_HEAP_ENTRY_0 {
     fn default() -> Self {
@@ -2167,7 +2135,7 @@ unsafe impl ::windows::core::Abi for PROCESS_HEAP_ENTRY_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROCESS_HEAP_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_HEAP_ENTRY_0_0>()) == 0 }
+        self.hMem == other.hMem && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2208,7 +2176,7 @@ unsafe impl ::windows::core::Abi for PROCESS_HEAP_ENTRY_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROCESS_HEAP_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_HEAP_ENTRY_0_1>()) == 0 }
+        self.dwCommittedSize == other.dwCommittedSize && self.dwUnCommittedSize == other.dwUnCommittedSize && self.lpFirstBlock == other.lpFirstBlock && self.lpLastBlock == other.lpLastBlock
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2274,7 +2242,7 @@ unsafe impl ::windows::core::Abi for WIN32_MEMORY_PARTITION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WIN32_MEMORY_PARTITION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_MEMORY_PARTITION_INFORMATION>()) == 0 }
+        self.Flags == other.Flags && self.NumaNode == other.NumaNode && self.Channel == other.Channel && self.NumberOfNumaNodes == other.NumberOfNumaNodes && self.ResidentAvailablePages == other.ResidentAvailablePages && self.CommittedPages == other.CommittedPages && self.CommitLimit == other.CommitLimit && self.PeakCommitment == other.PeakCommitment && self.TotalNumberOfPages == other.TotalNumberOfPages && self.AvailablePages == other.AvailablePages && self.ZeroPages == other.ZeroPages && self.FreePages == other.FreePages && self.StandbyPages == other.StandbyPages && self.Reserved == other.Reserved && self.MaximumCommitLimit == other.MaximumCommitLimit && self.Reserved2 == other.Reserved2 && self.PartitionId == other.PartitionId
     }
 }
 impl ::core::cmp::Eq for WIN32_MEMORY_PARTITION_INFORMATION {}
@@ -2305,7 +2273,7 @@ unsafe impl ::windows::core::Abi for WIN32_MEMORY_RANGE_ENTRY {
 }
 impl ::core::cmp::PartialEq for WIN32_MEMORY_RANGE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_MEMORY_RANGE_ENTRY>()) == 0 }
+        self.VirtualAddress == other.VirtualAddress && self.NumberOfBytes == other.NumberOfBytes
     }
 }
 impl ::core::cmp::Eq for WIN32_MEMORY_RANGE_ENTRY {}
@@ -2332,12 +2300,6 @@ impl ::core::clone::Clone for WIN32_MEMORY_REGION_INFORMATION {
 unsafe impl ::windows::core::Abi for WIN32_MEMORY_REGION_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WIN32_MEMORY_REGION_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_MEMORY_REGION_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WIN32_MEMORY_REGION_INFORMATION {}
 impl ::core::default::Default for WIN32_MEMORY_REGION_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2358,12 +2320,6 @@ impl ::core::clone::Clone for WIN32_MEMORY_REGION_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for WIN32_MEMORY_REGION_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WIN32_MEMORY_REGION_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_MEMORY_REGION_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WIN32_MEMORY_REGION_INFORMATION_0 {}
 impl ::core::default::Default for WIN32_MEMORY_REGION_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2390,7 +2346,7 @@ unsafe impl ::windows::core::Abi for WIN32_MEMORY_REGION_INFORMATION_0_0 {
 }
 impl ::core::cmp::PartialEq for WIN32_MEMORY_REGION_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WIN32_MEMORY_REGION_INFORMATION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for WIN32_MEMORY_REGION_INFORMATION_0_0 {}

--- a/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
@@ -22,7 +22,7 @@ unsafe impl ::windows::core::Abi for PERCEPTION_PAYLOAD_FIELD {
 }
 impl ::core::cmp::PartialEq for PERCEPTION_PAYLOAD_FIELD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERCEPTION_PAYLOAD_FIELD>()) == 0 }
+        self.FieldId == other.FieldId && self.OffsetInBytes == other.OffsetInBytes && self.SizeInBytes == other.SizeInBytes
     }
 }
 impl ::core::cmp::Eq for PERCEPTION_PAYLOAD_FIELD {}
@@ -53,7 +53,7 @@ unsafe impl ::windows::core::Abi for PERCEPTION_STATE_STREAM_TIMESTAMPS {
 }
 impl ::core::cmp::PartialEq for PERCEPTION_STATE_STREAM_TIMESTAMPS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERCEPTION_STATE_STREAM_TIMESTAMPS>()) == 0 }
+        self.InputTimestampInQpcCounts == other.InputTimestampInQpcCounts && self.AvailableTimestampInQpcCounts == other.AvailableTimestampInQpcCounts
     }
 }
 impl ::core::cmp::Eq for PERCEPTION_STATE_STREAM_TIMESTAMPS {}

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
@@ -6314,7 +6314,7 @@ unsafe impl ::windows::core::Abi for CONTEXTMENUITEM {
 }
 impl ::core::cmp::PartialEq for CONTEXTMENUITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXTMENUITEM>()) == 0 }
+        self.strName == other.strName && self.strStatusBarText == other.strStatusBarText && self.lCommandID == other.lCommandID && self.lInsertionPointID == other.lInsertionPointID && self.fFlags == other.fFlags && self.fSpecialFlags == other.fSpecialFlags
     }
 }
 impl ::core::cmp::Eq for CONTEXTMENUITEM {}
@@ -6350,7 +6350,7 @@ unsafe impl ::windows::core::Abi for CONTEXTMENUITEM2 {
 }
 impl ::core::cmp::PartialEq for CONTEXTMENUITEM2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTEXTMENUITEM2>()) == 0 }
+        self.strName == other.strName && self.strStatusBarText == other.strStatusBarText && self.lCommandID == other.lCommandID && self.lInsertionPointID == other.lInsertionPointID && self.fFlags == other.fFlags && self.fSpecialFlags == other.fSpecialFlags && self.strLanguageIndependentName == other.strLanguageIndependentName
     }
 }
 impl ::core::cmp::Eq for CONTEXTMENUITEM2 {}
@@ -6382,7 +6382,7 @@ unsafe impl ::windows::core::Abi for MENUBUTTONDATA {
 }
 impl ::core::cmp::PartialEq for MENUBUTTONDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUBUTTONDATA>()) == 0 }
+        self.idCommand == other.idCommand && self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for MENUBUTTONDATA {}
@@ -6417,7 +6417,7 @@ unsafe impl ::windows::core::Abi for MMCBUTTON {
 }
 impl ::core::cmp::PartialEq for MMCBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMCBUTTON>()) == 0 }
+        self.nBitmap == other.nBitmap && self.idCommand == other.idCommand && self.fsState == other.fsState && self.fsType == other.fsType && self.lpButtonText == other.lpButtonText && self.lpTooltipText == other.lpTooltipText
     }
 }
 impl ::core::cmp::Eq for MMCBUTTON {}
@@ -6450,7 +6450,7 @@ unsafe impl ::windows::core::Abi for MMC_COLUMN_DATA {
 }
 impl ::core::cmp::PartialEq for MMC_COLUMN_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_COLUMN_DATA>()) == 0 }
+        self.nColIndex == other.nColIndex && self.dwFlags == other.dwFlags && self.nWidth == other.nWidth && self.ulReserved == other.ulReserved
     }
 }
 impl ::core::cmp::Eq for MMC_COLUMN_DATA {}
@@ -6482,7 +6482,7 @@ unsafe impl ::windows::core::Abi for MMC_COLUMN_SET_DATA {
 }
 impl ::core::cmp::PartialEq for MMC_COLUMN_SET_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_COLUMN_SET_DATA>()) == 0 }
+        self.cbSize == other.cbSize && self.nNumCols == other.nNumCols && self.pColData == other.pColData
     }
 }
 impl ::core::cmp::Eq for MMC_COLUMN_SET_DATA {}
@@ -6520,7 +6520,7 @@ unsafe impl ::windows::core::Abi for MMC_EXPANDSYNC_STRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MMC_EXPANDSYNC_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_EXPANDSYNC_STRUCT>()) == 0 }
+        self.bHandled == other.bHandled && self.bExpanding == other.bExpanding && self.hItem == other.hItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6562,7 +6562,7 @@ unsafe impl ::windows::core::Abi for MMC_EXT_VIEW_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MMC_EXT_VIEW_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_EXT_VIEW_DATA>()) == 0 }
+        self.viewID == other.viewID && self.pszURL == other.pszURL && self.pszViewTitle == other.pszViewTitle && self.pszTooltipText == other.pszTooltipText && self.bReplacesDefaultView == other.bReplacesDefaultView
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6596,7 +6596,7 @@ unsafe impl ::windows::core::Abi for MMC_FILTERDATA {
 }
 impl ::core::cmp::PartialEq for MMC_FILTERDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_FILTERDATA>()) == 0 }
+        self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.lValue == other.lValue
     }
 }
 impl ::core::cmp::Eq for MMC_FILTERDATA {}
@@ -6628,7 +6628,7 @@ unsafe impl ::windows::core::Abi for MMC_LISTPAD_INFO {
 }
 impl ::core::cmp::PartialEq for MMC_LISTPAD_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_LISTPAD_INFO>()) == 0 }
+        self.szTitle == other.szTitle && self.szButtonText == other.szButtonText && self.nCommandID == other.nCommandID
     }
 }
 impl ::core::cmp::Eq for MMC_LISTPAD_INFO {}
@@ -6661,7 +6661,7 @@ unsafe impl ::windows::core::Abi for MMC_RESTORE_VIEW {
 }
 impl ::core::cmp::PartialEq for MMC_RESTORE_VIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_RESTORE_VIEW>()) == 0 }
+        self.dwSize == other.dwSize && self.cookie == other.cookie && self.pViewType == other.pViewType && self.lViewOptions == other.lViewOptions
     }
 }
 impl ::core::cmp::Eq for MMC_RESTORE_VIEW {}
@@ -6688,14 +6688,6 @@ impl ::core::clone::Clone for MMC_SNAPIN_PROPERTY {
 unsafe impl ::windows::core::Abi for MMC_SNAPIN_PROPERTY {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for MMC_SNAPIN_PROPERTY {
-    fn eq(&self, other: &Self) -> bool {
-        self.pszPropName == other.pszPropName && self.varValue == other.varValue && self.eAction == other.eAction
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for MMC_SNAPIN_PROPERTY {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for MMC_SNAPIN_PROPERTY {
     fn default() -> Self {
@@ -6725,7 +6717,7 @@ unsafe impl ::windows::core::Abi for MMC_SORT_DATA {
 }
 impl ::core::cmp::PartialEq for MMC_SORT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_SORT_DATA>()) == 0 }
+        self.nColIndex == other.nColIndex && self.dwSortOptions == other.dwSortOptions && self.ulReserved == other.ulReserved
     }
 }
 impl ::core::cmp::Eq for MMC_SORT_DATA {}
@@ -6757,7 +6749,7 @@ unsafe impl ::windows::core::Abi for MMC_SORT_SET_DATA {
 }
 impl ::core::cmp::PartialEq for MMC_SORT_SET_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_SORT_SET_DATA>()) == 0 }
+        self.cbSize == other.cbSize && self.nNumItems == other.nNumItems && self.pSortData == other.pSortData
     }
 }
 impl ::core::cmp::Eq for MMC_SORT_SET_DATA {}
@@ -6784,12 +6776,6 @@ impl ::core::clone::Clone for MMC_TASK {
 unsafe impl ::windows::core::Abi for MMC_TASK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMC_TASK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMC_TASK {}
 impl ::core::default::Default for MMC_TASK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6811,12 +6797,6 @@ impl ::core::clone::Clone for MMC_TASK_0 {
 unsafe impl ::windows::core::Abi for MMC_TASK_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMC_TASK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMC_TASK_0 {}
 impl ::core::default::Default for MMC_TASK_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6844,7 +6824,7 @@ unsafe impl ::windows::core::Abi for MMC_TASK_DISPLAY_BITMAP {
 }
 impl ::core::cmp::PartialEq for MMC_TASK_DISPLAY_BITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK_DISPLAY_BITMAP>()) == 0 }
+        self.szMouseOverBitmap == other.szMouseOverBitmap && self.szMouseOffBitmap == other.szMouseOffBitmap
     }
 }
 impl ::core::cmp::Eq for MMC_TASK_DISPLAY_BITMAP {}
@@ -6868,12 +6848,6 @@ impl ::core::clone::Clone for MMC_TASK_DISPLAY_OBJECT {
 unsafe impl ::windows::core::Abi for MMC_TASK_DISPLAY_OBJECT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMC_TASK_DISPLAY_OBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK_DISPLAY_OBJECT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMC_TASK_DISPLAY_OBJECT {}
 impl ::core::default::Default for MMC_TASK_DISPLAY_OBJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6894,12 +6868,6 @@ impl ::core::clone::Clone for MMC_TASK_DISPLAY_OBJECT_0 {
 unsafe impl ::windows::core::Abi for MMC_TASK_DISPLAY_OBJECT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MMC_TASK_DISPLAY_OBJECT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK_DISPLAY_OBJECT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MMC_TASK_DISPLAY_OBJECT_0 {}
 impl ::core::default::Default for MMC_TASK_DISPLAY_OBJECT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6928,7 +6896,7 @@ unsafe impl ::windows::core::Abi for MMC_TASK_DISPLAY_SYMBOL {
 }
 impl ::core::cmp::PartialEq for MMC_TASK_DISPLAY_SYMBOL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_TASK_DISPLAY_SYMBOL>()) == 0 }
+        self.szFontFamilyName == other.szFontFamilyName && self.szURLtoEOT == other.szURLtoEOT && self.szSymbolString == other.szSymbolString
     }
 }
 impl ::core::cmp::Eq for MMC_TASK_DISPLAY_SYMBOL {}
@@ -6959,7 +6927,7 @@ unsafe impl ::windows::core::Abi for MMC_VISIBLE_COLUMNS {
 }
 impl ::core::cmp::PartialEq for MMC_VISIBLE_COLUMNS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MMC_VISIBLE_COLUMNS>()) == 0 }
+        self.nVisibleColumns == other.nVisibleColumns && self.rgVisibleCols == other.rgVisibleCols
     }
 }
 impl ::core::cmp::Eq for MMC_VISIBLE_COLUMNS {}
@@ -7000,7 +6968,7 @@ unsafe impl ::windows::core::Abi for RDCOMPARE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RDCOMPARE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RDCOMPARE>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.nColumn == other.nColumn && self.lUserParam == other.lUserParam && self.prdch1 == other.prdch1 && self.prdch2 == other.prdch2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7040,7 +7008,7 @@ unsafe impl ::windows::core::Abi for RDITEMHDR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RDITEMHDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RDITEMHDR>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cookie == other.cookie && self.lpReserved == other.lpReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7087,7 +7055,7 @@ unsafe impl ::windows::core::Abi for RESULTDATAITEM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESULTDATAITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESULTDATAITEM>()) == 0 }
+        self.mask == other.mask && self.bScopeItem == other.bScopeItem && self.itemID == other.itemID && self.nIndex == other.nIndex && self.nCol == other.nCol && self.str == other.str && self.nImage == other.nImage && self.nState == other.nState && self.lParam == other.lParam && self.iIndent == other.iIndent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7121,7 +7089,7 @@ unsafe impl ::windows::core::Abi for RESULTFINDINFO {
 }
 impl ::core::cmp::PartialEq for RESULTFINDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESULTFINDINFO>()) == 0 }
+        self.psz == other.psz && self.nStart == other.nStart && self.dwOptions == other.dwOptions
     }
 }
 impl ::core::cmp::Eq for RESULTFINDINFO {}
@@ -7151,12 +7119,6 @@ impl ::core::clone::Clone for RESULT_VIEW_TYPE_INFO {
 unsafe impl ::windows::core::Abi for RESULT_VIEW_TYPE_INFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for RESULT_VIEW_TYPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.pstrPersistableViewDescription == other.pstrPersistableViewDescription && self.eViewType == other.eViewType && self.dwMiscOptions == other.dwMiscOptions && self.Anonymous == other.Anonymous
-    }
-}
-impl ::core::cmp::Eq for RESULT_VIEW_TYPE_INFO {}
 impl ::core::default::Default for RESULT_VIEW_TYPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7177,12 +7139,6 @@ impl ::core::clone::Clone for RESULT_VIEW_TYPE_INFO_0 {
 unsafe impl ::windows::core::Abi for RESULT_VIEW_TYPE_INFO_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for RESULT_VIEW_TYPE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESULT_VIEW_TYPE_INFO_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RESULT_VIEW_TYPE_INFO_0 {}
 impl ::core::default::Default for RESULT_VIEW_TYPE_INFO_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7210,7 +7166,7 @@ unsafe impl ::windows::core::Abi for RESULT_VIEW_TYPE_INFO_0_0 {
 }
 impl ::core::cmp::PartialEq for RESULT_VIEW_TYPE_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESULT_VIEW_TYPE_INFO_0_0>()) == 0 }
+        self.dwHTMLOptions == other.dwHTMLOptions && self.pstrURL == other.pstrURL
     }
 }
 impl ::core::cmp::Eq for RESULT_VIEW_TYPE_INFO_0_0 {}
@@ -7284,7 +7240,7 @@ unsafe impl ::windows::core::Abi for SCOPEDATAITEM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCOPEDATAITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPEDATAITEM>()) == 0 }
+        self.mask == other.mask && self.displayname == other.displayname && self.nImage == other.nImage && self.nOpenImage == other.nOpenImage && self.nState == other.nState && self.cChildren == other.cChildren && self.lParam == other.lParam && self.relativeID == other.relativeID && self.ID == other.ID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7318,7 +7274,7 @@ unsafe impl ::windows::core::Abi for SColumnSetID {
 }
 impl ::core::cmp::PartialEq for SColumnSetID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SColumnSetID>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cBytes == other.cBytes && self.id == other.id
     }
 }
 impl ::core::cmp::Eq for SColumnSetID {}
@@ -7386,7 +7342,7 @@ unsafe impl ::windows::core::Abi for SMMCObjectTypes {
 }
 impl ::core::cmp::PartialEq for SMMCObjectTypes {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMMCObjectTypes>()) == 0 }
+        self.count == other.count && self.guid == other.guid
     }
 }
 impl ::core::cmp::Eq for SMMCObjectTypes {}
@@ -7417,7 +7373,7 @@ unsafe impl ::windows::core::Abi for SNodeID {
 }
 impl ::core::cmp::PartialEq for SNodeID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SNodeID>()) == 0 }
+        self.cBytes == other.cBytes && self.id == other.id
     }
 }
 impl ::core::cmp::Eq for SNodeID {}
@@ -7449,7 +7405,7 @@ unsafe impl ::windows::core::Abi for SNodeID2 {
 }
 impl ::core::cmp::PartialEq for SNodeID2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SNodeID2>()) == 0 }
+        self.dwFlags == other.dwFlags && self.cBytes == other.cBytes && self.id == other.id
     }
 }
 impl ::core::cmp::Eq for SNodeID2 {}

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -15411,14 +15411,6 @@ unsafe impl ::windows::core::Abi for ARRAYDESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for ARRAYDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARRAYDESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for ARRAYDESC {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for ARRAYDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15446,7 +15438,7 @@ unsafe impl ::windows::core::Abi for CADWORD {
 }
 impl ::core::cmp::PartialEq for CADWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CADWORD>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CADWORD {}
@@ -15477,7 +15469,7 @@ unsafe impl ::windows::core::Abi for CALPOLESTR {
 }
 impl ::core::cmp::PartialEq for CALPOLESTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CALPOLESTR>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CALPOLESTR {}
@@ -15508,7 +15500,7 @@ unsafe impl ::windows::core::Abi for CAUUID {
 }
 impl ::core::cmp::PartialEq for CAUUID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CAUUID>()) == 0 }
+        self.cElems == other.cElems && self.pElems == other.pElems
     }
 }
 impl ::core::cmp::Eq for CAUUID {}
@@ -15578,7 +15570,7 @@ unsafe impl ::windows::core::Abi for CONTROLINFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for CONTROLINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTROLINFO>()) == 0 }
+        self.cb == other.cb && self.hAccel == other.hAccel && self.cAccel == other.cAccel && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -15611,7 +15603,7 @@ unsafe impl ::windows::core::Abi for DVASPECTINFO {
 }
 impl ::core::cmp::PartialEq for DVASPECTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DVASPECTINFO>()) == 0 }
+        self.cb == other.cb && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for DVASPECTINFO {}
@@ -15649,7 +15641,7 @@ unsafe impl ::windows::core::Abi for DVEXTENTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DVEXTENTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DVEXTENTINFO>()) == 0 }
+        self.cb == other.cb && self.dwExtentMode == other.dwExtentMode && self.sizelProposed == other.sizelProposed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15686,14 +15678,6 @@ unsafe impl ::windows::core::Abi for FONTDESC {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for FONTDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FONTDESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for FONTDESC {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for FONTDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15727,7 +15711,7 @@ unsafe impl ::windows::core::Abi for INTERFACEDATA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for INTERFACEDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERFACEDATA>()) == 0 }
+        self.pmethdata == other.pmethdata && self.cMembers == other.cMembers
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -15767,7 +15751,7 @@ unsafe impl ::windows::core::Abi for LICINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LICINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LICINFO>()) == 0 }
+        self.cbLicInfo == other.cbLicInfo && self.fRuntimeKeyAvail == other.fRuntimeKeyAvail && self.fLicVerified == other.fLicVerified
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15812,7 +15796,7 @@ unsafe impl ::windows::core::Abi for METHODDATA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for METHODDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<METHODDATA>()) == 0 }
+        self.szName == other.szName && self.ppdata == other.ppdata && self.dispid == other.dispid && self.iMeth == other.iMeth && self.cc == other.cc && self.cArgs == other.cArgs && self.wFlags == other.wFlags && self.vtReturn == other.vtReturn
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -15849,7 +15833,7 @@ unsafe impl ::windows::core::Abi for NUMPARSE {
 }
 impl ::core::cmp::PartialEq for NUMPARSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NUMPARSE>()) == 0 }
+        self.cDig == other.cDig && self.dwInFlags == other.dwInFlags && self.dwOutFlags == other.dwOutFlags && self.cchUsed == other.cchUsed && self.nBaseShift == other.nBaseShift && self.nPwr10 == other.nPwr10
     }
 }
 impl ::core::cmp::Eq for NUMPARSE {}
@@ -15892,7 +15876,7 @@ unsafe impl ::windows::core::Abi for OBJECTDESCRIPTOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OBJECTDESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTDESCRIPTOR>()) == 0 }
+        self.cbSize == other.cbSize && self.clsid == other.clsid && self.dwDrawAspect == other.dwDrawAspect && self.sizel == other.sizel && self.pointl == other.pointl && self.dwStatus == other.dwStatus && self.dwFullUserTypeName == other.dwFullUserTypeName && self.dwSrcOfCopy == other.dwSrcOfCopy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15940,7 +15924,7 @@ unsafe impl ::windows::core::Abi for OCPFIPARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OCPFIPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OCPFIPARAMS>()) == 0 }
+        self.cbStructSize == other.cbStructSize && self.hWndOwner == other.hWndOwner && self.x == other.x && self.y == other.y && self.lpszCaption == other.lpszCaption && self.cObjects == other.cObjects && self.lplpUnk == other.lplpUnk && self.cPages == other.cPages && self.lpPages == other.lpPages && self.lcid == other.lcid && self.dispidInitialProperty == other.dispidInitialProperty
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15973,7 +15957,7 @@ unsafe impl ::windows::core::Abi for OLECMD {
 }
 impl ::core::cmp::PartialEq for OLECMD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLECMD>()) == 0 }
+        self.cmdID == other.cmdID && self.cmdf == other.cmdf
     }
 }
 impl ::core::cmp::Eq for OLECMD {}
@@ -16006,7 +15990,7 @@ unsafe impl ::windows::core::Abi for OLECMDTEXT {
 }
 impl ::core::cmp::PartialEq for OLECMDTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLECMDTEXT>()) == 0 }
+        self.cmdtextf == other.cmdtextf && self.cwActual == other.cwActual && self.cwBuf == other.cwBuf && self.rgwz == other.rgwz
     }
 }
 impl ::core::cmp::Eq for OLECMDTEXT {}
@@ -16046,7 +16030,7 @@ unsafe impl ::windows::core::Abi for OLEINPLACEFRAMEINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for OLEINPLACEFRAMEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEINPLACEFRAMEINFO>()) == 0 }
+        self.cb == other.cb && self.fMDIApp == other.fMDIApp && self.hwndFrame == other.hwndFrame && self.haccel == other.haccel && self.cAccelEntries == other.cAccelEntries
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -16078,7 +16062,7 @@ unsafe impl ::windows::core::Abi for OLEMENUGROUPWIDTHS {
 }
 impl ::core::cmp::PartialEq for OLEMENUGROUPWIDTHS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEMENUGROUPWIDTHS>()) == 0 }
+        self.width == other.width
     }
 }
 impl ::core::cmp::Eq for OLEMENUGROUPWIDTHS {}
@@ -16114,21 +16098,13 @@ impl ::core::clone::Clone for OLEUIBUSYA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 impl ::core::fmt::Debug for OLEUIBUSYA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIBUSYA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hTask", &self.hTask).field("lphWndDialog", &self.lphWndDialog).finish()
+        f.debug_struct("OLEUIBUSYA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hTask", &self.hTask).field("lphWndDialog", &self.lphWndDialog).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 unsafe impl ::windows::core::Abi for OLEUIBUSYA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
-impl ::core::cmp::PartialEq for OLEUIBUSYA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIBUSYA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
-impl ::core::cmp::Eq for OLEUIBUSYA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 impl ::core::default::Default for OLEUIBUSYA {
     fn default() -> Self {
@@ -16162,21 +16138,13 @@ impl ::core::clone::Clone for OLEUIBUSYW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 impl ::core::fmt::Debug for OLEUIBUSYW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIBUSYW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hTask", &self.hTask).field("lphWndDialog", &self.lphWndDialog).finish()
+        f.debug_struct("OLEUIBUSYW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hTask", &self.hTask).field("lphWndDialog", &self.lphWndDialog).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 unsafe impl ::windows::core::Abi for OLEUIBUSYW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
-impl ::core::cmp::PartialEq for OLEUIBUSYW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIBUSYW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
-impl ::core::cmp::Eq for OLEUIBUSYW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media"))]
 impl ::core::default::Default for OLEUIBUSYW {
     fn default() -> Self {
@@ -16212,35 +16180,13 @@ impl ::core::clone::Clone for OLEUICHANGEICONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for OLEUICHANGEICONA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUICHANGEICONA")
-            .field("cbStruct", &self.cbStruct)
-            .field("dwFlags", &self.dwFlags)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
-            .field("lCustData", &self.lCustData)
-            .field("hInstance", &self.hInstance)
-            .field("lpszTemplate", &self.lpszTemplate)
-            .field("hResource", &self.hResource)
-            .field("hMetaPict", &self.hMetaPict)
-            .field("clsid", &self.clsid)
-            .field("szIconExe", &self.szIconExe)
-            .field("cchIconExe", &self.cchIconExe)
-            .finish()
+        f.debug_struct("OLEUICHANGEICONA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hMetaPict", &self.hMetaPict).field("clsid", &self.clsid).field("szIconExe", &self.szIconExe).field("cchIconExe", &self.cchIconExe).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for OLEUICHANGEICONA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUICHANGEICONA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUICHANGEICONA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUICHANGEICONA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUICHANGEICONA {
     fn default() -> Self {
@@ -16276,35 +16222,13 @@ impl ::core::clone::Clone for OLEUICHANGEICONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for OLEUICHANGEICONW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUICHANGEICONW")
-            .field("cbStruct", &self.cbStruct)
-            .field("dwFlags", &self.dwFlags)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
-            .field("lCustData", &self.lCustData)
-            .field("hInstance", &self.hInstance)
-            .field("lpszTemplate", &self.lpszTemplate)
-            .field("hResource", &self.hResource)
-            .field("hMetaPict", &self.hMetaPict)
-            .field("clsid", &self.clsid)
-            .field("szIconExe", &self.szIconExe)
-            .field("cchIconExe", &self.cchIconExe)
-            .finish()
+        f.debug_struct("OLEUICHANGEICONW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("hMetaPict", &self.hMetaPict).field("clsid", &self.clsid).field("szIconExe", &self.szIconExe).field("cchIconExe", &self.cchIconExe).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for OLEUICHANGEICONW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUICHANGEICONW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUICHANGEICONW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUICHANGEICONW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUICHANGEICONW {
     fn default() -> Self {
@@ -16365,7 +16289,6 @@ impl ::core::fmt::Debug for OLEUICHANGESOURCEA {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -16385,14 +16308,6 @@ impl ::core::fmt::Debug for OLEUICHANGESOURCEA {
 unsafe impl ::windows::core::Abi for OLEUICHANGESOURCEA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
-impl ::core::cmp::PartialEq for OLEUICHANGESOURCEA {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.hWndOwner == other.hWndOwner && self.lpszCaption == other.lpszCaption && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize) && self.lCustData == other.lCustData && self.hInstance == other.hInstance && self.lpszTemplate == other.lpszTemplate && self.hResource == other.hResource && self.lpOFN == other.lpOFN && self.dwReserved1 == other.dwReserved1 && self.lpOleUILinkContainer == other.lpOleUILinkContainer && self.dwLink == other.dwLink && self.lpszDisplayName == other.lpszDisplayName && self.nFileLength == other.nFileLength && self.lpszFrom == other.lpszFrom && self.lpszTo == other.lpszTo
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
-impl ::core::cmp::Eq for OLEUICHANGESOURCEA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
 impl ::core::default::Default for OLEUICHANGESOURCEA {
     fn default() -> Self {
@@ -16453,7 +16368,6 @@ impl ::core::fmt::Debug for OLEUICHANGESOURCEW {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -16473,14 +16387,6 @@ impl ::core::fmt::Debug for OLEUICHANGESOURCEW {
 unsafe impl ::windows::core::Abi for OLEUICHANGESOURCEW {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
-impl ::core::cmp::PartialEq for OLEUICHANGESOURCEW {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.hWndOwner == other.hWndOwner && self.lpszCaption == other.lpszCaption && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize) && self.lCustData == other.lCustData && self.hInstance == other.hInstance && self.lpszTemplate == other.lpszTemplate && self.hResource == other.hResource && self.lpOFN == other.lpOFN && self.dwReserved1 == other.dwReserved1 && self.lpOleUILinkContainer == other.lpOleUILinkContainer && self.dwLink == other.dwLink && self.lpszDisplayName == other.lpszDisplayName && self.nFileLength == other.nFileLength && self.lpszFrom == other.lpszFrom && self.lpszTo == other.lpszTo
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
-impl ::core::cmp::Eq for OLEUICHANGESOURCEW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls_Dialogs"))]
 impl ::core::default::Default for OLEUICHANGESOURCEW {
     fn default() -> Self {
@@ -16530,7 +16436,6 @@ impl ::core::fmt::Debug for OLEUICONVERTA {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -16555,14 +16460,6 @@ impl ::core::fmt::Debug for OLEUICONVERTA {
 unsafe impl ::windows::core::Abi for OLEUICONVERTA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUICONVERTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUICONVERTA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUICONVERTA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUICONVERTA {
     fn default() -> Self {
@@ -16612,7 +16509,6 @@ impl ::core::fmt::Debug for OLEUICONVERTW {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -16637,14 +16533,6 @@ impl ::core::fmt::Debug for OLEUICONVERTW {
 unsafe impl ::windows::core::Abi for OLEUICONVERTW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUICONVERTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUICONVERTW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUICONVERTW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUICONVERTW {
     fn default() -> Self {
@@ -16686,21 +16574,13 @@ impl ::core::clone::Clone for OLEUIEDITLINKSA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for OLEUIEDITLINKSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIEDITLINKSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("lpOleUILinkContainer", &self.lpOleUILinkContainer).finish()
+        f.debug_struct("OLEUIEDITLINKSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("lpOleUILinkContainer", &self.lpOleUILinkContainer).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for OLEUIEDITLINKSA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUIEDITLINKSA {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.hWndOwner == other.hWndOwner && self.lpszCaption == other.lpszCaption && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize) && self.lCustData == other.lCustData && self.hInstance == other.hInstance && self.lpszTemplate == other.lpszTemplate && self.hResource == other.hResource && self.lpOleUILinkContainer == other.lpOleUILinkContainer
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUIEDITLINKSA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUIEDITLINKSA {
     fn default() -> Self {
@@ -16742,21 +16622,13 @@ impl ::core::clone::Clone for OLEUIEDITLINKSW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for OLEUIEDITLINKSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIEDITLINKSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("lpOleUILinkContainer", &self.lpOleUILinkContainer).finish()
+        f.debug_struct("OLEUIEDITLINKSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("hWndOwner", &self.hWndOwner).field("lpszCaption", &self.lpszCaption).field("lCustData", &self.lCustData).field("hInstance", &self.hInstance).field("lpszTemplate", &self.lpszTemplate).field("hResource", &self.hResource).field("lpOleUILinkContainer", &self.lpOleUILinkContainer).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for OLEUIEDITLINKSW {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OLEUIEDITLINKSW {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct && self.dwFlags == other.dwFlags && self.hWndOwner == other.hWndOwner && self.lpszCaption == other.lpszCaption && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize) && self.lCustData == other.lCustData && self.hInstance == other.hInstance && self.lpszTemplate == other.lpszTemplate && self.hResource == other.hResource && self.lpOleUILinkContainer == other.lpOleUILinkContainer
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OLEUIEDITLINKSW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OLEUIEDITLINKSW {
     fn default() -> Self {
@@ -16786,21 +16658,13 @@ impl ::core::clone::Clone for OLEUIGNRLPROPSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUIGNRLPROPSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIGNRLPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
+        f.debug_struct("OLEUIGNRLPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUIGNRLPROPSA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUIGNRLPROPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIGNRLPROPSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUIGNRLPROPSA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUIGNRLPROPSA {
     fn default() -> Self {
@@ -16830,21 +16694,13 @@ impl ::core::clone::Clone for OLEUIGNRLPROPSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUIGNRLPROPSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIGNRLPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
+        f.debug_struct("OLEUIGNRLPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUIGNRLPROPSW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUIGNRLPROPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIGNRLPROPSW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUIGNRLPROPSW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUIGNRLPROPSW {
     fn default() -> Self {
@@ -16915,7 +16771,6 @@ impl ::core::fmt::Debug for OLEUIINSERTOBJECTA {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -16940,35 +16795,6 @@ impl ::core::fmt::Debug for OLEUIINSERTOBJECTA {
 unsafe impl ::windows::core::Abi for OLEUIINSERTOBJECTA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for OLEUIINSERTOBJECTA {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct
-            && self.dwFlags == other.dwFlags
-            && self.hWndOwner == other.hWndOwner
-            && self.lpszCaption == other.lpszCaption
-            && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize)
-            && self.lCustData == other.lCustData
-            && self.hInstance == other.hInstance
-            && self.lpszTemplate == other.lpszTemplate
-            && self.hResource == other.hResource
-            && self.clsid == other.clsid
-            && self.lpszFile == other.lpszFile
-            && self.cchFile == other.cchFile
-            && self.cClsidExclude == other.cClsidExclude
-            && self.lpClsidExclude == other.lpClsidExclude
-            && self.iid == other.iid
-            && self.oleRender == other.oleRender
-            && self.lpFormatEtc == other.lpFormatEtc
-            && self.lpIOleClientSite == other.lpIOleClientSite
-            && self.lpIStorage == other.lpIStorage
-            && self.ppvObj == other.ppvObj
-            && self.sc == other.sc
-            && self.hMetaPict == other.hMetaPict
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for OLEUIINSERTOBJECTA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for OLEUIINSERTOBJECTA {
     fn default() -> Self {
@@ -17039,7 +16865,6 @@ impl ::core::fmt::Debug for OLEUIINSERTOBJECTW {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -17064,35 +16889,6 @@ impl ::core::fmt::Debug for OLEUIINSERTOBJECTW {
 unsafe impl ::windows::core::Abi for OLEUIINSERTOBJECTW {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for OLEUIINSERTOBJECTW {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct
-            && self.dwFlags == other.dwFlags
-            && self.hWndOwner == other.hWndOwner
-            && self.lpszCaption == other.lpszCaption
-            && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize)
-            && self.lCustData == other.lCustData
-            && self.hInstance == other.hInstance
-            && self.lpszTemplate == other.lpszTemplate
-            && self.hResource == other.hResource
-            && self.clsid == other.clsid
-            && self.lpszFile == other.lpszFile
-            && self.cchFile == other.cchFile
-            && self.cClsidExclude == other.cClsidExclude
-            && self.lpClsidExclude == other.lpClsidExclude
-            && self.iid == other.iid
-            && self.oleRender == other.oleRender
-            && self.lpFormatEtc == other.lpFormatEtc
-            && self.lpIOleClientSite == other.lpIOleClientSite
-            && self.lpIStorage == other.lpIStorage
-            && self.ppvObj == other.ppvObj
-            && self.sc == other.sc
-            && self.hMetaPict == other.hMetaPict
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for OLEUIINSERTOBJECTW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for OLEUIINSERTOBJECTW {
     fn default() -> Self {
@@ -17122,21 +16918,13 @@ impl ::core::clone::Clone for OLEUILINKPROPSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUILINKPROPSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUILINKPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
+        f.debug_struct("OLEUILINKPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUILINKPROPSA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUILINKPROPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUILINKPROPSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUILINKPROPSA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUILINKPROPSA {
     fn default() -> Self {
@@ -17166,21 +16954,13 @@ impl ::core::clone::Clone for OLEUILINKPROPSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUILINKPROPSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUILINKPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
+        f.debug_struct("OLEUILINKPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUILINKPROPSW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUILINKPROPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUILINKPROPSW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUILINKPROPSW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUILINKPROPSW {
     fn default() -> Self {
@@ -17330,7 +17110,7 @@ unsafe impl ::windows::core::Abi for OLEUIPASTEENTRYA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for OLEUIPASTEENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIPASTEENTRYA>()) == 0 }
+        self.fmtetc == other.fmtetc && self.lpstrFormatName == other.lpstrFormatName && self.lpstrResultText == other.lpstrResultText && self.dwFlags == other.dwFlags && self.dwScratchSpace == other.dwScratchSpace
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -17372,7 +17152,7 @@ unsafe impl ::windows::core::Abi for OLEUIPASTEENTRYW {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for OLEUIPASTEENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIPASTEENTRYW>()) == 0 }
+        self.fmtetc == other.fmtetc && self.lpstrFormatName == other.lpstrFormatName && self.lpstrResultText == other.lpstrResultText && self.dwFlags == other.dwFlags && self.dwScratchSpace == other.dwScratchSpace
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -17443,7 +17223,6 @@ impl ::core::fmt::Debug for OLEUIPASTESPECIALA {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -17466,33 +17245,6 @@ impl ::core::fmt::Debug for OLEUIPASTESPECIALA {
 unsafe impl ::windows::core::Abi for OLEUIPASTESPECIALA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for OLEUIPASTESPECIALA {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct
-            && self.dwFlags == other.dwFlags
-            && self.hWndOwner == other.hWndOwner
-            && self.lpszCaption == other.lpszCaption
-            && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize)
-            && self.lCustData == other.lCustData
-            && self.hInstance == other.hInstance
-            && self.lpszTemplate == other.lpszTemplate
-            && self.hResource == other.hResource
-            && self.lpSrcDataObj == other.lpSrcDataObj
-            && self.arrPasteEntries == other.arrPasteEntries
-            && self.cPasteEntries == other.cPasteEntries
-            && self.arrLinkTypes == other.arrLinkTypes
-            && self.cLinkTypes == other.cLinkTypes
-            && self.cClsidExclude == other.cClsidExclude
-            && self.lpClsidExclude == other.lpClsidExclude
-            && self.nSelectedIndex == other.nSelectedIndex
-            && self.fLink == other.fLink
-            && self.hMetaPict == other.hMetaPict
-            && self.sizel == other.sizel
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for OLEUIPASTESPECIALA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for OLEUIPASTESPECIALA {
     fn default() -> Self {
@@ -17559,7 +17311,6 @@ impl ::core::fmt::Debug for OLEUIPASTESPECIALW {
             .field("dwFlags", &self.dwFlags)
             .field("hWndOwner", &self.hWndOwner)
             .field("lpszCaption", &self.lpszCaption)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lCustData", &self.lCustData)
             .field("hInstance", &self.hInstance)
             .field("lpszTemplate", &self.lpszTemplate)
@@ -17582,33 +17333,6 @@ impl ::core::fmt::Debug for OLEUIPASTESPECIALW {
 unsafe impl ::windows::core::Abi for OLEUIPASTESPECIALW {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for OLEUIPASTESPECIALW {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbStruct == other.cbStruct
-            && self.dwFlags == other.dwFlags
-            && self.hWndOwner == other.hWndOwner
-            && self.lpszCaption == other.lpszCaption
-            && self.lpfnHook.map(|f| f as usize) == other.lpfnHook.map(|f| f as usize)
-            && self.lCustData == other.lCustData
-            && self.hInstance == other.hInstance
-            && self.lpszTemplate == other.lpszTemplate
-            && self.hResource == other.hResource
-            && self.lpSrcDataObj == other.lpSrcDataObj
-            && self.arrPasteEntries == other.arrPasteEntries
-            && self.cPasteEntries == other.cPasteEntries
-            && self.arrLinkTypes == other.arrLinkTypes
-            && self.cLinkTypes == other.cLinkTypes
-            && self.cClsidExclude == other.cClsidExclude
-            && self.lpClsidExclude == other.lpClsidExclude
-            && self.nSelectedIndex == other.nSelectedIndex
-            && self.fLink == other.fLink
-            && self.hMetaPict == other.hMetaPict
-            && self.sizel == other.sizel
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for OLEUIPASTESPECIALW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for OLEUIPASTESPECIALW {
     fn default() -> Self {
@@ -17640,21 +17364,13 @@ impl ::core::clone::Clone for OLEUIVIEWPROPSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUIVIEWPROPSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIVIEWPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).field("nScaleMin", &self.nScaleMin).field("nScaleMax", &self.nScaleMax).finish()
+        f.debug_struct("OLEUIVIEWPROPSA").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).field("nScaleMin", &self.nScaleMin).field("nScaleMax", &self.nScaleMax).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUIVIEWPROPSA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUIVIEWPROPSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIVIEWPROPSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUIVIEWPROPSA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUIVIEWPROPSA {
     fn default() -> Self {
@@ -17686,21 +17402,13 @@ impl ::core::clone::Clone for OLEUIVIEWPROPSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::fmt::Debug for OLEUIVIEWPROPSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("OLEUIVIEWPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lpfnHook", &self.lpfnHook.map(|f| f as usize)).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).field("nScaleMin", &self.nScaleMin).field("nScaleMax", &self.nScaleMax).finish()
+        f.debug_struct("OLEUIVIEWPROPSW").field("cbStruct", &self.cbStruct).field("dwFlags", &self.dwFlags).field("dwReserved1", &self.dwReserved1).field("lCustData", &self.lCustData).field("dwReserved2", &self.dwReserved2).field("lpOP", &self.lpOP).field("nScaleMin", &self.nScaleMin).field("nScaleMax", &self.nScaleMax).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 unsafe impl ::windows::core::Abi for OLEUIVIEWPROPSW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for OLEUIVIEWPROPSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEUIVIEWPROPSW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for OLEUIVIEWPROPSW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for OLEUIVIEWPROPSW {
     fn default() -> Self {
@@ -17737,7 +17445,7 @@ unsafe impl ::windows::core::Abi for OLEVERB {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for OLEVERB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OLEVERB>()) == 0 }
+        self.lVerb == other.lVerb && self.lpszVerbName == other.lpszVerbName && self.fuFlags == other.fuFlags && self.grfAttribs == other.grfAttribs
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -17802,7 +17510,7 @@ unsafe impl ::windows::core::Abi for PAGERANGE {
 }
 impl ::core::cmp::PartialEq for PAGERANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGERANGE>()) == 0 }
+        self.nFromPage == other.nFromPage && self.nToPage == other.nToPage
     }
 }
 impl ::core::cmp::Eq for PAGERANGE {}
@@ -17842,7 +17550,7 @@ unsafe impl ::windows::core::Abi for PAGESET {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PAGESET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGESET>()) == 0 }
+        self.cbStruct == other.cbStruct && self.fOddPages == other.fOddPages && self.fEvenPages == other.fEvenPages && self.cPageRange == other.cPageRange && self.rgPages == other.rgPages
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17881,7 +17589,7 @@ unsafe impl ::windows::core::Abi for PARAMDATA {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for PARAMDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAMDATA>()) == 0 }
+        self.szName == other.szName && self.vt == other.vt
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -17920,7 +17628,7 @@ unsafe impl ::windows::core::Abi for PARAMDESC {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for PARAMDESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAMDESC>()) == 0 }
+        self.pparamdescex == other.pparamdescex && self.wParamFlags == other.wParamFlags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -17949,14 +17657,6 @@ unsafe impl ::windows::core::Abi for PARAMDESCEX {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for PARAMDESCEX {
-    fn eq(&self, other: &Self) -> bool {
-        self.cBytes == other.cBytes && self.varDefaultValue == other.varDefaultValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for PARAMDESCEX {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for PARAMDESCEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17982,14 +17682,6 @@ impl ::core::clone::Clone for PICTDESC {
 unsafe impl ::windows::core::Abi for PICTDESC {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PICTDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PICTDESC {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PICTDESC {
     fn default() -> Self {
@@ -18017,14 +17709,6 @@ impl ::core::clone::Clone for PICTDESC_0 {
 unsafe impl ::windows::core::Abi for PICTDESC_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PICTDESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PICTDESC_0 {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PICTDESC_0 {
     fn default() -> Self {
@@ -18059,7 +17743,7 @@ unsafe impl ::windows::core::Abi for PICTDESC_0_0 {
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for PICTDESC_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC_0_0>()) == 0 }
+        self.hbitmap == other.hbitmap && self.hpal == other.hpal
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -18097,7 +17781,7 @@ unsafe impl ::windows::core::Abi for PICTDESC_0_1 {
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for PICTDESC_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC_0_1>()) == 0 }
+        self.hemf == other.hemf
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -18135,7 +17819,7 @@ unsafe impl ::windows::core::Abi for PICTDESC_0_2 {
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for PICTDESC_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC_0_2>()) == 0 }
+        self.hicon == other.hicon
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -18175,7 +17859,7 @@ unsafe impl ::windows::core::Abi for PICTDESC_0_3 {
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for PICTDESC_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PICTDESC_0_3>()) == 0 }
+        self.hmeta == other.hmeta && self.xExt == other.xExt && self.yExt == other.yExt
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -18208,7 +17892,7 @@ unsafe impl ::windows::core::Abi for POINTF {
 }
 impl ::core::cmp::PartialEq for POINTF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTF>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for POINTF {}
@@ -18249,7 +17933,7 @@ unsafe impl ::windows::core::Abi for PROPPAGEINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROPPAGEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPPAGEINFO>()) == 0 }
+        self.cb == other.cb && self.pszTitle == other.pszTitle && self.size == other.size && self.pszDocString == other.pszDocString && self.pszHelpFile == other.pszHelpFile && self.dwHelpContext == other.dwHelpContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18371,7 +18055,7 @@ unsafe impl ::windows::core::Abi for QACONTROL {
 }
 impl ::core::cmp::PartialEq for QACONTROL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QACONTROL>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMiscStatus == other.dwMiscStatus && self.dwViewStatus == other.dwViewStatus && self.dwEventCookie == other.dwEventCookie && self.dwPropNotifyCookie == other.dwPropNotifyCookie && self.dwPointerActivationPolicy == other.dwPointerActivationPolicy
     }
 }
 impl ::core::cmp::Eq for QACONTROL {}
@@ -18399,14 +18083,6 @@ impl ::core::clone::Clone for SAFEARRAYUNION {
 unsafe impl ::windows::core::Abi for SAFEARRAYUNION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SAFEARRAYUNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARRAYUNION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SAFEARRAYUNION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SAFEARRAYUNION {
     fn default() -> Self {
@@ -18441,14 +18117,6 @@ unsafe impl ::windows::core::Abi for SAFEARRAYUNION_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SAFEARRAYUNION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARRAYUNION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SAFEARRAYUNION_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SAFEARRAYUNION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18476,7 +18144,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_BRECORD {
 }
 impl ::core::cmp::PartialEq for SAFEARR_BRECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_BRECORD>()) == 0 }
+        self.Size == other.Size && self.aRecord == other.aRecord
     }
 }
 impl ::core::cmp::Eq for SAFEARR_BRECORD {}
@@ -18513,7 +18181,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_BSTR {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SAFEARR_BSTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_BSTR>()) == 0 }
+        self.Size == other.Size && self.aBstr == other.aBstr
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -18552,7 +18220,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_DISPATCH {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SAFEARR_DISPATCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_DISPATCH>()) == 0 }
+        self.Size == other.Size && self.apDispatch == other.apDispatch
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -18586,7 +18254,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_HAVEIID {
 }
 impl ::core::cmp::PartialEq for SAFEARR_HAVEIID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_HAVEIID>()) == 0 }
+        self.Size == other.Size && self.apUnknown == other.apUnknown && self.iid == other.iid
     }
 }
 impl ::core::cmp::Eq for SAFEARR_HAVEIID {}
@@ -18617,7 +18285,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_UNKNOWN {
 }
 impl ::core::cmp::PartialEq for SAFEARR_UNKNOWN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_UNKNOWN>()) == 0 }
+        self.Size == other.Size && self.apUnknown == other.apUnknown
     }
 }
 impl ::core::cmp::Eq for SAFEARR_UNKNOWN {}
@@ -18654,7 +18322,7 @@ unsafe impl ::windows::core::Abi for SAFEARR_VARIANT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SAFEARR_VARIANT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAFEARR_VARIANT>()) == 0 }
+        self.Size == other.Size && self.aVariant == other.aVariant
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -18693,7 +18361,7 @@ unsafe impl ::windows::core::Abi for UDATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for UDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UDATE>()) == 0 }
+        self.st == other.st && self.wDayOfYear == other.wDayOfYear
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -18760,14 +18428,6 @@ unsafe impl ::windows::core::Abi for _wireSAFEARRAY {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for _wireSAFEARRAY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_wireSAFEARRAY>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for _wireSAFEARRAY {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for _wireSAFEARRAY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18803,14 +18463,6 @@ impl ::core::clone::Clone for _wireVARIANT {
 unsafe impl ::windows::core::Abi for _wireVARIANT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for _wireVARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        self.clSize == other.clSize && self.rpcReserved == other.rpcReserved && self.vt == other.vt && self.wReserved1 == other.wReserved1 && self.wReserved2 == other.wReserved2 && self.wReserved3 == other.wReserved3 && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for _wireVARIANT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for _wireVARIANT {
     fn default() -> Self {
@@ -18876,14 +18528,6 @@ impl ::core::clone::Clone for _wireVARIANT_0 {
 unsafe impl ::windows::core::Abi for _wireVARIANT_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for _wireVARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_wireVARIANT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for _wireVARIANT_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for _wireVARIANT_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/PasswordManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/PasswordManagement/mod.rs
@@ -49,7 +49,7 @@ unsafe impl ::windows::core::Abi for CYPHER_BLOCK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CYPHER_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CYPHER_BLOCK>()) == 0 }
+        self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -87,7 +87,7 @@ unsafe impl ::windows::core::Abi for ENCRYPTED_LM_OWF_PASSWORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ENCRYPTED_LM_OWF_PASSWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCRYPTED_LM_OWF_PASSWORD>()) == 0 }
+        self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -125,7 +125,7 @@ unsafe impl ::windows::core::Abi for LM_OWF_PASSWORD {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LM_OWF_PASSWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LM_OWF_PASSWORD>()) == 0 }
+        self.data == other.data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -157,7 +157,7 @@ unsafe impl ::windows::core::Abi for SAMPR_ENCRYPTED_USER_PASSWORD {
 }
 impl ::core::cmp::PartialEq for SAMPR_ENCRYPTED_USER_PASSWORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SAMPR_ENCRYPTED_USER_PASSWORD>()) == 0 }
+        self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for SAMPR_ENCRYPTED_USER_PASSWORD {}

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/HardwareCounterProfiling/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/HardwareCounterProfiling/mod.rs
@@ -88,7 +88,7 @@ unsafe impl ::windows::core::Abi for HARDWARE_COUNTER_DATA {
 }
 impl ::core::cmp::PartialEq for HARDWARE_COUNTER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HARDWARE_COUNTER_DATA>()) == 0 }
+        self.Type == other.Type && self.Reserved == other.Reserved && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for HARDWARE_COUNTER_DATA {}
@@ -126,7 +126,7 @@ unsafe impl ::windows::core::Abi for PERFORMANCE_DATA {
 }
 impl ::core::cmp::PartialEq for PERFORMANCE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERFORMANCE_DATA>()) == 0 }
+        self.Size == other.Size && self.Version == other.Version && self.HwCountersCount == other.HwCountersCount && self.ContextSwitchCount == other.ContextSwitchCount && self.WaitReasonBitMap == other.WaitReasonBitMap && self.CycleTime == other.CycleTime && self.RetryCount == other.RetryCount && self.Reserved == other.Reserved && self.HwCounters == other.HwCounters
     }
 }
 impl ::core::cmp::Eq for PERFORMANCE_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
@@ -8400,32 +8400,13 @@ impl ::core::clone::Clone for PDH_BROWSE_DLG_CONFIG_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PDH_BROWSE_DLG_CONFIG_A {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PDH_BROWSE_DLG_CONFIG_A")
-            .field("_bitfield", &self._bitfield)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("szDataSource", &self.szDataSource)
-            .field("szReturnPathBuffer", &self.szReturnPathBuffer)
-            .field("cchReturnPathLength", &self.cchReturnPathLength)
-            .field("pCallBack", &self.pCallBack.map(|f| f as usize))
-            .field("dwCallBackArg", &self.dwCallBackArg)
-            .field("CallBackStatus", &self.CallBackStatus)
-            .field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel)
-            .field("szDialogBoxCaption", &self.szDialogBoxCaption)
-            .finish()
+        f.debug_struct("PDH_BROWSE_DLG_CONFIG_A").field("_bitfield", &self._bitfield).field("hWndOwner", &self.hWndOwner).field("szDataSource", &self.szDataSource).field("szReturnPathBuffer", &self.szReturnPathBuffer).field("cchReturnPathLength", &self.cchReturnPathLength).field("dwCallBackArg", &self.dwCallBackArg).field("CallBackStatus", &self.CallBackStatus).field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel).field("szDialogBoxCaption", &self.szDialogBoxCaption).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PDH_BROWSE_DLG_CONFIG_A {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_BROWSE_DLG_CONFIG_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_BROWSE_DLG_CONFIG_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_BROWSE_DLG_CONFIG_A {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_BROWSE_DLG_CONFIG_A {
     fn default() -> Self {
@@ -8458,32 +8439,13 @@ impl ::core::clone::Clone for PDH_BROWSE_DLG_CONFIG_HA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PDH_BROWSE_DLG_CONFIG_HA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PDH_BROWSE_DLG_CONFIG_HA")
-            .field("_bitfield", &self._bitfield)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("hDataSource", &self.hDataSource)
-            .field("szReturnPathBuffer", &self.szReturnPathBuffer)
-            .field("cchReturnPathLength", &self.cchReturnPathLength)
-            .field("pCallBack", &self.pCallBack.map(|f| f as usize))
-            .field("dwCallBackArg", &self.dwCallBackArg)
-            .field("CallBackStatus", &self.CallBackStatus)
-            .field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel)
-            .field("szDialogBoxCaption", &self.szDialogBoxCaption)
-            .finish()
+        f.debug_struct("PDH_BROWSE_DLG_CONFIG_HA").field("_bitfield", &self._bitfield).field("hWndOwner", &self.hWndOwner).field("hDataSource", &self.hDataSource).field("szReturnPathBuffer", &self.szReturnPathBuffer).field("cchReturnPathLength", &self.cchReturnPathLength).field("dwCallBackArg", &self.dwCallBackArg).field("CallBackStatus", &self.CallBackStatus).field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel).field("szDialogBoxCaption", &self.szDialogBoxCaption).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PDH_BROWSE_DLG_CONFIG_HA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_BROWSE_DLG_CONFIG_HA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_BROWSE_DLG_CONFIG_HA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_BROWSE_DLG_CONFIG_HA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_BROWSE_DLG_CONFIG_HA {
     fn default() -> Self {
@@ -8516,32 +8478,13 @@ impl ::core::clone::Clone for PDH_BROWSE_DLG_CONFIG_HW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PDH_BROWSE_DLG_CONFIG_HW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PDH_BROWSE_DLG_CONFIG_HW")
-            .field("_bitfield", &self._bitfield)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("hDataSource", &self.hDataSource)
-            .field("szReturnPathBuffer", &self.szReturnPathBuffer)
-            .field("cchReturnPathLength", &self.cchReturnPathLength)
-            .field("pCallBack", &self.pCallBack.map(|f| f as usize))
-            .field("dwCallBackArg", &self.dwCallBackArg)
-            .field("CallBackStatus", &self.CallBackStatus)
-            .field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel)
-            .field("szDialogBoxCaption", &self.szDialogBoxCaption)
-            .finish()
+        f.debug_struct("PDH_BROWSE_DLG_CONFIG_HW").field("_bitfield", &self._bitfield).field("hWndOwner", &self.hWndOwner).field("hDataSource", &self.hDataSource).field("szReturnPathBuffer", &self.szReturnPathBuffer).field("cchReturnPathLength", &self.cchReturnPathLength).field("dwCallBackArg", &self.dwCallBackArg).field("CallBackStatus", &self.CallBackStatus).field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel).field("szDialogBoxCaption", &self.szDialogBoxCaption).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PDH_BROWSE_DLG_CONFIG_HW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_BROWSE_DLG_CONFIG_HW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_BROWSE_DLG_CONFIG_HW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_BROWSE_DLG_CONFIG_HW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_BROWSE_DLG_CONFIG_HW {
     fn default() -> Self {
@@ -8574,32 +8517,13 @@ impl ::core::clone::Clone for PDH_BROWSE_DLG_CONFIG_W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for PDH_BROWSE_DLG_CONFIG_W {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PDH_BROWSE_DLG_CONFIG_W")
-            .field("_bitfield", &self._bitfield)
-            .field("hWndOwner", &self.hWndOwner)
-            .field("szDataSource", &self.szDataSource)
-            .field("szReturnPathBuffer", &self.szReturnPathBuffer)
-            .field("cchReturnPathLength", &self.cchReturnPathLength)
-            .field("pCallBack", &self.pCallBack.map(|f| f as usize))
-            .field("dwCallBackArg", &self.dwCallBackArg)
-            .field("CallBackStatus", &self.CallBackStatus)
-            .field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel)
-            .field("szDialogBoxCaption", &self.szDialogBoxCaption)
-            .finish()
+        f.debug_struct("PDH_BROWSE_DLG_CONFIG_W").field("_bitfield", &self._bitfield).field("hWndOwner", &self.hWndOwner).field("szDataSource", &self.szDataSource).field("szReturnPathBuffer", &self.szReturnPathBuffer).field("cchReturnPathLength", &self.cchReturnPathLength).field("dwCallBackArg", &self.dwCallBackArg).field("CallBackStatus", &self.CallBackStatus).field("dwDefaultDetailLevel", &self.dwDefaultDetailLevel).field("szDialogBoxCaption", &self.szDialogBoxCaption).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for PDH_BROWSE_DLG_CONFIG_W {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_BROWSE_DLG_CONFIG_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_BROWSE_DLG_CONFIG_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_BROWSE_DLG_CONFIG_W {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_BROWSE_DLG_CONFIG_W {
     fn default() -> Self {
@@ -8631,12 +8555,6 @@ impl ::core::clone::Clone for PDH_COUNTER_INFO_A {
 unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_COUNTER_INFO_A {}
 impl ::core::default::Default for PDH_COUNTER_INFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8658,12 +8576,6 @@ impl ::core::clone::Clone for PDH_COUNTER_INFO_A_0 {
 unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_COUNTER_INFO_A_0 {}
 impl ::core::default::Default for PDH_COUNTER_INFO_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8695,7 +8607,7 @@ unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_A_0_0 {
 }
 impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_A_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_A_0_0>()) == 0 }
+        self.szMachineName == other.szMachineName && self.szObjectName == other.szObjectName && self.szInstanceName == other.szInstanceName && self.szParentInstance == other.szParentInstance && self.dwInstanceIndex == other.dwInstanceIndex && self.szCounterName == other.szCounterName
     }
 }
 impl ::core::cmp::Eq for PDH_COUNTER_INFO_A_0_0 {}
@@ -8729,12 +8641,6 @@ impl ::core::clone::Clone for PDH_COUNTER_INFO_W {
 unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_COUNTER_INFO_W {}
 impl ::core::default::Default for PDH_COUNTER_INFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8756,12 +8662,6 @@ impl ::core::clone::Clone for PDH_COUNTER_INFO_W_0 {
 unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_COUNTER_INFO_W_0 {}
 impl ::core::default::Default for PDH_COUNTER_INFO_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8793,7 +8693,7 @@ unsafe impl ::windows::core::Abi for PDH_COUNTER_INFO_W_0_0 {
 }
 impl ::core::cmp::PartialEq for PDH_COUNTER_INFO_W_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_INFO_W_0_0>()) == 0 }
+        self.szMachineName == other.szMachineName && self.szObjectName == other.szObjectName && self.szInstanceName == other.szInstanceName && self.szParentInstance == other.szParentInstance && self.dwInstanceIndex == other.dwInstanceIndex && self.szCounterName == other.szCounterName
     }
 }
 impl ::core::cmp::Eq for PDH_COUNTER_INFO_W_0_0 {}
@@ -8828,7 +8728,7 @@ unsafe impl ::windows::core::Abi for PDH_COUNTER_PATH_ELEMENTS_A {
 }
 impl ::core::cmp::PartialEq for PDH_COUNTER_PATH_ELEMENTS_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_PATH_ELEMENTS_A>()) == 0 }
+        self.szMachineName == other.szMachineName && self.szObjectName == other.szObjectName && self.szInstanceName == other.szInstanceName && self.szParentInstance == other.szParentInstance && self.dwInstanceIndex == other.dwInstanceIndex && self.szCounterName == other.szCounterName
     }
 }
 impl ::core::cmp::Eq for PDH_COUNTER_PATH_ELEMENTS_A {}
@@ -8863,7 +8763,7 @@ unsafe impl ::windows::core::Abi for PDH_COUNTER_PATH_ELEMENTS_W {
 }
 impl ::core::cmp::PartialEq for PDH_COUNTER_PATH_ELEMENTS_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_COUNTER_PATH_ELEMENTS_W>()) == 0 }
+        self.szMachineName == other.szMachineName && self.szObjectName == other.szObjectName && self.szInstanceName == other.szInstanceName && self.szParentInstance == other.szParentInstance && self.dwInstanceIndex == other.dwInstanceIndex && self.szCounterName == other.szCounterName
     }
 }
 impl ::core::cmp::Eq for PDH_COUNTER_PATH_ELEMENTS_W {}
@@ -8896,7 +8796,7 @@ unsafe impl ::windows::core::Abi for PDH_DATA_ITEM_PATH_ELEMENTS_A {
 }
 impl ::core::cmp::PartialEq for PDH_DATA_ITEM_PATH_ELEMENTS_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_DATA_ITEM_PATH_ELEMENTS_A>()) == 0 }
+        self.szMachineName == other.szMachineName && self.ObjectGUID == other.ObjectGUID && self.dwItemId == other.dwItemId && self.szInstanceName == other.szInstanceName
     }
 }
 impl ::core::cmp::Eq for PDH_DATA_ITEM_PATH_ELEMENTS_A {}
@@ -8929,7 +8829,7 @@ unsafe impl ::windows::core::Abi for PDH_DATA_ITEM_PATH_ELEMENTS_W {
 }
 impl ::core::cmp::PartialEq for PDH_DATA_ITEM_PATH_ELEMENTS_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_DATA_ITEM_PATH_ELEMENTS_W>()) == 0 }
+        self.szMachineName == other.szMachineName && self.ObjectGUID == other.ObjectGUID && self.dwItemId == other.dwItemId && self.szInstanceName == other.szInstanceName
     }
 }
 impl ::core::cmp::Eq for PDH_DATA_ITEM_PATH_ELEMENTS_W {}
@@ -8953,12 +8853,6 @@ impl ::core::clone::Clone for PDH_FMT_COUNTERVALUE {
 unsafe impl ::windows::core::Abi for PDH_FMT_COUNTERVALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_FMT_COUNTERVALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_FMT_COUNTERVALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_FMT_COUNTERVALUE {}
 impl ::core::default::Default for PDH_FMT_COUNTERVALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8982,12 +8876,6 @@ impl ::core::clone::Clone for PDH_FMT_COUNTERVALUE_0 {
 unsafe impl ::windows::core::Abi for PDH_FMT_COUNTERVALUE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_FMT_COUNTERVALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_FMT_COUNTERVALUE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_FMT_COUNTERVALUE_0 {}
 impl ::core::default::Default for PDH_FMT_COUNTERVALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9008,12 +8896,6 @@ impl ::core::clone::Clone for PDH_FMT_COUNTERVALUE_ITEM_A {
 unsafe impl ::windows::core::Abi for PDH_FMT_COUNTERVALUE_ITEM_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_FMT_COUNTERVALUE_ITEM_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_FMT_COUNTERVALUE_ITEM_A {}
 impl ::core::default::Default for PDH_FMT_COUNTERVALUE_ITEM_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9034,12 +8916,6 @@ impl ::core::clone::Clone for PDH_FMT_COUNTERVALUE_ITEM_W {
 unsafe impl ::windows::core::Abi for PDH_FMT_COUNTERVALUE_ITEM_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_FMT_COUNTERVALUE_ITEM_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_FMT_COUNTERVALUE_ITEM_W {}
 impl ::core::default::Default for PDH_FMT_COUNTERVALUE_ITEM_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9072,14 +8948,6 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_LOG_SERVICE_QUERY_INFO_A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_LOG_SERVICE_QUERY_INFO_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9104,14 +8972,6 @@ impl ::core::clone::Clone for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
 unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_A_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_LOG_SERVICE_QUERY_INFO_A_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
     fn default() -> Self {
@@ -9152,7 +9012,7 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_A_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_A_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_A_0_0>()) == 0 }
+        self.PdlAutoNameInterval == other.PdlAutoNameInterval && self.PdlAutoNameUnits == other.PdlAutoNameUnits && self.PdlCommandFilename == other.PdlCommandFilename && self.PdlCounterList == other.PdlCounterList && self.PdlAutoNameFormat == other.PdlAutoNameFormat && self.PdlSampleInterval == other.PdlSampleInterval && self.PdlLogStartTime == other.PdlLogStartTime && self.PdlLogEndTime == other.PdlLogEndTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9210,7 +9070,7 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_A_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_A_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_A_0_1>()) == 0 }
+        self.TlNumberOfBuffers == other.TlNumberOfBuffers && self.TlMinimumBuffers == other.TlMinimumBuffers && self.TlMaximumBuffers == other.TlMaximumBuffers && self.TlFreeBuffers == other.TlFreeBuffers && self.TlBufferSize == other.TlBufferSize && self.TlEventsLost == other.TlEventsLost && self.TlLoggerThreadId == other.TlLoggerThreadId && self.TlBuffersWritten == other.TlBuffersWritten && self.TlLogHandle == other.TlLogHandle && self.TlLogFileName == other.TlLogFileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9248,14 +9108,6 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_W {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_LOG_SERVICE_QUERY_INFO_W {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_LOG_SERVICE_QUERY_INFO_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9280,14 +9132,6 @@ impl ::core::clone::Clone for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
 unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_W_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PDH_LOG_SERVICE_QUERY_INFO_W_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
     fn default() -> Self {
@@ -9328,7 +9172,7 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_W_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_W_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_W_0_0>()) == 0 }
+        self.PdlAutoNameInterval == other.PdlAutoNameInterval && self.PdlAutoNameUnits == other.PdlAutoNameUnits && self.PdlCommandFilename == other.PdlCommandFilename && self.PdlCounterList == other.PdlCounterList && self.PdlAutoNameFormat == other.PdlAutoNameFormat && self.PdlSampleInterval == other.PdlSampleInterval && self.PdlLogStartTime == other.PdlLogStartTime && self.PdlLogEndTime == other.PdlLogEndTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9386,7 +9230,7 @@ unsafe impl ::windows::core::Abi for PDH_LOG_SERVICE_QUERY_INFO_W_0_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_LOG_SERVICE_QUERY_INFO_W_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_LOG_SERVICE_QUERY_INFO_W_0_1>()) == 0 }
+        self.TlNumberOfBuffers == other.TlNumberOfBuffers && self.TlMinimumBuffers == other.TlMinimumBuffers && self.TlMaximumBuffers == other.TlMaximumBuffers && self.TlFreeBuffers == other.TlFreeBuffers && self.TlBufferSize == other.TlBufferSize && self.TlEventsLost == other.TlEventsLost && self.TlLoggerThreadId == other.TlLoggerThreadId && self.TlBuffersWritten == other.TlBuffersWritten && self.TlLogHandle == other.TlLogHandle && self.TlLogFileName == other.TlLogFileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9428,7 +9272,7 @@ unsafe impl ::windows::core::Abi for PDH_RAW_COUNTER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_RAW_COUNTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_RAW_COUNTER>()) == 0 }
+        self.CStatus == other.CStatus && self.TimeStamp == other.TimeStamp && self.FirstValue == other.FirstValue && self.SecondValue == other.SecondValue && self.MultiCount == other.MultiCount
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9467,7 +9311,7 @@ unsafe impl ::windows::core::Abi for PDH_RAW_COUNTER_ITEM_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_RAW_COUNTER_ITEM_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_RAW_COUNTER_ITEM_A>()) == 0 }
+        self.szName == other.szName && self.RawValue == other.RawValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9506,7 +9350,7 @@ unsafe impl ::windows::core::Abi for PDH_RAW_COUNTER_ITEM_W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PDH_RAW_COUNTER_ITEM_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_RAW_COUNTER_ITEM_W>()) == 0 }
+        self.szName == other.szName && self.RawValue == other.RawValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9541,7 +9385,7 @@ unsafe impl ::windows::core::Abi for PDH_RAW_LOG_RECORD {
 }
 impl ::core::cmp::PartialEq for PDH_RAW_LOG_RECORD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_RAW_LOG_RECORD>()) == 0 }
+        self.dwStructureSize == other.dwStructureSize && self.dwRecordType == other.dwRecordType && self.dwItems == other.dwItems && self.RawBytes == other.RawBytes
     }
 }
 impl ::core::cmp::Eq for PDH_RAW_LOG_RECORD {}
@@ -9568,12 +9412,6 @@ impl ::core::clone::Clone for PDH_STATISTICS {
 unsafe impl ::windows::core::Abi for PDH_STATISTICS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PDH_STATISTICS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_STATISTICS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PDH_STATISTICS {}
 impl ::core::default::Default for PDH_STATISTICS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9602,7 +9440,7 @@ unsafe impl ::windows::core::Abi for PDH_TIME_INFO {
 }
 impl ::core::cmp::PartialEq for PDH_TIME_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDH_TIME_INFO>()) == 0 }
+        self.StartTime == other.StartTime && self.EndTime == other.EndTime && self.SampleCount == other.SampleCount
     }
 }
 impl ::core::cmp::Eq for PDH_TIME_INFO {}
@@ -9635,7 +9473,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTERSET_INFO {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTERSET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTERSET_INFO>()) == 0 }
+        self.CounterSetGuid == other.CounterSetGuid && self.ProviderGuid == other.ProviderGuid && self.NumCounters == other.NumCounters && self.InstanceType == other.InstanceType
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTERSET_INFO {}
@@ -9669,7 +9507,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTERSET_INSTANCE {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTERSET_INSTANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTERSET_INSTANCE>()) == 0 }
+        self.CounterSetGuid == other.CounterSetGuid && self.dwSize == other.dwSize && self.InstanceId == other.InstanceId && self.InstanceNameOffset == other.InstanceNameOffset && self.InstanceNameSize == other.InstanceNameSize
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTERSET_INSTANCE {}
@@ -9703,7 +9541,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTERSET_REG_INFO {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTERSET_REG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTERSET_REG_INFO>()) == 0 }
+        self.CounterSetGuid == other.CounterSetGuid && self.CounterSetType == other.CounterSetType && self.DetailLevel == other.DetailLevel && self.NumCounters == other.NumCounters && self.InstanceType == other.InstanceType
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTERSET_REG_INFO {}
@@ -9733,7 +9571,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_BLOCK {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_BLOCK>()) == 0 }
+        self.ByteLength == other.ByteLength
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_BLOCK {}
@@ -9764,7 +9602,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_DATA {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_DATA>()) == 0 }
+        self.dwDataSize == other.dwDataSize && self.dwSize == other.dwSize
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_DATA {}
@@ -9820,7 +9658,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_DEFINITION {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for PERF_COUNTER_DEFINITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_DEFINITION>()) == 0 }
+        self.ByteLength == other.ByteLength && self.CounterNameTitleIndex == other.CounterNameTitleIndex && self.CounterNameTitle == other.CounterNameTitle && self.CounterHelpTitleIndex == other.CounterHelpTitleIndex && self.CounterHelpTitle == other.CounterHelpTitle && self.DefaultScale == other.DefaultScale && self.DetailLevel == other.DetailLevel && self.CounterType == other.CounterType && self.CounterSize == other.CounterSize && self.CounterOffset == other.CounterOffset
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -9878,7 +9716,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_DEFINITION {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for PERF_COUNTER_DEFINITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_DEFINITION>()) == 0 }
+        self.ByteLength == other.ByteLength && self.CounterNameTitleIndex == other.CounterNameTitleIndex && self.CounterNameTitle == other.CounterNameTitle && self.CounterHelpTitleIndex == other.CounterHelpTitleIndex && self.CounterHelpTitle == other.CounterHelpTitle && self.DefaultScale == other.DefaultScale && self.DetailLevel == other.DetailLevel && self.CounterType == other.CounterType && self.CounterSize == other.CounterSize && self.CounterOffset == other.CounterOffset
     }
 }
 #[cfg(target_arch = "x86")]
@@ -9913,7 +9751,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_HEADER {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_HEADER>()) == 0 }
+        self.dwStatus == other.dwStatus && self.dwType == other.dwType && self.dwSize == other.dwSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_HEADER {}
@@ -9949,7 +9787,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_IDENTIFIER>()) == 0 }
+        self.CounterSetGuid == other.CounterSetGuid && self.Status == other.Status && self.Size == other.Size && self.CounterId == other.CounterId && self.InstanceId == other.InstanceId && self.Index == other.Index && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_IDENTIFIER {}
@@ -9985,7 +9823,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_IDENTITY {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_IDENTITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_IDENTITY>()) == 0 }
+        self.CounterSetGuid == other.CounterSetGuid && self.BufferSize == other.BufferSize && self.CounterId == other.CounterId && self.InstanceId == other.InstanceId && self.MachineOffset == other.MachineOffset && self.NameOffset == other.NameOffset && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_IDENTITY {}
@@ -10021,7 +9859,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_INFO {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_INFO>()) == 0 }
+        self.CounterId == other.CounterId && self.Type == other.Type && self.Attrib == other.Attrib && self.Size == other.Size && self.DetailLevel == other.DetailLevel && self.Scale == other.Scale && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_INFO {}
@@ -10061,7 +9899,7 @@ unsafe impl ::windows::core::Abi for PERF_COUNTER_REG_INFO {
 }
 impl ::core::cmp::PartialEq for PERF_COUNTER_REG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_COUNTER_REG_INFO>()) == 0 }
+        self.CounterId == other.CounterId && self.Type == other.Type && self.Attrib == other.Attrib && self.DetailLevel == other.DetailLevel && self.DefaultScale == other.DefaultScale && self.BaseCounterId == other.BaseCounterId && self.PerfTimeId == other.PerfTimeId && self.PerfFreqId == other.PerfFreqId && self.MultiId == other.MultiId && self.AggregateFunc == other.AggregateFunc && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PERF_COUNTER_REG_INFO {}
@@ -10125,7 +9963,7 @@ unsafe impl ::windows::core::Abi for PERF_DATA_BLOCK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERF_DATA_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_DATA_BLOCK>()) == 0 }
+        self.Signature == other.Signature && self.LittleEndian == other.LittleEndian && self.Version == other.Version && self.Revision == other.Revision && self.TotalByteLength == other.TotalByteLength && self.HeaderLength == other.HeaderLength && self.NumObjectTypes == other.NumObjectTypes && self.DefaultObject == other.DefaultObject && self.SystemTime == other.SystemTime && self.PerfTime == other.PerfTime && self.PerfFreq == other.PerfFreq && self.PerfTime100nSec == other.PerfTime100nSec && self.SystemNameLength == other.SystemNameLength && self.SystemNameOffset == other.SystemNameOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10168,7 +10006,7 @@ unsafe impl ::windows::core::Abi for PERF_DATA_HEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERF_DATA_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_DATA_HEADER>()) == 0 }
+        self.dwTotalSize == other.dwTotalSize && self.dwNumCounters == other.dwNumCounters && self.PerfTimeStamp == other.PerfTimeStamp && self.PerfTime100NSec == other.PerfTime100NSec && self.PerfFreq == other.PerfFreq && self.SystemTime == other.SystemTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10205,7 +10043,7 @@ unsafe impl ::windows::core::Abi for PERF_INSTANCE_DEFINITION {
 }
 impl ::core::cmp::PartialEq for PERF_INSTANCE_DEFINITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_INSTANCE_DEFINITION>()) == 0 }
+        self.ByteLength == other.ByteLength && self.ParentObjectTitleIndex == other.ParentObjectTitleIndex && self.ParentObjectInstance == other.ParentObjectInstance && self.UniqueID == other.UniqueID && self.NameOffset == other.NameOffset && self.NameLength == other.NameLength
     }
 }
 impl ::core::cmp::Eq for PERF_INSTANCE_DEFINITION {}
@@ -10236,7 +10074,7 @@ unsafe impl ::windows::core::Abi for PERF_INSTANCE_HEADER {
 }
 impl ::core::cmp::PartialEq for PERF_INSTANCE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_INSTANCE_HEADER>()) == 0 }
+        self.Size == other.Size && self.InstanceId == other.InstanceId
     }
 }
 impl ::core::cmp::Eq for PERF_INSTANCE_HEADER {}
@@ -10267,7 +10105,7 @@ unsafe impl ::windows::core::Abi for PERF_MULTI_COUNTERS {
 }
 impl ::core::cmp::PartialEq for PERF_MULTI_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_MULTI_COUNTERS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCounters == other.dwCounters
     }
 }
 impl ::core::cmp::Eq for PERF_MULTI_COUNTERS {}
@@ -10298,7 +10136,7 @@ unsafe impl ::windows::core::Abi for PERF_MULTI_INSTANCES {
 }
 impl ::core::cmp::PartialEq for PERF_MULTI_INSTANCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_MULTI_INSTANCES>()) == 0 }
+        self.dwTotalSize == other.dwTotalSize && self.dwInstances == other.dwInstances
     }
 }
 impl ::core::cmp::Eq for PERF_MULTI_INSTANCES {}
@@ -10362,7 +10200,7 @@ unsafe impl ::windows::core::Abi for PERF_OBJECT_TYPE {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for PERF_OBJECT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_OBJECT_TYPE>()) == 0 }
+        self.TotalByteLength == other.TotalByteLength && self.DefinitionLength == other.DefinitionLength && self.HeaderLength == other.HeaderLength && self.ObjectNameTitleIndex == other.ObjectNameTitleIndex && self.ObjectNameTitle == other.ObjectNameTitle && self.ObjectHelpTitleIndex == other.ObjectHelpTitleIndex && self.ObjectHelpTitle == other.ObjectHelpTitle && self.DetailLevel == other.DetailLevel && self.NumCounters == other.NumCounters && self.DefaultCounter == other.DefaultCounter && self.NumInstances == other.NumInstances && self.CodePage == other.CodePage && self.PerfTime == other.PerfTime && self.PerfFreq == other.PerfFreq
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -10428,7 +10266,7 @@ unsafe impl ::windows::core::Abi for PERF_OBJECT_TYPE {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for PERF_OBJECT_TYPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_OBJECT_TYPE>()) == 0 }
+        self.TotalByteLength == other.TotalByteLength && self.DefinitionLength == other.DefinitionLength && self.HeaderLength == other.HeaderLength && self.ObjectNameTitleIndex == other.ObjectNameTitleIndex && self.ObjectNameTitle == other.ObjectNameTitle && self.ObjectHelpTitleIndex == other.ObjectHelpTitleIndex && self.ObjectHelpTitle == other.ObjectHelpTitle && self.DetailLevel == other.DetailLevel && self.NumCounters == other.NumCounters && self.DefaultCounter == other.DefaultCounter && self.NumInstances == other.NumInstances && self.CodePage == other.CodePage && self.PerfTime == other.PerfTime && self.PerfFreq == other.PerfFreq
     }
 }
 #[cfg(target_arch = "x86")]
@@ -10457,18 +10295,12 @@ impl ::core::clone::Clone for PERF_PROVIDER_CONTEXT {
 }
 impl ::core::fmt::Debug for PERF_PROVIDER_CONTEXT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("PERF_PROVIDER_CONTEXT").field("ContextSize", &self.ContextSize).field("Reserved", &self.Reserved).field("ControlCallback", &self.ControlCallback.map(|f| f as usize)).field("MemAllocRoutine", &self.MemAllocRoutine.map(|f| f as usize)).field("MemFreeRoutine", &self.MemFreeRoutine.map(|f| f as usize)).field("pMemContext", &self.pMemContext).finish()
+        f.debug_struct("PERF_PROVIDER_CONTEXT").field("ContextSize", &self.ContextSize).field("Reserved", &self.Reserved).field("pMemContext", &self.pMemContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for PERF_PROVIDER_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PERF_PROVIDER_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_PROVIDER_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PERF_PROVIDER_CONTEXT {}
 impl ::core::default::Default for PERF_PROVIDER_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10496,7 +10328,7 @@ unsafe impl ::windows::core::Abi for PERF_STRING_BUFFER_HEADER {
 }
 impl ::core::cmp::PartialEq for PERF_STRING_BUFFER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_STRING_BUFFER_HEADER>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCounters == other.dwCounters
     }
 }
 impl ::core::cmp::Eq for PERF_STRING_BUFFER_HEADER {}
@@ -10527,7 +10359,7 @@ unsafe impl ::windows::core::Abi for PERF_STRING_COUNTER_HEADER {
 }
 impl ::core::cmp::PartialEq for PERF_STRING_COUNTER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERF_STRING_COUNTER_HEADER>()) == 0 }
+        self.dwCounterId == other.dwCounterId && self.dwOffset == other.dwOffset
     }
 }
 impl ::core::cmp::Eq for PERF_STRING_COUNTER_HEADER {}

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -2075,7 +2075,7 @@ unsafe impl ::windows::core::Abi for ACPI_REAL_TIME {
 }
 impl ::core::cmp::PartialEq for ACPI_REAL_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACPI_REAL_TIME>()) == 0 }
+        self.Year == other.Year && self.Month == other.Month && self.Day == other.Day && self.Hour == other.Hour && self.Minute == other.Minute && self.Second == other.Second && self.Valid == other.Valid && self.Milliseconds == other.Milliseconds && self.TimeZone == other.TimeZone && self.DayLight == other.DayLight && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for ACPI_REAL_TIME {}
@@ -2110,7 +2110,7 @@ unsafe impl ::windows::core::Abi for ADMINISTRATOR_POWER_POLICY {
 }
 impl ::core::cmp::PartialEq for ADMINISTRATOR_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ADMINISTRATOR_POWER_POLICY>()) == 0 }
+        self.MinSleep == other.MinSleep && self.MaxSleep == other.MaxSleep && self.MinVideoTimeout == other.MinVideoTimeout && self.MaxVideoTimeout == other.MaxVideoTimeout && self.MinSpindownTimeout == other.MinSpindownTimeout && self.MaxSpindownTimeout == other.MaxSpindownTimeout
     }
 }
 impl ::core::cmp::Eq for ADMINISTRATOR_POWER_POLICY {}
@@ -2141,7 +2141,7 @@ unsafe impl ::windows::core::Abi for BATTERY_CHARGER_STATUS {
 }
 impl ::core::cmp::PartialEq for BATTERY_CHARGER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_CHARGER_STATUS>()) == 0 }
+        self.Type == other.Type && self.VaData == other.VaData
     }
 }
 impl ::core::cmp::Eq for BATTERY_CHARGER_STATUS {}
@@ -2172,7 +2172,7 @@ unsafe impl ::windows::core::Abi for BATTERY_CHARGING_SOURCE {
 }
 impl ::core::cmp::PartialEq for BATTERY_CHARGING_SOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_CHARGING_SOURCE>()) == 0 }
+        self.Type == other.Type && self.MaxCurrent == other.MaxCurrent
     }
 }
 impl ::core::cmp::Eq for BATTERY_CHARGING_SOURCE {}
@@ -2209,7 +2209,7 @@ unsafe impl ::windows::core::Abi for BATTERY_CHARGING_SOURCE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BATTERY_CHARGING_SOURCE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_CHARGING_SOURCE_INFORMATION>()) == 0 }
+        self.Type == other.Type && self.SourceOnline == other.SourceOnline
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2250,7 +2250,7 @@ unsafe impl ::windows::core::Abi for BATTERY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for BATTERY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_INFORMATION>()) == 0 }
+        self.Capabilities == other.Capabilities && self.Technology == other.Technology && self.Reserved == other.Reserved && self.Chemistry == other.Chemistry && self.DesignedCapacity == other.DesignedCapacity && self.FullChargedCapacity == other.FullChargedCapacity && self.DefaultAlert1 == other.DefaultAlert1 && self.DefaultAlert2 == other.DefaultAlert2 && self.CriticalBias == other.CriticalBias && self.CycleCount == other.CycleCount
     }
 }
 impl ::core::cmp::Eq for BATTERY_INFORMATION {}
@@ -2282,7 +2282,7 @@ unsafe impl ::windows::core::Abi for BATTERY_MANUFACTURE_DATE {
 }
 impl ::core::cmp::PartialEq for BATTERY_MANUFACTURE_DATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_MANUFACTURE_DATE>()) == 0 }
+        self.Day == other.Day && self.Month == other.Month && self.Year == other.Year
     }
 }
 impl ::core::cmp::Eq for BATTERY_MANUFACTURE_DATE {}
@@ -2314,7 +2314,7 @@ unsafe impl ::windows::core::Abi for BATTERY_QUERY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for BATTERY_QUERY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_QUERY_INFORMATION>()) == 0 }
+        self.BatteryTag == other.BatteryTag && self.InformationLevel == other.InformationLevel && self.AtRate == other.AtRate
     }
 }
 impl ::core::cmp::Eq for BATTERY_QUERY_INFORMATION {}
@@ -2345,7 +2345,7 @@ unsafe impl ::windows::core::Abi for BATTERY_REPORTING_SCALE {
 }
 impl ::core::cmp::PartialEq for BATTERY_REPORTING_SCALE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_REPORTING_SCALE>()) == 0 }
+        self.Granularity == other.Granularity && self.Capacity == other.Capacity
     }
 }
 impl ::core::cmp::Eq for BATTERY_REPORTING_SCALE {}
@@ -2377,7 +2377,7 @@ unsafe impl ::windows::core::Abi for BATTERY_SET_INFORMATION {
 }
 impl ::core::cmp::PartialEq for BATTERY_SET_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_SET_INFORMATION>()) == 0 }
+        self.BatteryTag == other.BatteryTag && self.InformationLevel == other.InformationLevel && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for BATTERY_SET_INFORMATION {}
@@ -2410,7 +2410,7 @@ unsafe impl ::windows::core::Abi for BATTERY_STATUS {
 }
 impl ::core::cmp::PartialEq for BATTERY_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_STATUS>()) == 0 }
+        self.PowerState == other.PowerState && self.Capacity == other.Capacity && self.Voltage == other.Voltage && self.Rate == other.Rate
     }
 }
 impl ::core::cmp::Eq for BATTERY_STATUS {}
@@ -2448,7 +2448,7 @@ unsafe impl ::windows::core::Abi for BATTERY_USB_CHARGER_STATUS {
 }
 impl ::core::cmp::PartialEq for BATTERY_USB_CHARGER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_USB_CHARGER_STATUS>()) == 0 }
+        self.Type == other.Type && self.Reserved == other.Reserved && self.Flags == other.Flags && self.MaxCurrent == other.MaxCurrent && self.Voltage == other.Voltage && self.PortType == other.PortType && self.PortId == other.PortId && self.PowerSourceInformation == other.PowerSourceInformation && self.OemCharger == other.OemCharger
     }
 }
 impl ::core::cmp::Eq for BATTERY_USB_CHARGER_STATUS {}
@@ -2482,7 +2482,7 @@ unsafe impl ::windows::core::Abi for BATTERY_WAIT_STATUS {
 }
 impl ::core::cmp::PartialEq for BATTERY_WAIT_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BATTERY_WAIT_STATUS>()) == 0 }
+        self.BatteryTag == other.BatteryTag && self.Timeout == other.Timeout && self.PowerState == other.PowerState && self.LowCapacity == other.LowCapacity && self.HighCapacity == other.HighCapacity
     }
 }
 impl ::core::cmp::Eq for BATTERY_WAIT_STATUS {}
@@ -2519,7 +2519,7 @@ unsafe impl ::windows::core::Abi for CM_POWER_DATA {
 }
 impl ::core::cmp::PartialEq for CM_POWER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_POWER_DATA>()) == 0 }
+        self.PD_Size == other.PD_Size && self.PD_MostRecentPowerState == other.PD_MostRecentPowerState && self.PD_Capabilities == other.PD_Capabilities && self.PD_D1Latency == other.PD_D1Latency && self.PD_D2Latency == other.PD_D2Latency && self.PD_D3Latency == other.PD_D3Latency && self.PD_PowerStateMapping == other.PD_PowerStateMapping && self.PD_DeepestSystemWake == other.PD_DeepestSystemWake
     }
 }
 impl ::core::cmp::Eq for CM_POWER_DATA {}
@@ -2542,18 +2542,12 @@ impl ::core::clone::Clone for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
 }
 impl ::core::fmt::Debug for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS").field("Callback", &self.Callback.map(|f| f as usize)).field("Context", &self.Context).finish()
+        f.debug_struct("DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS").field("Context", &self.Context).finish()
     }
 }
 unsafe impl ::windows::core::Abi for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {}
 impl ::core::default::Default for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2581,7 +2575,7 @@ unsafe impl ::windows::core::Abi for EMI_CHANNEL_MEASUREMENT_DATA {
 }
 impl ::core::cmp::PartialEq for EMI_CHANNEL_MEASUREMENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_CHANNEL_MEASUREMENT_DATA>()) == 0 }
+        self.AbsoluteEnergy == other.AbsoluteEnergy && self.AbsoluteTime == other.AbsoluteTime
     }
 }
 impl ::core::cmp::Eq for EMI_CHANNEL_MEASUREMENT_DATA {}
@@ -2613,7 +2607,7 @@ unsafe impl ::windows::core::Abi for EMI_CHANNEL_V2 {
 }
 impl ::core::cmp::PartialEq for EMI_CHANNEL_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_CHANNEL_V2>()) == 0 }
+        self.MeasurementUnit == other.MeasurementUnit && self.ChannelNameSize == other.ChannelNameSize && self.ChannelName == other.ChannelName
     }
 }
 impl ::core::cmp::Eq for EMI_CHANNEL_V2 {}
@@ -2643,7 +2637,7 @@ unsafe impl ::windows::core::Abi for EMI_MEASUREMENT_DATA_V2 {
 }
 impl ::core::cmp::PartialEq for EMI_MEASUREMENT_DATA_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_MEASUREMENT_DATA_V2>()) == 0 }
+        self.ChannelData == other.ChannelData
     }
 }
 impl ::core::cmp::Eq for EMI_MEASUREMENT_DATA_V2 {}
@@ -2673,7 +2667,7 @@ unsafe impl ::windows::core::Abi for EMI_METADATA_SIZE {
 }
 impl ::core::cmp::PartialEq for EMI_METADATA_SIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_METADATA_SIZE>()) == 0 }
+        self.MetadataSize == other.MetadataSize
     }
 }
 impl ::core::cmp::Eq for EMI_METADATA_SIZE {}
@@ -2708,7 +2702,7 @@ unsafe impl ::windows::core::Abi for EMI_METADATA_V1 {
 }
 impl ::core::cmp::PartialEq for EMI_METADATA_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_METADATA_V1>()) == 0 }
+        self.MeasurementUnit == other.MeasurementUnit && self.HardwareOEM == other.HardwareOEM && self.HardwareModel == other.HardwareModel && self.HardwareRevision == other.HardwareRevision && self.MeteredHardwareNameSize == other.MeteredHardwareNameSize && self.MeteredHardwareName == other.MeteredHardwareName
     }
 }
 impl ::core::cmp::Eq for EMI_METADATA_V1 {}
@@ -2742,7 +2736,7 @@ unsafe impl ::windows::core::Abi for EMI_METADATA_V2 {
 }
 impl ::core::cmp::PartialEq for EMI_METADATA_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_METADATA_V2>()) == 0 }
+        self.HardwareOEM == other.HardwareOEM && self.HardwareModel == other.HardwareModel && self.HardwareRevision == other.HardwareRevision && self.ChannelCount == other.ChannelCount && self.Channels == other.Channels
     }
 }
 impl ::core::cmp::Eq for EMI_METADATA_V2 {}
@@ -2772,7 +2766,7 @@ unsafe impl ::windows::core::Abi for EMI_VERSION {
 }
 impl ::core::cmp::PartialEq for EMI_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMI_VERSION>()) == 0 }
+        self.EmiVersion == other.EmiVersion
     }
 }
 impl ::core::cmp::Eq for EMI_VERSION {}
@@ -2805,7 +2799,7 @@ unsafe impl ::windows::core::Abi for GLOBAL_MACHINE_POWER_POLICY {
 }
 impl ::core::cmp::PartialEq for GLOBAL_MACHINE_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLOBAL_MACHINE_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision && self.LidOpenWakeAc == other.LidOpenWakeAc && self.LidOpenWakeDc == other.LidOpenWakeDc && self.BroadcastCapacityResolution == other.BroadcastCapacityResolution
     }
 }
 impl ::core::cmp::Eq for GLOBAL_MACHINE_POWER_POLICY {}
@@ -2842,7 +2836,7 @@ unsafe impl ::windows::core::Abi for GLOBAL_POWER_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GLOBAL_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLOBAL_POWER_POLICY>()) == 0 }
+        self.user == other.user && self.mach == other.mach
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2888,7 +2882,7 @@ unsafe impl ::windows::core::Abi for GLOBAL_USER_POWER_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GLOBAL_USER_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLOBAL_USER_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision && self.PowerButtonAc == other.PowerButtonAc && self.PowerButtonDc == other.PowerButtonDc && self.SleepButtonAc == other.SleepButtonAc && self.SleepButtonDc == other.SleepButtonDc && self.LidCloseAc == other.LidCloseAc && self.LidCloseDc == other.LidCloseDc && self.DischargePolicy == other.DischargePolicy && self.GlobalFlags == other.GlobalFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2980,7 +2974,7 @@ unsafe impl ::windows::core::Abi for MACHINE_POWER_POLICY {
 }
 impl ::core::cmp::PartialEq for MACHINE_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MACHINE_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision && self.MinSleepAc == other.MinSleepAc && self.MinSleepDc == other.MinSleepDc && self.ReducedLatencySleepAc == other.ReducedLatencySleepAc && self.ReducedLatencySleepDc == other.ReducedLatencySleepDc && self.DozeTimeoutAc == other.DozeTimeoutAc && self.DozeTimeoutDc == other.DozeTimeoutDc && self.DozeS4TimeoutAc == other.DozeS4TimeoutAc && self.DozeS4TimeoutDc == other.DozeS4TimeoutDc && self.MinThrottleAc == other.MinThrottleAc && self.MinThrottleDc == other.MinThrottleDc && self.pad1 == other.pad1 && self.OverThrottledAc == other.OverThrottledAc && self.OverThrottledDc == other.OverThrottledDc
     }
 }
 impl ::core::cmp::Eq for MACHINE_POWER_POLICY {}
@@ -3012,7 +3006,7 @@ unsafe impl ::windows::core::Abi for MACHINE_PROCESSOR_POWER_POLICY {
 }
 impl ::core::cmp::PartialEq for MACHINE_PROCESSOR_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MACHINE_PROCESSOR_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision && self.ProcessorPolicyAc == other.ProcessorPolicyAc && self.ProcessorPolicyDc == other.ProcessorPolicyDc
     }
 }
 impl ::core::cmp::Eq for MACHINE_PROCESSOR_POWER_POLICY {}
@@ -3044,7 +3038,7 @@ unsafe impl ::windows::core::Abi for POWERBROADCAST_SETTING {
 }
 impl ::core::cmp::PartialEq for POWERBROADCAST_SETTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWERBROADCAST_SETTING>()) == 0 }
+        self.PowerSetting == other.PowerSetting && self.DataLength == other.DataLength && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for POWERBROADCAST_SETTING {}
@@ -3076,7 +3070,7 @@ unsafe impl ::windows::core::Abi for POWER_ACTION_POLICY {
 }
 impl ::core::cmp::PartialEq for POWER_ACTION_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_ACTION_POLICY>()) == 0 }
+        self.Action == other.Action && self.Flags == other.Flags && self.EventCode == other.EventCode
     }
 }
 impl ::core::cmp::Eq for POWER_ACTION_POLICY {}
@@ -3113,7 +3107,7 @@ unsafe impl ::windows::core::Abi for POWER_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_POLICY>()) == 0 }
+        self.user == other.user && self.mach == other.mach
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3147,7 +3141,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_OBJECT_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_OBJECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_OBJECT_INFO>()) == 0 }
+        self.PhysicalID == other.PhysicalID && self.PBlkAddress == other.PBlkAddress && self.PBlkLength == other.PBlkLength
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_OBJECT_INFO {}
@@ -3180,7 +3174,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_OBJECT_INFO_EX {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_OBJECT_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_OBJECT_INFO_EX>()) == 0 }
+        self.PhysicalID == other.PhysicalID && self.PBlkAddress == other.PBlkAddress && self.PBlkLength == other.PBlkLength && self.InitialApicId == other.InitialApicId
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_OBJECT_INFO_EX {}
@@ -3215,7 +3209,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_POWER_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_POWER_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_POWER_INFORMATION>()) == 0 }
+        self.Number == other.Number && self.MaxMhz == other.MaxMhz && self.CurrentMhz == other.CurrentMhz && self.MhzLimit == other.MhzLimit && self.MaxIdleState == other.MaxIdleState && self.CurrentIdleState == other.CurrentIdleState
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_POWER_INFORMATION {}
@@ -3250,7 +3244,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_POWER_POLICY {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision && self.DynamicThrottle == other.DynamicThrottle && self.Spare == other.Spare && self._bitfield == other._bitfield && self.PolicyCount == other.PolicyCount && self.Policy == other.Policy
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_POWER_POLICY {}
@@ -3286,7 +3280,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_POWER_POLICY_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_POWER_POLICY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_POWER_POLICY_INFO>()) == 0 }
+        self.TimeCheck == other.TimeCheck && self.DemoteLimit == other.DemoteLimit && self.PromoteLimit == other.PromoteLimit && self.DemotePercent == other.DemotePercent && self.PromotePercent == other.PromotePercent && self.Spare == other.Spare && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_POWER_POLICY_INFO {}
@@ -3320,7 +3314,7 @@ unsafe impl ::windows::core::Abi for SET_POWER_SETTING_VALUE {
 }
 impl ::core::cmp::PartialEq for SET_POWER_SETTING_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SET_POWER_SETTING_VALUE>()) == 0 }
+        self.Version == other.Version && self.Guid == other.Guid && self.PowerCondition == other.PowerCondition && self.DataLength == other.DataLength && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SET_POWER_SETTING_VALUE {}
@@ -3380,7 +3374,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_BATTERY_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_BATTERY_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_BATTERY_STATE>()) == 0 }
+        self.AcOnLine == other.AcOnLine && self.BatteryPresent == other.BatteryPresent && self.Charging == other.Charging && self.Discharging == other.Discharging && self.Spare1 == other.Spare1 && self.Tag == other.Tag && self.MaxCapacity == other.MaxCapacity && self.RemainingCapacity == other.RemainingCapacity && self.Rate == other.Rate && self.EstimatedTime == other.EstimatedTime && self.DefaultAlert1 == other.DefaultAlert1 && self.DefaultAlert2 == other.DefaultAlert2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3484,7 +3478,39 @@ unsafe impl ::windows::core::Abi for SYSTEM_POWER_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_POWER_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POWER_CAPABILITIES>()) == 0 }
+        self.PowerButtonPresent == other.PowerButtonPresent
+            && self.SleepButtonPresent == other.SleepButtonPresent
+            && self.LidPresent == other.LidPresent
+            && self.SystemS1 == other.SystemS1
+            && self.SystemS2 == other.SystemS2
+            && self.SystemS3 == other.SystemS3
+            && self.SystemS4 == other.SystemS4
+            && self.SystemS5 == other.SystemS5
+            && self.HiberFilePresent == other.HiberFilePresent
+            && self.FullWake == other.FullWake
+            && self.VideoDimPresent == other.VideoDimPresent
+            && self.ApmPresent == other.ApmPresent
+            && self.UpsPresent == other.UpsPresent
+            && self.ThermalControl == other.ThermalControl
+            && self.ProcessorThrottle == other.ProcessorThrottle
+            && self.ProcessorMinThrottle == other.ProcessorMinThrottle
+            && self.ProcessorMaxThrottle == other.ProcessorMaxThrottle
+            && self.FastSystemS4 == other.FastSystemS4
+            && self.Hiberboot == other.Hiberboot
+            && self.WakeAlarmPresent == other.WakeAlarmPresent
+            && self.AoAc == other.AoAc
+            && self.DiskSpinDown == other.DiskSpinDown
+            && self.HiberFileType == other.HiberFileType
+            && self.AoAcConnectivitySupported == other.AoAcConnectivitySupported
+            && self.spare3 == other.spare3
+            && self.SystemBatteriesPresent == other.SystemBatteriesPresent
+            && self.BatteriesAreShortTerm == other.BatteriesAreShortTerm
+            && self.BatteryScale == other.BatteryScale
+            && self.AcOnLineWake == other.AcOnLineWake
+            && self.SoftLidWake == other.SoftLidWake
+            && self.RtcWake == other.RtcWake
+            && self.MinDeviceWakeState == other.MinDeviceWakeState
+            && self.DefaultLowLatencyWake == other.DefaultLowLatencyWake
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3519,7 +3545,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_POWER_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_POWER_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POWER_INFORMATION>()) == 0 }
+        self.MaxIdlenessAllowed == other.MaxIdlenessAllowed && self.Idleness == other.Idleness && self.TimeRemaining == other.TimeRemaining && self.CoolingMode == other.CoolingMode
     }
 }
 impl ::core::cmp::Eq for SYSTEM_POWER_INFORMATION {}
@@ -3559,7 +3585,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_POWER_LEVEL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_POWER_LEVEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POWER_LEVEL>()) == 0 }
+        self.Enable == other.Enable && self.Spare == other.Spare && self.BatteryLevel == other.BatteryLevel && self.PowerPolicy == other.PowerPolicy && self.MinSystemState == other.MinSystemState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3653,7 +3679,34 @@ unsafe impl ::windows::core::Abi for SYSTEM_POWER_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision
+            && self.PowerButton == other.PowerButton
+            && self.SleepButton == other.SleepButton
+            && self.LidClose == other.LidClose
+            && self.LidOpenWake == other.LidOpenWake
+            && self.Reserved == other.Reserved
+            && self.Idle == other.Idle
+            && self.IdleTimeout == other.IdleTimeout
+            && self.IdleSensitivity == other.IdleSensitivity
+            && self.DynamicThrottle == other.DynamicThrottle
+            && self.Spare2 == other.Spare2
+            && self.MinSleep == other.MinSleep
+            && self.MaxSleep == other.MaxSleep
+            && self.ReducedLatencySleep == other.ReducedLatencySleep
+            && self.WinLogonFlags == other.WinLogonFlags
+            && self.Spare3 == other.Spare3
+            && self.DozeS4Timeout == other.DozeS4Timeout
+            && self.BroadcastCapacityResolution == other.BroadcastCapacityResolution
+            && self.DischargePolicy == other.DischargePolicy
+            && self.VideoTimeout == other.VideoTimeout
+            && self.VideoDimDisplay == other.VideoDimDisplay
+            && self.VideoReserved == other.VideoReserved
+            && self.SpindownTimeout == other.SpindownTimeout
+            && self.OptimizeForPower == other.OptimizeForPower
+            && self.FanThrottleTolerance == other.FanThrottleTolerance
+            && self.ForcedThrottle == other.ForcedThrottle
+            && self.MinThrottle == other.MinThrottle
+            && self.OverThrottled == other.OverThrottled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3690,7 +3743,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_POWER_STATUS {
 }
 impl ::core::cmp::PartialEq for SYSTEM_POWER_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POWER_STATUS>()) == 0 }
+        self.ACLineStatus == other.ACLineStatus && self.BatteryFlag == other.BatteryFlag && self.BatteryLifePercent == other.BatteryLifePercent && self.SystemStatusFlag == other.SystemStatusFlag && self.BatteryLifeTime == other.BatteryLifeTime && self.BatteryFullLifeTime == other.BatteryFullLifeTime
     }
 }
 impl ::core::cmp::Eq for SYSTEM_POWER_STATUS {}
@@ -3725,7 +3778,7 @@ unsafe impl ::windows::core::Abi for THERMAL_EVENT {
 }
 impl ::core::cmp::PartialEq for THERMAL_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THERMAL_EVENT>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.Type == other.Type && self.Temperature == other.Temperature && self.TripPointTemperature == other.TripPointTemperature && self.Initiator == other.Initiator
     }
 }
 impl ::core::cmp::Eq for THERMAL_EVENT {}
@@ -3775,7 +3828,7 @@ unsafe impl ::windows::core::Abi for THERMAL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for THERMAL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THERMAL_INFORMATION>()) == 0 }
+        self.ThermalStamp == other.ThermalStamp && self.ThermalConstant1 == other.ThermalConstant1 && self.ThermalConstant2 == other.ThermalConstant2 && self.Processors == other.Processors && self.SamplingPeriod == other.SamplingPeriod && self.CurrentTemperature == other.CurrentTemperature && self.PassiveTripPoint == other.PassiveTripPoint && self.CriticalTripPoint == other.CriticalTripPoint && self.ActiveTripPointCount == other.ActiveTripPointCount && self.ActiveTripPoint == other.ActiveTripPoint
     }
 }
 impl ::core::cmp::Eq for THERMAL_INFORMATION {}
@@ -3819,7 +3872,7 @@ unsafe impl ::windows::core::Abi for THERMAL_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for THERMAL_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THERMAL_POLICY>()) == 0 }
+        self.Version == other.Version && self.WaitForUpdate == other.WaitForUpdate && self.Hibernate == other.Hibernate && self.Critical == other.Critical && self.ThermalStandby == other.ThermalStandby && self.ActivationReasons == other.ActivationReasons && self.PassiveLimit == other.PassiveLimit && self.ActiveLevel == other.ActiveLevel && self.OverThrottled == other.OverThrottled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3853,7 +3906,7 @@ unsafe impl ::windows::core::Abi for THERMAL_WAIT_READ {
 }
 impl ::core::cmp::PartialEq for THERMAL_WAIT_READ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THERMAL_WAIT_READ>()) == 0 }
+        self.Timeout == other.Timeout && self.LowTemperature == other.LowTemperature && self.HighTemperature == other.HighTemperature
     }
 }
 impl ::core::cmp::Eq for THERMAL_WAIT_READ {}
@@ -3933,7 +3986,28 @@ unsafe impl ::windows::core::Abi for USER_POWER_POLICY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USER_POWER_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_POWER_POLICY>()) == 0 }
+        self.Revision == other.Revision
+            && self.IdleAc == other.IdleAc
+            && self.IdleDc == other.IdleDc
+            && self.IdleTimeoutAc == other.IdleTimeoutAc
+            && self.IdleTimeoutDc == other.IdleTimeoutDc
+            && self.IdleSensitivityAc == other.IdleSensitivityAc
+            && self.IdleSensitivityDc == other.IdleSensitivityDc
+            && self.ThrottlePolicyAc == other.ThrottlePolicyAc
+            && self.ThrottlePolicyDc == other.ThrottlePolicyDc
+            && self.MaxSleepAc == other.MaxSleepAc
+            && self.MaxSleepDc == other.MaxSleepDc
+            && self.Reserved == other.Reserved
+            && self.VideoTimeoutAc == other.VideoTimeoutAc
+            && self.VideoTimeoutDc == other.VideoTimeoutDc
+            && self.SpindownTimeoutAc == other.SpindownTimeoutAc
+            && self.SpindownTimeoutDc == other.SpindownTimeoutDc
+            && self.OptimizeForPowerAc == other.OptimizeForPowerAc
+            && self.OptimizeForPowerDc == other.OptimizeForPowerDc
+            && self.FanThrottleToleranceAc == other.FanThrottleToleranceAc
+            && self.FanThrottleToleranceDc == other.FanThrottleToleranceDc
+            && self.ForcedThrottleAc == other.ForcedThrottleAc
+            && self.ForcedThrottleDc == other.ForcedThrottleDc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3966,7 +4040,7 @@ unsafe impl ::windows::core::Abi for WAKE_ALARM_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WAKE_ALARM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WAKE_ALARM_INFORMATION>()) == 0 }
+        self.TimerIdentifier == other.TimerIdentifier && self.Timeout == other.Timeout
     }
 }
 impl ::core::cmp::Eq for WAKE_ALARM_INFORMATION {}

--- a/crates/libs/windows/src/Windows/Win32/System/ProcessStatus/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ProcessStatus/mod.rs
@@ -300,7 +300,7 @@ unsafe impl ::windows::core::Abi for ENUM_PAGE_FILE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ENUM_PAGE_FILE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUM_PAGE_FILE_INFORMATION>()) == 0 }
+        self.cb == other.cb && self.Reserved == other.Reserved && self.TotalSize == other.TotalSize && self.TotalInUse == other.TotalInUse && self.PeakUsage == other.PeakUsage
     }
 }
 impl ::core::cmp::Eq for ENUM_PAGE_FILE_INFORMATION {}
@@ -332,7 +332,7 @@ unsafe impl ::windows::core::Abi for MODULEINFO {
 }
 impl ::core::cmp::PartialEq for MODULEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULEINFO>()) == 0 }
+        self.lpBaseOfDll == other.lpBaseOfDll && self.SizeOfImage == other.SizeOfImage && self.EntryPoint == other.EntryPoint
     }
 }
 impl ::core::cmp::Eq for MODULEINFO {}
@@ -390,7 +390,7 @@ unsafe impl ::windows::core::Abi for PERFORMANCE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PERFORMANCE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERFORMANCE_INFORMATION>()) == 0 }
+        self.cb == other.cb && self.CommitTotal == other.CommitTotal && self.CommitLimit == other.CommitLimit && self.CommitPeak == other.CommitPeak && self.PhysicalTotal == other.PhysicalTotal && self.PhysicalAvailable == other.PhysicalAvailable && self.SystemCache == other.SystemCache && self.KernelTotal == other.KernelTotal && self.KernelPaged == other.KernelPaged && self.KernelNonpaged == other.KernelNonpaged && self.PageSize == other.PageSize && self.HandleCount == other.HandleCount && self.ProcessCount == other.ProcessCount && self.ThreadCount == other.ThreadCount
     }
 }
 impl ::core::cmp::Eq for PERFORMANCE_INFORMATION {}
@@ -440,7 +440,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MEMORY_COUNTERS {
 }
 impl ::core::cmp::PartialEq for PROCESS_MEMORY_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MEMORY_COUNTERS>()) == 0 }
+        self.cb == other.cb && self.PageFaultCount == other.PageFaultCount && self.PeakWorkingSetSize == other.PeakWorkingSetSize && self.WorkingSetSize == other.WorkingSetSize && self.QuotaPeakPagedPoolUsage == other.QuotaPeakPagedPoolUsage && self.QuotaPagedPoolUsage == other.QuotaPagedPoolUsage && self.QuotaPeakNonPagedPoolUsage == other.QuotaPeakNonPagedPoolUsage && self.QuotaNonPagedPoolUsage == other.QuotaNonPagedPoolUsage && self.PagefileUsage == other.PagefileUsage && self.PeakPagefileUsage == other.PeakPagefileUsage
     }
 }
 impl ::core::cmp::Eq for PROCESS_MEMORY_COUNTERS {}
@@ -492,7 +492,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MEMORY_COUNTERS_EX {
 }
 impl ::core::cmp::PartialEq for PROCESS_MEMORY_COUNTERS_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>()) == 0 }
+        self.cb == other.cb && self.PageFaultCount == other.PageFaultCount && self.PeakWorkingSetSize == other.PeakWorkingSetSize && self.WorkingSetSize == other.WorkingSetSize && self.QuotaPeakPagedPoolUsage == other.QuotaPeakPagedPoolUsage && self.QuotaPagedPoolUsage == other.QuotaPagedPoolUsage && self.QuotaPeakNonPagedPoolUsage == other.QuotaPeakNonPagedPoolUsage && self.QuotaNonPagedPoolUsage == other.QuotaNonPagedPoolUsage && self.PagefileUsage == other.PagefileUsage && self.PeakPagefileUsage == other.PeakPagefileUsage && self.PrivateUsage == other.PrivateUsage
     }
 }
 impl ::core::cmp::Eq for PROCESS_MEMORY_COUNTERS_EX {}
@@ -516,12 +516,6 @@ impl ::core::clone::Clone for PSAPI_WORKING_SET_BLOCK {
 unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_BLOCK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_BLOCK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_BLOCK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PSAPI_WORKING_SET_BLOCK {}
 impl ::core::default::Default for PSAPI_WORKING_SET_BLOCK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -548,7 +542,7 @@ unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_BLOCK_0 {
 }
 impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_BLOCK_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_BLOCK_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PSAPI_WORKING_SET_BLOCK_0 {}
@@ -572,12 +566,6 @@ impl ::core::clone::Clone for PSAPI_WORKING_SET_EX_BLOCK {
 unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_EX_BLOCK {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_EX_BLOCK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_EX_BLOCK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PSAPI_WORKING_SET_EX_BLOCK {}
 impl ::core::default::Default for PSAPI_WORKING_SET_EX_BLOCK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -598,12 +586,6 @@ impl ::core::clone::Clone for PSAPI_WORKING_SET_EX_BLOCK_0 {
 unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_EX_BLOCK_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_EX_BLOCK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_EX_BLOCK_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PSAPI_WORKING_SET_EX_BLOCK_0 {}
 impl ::core::default::Default for PSAPI_WORKING_SET_EX_BLOCK_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -630,7 +612,7 @@ unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_EX_BLOCK_0_0 {
 }
 impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_EX_BLOCK_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_EX_BLOCK_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PSAPI_WORKING_SET_EX_BLOCK_0_0 {}
@@ -660,7 +642,7 @@ unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_EX_BLOCK_0_1 {
 }
 impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_EX_BLOCK_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_EX_BLOCK_0_1>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PSAPI_WORKING_SET_EX_BLOCK_0_1 {}
@@ -684,12 +666,6 @@ impl ::core::clone::Clone for PSAPI_WORKING_SET_EX_INFORMATION {
 unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_EX_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_EX_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_EX_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PSAPI_WORKING_SET_EX_INFORMATION {}
 impl ::core::default::Default for PSAPI_WORKING_SET_EX_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -710,12 +686,6 @@ impl ::core::clone::Clone for PSAPI_WORKING_SET_INFORMATION {
 unsafe impl ::windows::core::Abi for PSAPI_WORKING_SET_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PSAPI_WORKING_SET_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WORKING_SET_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PSAPI_WORKING_SET_INFORMATION {}
 impl ::core::default::Default for PSAPI_WORKING_SET_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -743,7 +713,7 @@ unsafe impl ::windows::core::Abi for PSAPI_WS_WATCH_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PSAPI_WS_WATCH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WS_WATCH_INFORMATION>()) == 0 }
+        self.FaultingPc == other.FaultingPc && self.FaultingVa == other.FaultingVa
     }
 }
 impl ::core::cmp::Eq for PSAPI_WS_WATCH_INFORMATION {}
@@ -775,7 +745,7 @@ unsafe impl ::windows::core::Abi for PSAPI_WS_WATCH_INFORMATION_EX {
 }
 impl ::core::cmp::PartialEq for PSAPI_WS_WATCH_INFORMATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSAPI_WS_WATCH_INFORMATION_EX>()) == 0 }
+        self.BasicInfo == other.BasicInfo && self.FaultingThreadId == other.FaultingThreadId && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for PSAPI_WS_WATCH_INFORMATION_EX {}

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
@@ -6853,7 +6853,7 @@ unsafe impl ::windows::core::Abi for TRANSPORT_SETTING {
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ::core::cmp::PartialEq for TRANSPORT_SETTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSPORT_SETTING>()) == 0 }
+        self.SettingId == other.SettingId && self.Length == other.Length && self.Value == other.Value
     }
 }
 #[cfg(feature = "Win32_Networking_WinSock")]

--- a/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
@@ -3200,7 +3200,7 @@ unsafe impl ::windows::core::Abi for DSKTLSYSTEMTIME {
 }
 impl ::core::cmp::PartialEq for DSKTLSYSTEMTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DSKTLSYSTEMTIME>()) == 0 }
+        self.wYear == other.wYear && self.wMonth == other.wMonth && self.wDayOfWeek == other.wDayOfWeek && self.wDay == other.wDay && self.wHour == other.wHour && self.wMinute == other.wMinute && self.wSecond == other.wSecond && self.wMilliseconds == other.wMilliseconds && self.wResult == other.wResult
     }
 }
 impl ::core::cmp::Eq for DSKTLSYSTEMTIME {}
@@ -3265,7 +3265,7 @@ unsafe impl ::windows::core::Abi for PVALUEA {
 }
 impl ::core::cmp::PartialEq for PVALUEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PVALUEA>()) == 0 }
+        self.pv_valuename == other.pv_valuename && self.pv_valuelen == other.pv_valuelen && self.pv_value_context == other.pv_value_context && self.pv_type == other.pv_type
     }
 }
 impl ::core::cmp::Eq for PVALUEA {}
@@ -3298,7 +3298,7 @@ unsafe impl ::windows::core::Abi for PVALUEW {
 }
 impl ::core::cmp::PartialEq for PVALUEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PVALUEW>()) == 0 }
+        self.pv_valuename == other.pv_valuename && self.pv_valuelen == other.pv_valuelen && self.pv_value_context == other.pv_value_context && self.pv_type == other.pv_type
     }
 }
 impl ::core::cmp::Eq for PVALUEW {}
@@ -3325,18 +3325,12 @@ impl ::core::clone::Clone for REG_PROVIDER {
 }
 impl ::core::fmt::Debug for REG_PROVIDER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("REG_PROVIDER").field("pi_R0_1val", &self.pi_R0_1val.map(|f| f as usize)).field("pi_R0_allvals", &self.pi_R0_allvals.map(|f| f as usize)).field("pi_R3_1val", &self.pi_R3_1val.map(|f| f as usize)).field("pi_R3_allvals", &self.pi_R3_allvals.map(|f| f as usize)).field("pi_flags", &self.pi_flags).field("pi_key_context", &self.pi_key_context).finish()
+        f.debug_struct("REG_PROVIDER").field("pi_flags", &self.pi_flags).field("pi_key_context", &self.pi_key_context).finish()
     }
 }
 unsafe impl ::windows::core::Abi for REG_PROVIDER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for REG_PROVIDER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REG_PROVIDER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for REG_PROVIDER {}
 impl ::core::default::Default for REG_PROVIDER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3366,7 +3360,7 @@ unsafe impl ::windows::core::Abi for VALENTA {
 }
 impl ::core::cmp::PartialEq for VALENTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VALENTA>()) == 0 }
+        self.ve_valuename == other.ve_valuename && self.ve_valuelen == other.ve_valuelen && self.ve_valueptr == other.ve_valueptr && self.ve_type == other.ve_type
     }
 }
 impl ::core::cmp::Eq for VALENTA {}
@@ -3399,7 +3393,7 @@ unsafe impl ::windows::core::Abi for VALENTW {
 }
 impl ::core::cmp::PartialEq for VALENTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VALENTW>()) == 0 }
+        self.ve_valuename == other.ve_valuename && self.ve_valuelen == other.ve_valuelen && self.ve_valueptr == other.ve_valueptr && self.ve_type == other.ve_type
     }
 }
 impl ::core::cmp::Eq for VALENTW {}
@@ -3431,7 +3425,7 @@ unsafe impl ::windows::core::Abi for val_context {
 }
 impl ::core::cmp::PartialEq for val_context {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<val_context>()) == 0 }
+        self.valuelen == other.valuelen && self.value_context == other.value_context && self.val_buff_ptr == other.val_buff_ptr
     }
 }
 impl ::core::cmp::Eq for val_context {}

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -9460,7 +9460,7 @@ unsafe impl ::windows::core::Abi for AE_CURRENT_POSITION {
 }
 impl ::core::cmp::PartialEq for AE_CURRENT_POSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AE_CURRENT_POSITION>()) == 0 }
+        self.u64DevicePosition == other.u64DevicePosition && self.u64StreamPosition == other.u64StreamPosition && self.u64PaddingFrames == other.u64PaddingFrames && self.hnsQPCPosition == other.hnsQPCPosition && self.f32FramesPerSecond == other.f32FramesPerSecond && self.Flag == other.Flag
     }
 }
 impl ::core::cmp::Eq for AE_CURRENT_POSITION {}
@@ -9491,7 +9491,7 @@ unsafe impl ::windows::core::Abi for BITMAP_RENDERER_STATISTICS {
 }
 impl ::core::cmp::PartialEq for BITMAP_RENDERER_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BITMAP_RENDERER_STATISTICS>()) == 0 }
+        self.dwFramesDelivered == other.dwFramesDelivered && self.dwFramesDropped == other.dwFramesDropped
     }
 }
 impl ::core::cmp::Eq for BITMAP_RENDERER_STATISTICS {}
@@ -9520,14 +9520,6 @@ unsafe impl ::windows::core::Abi for CHANNEL_DEF {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHANNEL_DEF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANNEL_DEF>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHANNEL_DEF {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHANNEL_DEF {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9555,21 +9547,13 @@ impl ::core::clone::Clone for CHANNEL_ENTRY_POINTS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for CHANNEL_ENTRY_POINTS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CHANNEL_ENTRY_POINTS").field("cbSize", &self.cbSize).field("protocolVersion", &self.protocolVersion).field("pVirtualChannelInit", &self.pVirtualChannelInit.map(|f| f as usize)).field("pVirtualChannelOpen", &self.pVirtualChannelOpen.map(|f| f as usize)).field("pVirtualChannelClose", &self.pVirtualChannelClose.map(|f| f as usize)).field("pVirtualChannelWrite", &self.pVirtualChannelWrite.map(|f| f as usize)).finish()
+        f.debug_struct("CHANNEL_ENTRY_POINTS").field("cbSize", &self.cbSize).field("protocolVersion", &self.protocolVersion).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for CHANNEL_ENTRY_POINTS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHANNEL_ENTRY_POINTS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANNEL_ENTRY_POINTS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHANNEL_ENTRY_POINTS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHANNEL_ENTRY_POINTS {
     fn default() -> Self {
@@ -9598,7 +9582,7 @@ unsafe impl ::windows::core::Abi for CHANNEL_PDU_HEADER {
 }
 impl ::core::cmp::PartialEq for CHANNEL_PDU_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANNEL_PDU_HEADER>()) == 0 }
+        self.length == other.length && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for CHANNEL_PDU_HEADER {}
@@ -9630,7 +9614,7 @@ unsafe impl ::windows::core::Abi for CLIENT_DISPLAY {
 }
 impl ::core::cmp::PartialEq for CLIENT_DISPLAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIENT_DISPLAY>()) == 0 }
+        self.HorizontalResolution == other.HorizontalResolution && self.VerticalResolution == other.VerticalResolution && self.ColorDepth == other.ColorDepth
     }
 }
 impl ::core::cmp::Eq for CLIENT_DISPLAY {}
@@ -9699,7 +9683,7 @@ unsafe impl ::windows::core::Abi for PRODUCT_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PRODUCT_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRODUCT_INFOA>()) == 0 }
+        self.CompanyName == other.CompanyName && self.ProductID == other.ProductID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9732,7 +9716,7 @@ unsafe impl ::windows::core::Abi for PRODUCT_INFOW {
 }
 impl ::core::cmp::PartialEq for PRODUCT_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRODUCT_INFOW>()) == 0 }
+        self.CompanyName == other.CompanyName && self.ProductID == other.ProductID
     }
 }
 impl ::core::cmp::Eq for PRODUCT_INFOW {}
@@ -9767,14 +9751,6 @@ unsafe impl ::windows::core::Abi for RFX_GFX_MONITOR_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RFX_GFX_MONITOR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MONITOR_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RFX_GFX_MONITOR_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RFX_GFX_MONITOR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9794,12 +9770,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {}
 impl ::core::default::Default for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9828,14 +9798,6 @@ unsafe impl ::windows::core::Abi for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9855,12 +9817,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {}
 impl ::core::default::Default for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9884,12 +9840,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {}
 impl ::core::default::Default for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9911,12 +9861,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_DESKTOP_INPUT_RESET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_DESKTOP_INPUT_RESET {}
 impl ::core::default::Default for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9937,12 +9881,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_DESKTOP_RESEND_REQUEST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {}
 impl ::core::default::Default for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9963,12 +9901,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_DISCONNECT_NOTIFY {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_DISCONNECT_NOTIFY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_DISCONNECT_NOTIFY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_DISCONNECT_NOTIFY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_DISCONNECT_NOTIFY {}
 impl ::core::default::Default for RFX_GFX_MSG_DISCONNECT_NOTIFY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9989,12 +9921,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_HEADER {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_HEADER {}
 impl ::core::default::Default for RFX_GFX_MSG_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10015,12 +9941,6 @@ impl ::core::clone::Clone for RFX_GFX_MSG_RDP_DATA {
 unsafe impl ::windows::core::Abi for RFX_GFX_MSG_RDP_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_MSG_RDP_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_MSG_RDP_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_MSG_RDP_DATA {}
 impl ::core::default::Default for RFX_GFX_MSG_RDP_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10043,12 +9963,6 @@ impl ::core::clone::Clone for RFX_GFX_RECT {
 unsafe impl ::windows::core::Abi for RFX_GFX_RECT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RFX_GFX_RECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RFX_GFX_RECT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RFX_GFX_RECT {}
 impl ::core::default::Default for RFX_GFX_RECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10078,7 +9992,7 @@ unsafe impl ::windows::core::Abi for TSSD_ConnectionPoint {
 }
 impl ::core::cmp::PartialEq for TSSD_ConnectionPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TSSD_ConnectionPoint>()) == 0 }
+        self.ServerAddressB == other.ServerAddressB && self.AddressType == other.AddressType && self.PortNumber == other.PortNumber && self.AddressScope == other.AddressScope
     }
 }
 impl ::core::cmp::Eq for TSSD_ConnectionPoint {}
@@ -10109,7 +10023,7 @@ unsafe impl ::windows::core::Abi for VM_NOTIFY_ENTRY {
 }
 impl ::core::cmp::PartialEq for VM_NOTIFY_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VM_NOTIFY_ENTRY>()) == 0 }
+        self.VmName == other.VmName && self.VmHost == other.VmHost
     }
 }
 impl ::core::cmp::Eq for VM_NOTIFY_ENTRY {}
@@ -10140,7 +10054,7 @@ unsafe impl ::windows::core::Abi for VM_NOTIFY_INFO {
 }
 impl ::core::cmp::PartialEq for VM_NOTIFY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VM_NOTIFY_INFO>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.ppVmEntries == other.ppVmEntries
     }
 }
 impl ::core::cmp::Eq for VM_NOTIFY_INFO {}
@@ -10171,7 +10085,7 @@ unsafe impl ::windows::core::Abi for VM_PATCH_INFO {
 }
 impl ::core::cmp::PartialEq for VM_PATCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VM_PATCH_INFO>()) == 0 }
+        self.dwNumEntries == other.dwNumEntries && self.pVmNames == other.pVmNames
     }
 }
 impl ::core::cmp::Eq for VM_PATCH_INFO {}
@@ -10199,14 +10113,6 @@ unsafe impl ::windows::core::Abi for WRDS_CONNECTION_SETTING {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WRDS_CONNECTION_SETTING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_CONNECTION_SETTING>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WRDS_CONNECTION_SETTING {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WRDS_CONNECTION_SETTING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10231,14 +10137,6 @@ impl ::core::clone::Clone for WRDS_CONNECTION_SETTINGS {
 unsafe impl ::windows::core::Abi for WRDS_CONNECTION_SETTINGS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WRDS_CONNECTION_SETTINGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_CONNECTION_SETTINGS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WRDS_CONNECTION_SETTINGS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WRDS_CONNECTION_SETTINGS {
     fn default() -> Self {
@@ -10328,14 +10226,6 @@ unsafe impl ::windows::core::Abi for WRDS_CONNECTION_SETTINGS_1 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WRDS_CONNECTION_SETTINGS_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_CONNECTION_SETTINGS_1>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WRDS_CONNECTION_SETTINGS_1 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WRDS_CONNECTION_SETTINGS_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10370,7 +10260,7 @@ unsafe impl ::windows::core::Abi for WRDS_DYNAMIC_TIME_ZONE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WRDS_DYNAMIC_TIME_ZONE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_DYNAMIC_TIME_ZONE_INFORMATION>()) == 0 }
+        self.Bias == other.Bias && self.StandardName == other.StandardName && self.StandardDate == other.StandardDate && self.StandardBias == other.StandardBias && self.DaylightName == other.DaylightName && self.DaylightDate == other.DaylightDate && self.DaylightBias == other.DaylightBias && self.TimeZoneKeyName == other.TimeZoneKeyName && self.DynamicDaylightTimeDisabled == other.DynamicDaylightTimeDisabled
     }
 }
 impl ::core::cmp::Eq for WRDS_DYNAMIC_TIME_ZONE_INFORMATION {}
@@ -10393,12 +10283,6 @@ impl ::core::clone::Clone for WRDS_LISTENER_SETTING {
 unsafe impl ::windows::core::Abi for WRDS_LISTENER_SETTING {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WRDS_LISTENER_SETTING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_LISTENER_SETTING>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WRDS_LISTENER_SETTING {}
 impl ::core::default::Default for WRDS_LISTENER_SETTING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10419,12 +10303,6 @@ impl ::core::clone::Clone for WRDS_LISTENER_SETTINGS {
 unsafe impl ::windows::core::Abi for WRDS_LISTENER_SETTINGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WRDS_LISTENER_SETTINGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_LISTENER_SETTINGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WRDS_LISTENER_SETTINGS {}
 impl ::core::default::Default for WRDS_LISTENER_SETTINGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10453,7 +10331,7 @@ unsafe impl ::windows::core::Abi for WRDS_LISTENER_SETTINGS_1 {
 }
 impl ::core::cmp::PartialEq for WRDS_LISTENER_SETTINGS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_LISTENER_SETTINGS_1>()) == 0 }
+        self.MaxProtocolListenerConnectionCount == other.MaxProtocolListenerConnectionCount && self.SecurityDescriptorSize == other.SecurityDescriptorSize && self.pSecurityDescriptor == other.pSecurityDescriptor
     }
 }
 impl ::core::cmp::Eq for WRDS_LISTENER_SETTINGS_1 {}
@@ -10481,14 +10359,6 @@ unsafe impl ::windows::core::Abi for WRDS_SETTING {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WRDS_SETTING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_SETTING>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WRDS_SETTING {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WRDS_SETTING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10514,14 +10384,6 @@ impl ::core::clone::Clone for WRDS_SETTINGS {
 unsafe impl ::windows::core::Abi for WRDS_SETTINGS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WRDS_SETTINGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_SETTINGS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WRDS_SETTINGS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WRDS_SETTINGS {
     fn default() -> Self {
@@ -10617,7 +10479,37 @@ unsafe impl ::windows::core::Abi for WRDS_SETTINGS_1 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WRDS_SETTINGS_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WRDS_SETTINGS_1>()) == 0 }
+        self.WRdsDisableClipStatus == other.WRdsDisableClipStatus
+            && self.WRdsDisableClipValue == other.WRdsDisableClipValue
+            && self.WRdsDisableLPTStatus == other.WRdsDisableLPTStatus
+            && self.WRdsDisableLPTValue == other.WRdsDisableLPTValue
+            && self.WRdsDisableCcmStatus == other.WRdsDisableCcmStatus
+            && self.WRdsDisableCcmValue == other.WRdsDisableCcmValue
+            && self.WRdsDisableCdmStatus == other.WRdsDisableCdmStatus
+            && self.WRdsDisableCdmValue == other.WRdsDisableCdmValue
+            && self.WRdsDisableCpmStatus == other.WRdsDisableCpmStatus
+            && self.WRdsDisableCpmValue == other.WRdsDisableCpmValue
+            && self.WRdsDisablePnpStatus == other.WRdsDisablePnpStatus
+            && self.WRdsDisablePnpValue == other.WRdsDisablePnpValue
+            && self.WRdsEncryptionLevelStatus == other.WRdsEncryptionLevelStatus
+            && self.WRdsEncryptionValue == other.WRdsEncryptionValue
+            && self.WRdsColorDepthStatus == other.WRdsColorDepthStatus
+            && self.WRdsColorDepthValue == other.WRdsColorDepthValue
+            && self.WRdsDisableAutoReconnecetStatus == other.WRdsDisableAutoReconnecetStatus
+            && self.WRdsDisableAutoReconnecetValue == other.WRdsDisableAutoReconnecetValue
+            && self.WRdsDisableEncryptionStatus == other.WRdsDisableEncryptionStatus
+            && self.WRdsDisableEncryptionValue == other.WRdsDisableEncryptionValue
+            && self.WRdsResetBrokenStatus == other.WRdsResetBrokenStatus
+            && self.WRdsResetBrokenValue == other.WRdsResetBrokenValue
+            && self.WRdsMaxIdleTimeStatus == other.WRdsMaxIdleTimeStatus
+            && self.WRdsMaxIdleTimeValue == other.WRdsMaxIdleTimeValue
+            && self.WRdsMaxDisconnectTimeStatus == other.WRdsMaxDisconnectTimeStatus
+            && self.WRdsMaxDisconnectTimeValue == other.WRdsMaxDisconnectTimeValue
+            && self.WRdsMaxConnectTimeStatus == other.WRdsMaxConnectTimeStatus
+            && self.WRdsMaxConnectTimeValue == other.WRdsMaxConnectTimeValue
+            && self.WRdsKeepAliveStatus == other.WRdsKeepAliveStatus
+            && self.WRdsKeepAliveStartValue == other.WRdsKeepAliveStartValue
+            && self.WRdsKeepAliveIntervalValue == other.WRdsKeepAliveIntervalValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10693,7 +10585,25 @@ unsafe impl ::windows::core::Abi for WTSCLIENTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSCLIENTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSCLIENTA>()) == 0 }
+        self.ClientName == other.ClientName
+            && self.Domain == other.Domain
+            && self.UserName == other.UserName
+            && self.WorkDirectory == other.WorkDirectory
+            && self.InitialProgram == other.InitialProgram
+            && self.EncryptionLevel == other.EncryptionLevel
+            && self.ClientAddressFamily == other.ClientAddressFamily
+            && self.ClientAddress == other.ClientAddress
+            && self.HRes == other.HRes
+            && self.VRes == other.VRes
+            && self.ColorDepth == other.ColorDepth
+            && self.ClientDirectory == other.ClientDirectory
+            && self.ClientBuildNumber == other.ClientBuildNumber
+            && self.ClientHardwareId == other.ClientHardwareId
+            && self.ClientProductId == other.ClientProductId
+            && self.OutBufCountHost == other.OutBufCountHost
+            && self.OutBufCountClient == other.OutBufCountClient
+            && self.OutBufLength == other.OutBufLength
+            && self.DeviceId == other.DeviceId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10763,7 +10673,25 @@ unsafe impl ::windows::core::Abi for WTSCLIENTW {
 }
 impl ::core::cmp::PartialEq for WTSCLIENTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSCLIENTW>()) == 0 }
+        self.ClientName == other.ClientName
+            && self.Domain == other.Domain
+            && self.UserName == other.UserName
+            && self.WorkDirectory == other.WorkDirectory
+            && self.InitialProgram == other.InitialProgram
+            && self.EncryptionLevel == other.EncryptionLevel
+            && self.ClientAddressFamily == other.ClientAddressFamily
+            && self.ClientAddress == other.ClientAddress
+            && self.HRes == other.HRes
+            && self.VRes == other.VRes
+            && self.ColorDepth == other.ColorDepth
+            && self.ClientDirectory == other.ClientDirectory
+            && self.ClientBuildNumber == other.ClientBuildNumber
+            && self.ClientHardwareId == other.ClientHardwareId
+            && self.ClientProductId == other.ClientProductId
+            && self.OutBufCountHost == other.OutBufCountHost
+            && self.OutBufCountClient == other.OutBufCountClient
+            && self.OutBufLength == other.OutBufLength
+            && self.DeviceId == other.DeviceId
     }
 }
 impl ::core::cmp::Eq for WTSCLIENTW {}
@@ -10821,7 +10749,7 @@ unsafe impl ::windows::core::Abi for WTSCONFIGINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSCONFIGINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSCONFIGINFOA>()) == 0 }
+        self.version == other.version && self.fConnectClientDrivesAtLogon == other.fConnectClientDrivesAtLogon && self.fConnectPrinterAtLogon == other.fConnectPrinterAtLogon && self.fDisablePrinterRedirection == other.fDisablePrinterRedirection && self.fDisableDefaultMainClientPrinter == other.fDisableDefaultMainClientPrinter && self.ShadowSettings == other.ShadowSettings && self.LogonUserName == other.LogonUserName && self.LogonDomain == other.LogonDomain && self.WorkDirectory == other.WorkDirectory && self.InitialProgram == other.InitialProgram && self.ApplicationName == other.ApplicationName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10875,7 +10803,7 @@ unsafe impl ::windows::core::Abi for WTSCONFIGINFOW {
 }
 impl ::core::cmp::PartialEq for WTSCONFIGINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSCONFIGINFOW>()) == 0 }
+        self.version == other.version && self.fConnectClientDrivesAtLogon == other.fConnectClientDrivesAtLogon && self.fConnectPrinterAtLogon == other.fConnectPrinterAtLogon && self.fDisablePrinterRedirection == other.fDisablePrinterRedirection && self.fDisableDefaultMainClientPrinter == other.fDisableDefaultMainClientPrinter && self.ShadowSettings == other.ShadowSettings && self.LogonUserName == other.LogonUserName && self.LogonDomain == other.LogonDomain && self.WorkDirectory == other.WorkDirectory && self.InitialProgram == other.InitialProgram && self.ApplicationName == other.ApplicationName
     }
 }
 impl ::core::cmp::Eq for WTSCONFIGINFOW {}
@@ -10943,7 +10871,7 @@ unsafe impl ::windows::core::Abi for WTSINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOA>()) == 0 }
+        self.State == other.State && self.SessionId == other.SessionId && self.IncomingBytes == other.IncomingBytes && self.OutgoingBytes == other.OutgoingBytes && self.IncomingFrames == other.IncomingFrames && self.OutgoingFrames == other.OutgoingFrames && self.IncomingCompressedBytes == other.IncomingCompressedBytes && self.OutgoingCompressedBy == other.OutgoingCompressedBy && self.WinStationName == other.WinStationName && self.Domain == other.Domain && self.UserName == other.UserName && self.ConnectTime == other.ConnectTime && self.DisconnectTime == other.DisconnectTime && self.LastInputTime == other.LastInputTime && self.LogonTime == other.LogonTime && self.CurrentTime == other.CurrentTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10974,14 +10902,6 @@ unsafe impl ::windows::core::Abi for WTSINFOEXA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WTSINFOEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEXA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WTSINFOEXA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WTSINFOEXA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11002,12 +10922,6 @@ impl ::core::clone::Clone for WTSINFOEXW {
 unsafe impl ::windows::core::Abi for WTSINFOEXW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTSINFOEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEXW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTSINFOEXW {}
 impl ::core::default::Default for WTSINFOEXW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11074,7 +10988,7 @@ unsafe impl ::windows::core::Abi for WTSINFOEX_LEVEL1_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSINFOEX_LEVEL1_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEX_LEVEL1_A>()) == 0 }
+        self.SessionId == other.SessionId && self.SessionState == other.SessionState && self.SessionFlags == other.SessionFlags && self.WinStationName == other.WinStationName && self.UserName == other.UserName && self.DomainName == other.DomainName && self.LogonTime == other.LogonTime && self.ConnectTime == other.ConnectTime && self.DisconnectTime == other.DisconnectTime && self.LastInputTime == other.LastInputTime && self.CurrentTime == other.CurrentTime && self.IncomingBytes == other.IncomingBytes && self.OutgoingBytes == other.OutgoingBytes && self.IncomingFrames == other.IncomingFrames && self.OutgoingFrames == other.OutgoingFrames && self.IncomingCompressedBytes == other.IncomingCompressedBytes && self.OutgoingCompressedBytes == other.OutgoingCompressedBytes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11140,7 +11054,7 @@ unsafe impl ::windows::core::Abi for WTSINFOEX_LEVEL1_W {
 }
 impl ::core::cmp::PartialEq for WTSINFOEX_LEVEL1_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEX_LEVEL1_W>()) == 0 }
+        self.SessionId == other.SessionId && self.SessionState == other.SessionState && self.SessionFlags == other.SessionFlags && self.WinStationName == other.WinStationName && self.UserName == other.UserName && self.DomainName == other.DomainName && self.LogonTime == other.LogonTime && self.ConnectTime == other.ConnectTime && self.DisconnectTime == other.DisconnectTime && self.LastInputTime == other.LastInputTime && self.CurrentTime == other.CurrentTime && self.IncomingBytes == other.IncomingBytes && self.OutgoingBytes == other.OutgoingBytes && self.IncomingFrames == other.IncomingFrames && self.OutgoingFrames == other.OutgoingFrames && self.IncomingCompressedBytes == other.IncomingCompressedBytes && self.OutgoingCompressedBytes == other.OutgoingCompressedBytes
     }
 }
 impl ::core::cmp::Eq for WTSINFOEX_LEVEL1_W {}
@@ -11168,14 +11082,6 @@ unsafe impl ::windows::core::Abi for WTSINFOEX_LEVEL_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WTSINFOEX_LEVEL_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEX_LEVEL_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WTSINFOEX_LEVEL_A {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WTSINFOEX_LEVEL_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11195,12 +11101,6 @@ impl ::core::clone::Clone for WTSINFOEX_LEVEL_W {
 unsafe impl ::windows::core::Abi for WTSINFOEX_LEVEL_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTSINFOEX_LEVEL_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOEX_LEVEL_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTSINFOEX_LEVEL_W {}
 impl ::core::default::Default for WTSINFOEX_LEVEL_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11259,7 +11159,7 @@ unsafe impl ::windows::core::Abi for WTSINFOW {
 }
 impl ::core::cmp::PartialEq for WTSINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSINFOW>()) == 0 }
+        self.State == other.State && self.SessionId == other.SessionId && self.IncomingBytes == other.IncomingBytes && self.OutgoingBytes == other.OutgoingBytes && self.IncomingFrames == other.IncomingFrames && self.OutgoingFrames == other.OutgoingFrames && self.IncomingCompressedBytes == other.IncomingCompressedBytes && self.OutgoingCompressedBytes == other.OutgoingCompressedBytes && self.WinStationName == other.WinStationName && self.Domain == other.Domain && self.UserName == other.UserName && self.ConnectTime == other.ConnectTime && self.DisconnectTime == other.DisconnectTime && self.LastInputTime == other.LastInputTime && self.LogonTime == other.LogonTime && self.CurrentTime == other.CurrentTime
     }
 }
 impl ::core::cmp::Eq for WTSINFOW {}
@@ -11357,7 +11257,37 @@ unsafe impl ::windows::core::Abi for WTSLISTENERCONFIGA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSLISTENERCONFIGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSLISTENERCONFIGA>()) == 0 }
+        self.version == other.version
+            && self.fEnableListener == other.fEnableListener
+            && self.MaxConnectionCount == other.MaxConnectionCount
+            && self.fPromptForPassword == other.fPromptForPassword
+            && self.fInheritColorDepth == other.fInheritColorDepth
+            && self.ColorDepth == other.ColorDepth
+            && self.fInheritBrokenTimeoutSettings == other.fInheritBrokenTimeoutSettings
+            && self.BrokenTimeoutSettings == other.BrokenTimeoutSettings
+            && self.fDisablePrinterRedirection == other.fDisablePrinterRedirection
+            && self.fDisableDriveRedirection == other.fDisableDriveRedirection
+            && self.fDisableComPortRedirection == other.fDisableComPortRedirection
+            && self.fDisableLPTPortRedirection == other.fDisableLPTPortRedirection
+            && self.fDisableClipboardRedirection == other.fDisableClipboardRedirection
+            && self.fDisableAudioRedirection == other.fDisableAudioRedirection
+            && self.fDisablePNPRedirection == other.fDisablePNPRedirection
+            && self.fDisableDefaultMainClientPrinter == other.fDisableDefaultMainClientPrinter
+            && self.LanAdapter == other.LanAdapter
+            && self.PortNumber == other.PortNumber
+            && self.fInheritShadowSettings == other.fInheritShadowSettings
+            && self.ShadowSettings == other.ShadowSettings
+            && self.TimeoutSettingsConnection == other.TimeoutSettingsConnection
+            && self.TimeoutSettingsDisconnection == other.TimeoutSettingsDisconnection
+            && self.TimeoutSettingsIdle == other.TimeoutSettingsIdle
+            && self.SecurityLayer == other.SecurityLayer
+            && self.MinEncryptionLevel == other.MinEncryptionLevel
+            && self.UserAuthentication == other.UserAuthentication
+            && self.Comment == other.Comment
+            && self.LogonUserName == other.LogonUserName
+            && self.LogonDomain == other.LogonDomain
+            && self.WorkDirectory == other.WorkDirectory
+            && self.InitialProgram == other.InitialProgram
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11451,7 +11381,37 @@ unsafe impl ::windows::core::Abi for WTSLISTENERCONFIGW {
 }
 impl ::core::cmp::PartialEq for WTSLISTENERCONFIGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSLISTENERCONFIGW>()) == 0 }
+        self.version == other.version
+            && self.fEnableListener == other.fEnableListener
+            && self.MaxConnectionCount == other.MaxConnectionCount
+            && self.fPromptForPassword == other.fPromptForPassword
+            && self.fInheritColorDepth == other.fInheritColorDepth
+            && self.ColorDepth == other.ColorDepth
+            && self.fInheritBrokenTimeoutSettings == other.fInheritBrokenTimeoutSettings
+            && self.BrokenTimeoutSettings == other.BrokenTimeoutSettings
+            && self.fDisablePrinterRedirection == other.fDisablePrinterRedirection
+            && self.fDisableDriveRedirection == other.fDisableDriveRedirection
+            && self.fDisableComPortRedirection == other.fDisableComPortRedirection
+            && self.fDisableLPTPortRedirection == other.fDisableLPTPortRedirection
+            && self.fDisableClipboardRedirection == other.fDisableClipboardRedirection
+            && self.fDisableAudioRedirection == other.fDisableAudioRedirection
+            && self.fDisablePNPRedirection == other.fDisablePNPRedirection
+            && self.fDisableDefaultMainClientPrinter == other.fDisableDefaultMainClientPrinter
+            && self.LanAdapter == other.LanAdapter
+            && self.PortNumber == other.PortNumber
+            && self.fInheritShadowSettings == other.fInheritShadowSettings
+            && self.ShadowSettings == other.ShadowSettings
+            && self.TimeoutSettingsConnection == other.TimeoutSettingsConnection
+            && self.TimeoutSettingsDisconnection == other.TimeoutSettingsDisconnection
+            && self.TimeoutSettingsIdle == other.TimeoutSettingsIdle
+            && self.SecurityLayer == other.SecurityLayer
+            && self.MinEncryptionLevel == other.MinEncryptionLevel
+            && self.UserAuthentication == other.UserAuthentication
+            && self.Comment == other.Comment
+            && self.LogonUserName == other.LogonUserName
+            && self.LogonDomain == other.LogonDomain
+            && self.WorkDirectory == other.WorkDirectory
+            && self.InitialProgram == other.InitialProgram
     }
 }
 impl ::core::cmp::Eq for WTSLISTENERCONFIGW {}
@@ -11484,7 +11444,7 @@ unsafe impl ::windows::core::Abi for WTSSBX_IP_ADDRESS {
 }
 impl ::core::cmp::PartialEq for WTSSBX_IP_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSSBX_IP_ADDRESS>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.Address == other.Address && self.PortNumber == other.PortNumber && self.dwScope == other.dwScope
     }
 }
 impl ::core::cmp::Eq for WTSSBX_IP_ADDRESS {}
@@ -11517,7 +11477,7 @@ unsafe impl ::windows::core::Abi for WTSSBX_MACHINE_CONNECT_INFO {
 }
 impl ::core::cmp::PartialEq for WTSSBX_MACHINE_CONNECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSSBX_MACHINE_CONNECT_INFO>()) == 0 }
+        self.wczMachineFQDN == other.wczMachineFQDN && self.wczMachineNetBiosName == other.wczMachineNetBiosName && self.dwNumOfIPAddr == other.dwNumOfIPAddr && self.IPaddr == other.IPaddr
     }
 }
 impl ::core::cmp::Eq for WTSSBX_MACHINE_CONNECT_INFO {}
@@ -11554,7 +11514,7 @@ unsafe impl ::windows::core::Abi for WTSSBX_MACHINE_INFO {
 }
 impl ::core::cmp::PartialEq for WTSSBX_MACHINE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSSBX_MACHINE_INFO>()) == 0 }
+        self.ClientConnectInfo == other.ClientConnectInfo && self.wczFarmName == other.wczFarmName && self.InternalIPAddress == other.InternalIPAddress && self.dwMaxSessionsLimit == other.dwMaxSessionsLimit && self.ServerWeight == other.ServerWeight && self.SingleSessionMode == other.SingleSessionMode && self.InDrain == other.InDrain && self.MachineState == other.MachineState
     }
 }
 impl ::core::cmp::Eq for WTSSBX_MACHINE_INFO {}
@@ -11596,7 +11556,7 @@ unsafe impl ::windows::core::Abi for WTSSBX_SESSION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSSBX_SESSION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSSBX_SESSION_INFO>()) == 0 }
+        self.wszUserName == other.wszUserName && self.wszDomainName == other.wszDomainName && self.ApplicationType == other.ApplicationType && self.dwSessionId == other.dwSessionId && self.CreateTime == other.CreateTime && self.DisconnectTime == other.DisconnectTime && self.SessionState == other.SessionState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11629,7 +11589,7 @@ unsafe impl ::windows::core::Abi for WTSSESSION_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for WTSSESSION_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSSESSION_NOTIFICATION>()) == 0 }
+        self.cbSize == other.cbSize && self.dwSessionId == other.dwSessionId
     }
 }
 impl ::core::cmp::Eq for WTSSESSION_NOTIFICATION {}
@@ -11701,7 +11661,24 @@ unsafe impl ::windows::core::Abi for WTSUSERCONFIGA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTSUSERCONFIGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSUSERCONFIGA>()) == 0 }
+        self.Source == other.Source
+            && self.InheritInitialProgram == other.InheritInitialProgram
+            && self.AllowLogonTerminalServer == other.AllowLogonTerminalServer
+            && self.TimeoutSettingsConnections == other.TimeoutSettingsConnections
+            && self.TimeoutSettingsDisconnections == other.TimeoutSettingsDisconnections
+            && self.TimeoutSettingsIdle == other.TimeoutSettingsIdle
+            && self.DeviceClientDrives == other.DeviceClientDrives
+            && self.DeviceClientPrinters == other.DeviceClientPrinters
+            && self.ClientDefaultPrinter == other.ClientDefaultPrinter
+            && self.BrokenTimeoutSettings == other.BrokenTimeoutSettings
+            && self.ReconnectSettings == other.ReconnectSettings
+            && self.ShadowingSettings == other.ShadowingSettings
+            && self.TerminalServerRemoteHomeDir == other.TerminalServerRemoteHomeDir
+            && self.InitialProgram == other.InitialProgram
+            && self.WorkDirectory == other.WorkDirectory
+            && self.TerminalServerProfilePath == other.TerminalServerProfilePath
+            && self.TerminalServerHomeDir == other.TerminalServerHomeDir
+            && self.TerminalServerHomeDirDrive == other.TerminalServerHomeDirDrive
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11769,7 +11746,24 @@ unsafe impl ::windows::core::Abi for WTSUSERCONFIGW {
 }
 impl ::core::cmp::PartialEq for WTSUSERCONFIGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTSUSERCONFIGW>()) == 0 }
+        self.Source == other.Source
+            && self.InheritInitialProgram == other.InheritInitialProgram
+            && self.AllowLogonTerminalServer == other.AllowLogonTerminalServer
+            && self.TimeoutSettingsConnections == other.TimeoutSettingsConnections
+            && self.TimeoutSettingsDisconnections == other.TimeoutSettingsDisconnections
+            && self.TimeoutSettingsIdle == other.TimeoutSettingsIdle
+            && self.DeviceClientDrives == other.DeviceClientDrives
+            && self.DeviceClientPrinters == other.DeviceClientPrinters
+            && self.ClientDefaultPrinter == other.ClientDefaultPrinter
+            && self.BrokenTimeoutSettings == other.BrokenTimeoutSettings
+            && self.ReconnectSettings == other.ReconnectSettings
+            && self.ShadowingSettings == other.ShadowingSettings
+            && self.TerminalServerRemoteHomeDir == other.TerminalServerRemoteHomeDir
+            && self.InitialProgram == other.InitialProgram
+            && self.WorkDirectory == other.WorkDirectory
+            && self.TerminalServerProfilePath == other.TerminalServerProfilePath
+            && self.TerminalServerHomeDir == other.TerminalServerHomeDir
+            && self.TerminalServerHomeDirDrive == other.TerminalServerHomeDirDrive
     }
 }
 impl ::core::cmp::Eq for WTSUSERCONFIGW {}
@@ -11795,12 +11789,6 @@ impl ::core::clone::Clone for WTS_CACHE_STATS {
 unsafe impl ::windows::core::Abi for WTS_CACHE_STATS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_CACHE_STATS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_CACHE_STATS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_CACHE_STATS {}
 impl ::core::default::Default for WTS_CACHE_STATS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11822,12 +11810,6 @@ impl ::core::clone::Clone for WTS_CACHE_STATS_UN {
 unsafe impl ::windows::core::Abi for WTS_CACHE_STATS_UN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_CACHE_STATS_UN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_CACHE_STATS_UN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_CACHE_STATS_UN {}
 impl ::core::default::Default for WTS_CACHE_STATS_UN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11855,7 +11837,7 @@ unsafe impl ::windows::core::Abi for WTS_CLIENT_ADDRESS {
 }
 impl ::core::cmp::PartialEq for WTS_CLIENT_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_CLIENT_ADDRESS>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for WTS_CLIENT_ADDRESS {}
@@ -11937,14 +11919,6 @@ unsafe impl ::windows::core::Abi for WTS_CLIENT_DATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for WTS_CLIENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_CLIENT_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for WTS_CLIENT_DATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for WTS_CLIENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11973,7 +11947,7 @@ unsafe impl ::windows::core::Abi for WTS_CLIENT_DISPLAY {
 }
 impl ::core::cmp::PartialEq for WTS_CLIENT_DISPLAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_CLIENT_DISPLAY>()) == 0 }
+        self.HorizontalResolution == other.HorizontalResolution && self.VerticalResolution == other.VerticalResolution && self.ColorDepth == other.ColorDepth
     }
 }
 impl ::core::cmp::Eq for WTS_CLIENT_DISPLAY {}
@@ -12004,7 +11978,7 @@ unsafe impl ::windows::core::Abi for WTS_DISPLAY_IOCTL {
 }
 impl ::core::cmp::PartialEq for WTS_DISPLAY_IOCTL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_DISPLAY_IOCTL>()) == 0 }
+        self.pDisplayIOCtlData == other.pDisplayIOCtlData && self.cbDisplayIOCtlData == other.cbDisplayIOCtlData
     }
 }
 impl ::core::cmp::Eq for WTS_DISPLAY_IOCTL {}
@@ -12045,7 +12019,7 @@ unsafe impl ::windows::core::Abi for WTS_LICENSE_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_LICENSE_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_LICENSE_CAPABILITIES>()) == 0 }
+        self.KeyExchangeAlg == other.KeyExchangeAlg && self.ProtocolVer == other.ProtocolVer && self.fAuthenticateServer == other.fAuthenticateServer && self.CertType == other.CertType && self.cbClientName == other.cbClientName && self.rgbClientName == other.rgbClientName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12103,7 +12077,7 @@ unsafe impl ::windows::core::Abi for WTS_POLICY_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_POLICY_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_POLICY_DATA>()) == 0 }
+        self.fDisableEncryption == other.fDisableEncryption && self.fDisableAutoReconnect == other.fDisableAutoReconnect && self.ColorDepth == other.ColorDepth && self.MinEncryptionLevel == other.MinEncryptionLevel && self.fDisableCpm == other.fDisableCpm && self.fDisableCdm == other.fDisableCdm && self.fDisableCcm == other.fDisableCcm && self.fDisableLPT == other.fDisableLPT && self.fDisableClip == other.fDisableClip && self.fDisablePNPRedir == other.fDisablePNPRedir
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12144,7 +12118,7 @@ unsafe impl ::windows::core::Abi for WTS_PROCESS_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_PROCESS_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROCESS_INFOA>()) == 0 }
+        self.SessionId == other.SessionId && self.ProcessId == other.ProcessId && self.pProcessName == other.pProcessName && self.pUserSid == other.pUserSid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12185,7 +12159,7 @@ unsafe impl ::windows::core::Abi for WTS_PROCESS_INFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_PROCESS_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROCESS_INFOW>()) == 0 }
+        self.SessionId == other.SessionId && self.ProcessId == other.ProcessId && self.pProcessName == other.pProcessName && self.pUserSid == other.pUserSid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12247,7 +12221,7 @@ unsafe impl ::windows::core::Abi for WTS_PROCESS_INFO_EXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_PROCESS_INFO_EXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROCESS_INFO_EXA>()) == 0 }
+        self.SessionId == other.SessionId && self.ProcessId == other.ProcessId && self.pProcessName == other.pProcessName && self.pUserSid == other.pUserSid && self.NumberOfThreads == other.NumberOfThreads && self.HandleCount == other.HandleCount && self.PagefileUsage == other.PagefileUsage && self.PeakPagefileUsage == other.PeakPagefileUsage && self.WorkingSetSize == other.WorkingSetSize && self.PeakWorkingSetSize == other.PeakWorkingSetSize && self.UserTime == other.UserTime && self.KernelTime == other.KernelTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12309,7 +12283,7 @@ unsafe impl ::windows::core::Abi for WTS_PROCESS_INFO_EXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_PROCESS_INFO_EXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROCESS_INFO_EXW>()) == 0 }
+        self.SessionId == other.SessionId && self.ProcessId == other.ProcessId && self.pProcessName == other.pProcessName && self.pUserSid == other.pUserSid && self.NumberOfThreads == other.NumberOfThreads && self.HandleCount == other.HandleCount && self.PagefileUsage == other.PagefileUsage && self.PeakPagefileUsage == other.PeakPagefileUsage && self.WorkingSetSize == other.WorkingSetSize && self.PeakWorkingSetSize == other.PeakWorkingSetSize && self.UserTime == other.UserTime && self.KernelTime == other.KernelTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12335,12 +12309,6 @@ impl ::core::clone::Clone for WTS_PROPERTY_VALUE {
 unsafe impl ::windows::core::Abi for WTS_PROPERTY_VALUE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_PROPERTY_VALUE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROPERTY_VALUE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_PROPERTY_VALUE {}
 impl ::core::default::Default for WTS_PROPERTY_VALUE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12363,12 +12331,6 @@ impl ::core::clone::Clone for WTS_PROPERTY_VALUE_0 {
 unsafe impl ::windows::core::Abi for WTS_PROPERTY_VALUE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_PROPERTY_VALUE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROPERTY_VALUE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_PROPERTY_VALUE_0 {}
 impl ::core::default::Default for WTS_PROPERTY_VALUE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12396,7 +12358,7 @@ unsafe impl ::windows::core::Abi for WTS_PROPERTY_VALUE_0_0 {
 }
 impl ::core::cmp::PartialEq for WTS_PROPERTY_VALUE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROPERTY_VALUE_0_0>()) == 0 }
+        self.size == other.size && self.pbVal == other.pbVal
     }
 }
 impl ::core::cmp::Eq for WTS_PROPERTY_VALUE_0_0 {}
@@ -12427,7 +12389,7 @@ unsafe impl ::windows::core::Abi for WTS_PROPERTY_VALUE_0_1 {
 }
 impl ::core::cmp::PartialEq for WTS_PROPERTY_VALUE_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROPERTY_VALUE_0_1>()) == 0 }
+        self.size == other.size && self.pstrVal == other.pstrVal
     }
 }
 impl ::core::cmp::Eq for WTS_PROPERTY_VALUE_0_1 {}
@@ -12458,7 +12420,7 @@ unsafe impl ::windows::core::Abi for WTS_PROTOCOL_CACHE {
 }
 impl ::core::cmp::PartialEq for WTS_PROTOCOL_CACHE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROTOCOL_CACHE>()) == 0 }
+        self.CacheReads == other.CacheReads && self.CacheHits == other.CacheHits
     }
 }
 impl ::core::cmp::Eq for WTS_PROTOCOL_CACHE {}
@@ -12524,7 +12486,7 @@ unsafe impl ::windows::core::Abi for WTS_PROTOCOL_COUNTERS {
 }
 impl ::core::cmp::PartialEq for WTS_PROTOCOL_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROTOCOL_COUNTERS>()) == 0 }
+        self.WdBytes == other.WdBytes && self.WdFrames == other.WdFrames && self.WaitForOutBuf == other.WaitForOutBuf && self.Frames == other.Frames && self.Bytes == other.Bytes && self.CompressedBytes == other.CompressedBytes && self.CompressFlushes == other.CompressFlushes && self.Errors == other.Errors && self.Timeouts == other.Timeouts && self.AsyncFramingError == other.AsyncFramingError && self.AsyncOverrunError == other.AsyncOverrunError && self.AsyncOverflowError == other.AsyncOverflowError && self.AsyncParityError == other.AsyncParityError && self.TdErrors == other.TdErrors && self.ProtocolType == other.ProtocolType && self.Length == other.Length && self.Specific == other.Specific && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for WTS_PROTOCOL_COUNTERS {}
@@ -12552,12 +12514,6 @@ impl ::core::clone::Clone for WTS_PROTOCOL_STATUS {
 unsafe impl ::windows::core::Abi for WTS_PROTOCOL_STATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_PROTOCOL_STATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_PROTOCOL_STATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_PROTOCOL_STATUS {}
 impl ::core::default::Default for WTS_PROTOCOL_STATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12584,7 +12540,7 @@ unsafe impl ::windows::core::Abi for WTS_SERVER_INFOA {
 }
 impl ::core::cmp::PartialEq for WTS_SERVER_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SERVER_INFOA>()) == 0 }
+        self.pServerName == other.pServerName
     }
 }
 impl ::core::cmp::Eq for WTS_SERVER_INFOA {}
@@ -12614,7 +12570,7 @@ unsafe impl ::windows::core::Abi for WTS_SERVER_INFOW {
 }
 impl ::core::cmp::PartialEq for WTS_SERVER_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SERVER_INFOW>()) == 0 }
+        self.pServerName == other.pServerName
     }
 }
 impl ::core::cmp::Eq for WTS_SERVER_INFOW {}
@@ -12645,7 +12601,7 @@ unsafe impl ::windows::core::Abi for WTS_SERVICE_STATE {
 }
 impl ::core::cmp::PartialEq for WTS_SERVICE_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SERVICE_STATE>()) == 0 }
+        self.RcmServiceState == other.RcmServiceState && self.RcmDrainState == other.RcmDrainState
     }
 }
 impl ::core::cmp::Eq for WTS_SERVICE_STATE {}
@@ -12676,7 +12632,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_ADDRESS {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_ADDRESS>()) == 0 }
+        self.AddressFamily == other.AddressFamily && self.Address == other.Address
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_ADDRESS {}
@@ -12707,7 +12663,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_ID {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_ID>()) == 0 }
+        self.SessionUniqueGuid == other.SessionUniqueGuid && self.SessionId == other.SessionId
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_ID {}
@@ -12739,7 +12695,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_INFOA {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_INFOA>()) == 0 }
+        self.SessionId == other.SessionId && self.pWinStationName == other.pWinStationName && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_INFOA {}
@@ -12771,7 +12727,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_INFOW {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_INFOW>()) == 0 }
+        self.SessionId == other.SessionId && self.pWinStationName == other.pWinStationName && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_INFOW {}
@@ -12808,7 +12764,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_INFO_1A {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_INFO_1A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_INFO_1A>()) == 0 }
+        self.ExecEnvId == other.ExecEnvId && self.State == other.State && self.SessionId == other.SessionId && self.pSessionName == other.pSessionName && self.pHostName == other.pHostName && self.pUserName == other.pUserName && self.pDomainName == other.pDomainName && self.pFarmName == other.pFarmName
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_INFO_1A {}
@@ -12845,7 +12801,7 @@ unsafe impl ::windows::core::Abi for WTS_SESSION_INFO_1W {
 }
 impl ::core::cmp::PartialEq for WTS_SESSION_INFO_1W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SESSION_INFO_1W>()) == 0 }
+        self.ExecEnvId == other.ExecEnvId && self.State == other.State && self.SessionId == other.SessionId && self.pSessionName == other.pSessionName && self.pHostName == other.pHostName && self.pUserName == other.pUserName && self.pDomainName == other.pDomainName && self.pFarmName == other.pFarmName
     }
 }
 impl ::core::cmp::Eq for WTS_SESSION_INFO_1W {}
@@ -12878,7 +12834,7 @@ unsafe impl ::windows::core::Abi for WTS_SMALL_RECT {
 }
 impl ::core::cmp::PartialEq for WTS_SMALL_RECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SMALL_RECT>()) == 0 }
+        self.Left == other.Left && self.Top == other.Top && self.Right == other.Right && self.Bottom == other.Bottom
     }
 }
 impl ::core::cmp::Eq for WTS_SMALL_RECT {}
@@ -12902,12 +12858,6 @@ impl ::core::clone::Clone for WTS_SOCKADDR {
 unsafe impl ::windows::core::Abi for WTS_SOCKADDR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_SOCKADDR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SOCKADDR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_SOCKADDR {}
 impl ::core::default::Default for WTS_SOCKADDR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12928,12 +12878,6 @@ impl ::core::clone::Clone for WTS_SOCKADDR_0 {
 unsafe impl ::windows::core::Abi for WTS_SOCKADDR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WTS_SOCKADDR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SOCKADDR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WTS_SOCKADDR_0 {}
 impl ::core::default::Default for WTS_SOCKADDR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12962,7 +12906,7 @@ unsafe impl ::windows::core::Abi for WTS_SOCKADDR_0_0 {
 }
 impl ::core::cmp::PartialEq for WTS_SOCKADDR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SOCKADDR_0_0>()) == 0 }
+        self.sin_port == other.sin_port && self.IN_ADDR == other.IN_ADDR && self.sin_zero == other.sin_zero
     }
 }
 impl ::core::cmp::Eq for WTS_SOCKADDR_0_0 {}
@@ -12995,7 +12939,7 @@ unsafe impl ::windows::core::Abi for WTS_SOCKADDR_0_1 {
 }
 impl ::core::cmp::PartialEq for WTS_SOCKADDR_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SOCKADDR_0_1>()) == 0 }
+        self.sin6_port == other.sin6_port && self.sin6_flowinfo == other.sin6_flowinfo && self.sin6_addr == other.sin6_addr && self.sin6_scope_id == other.sin6_scope_id
     }
 }
 impl ::core::cmp::Eq for WTS_SOCKADDR_0_1 {}
@@ -13032,7 +12976,7 @@ unsafe impl ::windows::core::Abi for WTS_SYSTEMTIME {
 }
 impl ::core::cmp::PartialEq for WTS_SYSTEMTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_SYSTEMTIME>()) == 0 }
+        self.wYear == other.wYear && self.wMonth == other.wMonth && self.wDayOfWeek == other.wDayOfWeek && self.wDay == other.wDay && self.wHour == other.wHour && self.wMinute == other.wMinute && self.wSecond == other.wSecond && self.wMilliseconds == other.wMilliseconds
     }
 }
 impl ::core::cmp::Eq for WTS_SYSTEMTIME {}
@@ -13068,7 +13012,7 @@ unsafe impl ::windows::core::Abi for WTS_TIME_ZONE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WTS_TIME_ZONE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_TIME_ZONE_INFORMATION>()) == 0 }
+        self.Bias == other.Bias && self.StandardName == other.StandardName && self.StandardDate == other.StandardDate && self.StandardBias == other.StandardBias && self.DaylightName == other.DaylightName && self.DaylightDate == other.DaylightDate && self.DaylightBias == other.DaylightBias
     }
 }
 impl ::core::cmp::Eq for WTS_TIME_ZONE_INFORMATION {}
@@ -13100,7 +13044,7 @@ unsafe impl ::windows::core::Abi for WTS_USER_CREDENTIAL {
 }
 impl ::core::cmp::PartialEq for WTS_USER_CREDENTIAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_USER_CREDENTIAL>()) == 0 }
+        self.UserName == other.UserName && self.Password == other.Password && self.Domain == other.Domain
     }
 }
 impl ::core::cmp::Eq for WTS_USER_CREDENTIAL {}
@@ -13132,7 +13076,7 @@ unsafe impl ::windows::core::Abi for WTS_USER_DATA {
 }
 impl ::core::cmp::PartialEq for WTS_USER_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_USER_DATA>()) == 0 }
+        self.WorkDirectory == other.WorkDirectory && self.InitialProgram == other.InitialProgram && self.UserTimeZone == other.UserTimeZone
     }
 }
 impl ::core::cmp::Eq for WTS_USER_DATA {}
@@ -13172,7 +13116,7 @@ unsafe impl ::windows::core::Abi for WTS_VALIDATION_INFORMATIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WTS_VALIDATION_INFORMATIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_VALIDATION_INFORMATIONA>()) == 0 }
+        self.ProductInfo == other.ProductInfo && self.License == other.License && self.LicenseLength == other.LicenseLength && self.HardwareID == other.HardwareID && self.HardwareIDLength == other.HardwareIDLength
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13208,7 +13152,7 @@ unsafe impl ::windows::core::Abi for WTS_VALIDATION_INFORMATIONW {
 }
 impl ::core::cmp::PartialEq for WTS_VALIDATION_INFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_VALIDATION_INFORMATIONW>()) == 0 }
+        self.ProductInfo == other.ProductInfo && self.License == other.License && self.LicenseLength == other.LicenseLength && self.HardwareID == other.HardwareID && self.HardwareIDLength == other.HardwareIDLength
     }
 }
 impl ::core::cmp::Eq for WTS_VALIDATION_INFORMATIONW {}
@@ -13260,7 +13204,7 @@ unsafe impl ::windows::core::Abi for pluginResource {
 }
 impl ::core::cmp::PartialEq for pluginResource {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<pluginResource>()) == 0 }
+        self.alias == other.alias && self.name == other.name && self.resourceFileContents == other.resourceFileContents && self.fileExtension == other.fileExtension && self.resourcePluginType == other.resourcePluginType && self.isDiscoverable == other.isDiscoverable && self.resourceType == other.resourceType && self.pceIconSize == other.pceIconSize && self.iconContents == other.iconContents && self.pcePluginBlobSize == other.pcePluginBlobSize && self.blobContents == other.blobContents
     }
 }
 impl ::core::cmp::Eq for pluginResource {}
@@ -13295,7 +13239,7 @@ unsafe impl ::windows::core::Abi for pluginResource2 {
 }
 impl ::core::cmp::PartialEq for pluginResource2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<pluginResource2>()) == 0 }
+        self.resourceV1 == other.resourceV1 && self.pceFileAssocListSize == other.pceFileAssocListSize && self.fileAssocList == other.fileAssocList && self.securityDescriptor == other.securityDescriptor && self.pceFolderListSize == other.pceFolderListSize && self.folderList == other.folderList
     }
 }
 impl ::core::cmp::Eq for pluginResource2 {}
@@ -13328,7 +13272,7 @@ unsafe impl ::windows::core::Abi for pluginResource2FileAssociation {
 }
 impl ::core::cmp::PartialEq for pluginResource2FileAssociation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<pluginResource2FileAssociation>()) == 0 }
+        self.extName == other.extName && self.primaryHandler == other.primaryHandler && self.pceIconSize == other.pceIconSize && self.iconContents == other.iconContents
     }
 }
 impl ::core::cmp::Eq for pluginResource2FileAssociation {}

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -3012,12 +3012,6 @@ impl ::core::clone::Clone for WSMAN_AUTHENTICATION_CREDENTIALS {
 unsafe impl ::windows::core::Abi for WSMAN_AUTHENTICATION_CREDENTIALS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_AUTHENTICATION_CREDENTIALS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_AUTHENTICATION_CREDENTIALS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_AUTHENTICATION_CREDENTIALS {}
 impl ::core::default::Default for WSMAN_AUTHENTICATION_CREDENTIALS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3038,12 +3032,6 @@ impl ::core::clone::Clone for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
 unsafe impl ::windows::core::Abi for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_AUTHENTICATION_CREDENTIALS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_AUTHENTICATION_CREDENTIALS_0 {}
 impl ::core::default::Default for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3073,7 +3061,7 @@ unsafe impl ::windows::core::Abi for WSMAN_AUTHZ_QUOTA {
 }
 impl ::core::cmp::PartialEq for WSMAN_AUTHZ_QUOTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_AUTHZ_QUOTA>()) == 0 }
+        self.maxAllowedConcurrentShells == other.maxAllowedConcurrentShells && self.maxAllowedConcurrentOperations == other.maxAllowedConcurrentOperations && self.timeslotSize == other.timeslotSize && self.maxAllowedOperationsPerTimeslot == other.maxAllowedOperationsPerTimeslot
     }
 }
 impl ::core::cmp::Eq for WSMAN_AUTHZ_QUOTA {}
@@ -3106,7 +3094,7 @@ unsafe impl ::windows::core::Abi for WSMAN_CERTIFICATE_DETAILS {
 }
 impl ::core::cmp::PartialEq for WSMAN_CERTIFICATE_DETAILS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_CERTIFICATE_DETAILS>()) == 0 }
+        self.subject == other.subject && self.issuerName == other.issuerName && self.issuerThumbprint == other.issuerThumbprint && self.subjectName == other.subjectName
     }
 }
 impl ::core::cmp::Eq for WSMAN_CERTIFICATE_DETAILS {}
@@ -3139,7 +3127,7 @@ unsafe impl ::windows::core::Abi for WSMAN_COMMAND_ARG_SET {
 }
 impl ::core::cmp::PartialEq for WSMAN_COMMAND_ARG_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_COMMAND_ARG_SET>()) == 0 }
+        self.argsCount == other.argsCount && self.args == other.args
     }
 }
 impl ::core::cmp::Eq for WSMAN_COMMAND_ARG_SET {}
@@ -3162,12 +3150,6 @@ impl ::core::clone::Clone for WSMAN_CONNECT_DATA {
 unsafe impl ::windows::core::Abi for WSMAN_CONNECT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_CONNECT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_CONNECT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_CONNECT_DATA {}
 impl ::core::default::Default for WSMAN_CONNECT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3187,12 +3169,6 @@ impl ::core::clone::Clone for WSMAN_CREATE_SHELL_DATA {
 unsafe impl ::windows::core::Abi for WSMAN_CREATE_SHELL_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_CREATE_SHELL_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_CREATE_SHELL_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_CREATE_SHELL_DATA {}
 impl ::core::default::Default for WSMAN_CREATE_SHELL_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3213,12 +3189,6 @@ impl ::core::clone::Clone for WSMAN_DATA {
 unsafe impl ::windows::core::Abi for WSMAN_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_DATA {}
 impl ::core::default::Default for WSMAN_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3240,12 +3210,6 @@ impl ::core::clone::Clone for WSMAN_DATA_0 {
 unsafe impl ::windows::core::Abi for WSMAN_DATA_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_DATA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_DATA_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_DATA_0 {}
 impl ::core::default::Default for WSMAN_DATA_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3273,7 +3237,7 @@ unsafe impl ::windows::core::Abi for WSMAN_DATA_BINARY {
 }
 impl ::core::cmp::PartialEq for WSMAN_DATA_BINARY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_DATA_BINARY>()) == 0 }
+        self.dataLength == other.dataLength && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for WSMAN_DATA_BINARY {}
@@ -3304,7 +3268,7 @@ unsafe impl ::windows::core::Abi for WSMAN_DATA_TEXT {
 }
 impl ::core::cmp::PartialEq for WSMAN_DATA_TEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_DATA_TEXT>()) == 0 }
+        self.bufferLength == other.bufferLength && self.buffer == other.buffer
     }
 }
 impl ::core::cmp::Eq for WSMAN_DATA_TEXT {}
@@ -3335,7 +3299,7 @@ unsafe impl ::windows::core::Abi for WSMAN_ENVIRONMENT_VARIABLE {
 }
 impl ::core::cmp::PartialEq for WSMAN_ENVIRONMENT_VARIABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_ENVIRONMENT_VARIABLE>()) == 0 }
+        self.name == other.name && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WSMAN_ENVIRONMENT_VARIABLE {}
@@ -3366,7 +3330,7 @@ unsafe impl ::windows::core::Abi for WSMAN_ENVIRONMENT_VARIABLE_SET {
 }
 impl ::core::cmp::PartialEq for WSMAN_ENVIRONMENT_VARIABLE_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_ENVIRONMENT_VARIABLE_SET>()) == 0 }
+        self.varsCount == other.varsCount && self.vars == other.vars
     }
 }
 impl ::core::cmp::Eq for WSMAN_ENVIRONMENT_VARIABLE_SET {}
@@ -3400,7 +3364,7 @@ unsafe impl ::windows::core::Abi for WSMAN_ERROR {
 }
 impl ::core::cmp::PartialEq for WSMAN_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_ERROR>()) == 0 }
+        self.code == other.code && self.errorDetail == other.errorDetail && self.language == other.language && self.machineName == other.machineName && self.pluginName == other.pluginName
     }
 }
 impl ::core::cmp::Eq for WSMAN_ERROR {}
@@ -3431,7 +3395,7 @@ unsafe impl ::windows::core::Abi for WSMAN_FILTER {
 }
 impl ::core::cmp::PartialEq for WSMAN_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_FILTER>()) == 0 }
+        self.filter == other.filter && self.dialect == other.dialect
     }
 }
 impl ::core::cmp::Eq for WSMAN_FILTER {}
@@ -3462,7 +3426,7 @@ unsafe impl ::windows::core::Abi for WSMAN_FRAGMENT {
 }
 impl ::core::cmp::PartialEq for WSMAN_FRAGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_FRAGMENT>()) == 0 }
+        self.path == other.path && self.dialect == other.dialect
     }
 }
 impl ::core::cmp::Eq for WSMAN_FRAGMENT {}
@@ -3493,7 +3457,7 @@ unsafe impl ::windows::core::Abi for WSMAN_KEY {
 }
 impl ::core::cmp::PartialEq for WSMAN_KEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_KEY>()) == 0 }
+        self.key == other.key && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for WSMAN_KEY {}
@@ -3536,7 +3500,7 @@ unsafe impl ::windows::core::Abi for WSMAN_OPERATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_OPERATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_OPERATION_INFO>()) == 0 }
+        self.fragment == other.fragment && self.filter == other.filter && self.selectorSet == other.selectorSet && self.optionSet == other.optionSet && self.reserved == other.reserved && self.version == other.version
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3580,7 +3544,7 @@ unsafe impl ::windows::core::Abi for WSMAN_OPERATION_INFOEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_OPERATION_INFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_OPERATION_INFOEX>()) == 0 }
+        self.fragment == other.fragment && self.filter == other.filter && self.selectorSet == other.selectorSet && self.optionSet == other.optionSet && self.version == other.version && self.uiLocale == other.uiLocale && self.dataLocale == other.dataLocale
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3620,7 +3584,7 @@ unsafe impl ::windows::core::Abi for WSMAN_OPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_OPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_OPTION>()) == 0 }
+        self.name == other.name && self.value == other.value && self.mustComply == other.mustComply
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3660,7 +3624,7 @@ unsafe impl ::windows::core::Abi for WSMAN_OPTION_SET {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_OPTION_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_OPTION_SET>()) == 0 }
+        self.optionsCount == other.optionsCount && self.options == other.options && self.optionsMustUnderstand == other.optionsMustUnderstand
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3701,7 +3665,7 @@ unsafe impl ::windows::core::Abi for WSMAN_OPTION_SETEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_OPTION_SETEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_OPTION_SETEX>()) == 0 }
+        self.optionsCount == other.optionsCount && self.options == other.options && self.optionsMustUnderstand == other.optionsMustUnderstand && self.optionTypes == other.optionTypes
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3745,7 +3709,7 @@ unsafe impl ::windows::core::Abi for WSMAN_PLUGIN_REQUEST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_PLUGIN_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_PLUGIN_REQUEST>()) == 0 }
+        self.senderDetails == other.senderDetails && self.locale == other.locale && self.resourceUri == other.resourceUri && self.operationInfo == other.operationInfo && self.shutdownNotification == other.shutdownNotification && self.shutdownNotificationHandle == other.shutdownNotificationHandle && self.dataLocale == other.dataLocale
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3771,12 +3735,6 @@ impl ::core::clone::Clone for WSMAN_PROXY_INFO {
 unsafe impl ::windows::core::Abi for WSMAN_PROXY_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_PROXY_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_PROXY_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_PROXY_INFO {}
 impl ::core::default::Default for WSMAN_PROXY_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3799,12 +3757,6 @@ impl ::core::clone::Clone for WSMAN_RECEIVE_DATA_RESULT {
 unsafe impl ::windows::core::Abi for WSMAN_RECEIVE_DATA_RESULT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_RECEIVE_DATA_RESULT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_RECEIVE_DATA_RESULT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_RECEIVE_DATA_RESULT {}
 impl ::core::default::Default for WSMAN_RECEIVE_DATA_RESULT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3826,12 +3778,6 @@ impl ::core::clone::Clone for WSMAN_RESPONSE_DATA {
 unsafe impl ::windows::core::Abi for WSMAN_RESPONSE_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_RESPONSE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_RESPONSE_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_RESPONSE_DATA {}
 impl ::core::default::Default for WSMAN_RESPONSE_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3859,7 +3805,7 @@ unsafe impl ::windows::core::Abi for WSMAN_SELECTOR_SET {
 }
 impl ::core::cmp::PartialEq for WSMAN_SELECTOR_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SELECTOR_SET>()) == 0 }
+        self.numberKeys == other.numberKeys && self.keys == other.keys
     }
 }
 impl ::core::cmp::Eq for WSMAN_SELECTOR_SET {}
@@ -3899,7 +3845,7 @@ unsafe impl ::windows::core::Abi for WSMAN_SENDER_DETAILS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSMAN_SENDER_DETAILS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SENDER_DETAILS>()) == 0 }
+        self.senderName == other.senderName && self.authenticationMechanism == other.authenticationMechanism && self.certificateDetails == other.certificateDetails && self.clientToken == other.clientToken && self.httpURL == other.httpURL
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3928,18 +3874,12 @@ impl ::core::clone::Clone for WSMAN_SHELL_ASYNC {
 }
 impl ::core::fmt::Debug for WSMAN_SHELL_ASYNC {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WSMAN_SHELL_ASYNC").field("operationContext", &self.operationContext).field("completionFunction", &self.completionFunction.map(|f| f as usize)).finish()
+        f.debug_struct("WSMAN_SHELL_ASYNC").field("operationContext", &self.operationContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for WSMAN_SHELL_ASYNC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WSMAN_SHELL_ASYNC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SHELL_ASYNC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WSMAN_SHELL_ASYNC {}
 impl ::core::default::Default for WSMAN_SHELL_ASYNC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3966,7 +3906,7 @@ unsafe impl ::windows::core::Abi for WSMAN_SHELL_DISCONNECT_INFO {
 }
 impl ::core::cmp::PartialEq for WSMAN_SHELL_DISCONNECT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SHELL_DISCONNECT_INFO>()) == 0 }
+        self.idleTimeoutMs == other.idleTimeoutMs
     }
 }
 impl ::core::cmp::Eq for WSMAN_SHELL_DISCONNECT_INFO {}
@@ -4000,7 +3940,7 @@ unsafe impl ::windows::core::Abi for WSMAN_SHELL_STARTUP_INFO_V10 {
 }
 impl ::core::cmp::PartialEq for WSMAN_SHELL_STARTUP_INFO_V10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SHELL_STARTUP_INFO_V10>()) == 0 }
+        self.inputStreamSet == other.inputStreamSet && self.outputStreamSet == other.outputStreamSet && self.idleTimeoutMs == other.idleTimeoutMs && self.workingDirectory == other.workingDirectory && self.variableSet == other.variableSet
     }
 }
 impl ::core::cmp::Eq for WSMAN_SHELL_STARTUP_INFO_V10 {}
@@ -4031,7 +3971,7 @@ unsafe impl ::windows::core::Abi for WSMAN_SHELL_STARTUP_INFO_V11 {
 }
 impl ::core::cmp::PartialEq for WSMAN_SHELL_STARTUP_INFO_V11 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_SHELL_STARTUP_INFO_V11>()) == 0 }
+        self.Base == other.Base && self.name == other.name
     }
 }
 impl ::core::cmp::Eq for WSMAN_SHELL_STARTUP_INFO_V11 {}
@@ -4062,7 +4002,7 @@ unsafe impl ::windows::core::Abi for WSMAN_STREAM_ID_SET {
 }
 impl ::core::cmp::PartialEq for WSMAN_STREAM_ID_SET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_STREAM_ID_SET>()) == 0 }
+        self.streamIDsCount == other.streamIDsCount && self.streamIDs == other.streamIDs
     }
 }
 impl ::core::cmp::Eq for WSMAN_STREAM_ID_SET {}
@@ -4093,7 +4033,7 @@ unsafe impl ::windows::core::Abi for WSMAN_USERNAME_PASSWORD_CREDS {
 }
 impl ::core::cmp::PartialEq for WSMAN_USERNAME_PASSWORD_CREDS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSMAN_USERNAME_PASSWORD_CREDS>()) == 0 }
+        self.username == other.username && self.password == other.password
     }
 }
 impl ::core::cmp::Eq for WSMAN_USERNAME_PASSWORD_CREDS {}

--- a/crates/libs/windows/src/Windows/Win32/System/RestartManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RestartManager/mod.rs
@@ -319,14 +319,6 @@ unsafe impl ::windows::core::Abi for RM_FILTER_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RM_FILTER_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_FILTER_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RM_FILTER_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RM_FILTER_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -352,14 +344,6 @@ impl ::core::clone::Clone for RM_FILTER_INFO_0 {
 unsafe impl ::windows::core::Abi for RM_FILTER_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RM_FILTER_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_FILTER_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RM_FILTER_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RM_FILTER_INFO_0 {
     fn default() -> Self {
@@ -399,7 +383,7 @@ unsafe impl ::windows::core::Abi for RM_PROCESS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RM_PROCESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_PROCESS_INFO>()) == 0 }
+        self.Process == other.Process && self.strAppName == other.strAppName && self.strServiceShortName == other.strServiceShortName && self.ApplicationType == other.ApplicationType && self.AppStatus == other.AppStatus && self.TSSessionId == other.TSSessionId && self.bRestartable == other.bRestartable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -438,7 +422,7 @@ unsafe impl ::windows::core::Abi for RM_UNIQUE_PROCESS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RM_UNIQUE_PROCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RM_UNIQUE_PROCESS>()) == 0 }
+        self.dwProcessId == other.dwProcessId && self.ProcessStartTime == other.ProcessStartTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Restore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Restore/mod.rs
@@ -140,14 +140,6 @@ unsafe impl ::windows::core::Abi for RESTOREPOINTINFOA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RESTOREPOINTINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESTOREPOINTINFOA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RESTOREPOINTINFOA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RESTOREPOINTINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -176,14 +168,6 @@ unsafe impl ::windows::core::Abi for RESTOREPOINTINFOEX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RESTOREPOINTINFOEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESTOREPOINTINFOEX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RESTOREPOINTINFOEX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RESTOREPOINTINFOEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -206,12 +190,6 @@ impl ::core::clone::Clone for RESTOREPOINTINFOW {
 unsafe impl ::windows::core::Abi for RESTOREPOINTINFOW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RESTOREPOINTINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESTOREPOINTINFOW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RESTOREPOINTINFOW {}
 impl ::core::default::Default for RESTOREPOINTINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -232,12 +210,6 @@ impl ::core::clone::Clone for STATEMGRSTATUS {
 unsafe impl ::windows::core::Abi for STATEMGRSTATUS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STATEMGRSTATUS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STATEMGRSTATUS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STATEMGRSTATUS {}
 impl ::core::default::Default for STATEMGRSTATUS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -4964,7 +4964,7 @@ unsafe impl ::windows::core::Abi for ARRAY_INFO {
 }
 impl ::core::cmp::PartialEq for ARRAY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ARRAY_INFO>()) == 0 }
+        self.Dimension == other.Dimension && self.BufferConformanceMark == other.BufferConformanceMark && self.BufferVarianceMark == other.BufferVarianceMark && self.MaxCountArray == other.MaxCountArray && self.OffsetArray == other.OffsetArray && self.ActualCountArray == other.ActualCountArray
     }
 }
 impl ::core::cmp::Eq for ARRAY_INFO {}
@@ -4995,7 +4995,7 @@ unsafe impl ::windows::core::Abi for BinaryParam {
 }
 impl ::core::cmp::PartialEq for BinaryParam {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BinaryParam>()) == 0 }
+        self.Buffer == other.Buffer && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for BinaryParam {}
@@ -5019,12 +5019,6 @@ impl ::core::clone::Clone for CLIENT_CALL_RETURN {
 unsafe impl ::windows::core::Abi for CLIENT_CALL_RETURN {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CLIENT_CALL_RETURN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIENT_CALL_RETURN>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CLIENT_CALL_RETURN {}
 impl ::core::default::Default for CLIENT_CALL_RETURN {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5052,7 +5046,7 @@ unsafe impl ::windows::core::Abi for COMM_FAULT_OFFSETS {
 }
 impl ::core::cmp::PartialEq for COMM_FAULT_OFFSETS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMM_FAULT_OFFSETS>()) == 0 }
+        self.CommOffset == other.CommOffset && self.FaultOffset == other.FaultOffset
     }
 }
 impl ::core::cmp::Eq for COMM_FAULT_OFFSETS {}
@@ -5085,7 +5079,7 @@ unsafe impl ::windows::core::Abi for FULL_PTR_XLAT_TABLES {
 }
 impl ::core::cmp::PartialEq for FULL_PTR_XLAT_TABLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FULL_PTR_XLAT_TABLES>()) == 0 }
+        self.RefIdToPointer == other.RefIdToPointer && self.PointerToRefId == other.PointerToRefId && self.NextRefId == other.NextRefId && self.XlatSide == other.XlatSide
     }
 }
 impl ::core::cmp::Eq for FULL_PTR_XLAT_TABLES {}
@@ -5110,18 +5104,12 @@ impl ::core::clone::Clone for GENERIC_BINDING_INFO {
 }
 impl ::core::fmt::Debug for GENERIC_BINDING_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("GENERIC_BINDING_INFO").field("pObj", &self.pObj).field("Size", &self.Size).field("pfnBind", &self.pfnBind.map(|f| f as usize)).field("pfnUnbind", &self.pfnUnbind.map(|f| f as usize)).finish()
+        f.debug_struct("GENERIC_BINDING_INFO").field("pObj", &self.pObj).field("Size", &self.Size).finish()
     }
 }
 unsafe impl ::windows::core::Abi for GENERIC_BINDING_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GENERIC_BINDING_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GENERIC_BINDING_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GENERIC_BINDING_INFO {}
 impl ::core::default::Default for GENERIC_BINDING_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5141,18 +5129,12 @@ impl ::core::clone::Clone for GENERIC_BINDING_ROUTINE_PAIR {
 }
 impl ::core::fmt::Debug for GENERIC_BINDING_ROUTINE_PAIR {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("GENERIC_BINDING_ROUTINE_PAIR").field("pfnBind", &self.pfnBind.map(|f| f as usize)).field("pfnUnbind", &self.pfnUnbind.map(|f| f as usize)).finish()
+        f.debug_struct("GENERIC_BINDING_ROUTINE_PAIR").finish()
     }
 }
 unsafe impl ::windows::core::Abi for GENERIC_BINDING_ROUTINE_PAIR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GENERIC_BINDING_ROUTINE_PAIR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GENERIC_BINDING_ROUTINE_PAIR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GENERIC_BINDING_ROUTINE_PAIR {}
 impl ::core::default::Default for GENERIC_BINDING_ROUTINE_PAIR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5179,28 +5161,12 @@ impl ::core::clone::Clone for I_RpcProxyCallbackInterface {
 }
 impl ::core::fmt::Debug for I_RpcProxyCallbackInterface {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("I_RpcProxyCallbackInterface")
-            .field("IsValidMachineFn", &self.IsValidMachineFn.map(|f| f as usize))
-            .field("GetClientAddressFn", &self.GetClientAddressFn.map(|f| f as usize))
-            .field("GetConnectionTimeoutFn", &self.GetConnectionTimeoutFn.map(|f| f as usize))
-            .field("PerformCalloutFn", &self.PerformCalloutFn.map(|f| f as usize))
-            .field("FreeCalloutStateFn", &self.FreeCalloutStateFn.map(|f| f as usize))
-            .field("GetClientSessionAndResourceUUIDFn", &self.GetClientSessionAndResourceUUIDFn.map(|f| f as usize))
-            .field("ProxyFilterIfFn", &self.ProxyFilterIfFn.map(|f| f as usize))
-            .field("RpcProxyUpdatePerfCounterFn", &self.RpcProxyUpdatePerfCounterFn.map(|f| f as usize))
-            .field("RpcProxyUpdatePerfCounterBackendServerFn", &self.RpcProxyUpdatePerfCounterBackendServerFn.map(|f| f as usize))
-            .finish()
+        f.debug_struct("I_RpcProxyCallbackInterface").finish()
     }
 }
 unsafe impl ::windows::core::Abi for I_RpcProxyCallbackInterface {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for I_RpcProxyCallbackInterface {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<I_RpcProxyCallbackInterface>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for I_RpcProxyCallbackInterface {}
 impl ::core::default::Default for I_RpcProxyCallbackInterface {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5228,7 +5194,7 @@ unsafe impl ::windows::core::Abi for MALLOC_FREE_STRUCT {
 }
 impl ::core::cmp::PartialEq for MALLOC_FREE_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MALLOC_FREE_STRUCT>()) == 0 }
+        self.pfnAllocate == other.pfnAllocate && self.pfnFree == other.pfnFree
     }
 }
 impl ::core::cmp::Eq for MALLOC_FREE_STRUCT {}
@@ -5259,7 +5225,7 @@ unsafe impl ::windows::core::Abi for MIDL_FORMAT_STRING {
 }
 impl ::core::cmp::PartialEq for MIDL_FORMAT_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_FORMAT_STRING>()) == 0 }
+        self.Pad == other.Pad && self.Format == other.Format
     }
 }
 impl ::core::cmp::Eq for MIDL_FORMAT_STRING {}
@@ -5293,7 +5259,7 @@ unsafe impl ::windows::core::Abi for MIDL_INTERCEPTION_INFO {
 }
 impl ::core::cmp::PartialEq for MIDL_INTERCEPTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_INTERCEPTION_INFO>()) == 0 }
+        self.Version == other.Version && self.ProcString == other.ProcString && self.ProcFormatOffsetTable == other.ProcFormatOffsetTable && self.ProcCount == other.ProcCount && self.TypeString == other.TypeString
     }
 }
 impl ::core::cmp::Eq for MIDL_INTERCEPTION_INFO {}
@@ -5324,7 +5290,7 @@ unsafe impl ::windows::core::Abi for MIDL_INTERFACE_METHOD_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for MIDL_INTERFACE_METHOD_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_INTERFACE_METHOD_PROPERTIES>()) == 0 }
+        self.MethodCount == other.MethodCount && self.MethodProperties == other.MethodProperties
     }
 }
 impl ::core::cmp::Eq for MIDL_INTERFACE_METHOD_PROPERTIES {}
@@ -5355,7 +5321,7 @@ unsafe impl ::windows::core::Abi for MIDL_METHOD_PROPERTY {
 }
 impl ::core::cmp::PartialEq for MIDL_METHOD_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_METHOD_PROPERTY>()) == 0 }
+        self.Id == other.Id && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for MIDL_METHOD_PROPERTY {}
@@ -5386,7 +5352,7 @@ unsafe impl ::windows::core::Abi for MIDL_METHOD_PROPERTY_MAP {
 }
 impl ::core::cmp::PartialEq for MIDL_METHOD_PROPERTY_MAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_METHOD_PROPERTY_MAP>()) == 0 }
+        self.Count == other.Count && self.Properties == other.Properties
     }
 }
 impl ::core::cmp::Eq for MIDL_METHOD_PROPERTY_MAP {}
@@ -5429,7 +5395,7 @@ unsafe impl ::windows::core::Abi for MIDL_SERVER_INFO {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for MIDL_SERVER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_SERVER_INFO>()) == 0 }
+        self.pStubDesc == other.pStubDesc && self.DispatchTable == other.DispatchTable && self.ProcString == other.ProcString && self.FmtStringOffset == other.FmtStringOffset && self.ThunkTable == other.ThunkTable && self.pTransferSyntax == other.pTransferSyntax && self.nCount == other.nCount && self.pSyntaxInfo == other.pSyntaxInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -5472,7 +5438,7 @@ unsafe impl ::windows::core::Abi for MIDL_STUBLESS_PROXY_INFO {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for MIDL_STUBLESS_PROXY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_STUBLESS_PROXY_INFO>()) == 0 }
+        self.pStubDesc == other.pStubDesc && self.ProcFormatString == other.ProcFormatString && self.FormatStringOffset == other.FormatStringOffset && self.pTransferSyntax == other.pTransferSyntax && self.nCount == other.nCount && self.pSyntaxInfo == other.pSyntaxInfo
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -5521,14 +5487,6 @@ unsafe impl ::windows::core::Abi for MIDL_STUB_DESC {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for MIDL_STUB_DESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_STUB_DESC>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for MIDL_STUB_DESC {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for MIDL_STUB_DESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5554,14 +5512,6 @@ impl ::core::clone::Clone for MIDL_STUB_DESC_0 {
 unsafe impl ::windows::core::Abi for MIDL_STUB_DESC_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for MIDL_STUB_DESC_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_STUB_DESC_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for MIDL_STUB_DESC_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for MIDL_STUB_DESC_0 {
     fn default() -> Self {
@@ -5868,7 +5818,7 @@ unsafe impl ::windows::core::Abi for MIDL_SYNTAX_INFO {
 }
 impl ::core::cmp::PartialEq for MIDL_SYNTAX_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_SYNTAX_INFO>()) == 0 }
+        self.TransferSyntax == other.TransferSyntax && self.DispatchTable == other.DispatchTable && self.ProcString == other.ProcString && self.FmtStringOffset == other.FmtStringOffset && self.TypeString == other.TypeString && self.aUserMarshalQuadruple == other.aUserMarshalQuadruple && self.pMethodProperties == other.pMethodProperties && self.pReserved2 == other.pReserved2
     }
 }
 impl ::core::cmp::Eq for MIDL_SYNTAX_INFO {}
@@ -5900,7 +5850,7 @@ unsafe impl ::windows::core::Abi for MIDL_TYPE_PICKLING_INFO {
 }
 impl ::core::cmp::PartialEq for MIDL_TYPE_PICKLING_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_TYPE_PICKLING_INFO>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for MIDL_TYPE_PICKLING_INFO {}
@@ -5940,7 +5890,7 @@ unsafe impl ::windows::core::Abi for MIDL_WINRT_TYPE_SERIALIZATION_INFO {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for MIDL_WINRT_TYPE_SERIALIZATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MIDL_WINRT_TYPE_SERIALIZATION_INFO>()) == 0 }
+        self.Version == other.Version && self.TypeFormatString == other.TypeFormatString && self.FormatStringSize == other.FormatStringSize && self.TypeOffset == other.TypeOffset && self.StubDesc == other.StubDesc
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -5973,7 +5923,7 @@ unsafe impl ::windows::core::Abi for NDR64_ARRAY_ELEMENT_INFO {
 }
 impl ::core::cmp::PartialEq for NDR64_ARRAY_ELEMENT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_ARRAY_ELEMENT_INFO>()) == 0 }
+        self.ElementMemSize == other.ElementMemSize && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for NDR64_ARRAY_ELEMENT_INFO {}
@@ -6003,7 +5953,7 @@ unsafe impl ::windows::core::Abi for NDR64_ARRAY_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_ARRAY_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_ARRAY_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_ARRAY_FLAGS {}
@@ -6028,12 +5978,6 @@ impl ::core::clone::Clone for NDR64_BINDINGS {
 unsafe impl ::windows::core::Abi for NDR64_BINDINGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDR64_BINDINGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BINDINGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDR64_BINDINGS {}
 impl ::core::default::Default for NDR64_BINDINGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6061,7 +6005,7 @@ unsafe impl ::windows::core::Abi for NDR64_BIND_AND_NOTIFY_EXTENSION {
 }
 impl ::core::cmp::PartialEq for NDR64_BIND_AND_NOTIFY_EXTENSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BIND_AND_NOTIFY_EXTENSION>()) == 0 }
+        self.Binding == other.Binding && self.NotifyIndex == other.NotifyIndex
     }
 }
 impl ::core::cmp::Eq for NDR64_BIND_AND_NOTIFY_EXTENSION {}
@@ -6095,7 +6039,7 @@ unsafe impl ::windows::core::Abi for NDR64_BIND_CONTEXT {
 }
 impl ::core::cmp::PartialEq for NDR64_BIND_CONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BIND_CONTEXT>()) == 0 }
+        self.HandleType == other.HandleType && self.Flags == other.Flags && self.StackOffset == other.StackOffset && self.RoutineIndex == other.RoutineIndex && self.Ordinal == other.Ordinal
     }
 }
 impl ::core::cmp::Eq for NDR64_BIND_CONTEXT {}
@@ -6129,7 +6073,7 @@ unsafe impl ::windows::core::Abi for NDR64_BIND_GENERIC {
 }
 impl ::core::cmp::PartialEq for NDR64_BIND_GENERIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BIND_GENERIC>()) == 0 }
+        self.HandleType == other.HandleType && self.Flags == other.Flags && self.StackOffset == other.StackOffset && self.RoutineIndex == other.RoutineIndex && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for NDR64_BIND_GENERIC {}
@@ -6162,7 +6106,7 @@ unsafe impl ::windows::core::Abi for NDR64_BIND_PRIMITIVE {
 }
 impl ::core::cmp::PartialEq for NDR64_BIND_PRIMITIVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BIND_PRIMITIVE>()) == 0 }
+        self.HandleType == other.HandleType && self.Flags == other.Flags && self.StackOffset == other.StackOffset && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_BIND_PRIMITIVE {}
@@ -6197,7 +6141,7 @@ unsafe impl ::windows::core::Abi for NDR64_BOGUS_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_BOGUS_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BOGUS_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.NumberDims == other.NumberDims && self.NumberElements == other.NumberElements && self.Element == other.Element
     }
 }
 impl ::core::cmp::Eq for NDR64_BOGUS_ARRAY_HEADER_FORMAT {}
@@ -6234,7 +6178,7 @@ unsafe impl ::windows::core::Abi for NDR64_BOGUS_STRUCTURE_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_BOGUS_STRUCTURE_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BOGUS_STRUCTURE_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserve == other.Reserve && self.MemorySize == other.MemorySize && self.OriginalMemberLayout == other.OriginalMemberLayout && self.OriginalPointerLayout == other.OriginalPointerLayout && self.PointerLayout == other.PointerLayout
     }
 }
 impl ::core::cmp::Eq for NDR64_BOGUS_STRUCTURE_HEADER_FORMAT {}
@@ -6267,7 +6211,7 @@ unsafe impl ::windows::core::Abi for NDR64_BUFFER_ALIGN_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_BUFFER_ALIGN_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_BUFFER_ALIGN_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Reserved == other.Reserved && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for NDR64_BUFFER_ALIGN_FORMAT {}
@@ -6297,7 +6241,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONFORMANT_STRING_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONFORMANT_STRING_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONFORMANT_STRING_FORMAT>()) == 0 }
+        self.Header == other.Header
     }
 }
 impl ::core::cmp::Eq for NDR64_CONFORMANT_STRING_FORMAT {}
@@ -6332,7 +6276,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONF_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONF_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONF_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserved == other.Reserved && self.ElementSize == other.ElementSize && self.ConfDescriptor == other.ConfDescriptor
     }
 }
 impl ::core::cmp::Eq for NDR64_CONF_ARRAY_HEADER_FORMAT {}
@@ -6370,7 +6314,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Dimensions == other.Dimensions && self.MemorySize == other.MemorySize && self.OriginalMemberLayout == other.OriginalMemberLayout && self.OriginalPointerLayout == other.OriginalPointerLayout && self.PointerLayout == other.PointerLayout && self.ConfArrayDescription == other.ConfArrayDescription
     }
 }
 impl ::core::cmp::Eq for NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT {}
@@ -6405,7 +6349,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONF_STRUCTURE_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONF_STRUCTURE_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONF_STRUCTURE_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserve == other.Reserve && self.MemorySize == other.MemorySize && self.ArrayDescription == other.ArrayDescription
     }
 }
 impl ::core::cmp::Eq for NDR64_CONF_STRUCTURE_HEADER_FORMAT {}
@@ -6441,7 +6385,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONF_VAR_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONF_VAR_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONF_VAR_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserved == other.Reserved && self.ElementSize == other.ElementSize && self.ConfDescriptor == other.ConfDescriptor && self.VarDescriptor == other.VarDescriptor
     }
 }
 impl ::core::cmp::Eq for NDR64_CONF_VAR_ARRAY_HEADER_FORMAT {}
@@ -6474,7 +6418,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FixedArrayFormat == other.FixedArrayFormat && self.ConfDescription == other.ConfDescription && self.VarDescription == other.VarDescription && self.OffsetDescription == other.OffsetDescription
     }
 }
 impl ::core::cmp::Eq for NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {}
@@ -6507,7 +6451,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONSTANT_IID_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONSTANT_IID_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONSTANT_IID_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Guid == other.Guid
     }
 }
 impl ::core::cmp::Eq for NDR64_CONSTANT_IID_FORMAT {}
@@ -6537,7 +6481,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONTEXT_HANDLE_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_CONTEXT_HANDLE_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONTEXT_HANDLE_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_CONTEXT_HANDLE_FLAGS {}
@@ -6570,7 +6514,7 @@ unsafe impl ::windows::core::Abi for NDR64_CONTEXT_HANDLE_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_CONTEXT_HANDLE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_CONTEXT_HANDLE_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.ContextFlags == other.ContextFlags && self.RundownRoutineIndex == other.RundownRoutineIndex && self.Ordinal == other.Ordinal
     }
 }
 impl ::core::cmp::Eq for NDR64_CONTEXT_HANDLE_FORMAT {}
@@ -6603,7 +6547,7 @@ unsafe impl ::windows::core::Abi for NDR64_EMBEDDED_COMPLEX_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_EMBEDDED_COMPLEX_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EMBEDDED_COMPLEX_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Reserve1 == other.Reserve1 && self.Reserve2 == other.Reserve2 && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for NDR64_EMBEDDED_COMPLEX_FORMAT {}
@@ -6639,7 +6583,7 @@ unsafe impl ::windows::core::Abi for NDR64_ENCAPSULATED_UNION {
 }
 impl ::core::cmp::PartialEq for NDR64_ENCAPSULATED_UNION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_ENCAPSULATED_UNION>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.SwitchType == other.SwitchType && self.MemoryOffset == other.MemoryOffset && self.MemorySize == other.MemorySize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_ENCAPSULATED_UNION {}
@@ -6672,7 +6616,7 @@ unsafe impl ::windows::core::Abi for NDR64_EXPR_CONST32 {
 }
 impl ::core::cmp::PartialEq for NDR64_EXPR_CONST32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EXPR_CONST32>()) == 0 }
+        self.ExprType == other.ExprType && self.Reserved == other.Reserved && self.Reserved1 == other.Reserved1 && self.ConstValue == other.ConstValue
     }
 }
 impl ::core::cmp::Eq for NDR64_EXPR_CONST32 {}
@@ -6705,7 +6649,7 @@ unsafe impl ::windows::core::Abi for NDR64_EXPR_CONST64 {
 }
 impl ::core::cmp::PartialEq for NDR64_EXPR_CONST64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EXPR_CONST64>()) == 0 }
+        self.ExprType == other.ExprType && self.Reserved == other.Reserved && self.Reserved1 == other.Reserved1 && self.ConstValue == other.ConstValue
     }
 }
 impl ::core::cmp::Eq for NDR64_EXPR_CONST64 {}
@@ -6737,7 +6681,7 @@ unsafe impl ::windows::core::Abi for NDR64_EXPR_NOOP {
 }
 impl ::core::cmp::PartialEq for NDR64_EXPR_NOOP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EXPR_NOOP>()) == 0 }
+        self.ExprType == other.ExprType && self.Size == other.Size && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_EXPR_NOOP {}
@@ -6770,7 +6714,7 @@ unsafe impl ::windows::core::Abi for NDR64_EXPR_OPERATOR {
 }
 impl ::core::cmp::PartialEq for NDR64_EXPR_OPERATOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EXPR_OPERATOR>()) == 0 }
+        self.ExprType == other.ExprType && self.Operator == other.Operator && self.CastType == other.CastType && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_EXPR_OPERATOR {}
@@ -6803,7 +6747,7 @@ unsafe impl ::windows::core::Abi for NDR64_EXPR_VAR {
 }
 impl ::core::cmp::PartialEq for NDR64_EXPR_VAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_EXPR_VAR>()) == 0 }
+        self.ExprType == other.ExprType && self.VarType == other.VarType && self.Reserved == other.Reserved && self.Offset == other.Offset
     }
 }
 impl ::core::cmp::Eq for NDR64_EXPR_VAR {}
@@ -6835,7 +6779,7 @@ unsafe impl ::windows::core::Abi for NDR64_FIXED_REPEAT_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_FIXED_REPEAT_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_FIXED_REPEAT_FORMAT>()) == 0 }
+        self.RepeatFormat == other.RepeatFormat && self.Iterations == other.Iterations && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_FIXED_REPEAT_FORMAT {}
@@ -6869,7 +6813,7 @@ unsafe impl ::windows::core::Abi for NDR64_FIX_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_FIX_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_FIX_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserved == other.Reserved && self.TotalSize == other.TotalSize
     }
 }
 impl ::core::cmp::Eq for NDR64_FIX_ARRAY_HEADER_FORMAT {}
@@ -6899,7 +6843,7 @@ unsafe impl ::windows::core::Abi for NDR64_IID_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_IID_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_IID_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_IID_FLAGS {}
@@ -6932,7 +6876,7 @@ unsafe impl ::windows::core::Abi for NDR64_IID_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_IID_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_IID_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.IIDDescriptor == other.IIDDescriptor
     }
 }
 impl ::core::cmp::Eq for NDR64_IID_FORMAT {}
@@ -6965,7 +6909,7 @@ unsafe impl ::windows::core::Abi for NDR64_MEMPAD_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_MEMPAD_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_MEMPAD_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Reserve1 == other.Reserve1 && self.MemPad == other.MemPad && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for NDR64_MEMPAD_FORMAT {}
@@ -6996,7 +6940,7 @@ unsafe impl ::windows::core::Abi for NDR64_NON_CONFORMANT_STRING_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_NON_CONFORMANT_STRING_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_NON_CONFORMANT_STRING_FORMAT>()) == 0 }
+        self.Header == other.Header && self.TotalSize == other.TotalSize
     }
 }
 impl ::core::cmp::Eq for NDR64_NON_CONFORMANT_STRING_FORMAT {}
@@ -7032,7 +6976,7 @@ unsafe impl ::windows::core::Abi for NDR64_NON_ENCAPSULATED_UNION {
 }
 impl ::core::cmp::PartialEq for NDR64_NON_ENCAPSULATED_UNION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_NON_ENCAPSULATED_UNION>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.SwitchType == other.SwitchType && self.MemorySize == other.MemorySize && self.Switch == other.Switch && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_NON_ENCAPSULATED_UNION {}
@@ -7065,7 +7009,7 @@ unsafe impl ::windows::core::Abi for NDR64_NO_REPEAT_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_NO_REPEAT_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_NO_REPEAT_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for NDR64_NO_REPEAT_FORMAT {}
@@ -7095,7 +7039,7 @@ unsafe impl ::windows::core::Abi for NDR64_PARAM_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_PARAM_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PARAM_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_PARAM_FLAGS {}
@@ -7128,7 +7072,7 @@ unsafe impl ::windows::core::Abi for NDR64_PARAM_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_PARAM_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PARAM_FORMAT>()) == 0 }
+        self.Type == other.Type && self.Attributes == other.Attributes && self.Reserved == other.Reserved && self.StackOffset == other.StackOffset
     }
 }
 impl ::core::cmp::Eq for NDR64_PARAM_FORMAT {}
@@ -7158,7 +7102,7 @@ unsafe impl ::windows::core::Abi for NDR64_PIPE_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_PIPE_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PIPE_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_PIPE_FLAGS {}
@@ -7194,7 +7138,7 @@ unsafe impl ::windows::core::Abi for NDR64_PIPE_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_PIPE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PIPE_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Alignment == other.Alignment && self.Reserved == other.Reserved && self.Type == other.Type && self.MemorySize == other.MemorySize && self.BufferSize == other.BufferSize
     }
 }
 impl ::core::cmp::Eq for NDR64_PIPE_FORMAT {}
@@ -7227,7 +7171,7 @@ unsafe impl ::windows::core::Abi for NDR64_POINTER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_POINTER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_POINTER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Pointee == other.Pointee
     }
 }
 impl ::core::cmp::Eq for NDR64_POINTER_FORMAT {}
@@ -7258,7 +7202,7 @@ unsafe impl ::windows::core::Abi for NDR64_POINTER_INSTANCE_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_POINTER_INSTANCE_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_POINTER_INSTANCE_HEADER_FORMAT>()) == 0 }
+        self.Offset == other.Offset && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_POINTER_INSTANCE_HEADER_FORMAT {}
@@ -7288,7 +7232,7 @@ unsafe impl ::windows::core::Abi for NDR64_POINTER_REPEAT_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_POINTER_REPEAT_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_POINTER_REPEAT_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_POINTER_REPEAT_FLAGS {}
@@ -7318,7 +7262,7 @@ unsafe impl ::windows::core::Abi for NDR64_PROC_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_PROC_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PROC_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_PROC_FLAGS {}
@@ -7355,7 +7299,7 @@ unsafe impl ::windows::core::Abi for NDR64_PROC_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_PROC_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_PROC_FORMAT>()) == 0 }
+        self.Flags == other.Flags && self.StackSize == other.StackSize && self.ConstantClientBufferSize == other.ConstantClientBufferSize && self.ConstantServerBufferSize == other.ConstantServerBufferSize && self.RpcFlags == other.RpcFlags && self.FloatDoubleMask == other.FloatDoubleMask && self.NumberOfParams == other.NumberOfParams && self.ExtensionSize == other.ExtensionSize
     }
 }
 impl ::core::cmp::Eq for NDR64_PROC_FORMAT {}
@@ -7388,7 +7332,7 @@ unsafe impl ::windows::core::Abi for NDR64_RANGED_STRING_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_RANGED_STRING_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_RANGED_STRING_FORMAT>()) == 0 }
+        self.Header == other.Header && self.Reserved == other.Reserved && self.Min == other.Min && self.Max == other.Max
     }
 }
 impl ::core::cmp::Eq for NDR64_RANGED_STRING_FORMAT {}
@@ -7422,7 +7366,7 @@ unsafe impl ::windows::core::Abi for NDR64_RANGE_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_RANGE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_RANGE_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.RangeType == other.RangeType && self.Reserved == other.Reserved && self.MinValue == other.MinValue && self.MaxValue == other.MaxValue
     }
 }
 impl ::core::cmp::Eq for NDR64_RANGE_FORMAT {}
@@ -7460,7 +7404,7 @@ unsafe impl ::windows::core::Abi for NDR64_RANGE_PIPE_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_RANGE_PIPE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_RANGE_PIPE_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Alignment == other.Alignment && self.Reserved == other.Reserved && self.Type == other.Type && self.MemorySize == other.MemorySize && self.BufferSize == other.BufferSize && self.MinValue == other.MinValue && self.MaxValue == other.MaxValue
     }
 }
 impl ::core::cmp::Eq for NDR64_RANGE_PIPE_FORMAT {}
@@ -7495,7 +7439,7 @@ unsafe impl ::windows::core::Abi for NDR64_REPEAT_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_REPEAT_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_REPEAT_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.Increment == other.Increment && self.OffsetToArray == other.OffsetToArray && self.NumberOfPointers == other.NumberOfPointers
     }
 }
 impl ::core::cmp::Eq for NDR64_REPEAT_FORMAT {}
@@ -7525,7 +7469,7 @@ unsafe impl ::windows::core::Abi for NDR64_RPC_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_RPC_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_RPC_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_RPC_FLAGS {}
@@ -7558,7 +7502,7 @@ unsafe impl ::windows::core::Abi for NDR64_SIMPLE_MEMBER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_SIMPLE_MEMBER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_SIMPLE_MEMBER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3
     }
 }
 impl ::core::cmp::Eq for NDR64_SIMPLE_MEMBER_FORMAT {}
@@ -7591,7 +7535,7 @@ unsafe impl ::windows::core::Abi for NDR64_SIMPLE_REGION_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_SIMPLE_REGION_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_SIMPLE_REGION_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.RegionSize == other.RegionSize && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_SIMPLE_REGION_FORMAT {}
@@ -7622,7 +7566,7 @@ unsafe impl ::windows::core::Abi for NDR64_SIZED_CONFORMANT_STRING_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_SIZED_CONFORMANT_STRING_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_SIZED_CONFORMANT_STRING_FORMAT>()) == 0 }
+        self.Header == other.Header && self.SizeDescription == other.SizeDescription
     }
 }
 impl ::core::cmp::Eq for NDR64_SIZED_CONFORMANT_STRING_FORMAT {}
@@ -7652,7 +7596,7 @@ unsafe impl ::windows::core::Abi for NDR64_STRING_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_STRING_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_STRING_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_STRING_FLAGS {}
@@ -7684,7 +7628,7 @@ unsafe impl ::windows::core::Abi for NDR64_STRING_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_STRING_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_STRING_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.ElementSize == other.ElementSize
     }
 }
 impl ::core::cmp::Eq for NDR64_STRING_HEADER_FORMAT {}
@@ -7714,7 +7658,7 @@ unsafe impl ::windows::core::Abi for NDR64_STRUCTURE_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_STRUCTURE_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_STRUCTURE_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_STRUCTURE_FLAGS {}
@@ -7748,7 +7692,7 @@ unsafe impl ::windows::core::Abi for NDR64_STRUCTURE_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_STRUCTURE_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_STRUCTURE_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserve == other.Reserve && self.MemorySize == other.MemorySize
     }
 }
 impl ::core::cmp::Eq for NDR64_STRUCTURE_HEADER_FORMAT {}
@@ -7780,7 +7724,7 @@ unsafe impl ::windows::core::Abi for NDR64_SYSTEM_HANDLE_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_SYSTEM_HANDLE_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_SYSTEM_HANDLE_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.HandleType == other.HandleType && self.DesiredAccess == other.DesiredAccess
     }
 }
 impl ::core::cmp::Eq for NDR64_SYSTEM_HANDLE_FORMAT {}
@@ -7810,7 +7754,7 @@ unsafe impl ::windows::core::Abi for NDR64_TRANSMIT_AS_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_TRANSMIT_AS_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_TRANSMIT_AS_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_TRANSMIT_AS_FLAGS {}
@@ -7847,7 +7791,7 @@ unsafe impl ::windows::core::Abi for NDR64_TRANSMIT_AS_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_TRANSMIT_AS_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_TRANSMIT_AS_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.RoutineIndex == other.RoutineIndex && self.TransmittedTypeWireAlignment == other.TransmittedTypeWireAlignment && self.MemoryAlignment == other.MemoryAlignment && self.PresentedTypeMemorySize == other.PresentedTypeMemorySize && self.TransmittedTypeBufferSize == other.TransmittedTypeBufferSize && self.TransmittedType == other.TransmittedType
     }
 }
 impl ::core::cmp::Eq for NDR64_TRANSMIT_AS_FORMAT {}
@@ -7882,7 +7826,7 @@ unsafe impl ::windows::core::Abi for NDR64_TYPE_STRICT_CONTEXT_HANDLE {
 }
 impl ::core::cmp::PartialEq for NDR64_TYPE_STRICT_CONTEXT_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_TYPE_STRICT_CONTEXT_HANDLE>()) == 0 }
+        self.FormatCode == other.FormatCode && self.RealFormatCode == other.RealFormatCode && self.Reserved == other.Reserved && self.Type == other.Type && self.CtxtFlags == other.CtxtFlags && self.CtxtID == other.CtxtID
     }
 }
 impl ::core::cmp::Eq for NDR64_TYPE_STRICT_CONTEXT_HANDLE {}
@@ -7914,7 +7858,7 @@ unsafe impl ::windows::core::Abi for NDR64_UNION_ARM {
 }
 impl ::core::cmp::PartialEq for NDR64_UNION_ARM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_UNION_ARM>()) == 0 }
+        self.CaseValue == other.CaseValue && self.Type == other.Type && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for NDR64_UNION_ARM {}
@@ -7947,7 +7891,7 @@ unsafe impl ::windows::core::Abi for NDR64_UNION_ARM_SELECTOR {
 }
 impl ::core::cmp::PartialEq for NDR64_UNION_ARM_SELECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_UNION_ARM_SELECTOR>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Alignment == other.Alignment && self.Reserved2 == other.Reserved2 && self.Arms == other.Arms
     }
 }
 impl ::core::cmp::Eq for NDR64_UNION_ARM_SELECTOR {}
@@ -7977,7 +7921,7 @@ unsafe impl ::windows::core::Abi for NDR64_USER_MARSHAL_FLAGS {
 }
 impl ::core::cmp::PartialEq for NDR64_USER_MARSHAL_FLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_USER_MARSHAL_FLAGS>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for NDR64_USER_MARSHAL_FLAGS {}
@@ -8014,7 +7958,7 @@ unsafe impl ::windows::core::Abi for NDR64_USER_MARSHAL_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_USER_MARSHAL_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_USER_MARSHAL_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Flags == other.Flags && self.RoutineIndex == other.RoutineIndex && self.TransmittedTypeWireAlignment == other.TransmittedTypeWireAlignment && self.MemoryAlignment == other.MemoryAlignment && self.UserTypeMemorySize == other.UserTypeMemorySize && self.TransmittedTypeBufferSize == other.TransmittedTypeBufferSize && self.TransmittedType == other.TransmittedType
     }
 }
 impl ::core::cmp::Eq for NDR64_USER_MARSHAL_FORMAT {}
@@ -8050,7 +7994,7 @@ unsafe impl ::windows::core::Abi for NDR64_VAR_ARRAY_HEADER_FORMAT {
 }
 impl ::core::cmp::PartialEq for NDR64_VAR_ARRAY_HEADER_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR64_VAR_ARRAY_HEADER_FORMAT>()) == 0 }
+        self.FormatCode == other.FormatCode && self.Alignment == other.Alignment && self.Flags == other.Flags && self.Reserved == other.Reserved && self.TotalSize == other.TotalSize && self.ElementSize == other.ElementSize && self.VarDescriptor == other.VarDescriptor
     }
 }
 impl ::core::cmp::Eq for NDR64_VAR_ARRAY_HEADER_FORMAT {}
@@ -8083,7 +8027,7 @@ unsafe impl ::windows::core::Abi for NDR_CS_ROUTINES {
 }
 impl ::core::cmp::PartialEq for NDR_CS_ROUTINES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR_CS_ROUTINES>()) == 0 }
+        self.pSizeConvertRoutines == other.pSizeConvertRoutines && self.pTagGettingRoutines == other.pTagGettingRoutines
     }
 }
 impl ::core::cmp::Eq for NDR_CS_ROUTINES {}
@@ -8108,18 +8052,12 @@ impl ::core::clone::Clone for NDR_CS_SIZE_CONVERT_ROUTINES {
 }
 impl ::core::fmt::Debug for NDR_CS_SIZE_CONVERT_ROUTINES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("NDR_CS_SIZE_CONVERT_ROUTINES").field("pfnNetSize", &self.pfnNetSize.map(|f| f as usize)).field("pfnToNetCs", &self.pfnToNetCs.map(|f| f as usize)).field("pfnLocalSize", &self.pfnLocalSize.map(|f| f as usize)).field("pfnFromNetCs", &self.pfnFromNetCs.map(|f| f as usize)).finish()
+        f.debug_struct("NDR_CS_SIZE_CONVERT_ROUTINES").finish()
     }
 }
 unsafe impl ::windows::core::Abi for NDR_CS_SIZE_CONVERT_ROUTINES {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NDR_CS_SIZE_CONVERT_ROUTINES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR_CS_SIZE_CONVERT_ROUTINES>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NDR_CS_SIZE_CONVERT_ROUTINES {}
 impl ::core::default::Default for NDR_CS_SIZE_CONVERT_ROUTINES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8147,7 +8085,7 @@ unsafe impl ::windows::core::Abi for NDR_EXPR_DESC {
 }
 impl ::core::cmp::PartialEq for NDR_EXPR_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR_EXPR_DESC>()) == 0 }
+        self.pOffset == other.pOffset && self.pFormatExpr == other.pFormatExpr
     }
 }
 impl ::core::cmp::Eq for NDR_EXPR_DESC {}
@@ -8180,7 +8118,7 @@ unsafe impl ::windows::core::Abi for NDR_SCONTEXT_1 {
 }
 impl ::core::cmp::PartialEq for NDR_SCONTEXT_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR_SCONTEXT_1>()) == 0 }
+        self.pad == other.pad && self.userContext == other.userContext
     }
 }
 impl ::core::cmp::Eq for NDR_SCONTEXT_1 {}
@@ -8207,14 +8145,6 @@ unsafe impl ::windows::core::Abi for NDR_USER_MARSHAL_INFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for NDR_USER_MARSHAL_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.InformationLevel == other.InformationLevel && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for NDR_USER_MARSHAL_INFO {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for NDR_USER_MARSHAL_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8236,14 +8166,6 @@ impl ::core::clone::Clone for NDR_USER_MARSHAL_INFO_0 {
 unsafe impl ::windows::core::Abi for NDR_USER_MARSHAL_INFO_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for NDR_USER_MARSHAL_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NDR_USER_MARSHAL_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for NDR_USER_MARSHAL_INFO_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for NDR_USER_MARSHAL_INFO_0 {
     fn default() -> Self {
@@ -8347,7 +8269,7 @@ unsafe impl ::windows::core::Abi for RDR_CALLOUT_STATE {
 }
 impl ::core::cmp::PartialEq for RDR_CALLOUT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RDR_CALLOUT_STATE>()) == 0 }
+        self.LastError == other.LastError && self.LastEEInfo == other.LastEEInfo && self.LastCalledStage == other.LastCalledStage && self.ServerName == other.ServerName && self.ServerPort == other.ServerPort && self.RemoteUser == other.RemoteUser && self.AuthType == other.AuthType && self.ResourceTypePresent == other.ResourceTypePresent && self.SessionIdPresent == other.SessionIdPresent && self.InterfacePresent == other.InterfacePresent && self.ResourceType == other.ResourceType && self.SessionId == other.SessionId && self.Interface == other.Interface && self.CertContext == other.CertContext
     }
 }
 impl ::core::cmp::Eq for RDR_CALLOUT_STATE {}
@@ -8379,14 +8301,6 @@ unsafe impl ::windows::core::Abi for RPC_ASYNC_NOTIFICATION_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for RPC_ASYNC_NOTIFICATION_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ASYNC_NOTIFICATION_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for RPC_ASYNC_NOTIFICATION_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for RPC_ASYNC_NOTIFICATION_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8410,21 +8324,13 @@ impl ::core::clone::Clone for RPC_ASYNC_NOTIFICATION_INFO_0 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::fmt::Debug for RPC_ASYNC_NOTIFICATION_INFO_0 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("RPC_ASYNC_NOTIFICATION_INFO_0").field("NotificationRoutine", &self.NotificationRoutine.map(|f| f as usize)).field("hThread", &self.hThread).finish()
+        f.debug_struct("RPC_ASYNC_NOTIFICATION_INFO_0").field("hThread", &self.hThread).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 unsafe impl ::windows::core::Abi for RPC_ASYNC_NOTIFICATION_INFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for RPC_ASYNC_NOTIFICATION_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ASYNC_NOTIFICATION_INFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for RPC_ASYNC_NOTIFICATION_INFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for RPC_ASYNC_NOTIFICATION_INFO_0 {
     fn default() -> Self {
@@ -8461,7 +8367,7 @@ unsafe impl ::windows::core::Abi for RPC_ASYNC_NOTIFICATION_INFO_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for RPC_ASYNC_NOTIFICATION_INFO_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ASYNC_NOTIFICATION_INFO_1>()) == 0 }
+        self.hIOPort == other.hIOPort && self.dwNumberOfBytesTransferred == other.dwNumberOfBytesTransferred && self.dwCompletionKey == other.dwCompletionKey && self.lpOverlapped == other.lpOverlapped
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -8500,7 +8406,7 @@ unsafe impl ::windows::core::Abi for RPC_ASYNC_NOTIFICATION_INFO_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::cmp::PartialEq for RPC_ASYNC_NOTIFICATION_INFO_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ASYNC_NOTIFICATION_INFO_2>()) == 0 }
+        self.hWnd == other.hWnd && self.Msg == other.Msg
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
@@ -8540,14 +8446,6 @@ unsafe impl ::windows::core::Abi for RPC_ASYNC_STATE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::PartialEq for RPC_ASYNC_STATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ASYNC_STATE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
-impl ::core::cmp::Eq for RPC_ASYNC_STATE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl ::core::default::Default for RPC_ASYNC_STATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8577,7 +8475,7 @@ unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_OPTIONS_V1 {
 }
 impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_OPTIONS_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_OPTIONS_V1>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.ComTimeout == other.ComTimeout && self.CallTimeout == other.CallTimeout
     }
 }
 impl ::core::cmp::Eq for RPC_BINDING_HANDLE_OPTIONS_V1 {}
@@ -8618,7 +8516,7 @@ unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_SECURITY_V1_A {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_SECURITY_V1_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_SECURITY_V1_A>()) == 0 }
+        self.Version == other.Version && self.ServerPrincName == other.ServerPrincName && self.AuthnLevel == other.AuthnLevel && self.AuthnSvc == other.AuthnSvc && self.AuthIdentity == other.AuthIdentity && self.SecurityQos == other.SecurityQos
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -8661,7 +8559,7 @@ unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_SECURITY_V1_W {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_SECURITY_V1_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_SECURITY_V1_W>()) == 0 }
+        self.Version == other.Version && self.ServerPrincName == other.ServerPrincName && self.AuthnLevel == other.AuthnLevel && self.AuthnSvc == other.AuthnSvc && self.AuthIdentity == other.AuthIdentity && self.SecurityQos == other.SecurityQos
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -8692,12 +8590,6 @@ impl ::core::clone::Clone for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
 unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_TEMPLATE_V1_A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_BINDING_HANDLE_TEMPLATE_V1_A {}
 impl ::core::default::Default for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8717,12 +8609,6 @@ impl ::core::clone::Clone for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
 unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_TEMPLATE_V1_A_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {}
 impl ::core::default::Default for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8748,12 +8634,6 @@ impl ::core::clone::Clone for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
 unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_TEMPLATE_V1_W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_BINDING_HANDLE_TEMPLATE_V1_W {}
 impl ::core::default::Default for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8773,12 +8653,6 @@ impl ::core::clone::Clone for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
 unsafe impl ::windows::core::Abi for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_HANDLE_TEMPLATE_V1_W_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {}
 impl ::core::default::Default for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -8806,7 +8680,7 @@ unsafe impl ::windows::core::Abi for RPC_BINDING_VECTOR {
 }
 impl ::core::cmp::PartialEq for RPC_BINDING_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_BINDING_VECTOR>()) == 0 }
+        self.Count == other.Count && self.BindingH == other.BindingH
     }
 }
 impl ::core::cmp::Eq for RPC_BINDING_VECTOR {}
@@ -8860,7 +8734,7 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V1_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V1_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V1_A>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength && self.ServerPrincipalName == other.ServerPrincipalName && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength && self.ClientPrincipalName == other.ClientPrincipalName && self.AuthenticationLevel == other.AuthenticationLevel && self.AuthenticationService == other.AuthenticationService && self.NullSession == other.NullSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8916,7 +8790,7 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V1_W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V1_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V1_W>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength && self.ServerPrincipalName == other.ServerPrincipalName && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength && self.ClientPrincipalName == other.ClientPrincipalName && self.AuthenticationLevel == other.AuthenticationLevel && self.AuthenticationService == other.AuthenticationService && self.NullSession == other.NullSession
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -8990,7 +8864,24 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V2_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V2_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V2_A>()) == 0 }
+        self.Version == other.Version
+            && self.Flags == other.Flags
+            && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength
+            && self.ServerPrincipalName == other.ServerPrincipalName
+            && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength
+            && self.ClientPrincipalName == other.ClientPrincipalName
+            && self.AuthenticationLevel == other.AuthenticationLevel
+            && self.AuthenticationService == other.AuthenticationService
+            && self.NullSession == other.NullSession
+            && self.KernelModeCaller == other.KernelModeCaller
+            && self.ProtocolSequence == other.ProtocolSequence
+            && self.IsClientLocal == other.IsClientLocal
+            && self.ClientPID == other.ClientPID
+            && self.CallStatus == other.CallStatus
+            && self.CallType == other.CallType
+            && self.CallLocalAddress == other.CallLocalAddress
+            && self.OpNum == other.OpNum
+            && self.InterfaceUuid == other.InterfaceUuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9064,7 +8955,24 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V2_W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V2_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V2_W>()) == 0 }
+        self.Version == other.Version
+            && self.Flags == other.Flags
+            && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength
+            && self.ServerPrincipalName == other.ServerPrincipalName
+            && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength
+            && self.ClientPrincipalName == other.ClientPrincipalName
+            && self.AuthenticationLevel == other.AuthenticationLevel
+            && self.AuthenticationService == other.AuthenticationService
+            && self.NullSession == other.NullSession
+            && self.KernelModeCaller == other.KernelModeCaller
+            && self.ProtocolSequence == other.ProtocolSequence
+            && self.IsClientLocal == other.IsClientLocal
+            && self.ClientPID == other.ClientPID
+            && self.CallStatus == other.CallStatus
+            && self.CallType == other.CallType
+            && self.CallLocalAddress == other.CallLocalAddress
+            && self.OpNum == other.OpNum
+            && self.InterfaceUuid == other.InterfaceUuid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9142,7 +9050,26 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V3_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V3_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V3_A>()) == 0 }
+        self.Version == other.Version
+            && self.Flags == other.Flags
+            && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength
+            && self.ServerPrincipalName == other.ServerPrincipalName
+            && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength
+            && self.ClientPrincipalName == other.ClientPrincipalName
+            && self.AuthenticationLevel == other.AuthenticationLevel
+            && self.AuthenticationService == other.AuthenticationService
+            && self.NullSession == other.NullSession
+            && self.KernelModeCaller == other.KernelModeCaller
+            && self.ProtocolSequence == other.ProtocolSequence
+            && self.IsClientLocal == other.IsClientLocal
+            && self.ClientPID == other.ClientPID
+            && self.CallStatus == other.CallStatus
+            && self.CallType == other.CallType
+            && self.CallLocalAddress == other.CallLocalAddress
+            && self.OpNum == other.OpNum
+            && self.InterfaceUuid == other.InterfaceUuid
+            && self.ClientIdentifierBufferLength == other.ClientIdentifierBufferLength
+            && self.ClientIdentifier == other.ClientIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9220,7 +9147,26 @@ unsafe impl ::windows::core::Abi for RPC_CALL_ATTRIBUTES_V3_W {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RPC_CALL_ATTRIBUTES_V3_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_ATTRIBUTES_V3_W>()) == 0 }
+        self.Version == other.Version
+            && self.Flags == other.Flags
+            && self.ServerPrincipalNameBufferLength == other.ServerPrincipalNameBufferLength
+            && self.ServerPrincipalName == other.ServerPrincipalName
+            && self.ClientPrincipalNameBufferLength == other.ClientPrincipalNameBufferLength
+            && self.ClientPrincipalName == other.ClientPrincipalName
+            && self.AuthenticationLevel == other.AuthenticationLevel
+            && self.AuthenticationService == other.AuthenticationService
+            && self.NullSession == other.NullSession
+            && self.KernelModeCaller == other.KernelModeCaller
+            && self.ProtocolSequence == other.ProtocolSequence
+            && self.IsClientLocal == other.IsClientLocal
+            && self.ClientPID == other.ClientPID
+            && self.CallStatus == other.CallStatus
+            && self.CallType == other.CallType
+            && self.CallLocalAddress == other.CallLocalAddress
+            && self.OpNum == other.OpNum
+            && self.InterfaceUuid == other.InterfaceUuid
+            && self.ClientIdentifierBufferLength == other.ClientIdentifierBufferLength
+            && self.ClientIdentifier == other.ClientIdentifier
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9255,7 +9201,7 @@ unsafe impl ::windows::core::Abi for RPC_CALL_LOCAL_ADDRESS_V1 {
 }
 impl ::core::cmp::PartialEq for RPC_CALL_LOCAL_ADDRESS_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CALL_LOCAL_ADDRESS_V1>()) == 0 }
+        self.Version == other.Version && self.Buffer == other.Buffer && self.BufferSize == other.BufferSize && self.AddressFormat == other.AddressFormat
     }
 }
 impl ::core::cmp::Eq for RPC_CALL_LOCAL_ADDRESS_V1 {}
@@ -9288,7 +9234,7 @@ unsafe impl ::windows::core::Abi for RPC_CLIENT_INFORMATION1 {
 }
 impl ::core::cmp::PartialEq for RPC_CLIENT_INFORMATION1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CLIENT_INFORMATION1>()) == 0 }
+        self.UserName == other.UserName && self.ComputerName == other.ComputerName && self.Privilege == other.Privilege && self.AuthFlags == other.AuthFlags
     }
 }
 impl ::core::cmp::Eq for RPC_CLIENT_INFORMATION1 {}
@@ -9326,7 +9272,7 @@ unsafe impl ::windows::core::Abi for RPC_CLIENT_INTERFACE {
 }
 impl ::core::cmp::PartialEq for RPC_CLIENT_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_CLIENT_INTERFACE>()) == 0 }
+        self.Length == other.Length && self.InterfaceId == other.InterfaceId && self.TransferSyntax == other.TransferSyntax && self.DispatchTable == other.DispatchTable && self.RpcProtseqEndpointCount == other.RpcProtseqEndpointCount && self.RpcProtseqEndpoint == other.RpcProtseqEndpoint && self.Reserved == other.Reserved && self.InterpreterInfo == other.InterpreterInfo && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for RPC_CLIENT_INTERFACE {}
@@ -9357,7 +9303,7 @@ unsafe impl ::windows::core::Abi for RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR>()) == 0 }
+        self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR {}
@@ -9381,18 +9327,12 @@ impl ::core::clone::Clone for RPC_DISPATCH_TABLE {
 }
 impl ::core::fmt::Debug for RPC_DISPATCH_TABLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("RPC_DISPATCH_TABLE").field("DispatchTableCount", &self.DispatchTableCount).field("DispatchTable", &self.DispatchTable.map(|f| f as usize)).field("Reserved", &self.Reserved).finish()
+        f.debug_struct("RPC_DISPATCH_TABLE").field("DispatchTableCount", &self.DispatchTableCount).field("Reserved", &self.Reserved).finish()
     }
 }
 unsafe impl ::windows::core::Abi for RPC_DISPATCH_TABLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_DISPATCH_TABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_DISPATCH_TABLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_DISPATCH_TABLE {}
 impl ::core::default::Default for RPC_DISPATCH_TABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9413,12 +9353,6 @@ impl ::core::clone::Clone for RPC_EE_INFO_PARAM {
 unsafe impl ::windows::core::Abi for RPC_EE_INFO_PARAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_EE_INFO_PARAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_EE_INFO_PARAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_EE_INFO_PARAM {}
 impl ::core::default::Default for RPC_EE_INFO_PARAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9443,12 +9377,6 @@ impl ::core::clone::Clone for RPC_EE_INFO_PARAM_0 {
 unsafe impl ::windows::core::Abi for RPC_EE_INFO_PARAM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_EE_INFO_PARAM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_EE_INFO_PARAM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_EE_INFO_PARAM_0 {}
 impl ::core::default::Default for RPC_EE_INFO_PARAM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9479,7 +9407,7 @@ unsafe impl ::windows::core::Abi for RPC_ENDPOINT_TEMPLATEA {
 }
 impl ::core::cmp::PartialEq for RPC_ENDPOINT_TEMPLATEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ENDPOINT_TEMPLATEA>()) == 0 }
+        self.Version == other.Version && self.ProtSeq == other.ProtSeq && self.Endpoint == other.Endpoint && self.SecurityDescriptor == other.SecurityDescriptor && self.Backlog == other.Backlog
     }
 }
 impl ::core::cmp::Eq for RPC_ENDPOINT_TEMPLATEA {}
@@ -9513,7 +9441,7 @@ unsafe impl ::windows::core::Abi for RPC_ENDPOINT_TEMPLATEW {
 }
 impl ::core::cmp::PartialEq for RPC_ENDPOINT_TEMPLATEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ENDPOINT_TEMPLATEW>()) == 0 }
+        self.Version == other.Version && self.ProtSeq == other.ProtSeq && self.Endpoint == other.Endpoint && self.SecurityDescriptor == other.SecurityDescriptor && self.Backlog == other.Backlog
     }
 }
 impl ::core::cmp::Eq for RPC_ENDPOINT_TEMPLATEW {}
@@ -9545,7 +9473,7 @@ unsafe impl ::windows::core::Abi for RPC_ERROR_ENUM_HANDLE {
 }
 impl ::core::cmp::PartialEq for RPC_ERROR_ENUM_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_ERROR_ENUM_HANDLE>()) == 0 }
+        self.Signature == other.Signature && self.CurrentPos == other.CurrentPos && self.Head == other.Head
     }
 }
 impl ::core::cmp::Eq for RPC_ERROR_ENUM_HANDLE {}
@@ -9582,14 +9510,6 @@ unsafe impl ::windows::core::Abi for RPC_EXTENDED_ERROR_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RPC_EXTENDED_ERROR_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_EXTENDED_ERROR_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RPC_EXTENDED_ERROR_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RPC_EXTENDED_ERROR_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9614,14 +9534,6 @@ impl ::core::clone::Clone for RPC_EXTENDED_ERROR_INFO_0 {
 unsafe impl ::windows::core::Abi for RPC_EXTENDED_ERROR_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RPC_EXTENDED_ERROR_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_EXTENDED_ERROR_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RPC_EXTENDED_ERROR_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RPC_EXTENDED_ERROR_INFO_0 {
     fn default() -> Self {
@@ -9654,7 +9566,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_A {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_A>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_A {}
@@ -9702,7 +9614,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject && self.ProxyCredentials == other.ProxyCredentials && self.NumberOfProxyAuthnSchemes == other.NumberOfProxyAuthnSchemes && self.ProxyAuthnSchemes == other.ProxyAuthnSchemes
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {}
@@ -9750,7 +9662,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject && self.ProxyCredentials == other.ProxyCredentials && self.NumberOfProxyAuthnSchemes == other.NumberOfProxyAuthnSchemes && self.ProxyAuthnSchemes == other.ProxyAuthnSchemes
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W {}
@@ -9798,7 +9710,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject && self.ProxyCredentials == other.ProxyCredentials && self.NumberOfProxyAuthnSchemes == other.NumberOfProxyAuthnSchemes && self.ProxyAuthnSchemes == other.ProxyAuthnSchemes
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {}
@@ -9846,7 +9758,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject && self.ProxyCredentials == other.ProxyCredentials && self.NumberOfProxyAuthnSchemes == other.NumberOfProxyAuthnSchemes && self.ProxyAuthnSchemes == other.ProxyAuthnSchemes
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W {}
@@ -9881,7 +9793,7 @@ unsafe impl ::windows::core::Abi for RPC_HTTP_TRANSPORT_CREDENTIALS_W {
 }
 impl ::core::cmp::PartialEq for RPC_HTTP_TRANSPORT_CREDENTIALS_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_HTTP_TRANSPORT_CREDENTIALS_W>()) == 0 }
+        self.TransportCredentials == other.TransportCredentials && self.Flags == other.Flags && self.AuthenticationTarget == other.AuthenticationTarget && self.NumberOfAuthnSchemes == other.NumberOfAuthnSchemes && self.AuthnSchemes == other.AuthnSchemes && self.ServerCertificateSubject == other.ServerCertificateSubject
     }
 }
 impl ::core::cmp::Eq for RPC_HTTP_TRANSPORT_CREDENTIALS_W {}
@@ -9913,7 +9825,7 @@ unsafe impl ::windows::core::Abi for RPC_IF_ID {
 }
 impl ::core::cmp::PartialEq for RPC_IF_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_IF_ID>()) == 0 }
+        self.Uuid == other.Uuid && self.VersMajor == other.VersMajor && self.VersMinor == other.VersMinor
     }
 }
 impl ::core::cmp::Eq for RPC_IF_ID {}
@@ -9944,7 +9856,7 @@ unsafe impl ::windows::core::Abi for RPC_IF_ID_VECTOR {
 }
 impl ::core::cmp::PartialEq for RPC_IF_ID_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_IF_ID_VECTOR>()) == 0 }
+        self.Count == other.Count && self.IfId == other.IfId
     }
 }
 impl ::core::cmp::Eq for RPC_IF_ID_VECTOR {}
@@ -9976,7 +9888,7 @@ unsafe impl ::windows::core::Abi for RPC_IMPORT_CONTEXT_P {
 }
 impl ::core::cmp::PartialEq for RPC_IMPORT_CONTEXT_P {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_IMPORT_CONTEXT_P>()) == 0 }
+        self.LookupContext == other.LookupContext && self.ProposedHandle == other.ProposedHandle && self.Bindings == other.Bindings
     }
 }
 impl ::core::cmp::Eq for RPC_IMPORT_CONTEXT_P {}
@@ -10008,18 +9920,12 @@ impl ::core::clone::Clone for RPC_INTERFACE_TEMPLATEA {
 }
 impl ::core::fmt::Debug for RPC_INTERFACE_TEMPLATEA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("RPC_INTERFACE_TEMPLATEA").field("Version", &self.Version).field("IfSpec", &self.IfSpec).field("MgrTypeUuid", &self.MgrTypeUuid).field("MgrEpv", &self.MgrEpv).field("Flags", &self.Flags).field("MaxCalls", &self.MaxCalls).field("MaxRpcSize", &self.MaxRpcSize).field("IfCallback", &self.IfCallback.map(|f| f as usize)).field("UuidVector", &self.UuidVector).field("Annotation", &self.Annotation).field("SecurityDescriptor", &self.SecurityDescriptor).finish()
+        f.debug_struct("RPC_INTERFACE_TEMPLATEA").field("Version", &self.Version).field("IfSpec", &self.IfSpec).field("MgrTypeUuid", &self.MgrTypeUuid).field("MgrEpv", &self.MgrEpv).field("Flags", &self.Flags).field("MaxCalls", &self.MaxCalls).field("MaxRpcSize", &self.MaxRpcSize).field("UuidVector", &self.UuidVector).field("Annotation", &self.Annotation).field("SecurityDescriptor", &self.SecurityDescriptor).finish()
     }
 }
 unsafe impl ::windows::core::Abi for RPC_INTERFACE_TEMPLATEA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_INTERFACE_TEMPLATEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_INTERFACE_TEMPLATEA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_INTERFACE_TEMPLATEA {}
 impl ::core::default::Default for RPC_INTERFACE_TEMPLATEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10048,18 +9954,12 @@ impl ::core::clone::Clone for RPC_INTERFACE_TEMPLATEW {
 }
 impl ::core::fmt::Debug for RPC_INTERFACE_TEMPLATEW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("RPC_INTERFACE_TEMPLATEW").field("Version", &self.Version).field("IfSpec", &self.IfSpec).field("MgrTypeUuid", &self.MgrTypeUuid).field("MgrEpv", &self.MgrEpv).field("Flags", &self.Flags).field("MaxCalls", &self.MaxCalls).field("MaxRpcSize", &self.MaxRpcSize).field("IfCallback", &self.IfCallback.map(|f| f as usize)).field("UuidVector", &self.UuidVector).field("Annotation", &self.Annotation).field("SecurityDescriptor", &self.SecurityDescriptor).finish()
+        f.debug_struct("RPC_INTERFACE_TEMPLATEW").field("Version", &self.Version).field("IfSpec", &self.IfSpec).field("MgrTypeUuid", &self.MgrTypeUuid).field("MgrEpv", &self.MgrEpv).field("Flags", &self.Flags).field("MaxCalls", &self.MaxCalls).field("MaxRpcSize", &self.MaxRpcSize).field("UuidVector", &self.UuidVector).field("Annotation", &self.Annotation).field("SecurityDescriptor", &self.SecurityDescriptor).finish()
     }
 }
 unsafe impl ::windows::core::Abi for RPC_INTERFACE_TEMPLATEW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RPC_INTERFACE_TEMPLATEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_INTERFACE_TEMPLATEW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RPC_INTERFACE_TEMPLATEW {}
 impl ::core::default::Default for RPC_INTERFACE_TEMPLATEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10108,7 +10008,7 @@ unsafe impl ::windows::core::Abi for RPC_MESSAGE {
 }
 impl ::core::cmp::PartialEq for RPC_MESSAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_MESSAGE>()) == 0 }
+        self.Handle == other.Handle && self.DataRepresentation == other.DataRepresentation && self.Buffer == other.Buffer && self.BufferLength == other.BufferLength && self.ProcNum == other.ProcNum && self.TransferSyntax == other.TransferSyntax && self.RpcInterfaceInformation == other.RpcInterfaceInformation && self.ReservedForRuntime == other.ReservedForRuntime && self.ManagerEpv == other.ManagerEpv && self.ImportContext == other.ImportContext && self.RpcFlags == other.RpcFlags
     }
 }
 impl ::core::cmp::Eq for RPC_MESSAGE {}
@@ -10140,7 +10040,7 @@ unsafe impl ::windows::core::Abi for RPC_POLICY {
 }
 impl ::core::cmp::PartialEq for RPC_POLICY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_POLICY>()) == 0 }
+        self.Length == other.Length && self.EndpointFlags == other.EndpointFlags && self.NICFlags == other.NICFlags
     }
 }
 impl ::core::cmp::Eq for RPC_POLICY {}
@@ -10171,7 +10071,7 @@ unsafe impl ::windows::core::Abi for RPC_PROTSEQ_ENDPOINT {
 }
 impl ::core::cmp::PartialEq for RPC_PROTSEQ_ENDPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_PROTSEQ_ENDPOINT>()) == 0 }
+        self.RpcProtocolSequence == other.RpcProtocolSequence && self.Endpoint == other.Endpoint
     }
 }
 impl ::core::cmp::Eq for RPC_PROTSEQ_ENDPOINT {}
@@ -10202,7 +10102,7 @@ unsafe impl ::windows::core::Abi for RPC_PROTSEQ_VECTORA {
 }
 impl ::core::cmp::PartialEq for RPC_PROTSEQ_VECTORA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_PROTSEQ_VECTORA>()) == 0 }
+        self.Count == other.Count && self.Protseq == other.Protseq
     }
 }
 impl ::core::cmp::Eq for RPC_PROTSEQ_VECTORA {}
@@ -10233,7 +10133,7 @@ unsafe impl ::windows::core::Abi for RPC_PROTSEQ_VECTORW {
 }
 impl ::core::cmp::PartialEq for RPC_PROTSEQ_VECTORW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_PROTSEQ_VECTORW>()) == 0 }
+        self.Count == other.Count && self.Protseq == other.Protseq
     }
 }
 impl ::core::cmp::Eq for RPC_PROTSEQ_VECTORW {}
@@ -10272,7 +10172,7 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for RPC_SECURITY_QOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS>()) == 0 }
+        self.Version == other.Version && self.Capabilities == other.Capabilities && self.IdentityTracking == other.IdentityTracking && self.ImpersonationType == other.ImpersonationType
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -10307,14 +10207,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V2_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V2_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V2_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V2_A {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V2_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10338,14 +10230,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V2_A_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V2_A_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V2_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V2_A_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V2_A_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V2_A_0 {
     fn default() -> Self {
@@ -10376,14 +10260,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V2_W {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V2_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V2_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V2_W {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V2_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10407,14 +10283,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V2_W_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V2_W_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V2_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V2_W_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V2_W_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V2_W_0 {
     fn default() -> Self {
@@ -10446,14 +10314,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V3_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V3_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V3_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V3_A {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V3_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10477,14 +10337,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V3_A_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V3_A_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V3_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V3_A_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V3_A_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V3_A_0 {
     fn default() -> Self {
@@ -10516,14 +10368,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V3_W {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V3_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V3_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V3_W {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V3_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10547,14 +10391,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V3_W_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V3_W_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V3_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V3_W_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V3_W_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V3_W_0 {
     fn default() -> Self {
@@ -10587,14 +10423,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V4_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V4_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V4_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V4_A {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V4_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10618,14 +10446,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V4_A_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V4_A_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V4_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V4_A_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V4_A_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V4_A_0 {
     fn default() -> Self {
@@ -10658,14 +10478,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V4_W {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V4_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V4_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V4_W {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V4_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10689,14 +10501,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V4_W_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V4_W_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V4_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V4_W_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V4_W_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V4_W_0 {
     fn default() -> Self {
@@ -10730,14 +10534,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V5_A {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V5_A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V5_A>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V5_A {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V5_A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10761,14 +10557,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V5_A_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V5_A_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V5_A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V5_A_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V5_A_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V5_A_0 {
     fn default() -> Self {
@@ -10802,14 +10590,6 @@ unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V5_W {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V5_W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V5_W>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V5_W {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V5_W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10833,14 +10613,6 @@ impl ::core::clone::Clone for RPC_SECURITY_QOS_V5_W_0 {
 unsafe impl ::windows::core::Abi for RPC_SECURITY_QOS_V5_W_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for RPC_SECURITY_QOS_V5_W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SECURITY_QOS_V5_W_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for RPC_SECURITY_QOS_V5_W_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for RPC_SECURITY_QOS_V5_W_0 {
     fn default() -> Self {
@@ -10870,7 +10642,7 @@ unsafe impl ::windows::core::Abi for RPC_SEC_CONTEXT_KEY_INFO {
 }
 impl ::core::cmp::PartialEq for RPC_SEC_CONTEXT_KEY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SEC_CONTEXT_KEY_INFO>()) == 0 }
+        self.EncryptAlgorithm == other.EncryptAlgorithm && self.KeySize == other.KeySize && self.SignatureAlgorithm == other.SignatureAlgorithm
     }
 }
 impl ::core::cmp::Eq for RPC_SEC_CONTEXT_KEY_INFO {}
@@ -10908,7 +10680,7 @@ unsafe impl ::windows::core::Abi for RPC_SERVER_INTERFACE {
 }
 impl ::core::cmp::PartialEq for RPC_SERVER_INTERFACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SERVER_INTERFACE>()) == 0 }
+        self.Length == other.Length && self.InterfaceId == other.InterfaceId && self.TransferSyntax == other.TransferSyntax && self.DispatchTable == other.DispatchTable && self.RpcProtseqEndpointCount == other.RpcProtseqEndpointCount && self.RpcProtseqEndpoint == other.RpcProtseqEndpoint && self.DefaultManagerEpv == other.DefaultManagerEpv && self.InterpreterInfo == other.InterpreterInfo && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for RPC_SERVER_INTERFACE {}
@@ -10939,7 +10711,7 @@ unsafe impl ::windows::core::Abi for RPC_STATS_VECTOR {
 }
 impl ::core::cmp::PartialEq for RPC_STATS_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_STATS_VECTOR>()) == 0 }
+        self.Count == other.Count && self.Stats == other.Stats
     }
 }
 impl ::core::cmp::Eq for RPC_STATS_VECTOR {}
@@ -10970,7 +10742,7 @@ unsafe impl ::windows::core::Abi for RPC_SYNTAX_IDENTIFIER {
 }
 impl ::core::cmp::PartialEq for RPC_SYNTAX_IDENTIFIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_SYNTAX_IDENTIFIER>()) == 0 }
+        self.SyntaxGUID == other.SyntaxGUID && self.SyntaxVersion == other.SyntaxVersion
     }
 }
 impl ::core::cmp::Eq for RPC_SYNTAX_IDENTIFIER {}
@@ -11002,7 +10774,7 @@ unsafe impl ::windows::core::Abi for RPC_TRANSFER_SYNTAX {
 }
 impl ::core::cmp::PartialEq for RPC_TRANSFER_SYNTAX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_TRANSFER_SYNTAX>()) == 0 }
+        self.Uuid == other.Uuid && self.VersMajor == other.VersMajor && self.VersMinor == other.VersMinor
     }
 }
 impl ::core::cmp::Eq for RPC_TRANSFER_SYNTAX {}
@@ -11033,7 +10805,7 @@ unsafe impl ::windows::core::Abi for RPC_VERSION {
 }
 impl ::core::cmp::PartialEq for RPC_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RPC_VERSION>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for RPC_VERSION {}
@@ -11064,7 +10836,7 @@ unsafe impl ::windows::core::Abi for SCONTEXT_QUEUE {
 }
 impl ::core::cmp::PartialEq for SCONTEXT_QUEUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCONTEXT_QUEUE>()) == 0 }
+        self.NumberOfObjects == other.NumberOfObjects && self.ArrayOfObjects == other.ArrayOfObjects
     }
 }
 impl ::core::cmp::Eq for SCONTEXT_QUEUE {}
@@ -11100,7 +10872,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_A {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_A>()) == 0 }
+        self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_A {}
@@ -11136,7 +10908,7 @@ unsafe impl ::windows::core::Abi for SEC_WINNT_AUTH_IDENTITY_W {
 }
 impl ::core::cmp::PartialEq for SEC_WINNT_AUTH_IDENTITY_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_WINNT_AUTH_IDENTITY_W>()) == 0 }
+        self.User == other.User && self.UserLength == other.UserLength && self.Domain == other.Domain && self.DomainLength == other.DomainLength && self.Password == other.Password && self.PasswordLength == other.PasswordLength && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SEC_WINNT_AUTH_IDENTITY_W {}
@@ -11178,7 +10950,7 @@ unsafe impl ::windows::core::Abi for USER_MARSHAL_CB {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for USER_MARSHAL_CB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MARSHAL_CB>()) == 0 }
+        self.Flags == other.Flags && self.pStubMsg == other.pStubMsg && self.pReserve == other.pReserve && self.Signature == other.Signature && self.CBType == other.CBType && self.pFormat == other.pFormat && self.pTypeFormat == other.pTypeFormat
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -11205,18 +10977,12 @@ impl ::core::clone::Clone for USER_MARSHAL_ROUTINE_QUADRUPLE {
 }
 impl ::core::fmt::Debug for USER_MARSHAL_ROUTINE_QUADRUPLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("USER_MARSHAL_ROUTINE_QUADRUPLE").field("pfnBufferSize", &self.pfnBufferSize.map(|f| f as usize)).field("pfnMarshall", &self.pfnMarshall.map(|f| f as usize)).field("pfnUnmarshall", &self.pfnUnmarshall.map(|f| f as usize)).field("pfnFree", &self.pfnFree.map(|f| f as usize)).finish()
+        f.debug_struct("USER_MARSHAL_ROUTINE_QUADRUPLE").finish()
     }
 }
 unsafe impl ::windows::core::Abi for USER_MARSHAL_ROUTINE_QUADRUPLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for USER_MARSHAL_ROUTINE_QUADRUPLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USER_MARSHAL_ROUTINE_QUADRUPLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for USER_MARSHAL_ROUTINE_QUADRUPLE {}
 impl ::core::default::Default for USER_MARSHAL_ROUTINE_QUADRUPLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11244,7 +11010,7 @@ unsafe impl ::windows::core::Abi for UUID_VECTOR {
 }
 impl ::core::cmp::PartialEq for UUID_VECTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UUID_VECTOR>()) == 0 }
+        self.Count == other.Count && self.Uuid == other.Uuid
     }
 }
 impl ::core::cmp::Eq for UUID_VECTOR {}
@@ -11273,21 +11039,13 @@ impl ::core::clone::Clone for XMIT_ROUTINE_QUINTUPLE {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::fmt::Debug for XMIT_ROUTINE_QUINTUPLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("XMIT_ROUTINE_QUINTUPLE").field("pfnTranslateToXmit", &self.pfnTranslateToXmit.map(|f| f as usize)).field("pfnTranslateFromXmit", &self.pfnTranslateFromXmit.map(|f| f as usize)).field("pfnFreeXmit", &self.pfnFreeXmit.map(|f| f as usize)).field("pfnFreeInst", &self.pfnFreeInst.map(|f| f as usize)).finish()
+        f.debug_struct("XMIT_ROUTINE_QUINTUPLE").finish()
     }
 }
 #[cfg(feature = "Win32_System_Com")]
 unsafe impl ::windows::core::Abi for XMIT_ROUTINE_QUINTUPLE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for XMIT_ROUTINE_QUINTUPLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XMIT_ROUTINE_QUINTUPLE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for XMIT_ROUTINE_QUINTUPLE {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for XMIT_ROUTINE_QUINTUPLE {
     fn default() -> Self {
@@ -11322,7 +11080,7 @@ unsafe impl ::windows::core::Abi for _NDR_SCONTEXT {
 }
 impl ::core::cmp::PartialEq for _NDR_SCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_NDR_SCONTEXT>()) == 0 }
+        self.pad == other.pad && self.userContext == other.userContext
     }
 }
 impl ::core::cmp::Eq for _NDR_SCONTEXT {}

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -24738,7 +24738,7 @@ unsafe impl ::windows::core::Abi for AUTHENTICATION_INFO {
 }
 impl ::core::cmp::PartialEq for AUTHENTICATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTHENTICATION_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.atAuthenticationType == other.atAuthenticationType && self.pcwszUser == other.pcwszUser && self.pcwszPassword == other.pcwszPassword
     }
 }
 impl ::core::cmp::Eq for AUTHENTICATION_INFO {}
@@ -24769,7 +24769,7 @@ unsafe impl ::windows::core::Abi for BUCKETCATEGORIZE {
 }
 impl ::core::cmp::PartialEq for BUCKETCATEGORIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUCKETCATEGORIZE>()) == 0 }
+        self.cBuckets == other.cBuckets && self.Distribution == other.Distribution
     }
 }
 impl ::core::cmp::Eq for BUCKETCATEGORIZE {}
@@ -24799,14 +24799,6 @@ unsafe impl ::windows::core::Abi for CATEGORIZATION {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for CATEGORIZATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATEGORIZATION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for CATEGORIZATION {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for CATEGORIZATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24832,14 +24824,6 @@ impl ::core::clone::Clone for CATEGORIZATION_0 {
 unsafe impl ::windows::core::Abi for CATEGORIZATION_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for CATEGORIZATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATEGORIZATION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for CATEGORIZATION_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for CATEGORIZATION_0 {
     fn default() -> Self {
@@ -24874,7 +24858,7 @@ unsafe impl ::windows::core::Abi for CATEGORIZATIONSET {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for CATEGORIZATIONSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATEGORIZATIONSET>()) == 0 }
+        self.cCat == other.cCat && self.aCat == other.aCat
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
@@ -24913,7 +24897,7 @@ unsafe impl ::windows::core::Abi for COLUMNSET {
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for COLUMNSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLUMNSET>()) == 0 }
+        self.cCol == other.cCol && self.aCol == other.aCol
     }
 }
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
@@ -24946,14 +24930,6 @@ unsafe impl ::windows::core::Abi for CONTENTRESTRICTION {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for CONTENTRESTRICTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTENTRESTRICTION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for CONTENTRESTRICTION {}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for CONTENTRESTRICTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -24982,7 +24958,7 @@ unsafe impl ::windows::core::Abi for DATE_STRUCT {
 }
 impl ::core::cmp::PartialEq for DATE_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATE_STRUCT>()) == 0 }
+        self.year == other.year && self.month == other.month && self.day == other.day
     }
 }
 impl ::core::cmp::Eq for DATE_STRUCT {}
@@ -25011,14 +24987,6 @@ unsafe impl ::windows::core::Abi for DBBINDEXT {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBBINDEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBBINDEXT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBBINDEXT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBBINDEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25043,14 +25011,6 @@ impl ::core::clone::Clone for DBBINDEXT {
 unsafe impl ::windows::core::Abi for DBBINDEXT {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBBINDEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBBINDEXT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBBINDEXT {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBBINDEXT {
     fn default() -> Self {
@@ -25108,16 +25068,6 @@ unsafe impl ::windows::core::Abi for DBBINDING {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for DBBINDING {
-    fn eq(&self, other: &Self) -> bool {
-        self.iOrdinal == other.iOrdinal && self.obValue == other.obValue && self.obLength == other.obLength && self.obStatus == other.obStatus && self.pTypeInfo == other.pTypeInfo && self.pObject == other.pObject && self.pBindExt == other.pBindExt && self.dwPart == other.dwPart && self.dwMemOwner == other.dwMemOwner && self.eParamIO == other.eParamIO && self.cbMaxLen == other.cbMaxLen && self.dwFlags == other.dwFlags && self.wType == other.wType && self.bPrecision == other.bPrecision && self.bScale == other.bScale
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for DBBINDING {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for DBBINDING {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25149,16 +25099,6 @@ pub struct DBBINDING {
 unsafe impl ::windows::core::Abi for DBBINDING {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for DBBINDING {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBBINDING>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for DBBINDING {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for DBBINDING {
@@ -25198,16 +25138,6 @@ unsafe impl ::windows::core::Abi for DBCOLUMNACCESS {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for DBCOLUMNACCESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOLUMNACCESS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for DBCOLUMNACCESS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for DBCOLUMNACCESS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25243,16 +25173,6 @@ impl ::core::clone::Clone for DBCOLUMNACCESS {
 unsafe impl ::windows::core::Abi for DBCOLUMNACCESS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for DBCOLUMNACCESS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOLUMNACCESS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for DBCOLUMNACCESS {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for DBCOLUMNACCESS {
@@ -25301,16 +25221,6 @@ unsafe impl ::windows::core::Abi for DBCOLUMNDESC {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBCOLUMNDESC {
-    fn eq(&self, other: &Self) -> bool {
-        self.pwszTypeName == other.pwszTypeName && self.pTypeInfo == other.pTypeInfo && self.rgPropertySets == other.rgPropertySets && self.pclsid == other.pclsid && self.cPropertySets == other.cPropertySets && self.ulColumnSize == other.ulColumnSize && self.dbcid == other.dbcid && self.wType == other.wType && self.bPrecision == other.bPrecision && self.bScale == other.bScale
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBCOLUMNDESC {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBCOLUMNDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25337,16 +25247,6 @@ pub struct DBCOLUMNDESC {
 unsafe impl ::windows::core::Abi for DBCOLUMNDESC {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBCOLUMNDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOLUMNDESC>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBCOLUMNDESC {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBCOLUMNDESC {
@@ -25393,16 +25293,6 @@ unsafe impl ::windows::core::Abi for DBCOLUMNINFO {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for DBCOLUMNINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.pwszName == other.pwszName && self.pTypeInfo == other.pTypeInfo && self.iOrdinal == other.iOrdinal && self.dwFlags == other.dwFlags && self.ulColumnSize == other.ulColumnSize && self.wType == other.wType && self.bPrecision == other.bPrecision && self.bScale == other.bScale && self.columnid == other.columnid
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for DBCOLUMNINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl ::core::default::Default for DBCOLUMNINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25430,16 +25320,6 @@ unsafe impl ::windows::core::Abi for DBCOLUMNINFO {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for DBCOLUMNINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOLUMNINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for DBCOLUMNINFO {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl ::core::default::Default for DBCOLUMNINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25482,16 +25362,6 @@ unsafe impl ::windows::core::Abi for DBCONSTRAINTDESC {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBCONSTRAINTDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCONSTRAINTDESC>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBCONSTRAINTDESC {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBCONSTRAINTDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25534,16 +25404,6 @@ unsafe impl ::windows::core::Abi for DBCONSTRAINTDESC {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBCONSTRAINTDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCONSTRAINTDESC>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBCONSTRAINTDESC {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBCONSTRAINTDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25570,14 +25430,6 @@ unsafe impl ::windows::core::Abi for DBCOST {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBCOST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOST>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBCOST {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBCOST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25603,14 +25455,6 @@ impl ::core::clone::Clone for DBCOST {
 unsafe impl ::windows::core::Abi for DBCOST {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBCOST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBCOST>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBCOST {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBCOST {
     fn default() -> Self {
@@ -25640,7 +25484,7 @@ unsafe impl ::windows::core::Abi for DBDATE {
 }
 impl ::core::cmp::PartialEq for DBDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBDATE>()) == 0 }
+        self.year == other.year && self.month == other.month && self.day == other.day
     }
 }
 impl ::core::cmp::Eq for DBDATE {}
@@ -25671,7 +25515,7 @@ unsafe impl ::windows::core::Abi for DBDATETIM4 {
 }
 impl ::core::cmp::PartialEq for DBDATETIM4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBDATETIM4>()) == 0 }
+        self.numdays == other.numdays && self.nummins == other.nummins
     }
 }
 impl ::core::cmp::Eq for DBDATETIM4 {}
@@ -25702,7 +25546,7 @@ unsafe impl ::windows::core::Abi for DBDATETIME {
 }
 impl ::core::cmp::PartialEq for DBDATETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBDATETIME>()) == 0 }
+        self.dtdays == other.dtdays && self.dttime == other.dttime
     }
 }
 impl ::core::cmp::Eq for DBDATETIME {}
@@ -25732,14 +25576,6 @@ unsafe impl ::windows::core::Abi for DBFAILUREINFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBFAILUREINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBFAILUREINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBFAILUREINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBFAILUREINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25766,14 +25602,6 @@ unsafe impl ::windows::core::Abi for DBFAILUREINFO {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBFAILUREINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBFAILUREINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBFAILUREINFO {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBFAILUREINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25798,14 +25626,6 @@ unsafe impl ::windows::core::Abi for DBIMPLICITSESSION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBIMPLICITSESSION {
-    fn eq(&self, other: &Self) -> bool {
-        self.pUnkOuter == other.pUnkOuter && self.piid == other.piid && self.pSession == other.pSession
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBIMPLICITSESSION {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBIMPLICITSESSION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25823,14 +25643,6 @@ pub struct DBIMPLICITSESSION {
 unsafe impl ::windows::core::Abi for DBIMPLICITSESSION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBIMPLICITSESSION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBIMPLICITSESSION>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBIMPLICITSESSION {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBIMPLICITSESSION {
     fn default() -> Self {
@@ -25860,16 +25672,6 @@ impl ::core::clone::Clone for DBINDEXCOLUMNDESC {
 unsafe impl ::windows::core::Abi for DBINDEXCOLUMNDESC {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for DBINDEXCOLUMNDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBINDEXCOLUMNDESC>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for DBINDEXCOLUMNDESC {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for DBINDEXCOLUMNDESC {
@@ -25900,16 +25702,6 @@ impl ::core::clone::Clone for DBINDEXCOLUMNDESC {
 unsafe impl ::windows::core::Abi for DBINDEXCOLUMNDESC {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for DBINDEXCOLUMNDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBINDEXCOLUMNDESC>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for DBINDEXCOLUMNDESC {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for DBINDEXCOLUMNDESC {
@@ -25944,16 +25736,6 @@ impl ::core::clone::Clone for DBLITERALINFO {
 unsafe impl ::windows::core::Abi for DBLITERALINFO {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DBLITERALINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBLITERALINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DBLITERALINFO {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DBLITERALINFO {
@@ -25988,16 +25770,6 @@ impl ::core::clone::Clone for DBLITERALINFO {
 unsafe impl ::windows::core::Abi for DBLITERALINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DBLITERALINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBLITERALINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DBLITERALINFO {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DBLITERALINFO {
@@ -26027,7 +25799,7 @@ unsafe impl ::windows::core::Abi for DBMONEY {
 }
 impl ::core::cmp::PartialEq for DBMONEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBMONEY>()) == 0 }
+        self.mnyhigh == other.mnyhigh && self.mnylow == other.mnylow
     }
 }
 impl ::core::cmp::Eq for DBMONEY {}
@@ -26056,14 +25828,6 @@ unsafe impl ::windows::core::Abi for DBOBJECT {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBOBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBOBJECT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBOBJECT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBOBJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26088,14 +25852,6 @@ impl ::core::clone::Clone for DBOBJECT {
 unsafe impl ::windows::core::Abi for DBOBJECT {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBOBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBOBJECT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBOBJECT {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBOBJECT {
     fn default() -> Self {
@@ -26125,14 +25881,6 @@ impl ::core::clone::Clone for DBPARAMBINDINFO {
 unsafe impl ::windows::core::Abi for DBPARAMBINDINFO {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBPARAMBINDINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPARAMBINDINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBPARAMBINDINFO {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBPARAMBINDINFO {
     fn default() -> Self {
@@ -26162,14 +25910,6 @@ impl ::core::clone::Clone for DBPARAMBINDINFO {
 unsafe impl ::windows::core::Abi for DBPARAMBINDINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBPARAMBINDINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPARAMBINDINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBPARAMBINDINFO {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBPARAMBINDINFO {
     fn default() -> Self {
@@ -26213,16 +25953,6 @@ unsafe impl ::windows::core::Abi for DBPARAMINFO {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for DBPARAMINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwFlags == other.dwFlags && self.iOrdinal == other.iOrdinal && self.pwszName == other.pwszName && self.pTypeInfo == other.pTypeInfo && self.ulParamSize == other.ulParamSize && self.wType == other.wType && self.bPrecision == other.bPrecision && self.bScale == other.bScale
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for DBPARAMINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for DBPARAMINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26247,16 +25977,6 @@ pub struct DBPARAMINFO {
 unsafe impl ::windows::core::Abi for DBPARAMINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for DBPARAMINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPARAMINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for DBPARAMINFO {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for DBPARAMINFO {
@@ -26285,14 +26005,6 @@ unsafe impl ::windows::core::Abi for DBPARAMS {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPARAMS>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBPARAMS {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26318,14 +26030,6 @@ impl ::core::clone::Clone for DBPARAMS {
 unsafe impl ::windows::core::Abi for DBPARAMS {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPARAMS>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBPARAMS {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBPARAMS {
     fn default() -> Self {
@@ -26357,16 +26061,6 @@ unsafe impl ::windows::core::Abi for DBPROP {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROP {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwPropertyID == other.dwPropertyID && self.dwOptions == other.dwOptions && self.dwStatus == other.dwStatus && self.colid == other.colid && self.vValue == other.vValue
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROP {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26388,16 +26082,6 @@ pub struct DBPROP {
 unsafe impl ::windows::core::Abi for DBPROP {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROP>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROP {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROP {
@@ -26426,14 +26110,6 @@ unsafe impl ::windows::core::Abi for DBPROPIDSET {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBPROPIDSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPIDSET>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBPROPIDSET {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBPROPIDSET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26459,14 +26135,6 @@ impl ::core::clone::Clone for DBPROPIDSET {
 unsafe impl ::windows::core::Abi for DBPROPIDSET {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBPROPIDSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPIDSET>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBPROPIDSET {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBPROPIDSET {
     fn default() -> Self {
@@ -26504,16 +26172,6 @@ unsafe impl ::windows::core::Abi for DBPROPINFO {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.pwszDescription == other.pwszDescription && self.dwPropertyID == other.dwPropertyID && self.dwFlags == other.dwFlags && self.vtType == other.vtType && self.vValues == other.vValues
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26535,16 +26193,6 @@ pub struct DBPROPINFO {
 unsafe impl ::windows::core::Abi for DBPROPINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPINFO {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPINFO {
@@ -26578,16 +26226,6 @@ unsafe impl ::windows::core::Abi for DBPROPINFOSET {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPINFOSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPINFOSET>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPINFOSET {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPINFOSET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26617,16 +26255,6 @@ impl ::core::clone::Clone for DBPROPINFOSET {
 unsafe impl ::windows::core::Abi for DBPROPINFOSET {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPINFOSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPINFOSET>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPINFOSET {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPINFOSET {
@@ -26658,16 +26286,6 @@ impl ::core::clone::Clone for DBPROPSET {
 unsafe impl ::windows::core::Abi for DBPROPSET {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPSET>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPSET {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPSET {
@@ -26699,16 +26317,6 @@ impl ::core::clone::Clone for DBPROPSET {
 unsafe impl ::windows::core::Abi for DBPROPSET {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DBPROPSET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBPROPSET>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DBPROPSET {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DBPROPSET {
@@ -26737,14 +26345,6 @@ impl ::core::clone::Clone for DBROWWATCHCHANGE {
 unsafe impl ::windows::core::Abi for DBROWWATCHCHANGE {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBROWWATCHCHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBROWWATCHCHANGE>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBROWWATCHCHANGE {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBROWWATCHCHANGE {
     fn default() -> Self {
@@ -26772,14 +26372,6 @@ impl ::core::clone::Clone for DBROWWATCHCHANGE {
 unsafe impl ::windows::core::Abi for DBROWWATCHCHANGE {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBROWWATCHCHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBROWWATCHCHANGE>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBROWWATCHCHANGE {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBROWWATCHCHANGE {
     fn default() -> Self {
@@ -26809,7 +26401,7 @@ unsafe impl ::windows::core::Abi for DBTIME {
 }
 impl ::core::cmp::PartialEq for DBTIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBTIME>()) == 0 }
+        self.hour == other.hour && self.minute == other.minute && self.second == other.second
     }
 }
 impl ::core::cmp::Eq for DBTIME {}
@@ -26843,14 +26435,6 @@ unsafe impl ::windows::core::Abi for DBTIMESTAMP {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBTIMESTAMP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBTIMESTAMP>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBTIMESTAMP {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBTIMESTAMP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26881,14 +26465,6 @@ unsafe impl ::windows::core::Abi for DBTIMESTAMP {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBTIMESTAMP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBTIMESTAMP>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBTIMESTAMP {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBTIMESTAMP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26916,7 +26492,7 @@ unsafe impl ::windows::core::Abi for DBVARYBIN {
 }
 impl ::core::cmp::PartialEq for DBVARYBIN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBVARYBIN>()) == 0 }
+        self.len == other.len && self.array == other.array
     }
 }
 impl ::core::cmp::Eq for DBVARYBIN {}
@@ -26947,7 +26523,7 @@ unsafe impl ::windows::core::Abi for DBVARYCHAR {
 }
 impl ::core::cmp::PartialEq for DBVARYCHAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBVARYCHAR>()) == 0 }
+        self.len == other.len && self.str == other.str
     }
 }
 impl ::core::cmp::Eq for DBVARYCHAR {}
@@ -26976,14 +26552,6 @@ unsafe impl ::windows::core::Abi for DBVECTOR {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DBVECTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBVECTOR>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DBVECTOR {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DBVECTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27008,14 +26576,6 @@ impl ::core::clone::Clone for DBVECTOR {
 unsafe impl ::windows::core::Abi for DBVECTOR {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DBVECTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DBVECTOR>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DBVECTOR {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DBVECTOR {
     fn default() -> Self {
@@ -27046,7 +26606,7 @@ unsafe impl ::windows::core::Abi for DB_NUMERIC {
 }
 impl ::core::cmp::PartialEq for DB_NUMERIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DB_NUMERIC>()) == 0 }
+        self.precision == other.precision && self.scale == other.scale && self.sign == other.sign && self.val == other.val
     }
 }
 impl ::core::cmp::Eq for DB_NUMERIC {}
@@ -27079,7 +26639,7 @@ unsafe impl ::windows::core::Abi for DB_VARNUMERIC {
 }
 impl ::core::cmp::PartialEq for DB_VARNUMERIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DB_VARNUMERIC>()) == 0 }
+        self.precision == other.precision && self.scale == other.scale && self.sign == other.sign && self.val == other.val
     }
 }
 impl ::core::cmp::Eq for DB_VARNUMERIC {}
@@ -27105,14 +26665,6 @@ impl ::core::clone::Clone for DCINFO {
 unsafe impl ::windows::core::Abi for DCINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for DCINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.eInfoType == other.eInfoType && self.vData == other.vData
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for DCINFO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for DCINFO {
     fn default() -> Self {
@@ -27142,14 +26694,6 @@ unsafe impl ::windows::core::Abi for ERRORINFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for ERRORINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERRORINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for ERRORINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for ERRORINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27177,14 +26721,6 @@ impl ::core::clone::Clone for ERRORINFO {
 unsafe impl ::windows::core::Abi for ERRORINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for ERRORINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ERRORINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for ERRORINFO {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for ERRORINFO {
     fn default() -> Self {
@@ -27215,7 +26751,7 @@ unsafe impl ::windows::core::Abi for FILTERED_DATA_SOURCES {
 }
 impl ::core::cmp::PartialEq for FILTERED_DATA_SOURCES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTERED_DATA_SOURCES>()) == 0 }
+        self.pwcsExtension == other.pwcsExtension && self.pwcsMime == other.pwcsMime && self.pClsid == other.pClsid && self.pwcsOverride == other.pwcsOverride
     }
 }
 impl ::core::cmp::Eq for FILTERED_DATA_SOURCES {}
@@ -27278,7 +26814,7 @@ unsafe impl ::windows::core::Abi for HITRANGE {
 }
 impl ::core::cmp::PartialEq for HITRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HITRANGE>()) == 0 }
+        self.iPosition == other.iPosition && self.cLength == other.cLength
     }
 }
 impl ::core::cmp::Eq for HITRANGE {}
@@ -27315,7 +26851,7 @@ unsafe impl ::windows::core::Abi for INCREMENTAL_ACCESS_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INCREMENTAL_ACCESS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INCREMENTAL_ACCESS_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.ftLastModifiedTime == other.ftLastModifiedTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27345,14 +26881,6 @@ impl ::core::clone::Clone for ITEMPROP {
 unsafe impl ::windows::core::Abi for ITEMPROP {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for ITEMPROP {
-    fn eq(&self, other: &Self) -> bool {
-        self.variantValue == other.variantValue && self.pwszName == other.pwszName
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for ITEMPROP {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for ITEMPROP {
     fn default() -> Self {
@@ -27384,7 +26912,7 @@ unsafe impl ::windows::core::Abi for ITEM_INFO {
 }
 impl ::core::cmp::PartialEq for ITEM_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ITEM_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pcwszFromEMail == other.pcwszFromEMail && self.pcwszApplicationName == other.pcwszApplicationName && self.pcwszCatalogName == other.pcwszCatalogName && self.pcwszContentClass == other.pcwszContentClass
     }
 }
 impl ::core::cmp::Eq for ITEM_INFO {}
@@ -27411,14 +26939,6 @@ impl ::core::clone::Clone for KAGGETDIAG {
 unsafe impl ::windows::core::Abi for KAGGETDIAG {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for KAGGETDIAG {
-    fn eq(&self, other: &Self) -> bool {
-        self.ulSize == other.ulSize && self.vDiagInfo == other.vDiagInfo && self.sDiagField == other.sDiagField
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for KAGGETDIAG {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for KAGGETDIAG {
     fn default() -> Self {
@@ -27454,7 +26974,7 @@ unsafe impl ::windows::core::Abi for KAGREQDIAG {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for KAGREQDIAG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KAGREQDIAG>()) == 0 }
+        self.ulDiagFlags == other.ulDiagFlags && self.vt == other.vt && self.sDiagField == other.sDiagField
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -27489,14 +27009,6 @@ unsafe impl ::windows::core::Abi for MDAXISINFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for MDAXISINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDAXISINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for MDAXISINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for MDAXISINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27526,14 +27038,6 @@ unsafe impl ::windows::core::Abi for MDAXISINFO {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for MDAXISINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDAXISINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for MDAXISINFO {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for MDAXISINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27559,14 +27063,6 @@ impl ::core::clone::Clone for NATLANGUAGERESTRICTION {
 unsafe impl ::windows::core::Abi for NATLANGUAGERESTRICTION {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for NATLANGUAGERESTRICTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NATLANGUAGERESTRICTION>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for NATLANGUAGERESTRICTION {}
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for NATLANGUAGERESTRICTION {
     fn default() -> Self {
@@ -27602,7 +27098,7 @@ unsafe impl ::windows::core::Abi for NODERESTRICTION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for NODERESTRICTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NODERESTRICTION>()) == 0 }
+        self.cRes == other.cRes && self.paRes == other.paRes && self.reserved == other.reserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
@@ -27640,7 +27136,7 @@ unsafe impl ::windows::core::Abi for NOTRESTRICTION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for NOTRESTRICTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTRESTRICTION>()) == 0 }
+        self.pRes == other.pRes
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
@@ -27669,12 +27165,6 @@ impl ::core::clone::Clone for ODBC_VS_ARGS {
 unsafe impl ::windows::core::Abi for ODBC_VS_ARGS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ODBC_VS_ARGS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ODBC_VS_ARGS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ODBC_VS_ARGS {}
 impl ::core::default::Default for ODBC_VS_ARGS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27695,12 +27185,6 @@ impl ::core::clone::Clone for ODBC_VS_ARGS_0 {
 unsafe impl ::windows::core::Abi for ODBC_VS_ARGS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ODBC_VS_ARGS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ODBC_VS_ARGS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ODBC_VS_ARGS_0 {}
 impl ::core::default::Default for ODBC_VS_ARGS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27721,12 +27205,6 @@ impl ::core::clone::Clone for ODBC_VS_ARGS_1 {
 unsafe impl ::windows::core::Abi for ODBC_VS_ARGS_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ODBC_VS_ARGS_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ODBC_VS_ARGS_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ODBC_VS_ARGS_1 {}
 impl ::core::default::Default for ODBC_VS_ARGS_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27750,14 +27228,6 @@ impl ::core::clone::Clone for PROPERTYRESTRICTION {
 unsafe impl ::windows::core::Abi for PROPERTYRESTRICTION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for PROPERTYRESTRICTION {
-    fn eq(&self, other: &Self) -> bool {
-        self.rel == other.rel && self.prop == other.prop && self.prval == other.prval
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for PROPERTYRESTRICTION {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for PROPERTYRESTRICTION {
     fn default() -> Self {
@@ -27797,7 +27267,7 @@ unsafe impl ::windows::core::Abi for PROXY_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROXY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROXY_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.pcwszUserAgent == other.pcwszUserAgent && self.paUseProxy == other.paUseProxy && self.fLocalBypass == other.fLocalBypass && self.dwPortNumber == other.dwPortNumber && self.pcwszProxyName == other.pcwszProxyName && self.pcwszBypassList == other.pcwszBypassList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27836,7 +27306,7 @@ unsafe impl ::windows::core::Abi for RANGECATEGORIZE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for RANGECATEGORIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RANGECATEGORIZE>()) == 0 }
+        self.cRange == other.cRange && self.aRangeBegin == other.aRangeBegin
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -27866,14 +27336,6 @@ unsafe impl ::windows::core::Abi for RESTRICTION {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for RESTRICTION {
-    fn eq(&self, other: &Self) -> bool {
-        self.rt == other.rt && self.weight == other.weight && self.res == other.res
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for RESTRICTION {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for RESTRICTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27902,14 +27364,6 @@ impl ::core::clone::Clone for RESTRICTION_0 {
 unsafe impl ::windows::core::Abi for RESTRICTION_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for RESTRICTION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESTRICTION_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for RESTRICTION_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for RESTRICTION_0 {
     fn default() -> Self {
@@ -27965,16 +27419,6 @@ unsafe impl ::windows::core::Abi for RMTPACK {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for RMTPACK {
-    fn eq(&self, other: &Self) -> bool {
-        self.pISeqStream == other.pISeqStream && self.cbData == other.cbData && self.cBSTR == other.cBSTR && self.rgBSTR == other.rgBSTR && self.cVARIANT == other.cVARIANT && self.rgVARIANT == other.rgVARIANT && self.cIDISPATCH == other.cIDISPATCH && self.rgIDISPATCH == other.rgIDISPATCH && self.cIUNKNOWN == other.cIUNKNOWN && self.rgIUNKNOWN == other.rgIUNKNOWN && self.cPROPVARIANT == other.cPROPVARIANT && self.rgPROPVARIANT == other.rgPROPVARIANT && self.cArray == other.cArray && self.rgArray == other.rgArray
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for RMTPACK {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for RMTPACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28007,16 +27451,6 @@ unsafe impl ::windows::core::Abi for RMTPACK {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for RMTPACK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RMTPACK>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for RMTPACK {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for RMTPACK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28039,14 +27473,6 @@ impl ::core::clone::Clone for SEARCH_COLUMN_PROPERTIES {
 unsafe impl ::windows::core::Abi for SEARCH_COLUMN_PROPERTIES {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for SEARCH_COLUMN_PROPERTIES {
-    fn eq(&self, other: &Self) -> bool {
-        self.Value == other.Value && self.lcid == other.lcid
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for SEARCH_COLUMN_PROPERTIES {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for SEARCH_COLUMN_PROPERTIES {
     fn default() -> Self {
@@ -28084,7 +27510,7 @@ unsafe impl ::windows::core::Abi for SEARCH_ITEM_CHANGE {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SEARCH_ITEM_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEARCH_ITEM_CHANGE>()) == 0 }
+        self.Change == other.Change && self.Priority == other.Priority && self.pUserData == other.pUserData && self.lpwszURL == other.lpwszURL && self.lpwszOldURL == other.lpwszOldURL
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -28117,7 +27543,7 @@ unsafe impl ::windows::core::Abi for SEARCH_ITEM_INDEXING_STATUS {
 }
 impl ::core::cmp::PartialEq for SEARCH_ITEM_INDEXING_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEARCH_ITEM_INDEXING_STATUS>()) == 0 }
+        self.dwDocID == other.dwDocID && self.hrIndexingStatus == other.hrIndexingStatus
     }
 }
 impl ::core::cmp::Eq for SEARCH_ITEM_INDEXING_STATUS {}
@@ -28150,7 +27576,7 @@ unsafe impl ::windows::core::Abi for SEARCH_ITEM_PERSISTENT_CHANGE {
 }
 impl ::core::cmp::PartialEq for SEARCH_ITEM_PERSISTENT_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEARCH_ITEM_PERSISTENT_CHANGE>()) == 0 }
+        self.Change == other.Change && self.URL == other.URL && self.OldURL == other.OldURL && self.Priority == other.Priority
     }
 }
 impl ::core::cmp::Eq for SEARCH_ITEM_PERSISTENT_CHANGE {}
@@ -28184,16 +27610,6 @@ unsafe impl ::windows::core::Abi for SEC_OBJECT {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for SEC_OBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_OBJECT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for SEC_OBJECT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for SEC_OBJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28224,16 +27640,6 @@ unsafe impl ::windows::core::Abi for SEC_OBJECT {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for SEC_OBJECT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_OBJECT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for SEC_OBJECT {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for SEC_OBJECT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28262,16 +27668,6 @@ impl ::core::clone::Clone for SEC_OBJECT_ELEMENT {
 unsafe impl ::windows::core::Abi for SEC_OBJECT_ELEMENT {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for SEC_OBJECT_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_OBJECT_ELEMENT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for SEC_OBJECT_ELEMENT {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for SEC_OBJECT_ELEMENT {
@@ -28304,16 +27700,6 @@ unsafe impl ::windows::core::Abi for SEC_OBJECT_ELEMENT {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::PartialEq for SEC_OBJECT_ELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEC_OBJECT_ELEMENT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl ::core::cmp::Eq for SEC_OBJECT_ELEMENT {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ::core::default::Default for SEC_OBJECT_ELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28339,14 +27725,6 @@ impl ::core::clone::Clone for SORTKEY {
 unsafe impl ::windows::core::Abi for SORTKEY {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::PartialEq for SORTKEY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SORTKEY>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl ::core::cmp::Eq for SORTKEY {}
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::default::Default for SORTKEY {
     fn default() -> Self {
@@ -28381,7 +27759,7 @@ unsafe impl ::windows::core::Abi for SORTSET {
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for SORTSET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SORTSET>()) == 0 }
+        self.cCol == other.cCol && self.aCol == other.aCol
     }
 }
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
@@ -28479,7 +27857,39 @@ unsafe impl ::windows::core::Abi for SQLPERF {
 }
 impl ::core::cmp::PartialEq for SQLPERF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQLPERF>()) == 0 }
+        self.TimerResolution == other.TimerResolution
+            && self.SQLidu == other.SQLidu
+            && self.SQLiduRows == other.SQLiduRows
+            && self.SQLSelects == other.SQLSelects
+            && self.SQLSelectRows == other.SQLSelectRows
+            && self.Transactions == other.Transactions
+            && self.SQLPrepares == other.SQLPrepares
+            && self.ExecDirects == other.ExecDirects
+            && self.SQLExecutes == other.SQLExecutes
+            && self.CursorOpens == other.CursorOpens
+            && self.CursorSize == other.CursorSize
+            && self.CursorUsed == other.CursorUsed
+            && self.PercentCursorUsed == other.PercentCursorUsed
+            && self.AvgFetchTime == other.AvgFetchTime
+            && self.AvgCursorSize == other.AvgCursorSize
+            && self.AvgCursorUsed == other.AvgCursorUsed
+            && self.SQLFetchTime == other.SQLFetchTime
+            && self.SQLFetchCount == other.SQLFetchCount
+            && self.CurrentStmtCount == other.CurrentStmtCount
+            && self.MaxOpenStmt == other.MaxOpenStmt
+            && self.SumOpenStmt == other.SumOpenStmt
+            && self.CurrentConnectionCount == other.CurrentConnectionCount
+            && self.MaxConnectionsOpened == other.MaxConnectionsOpened
+            && self.SumConnectionsOpened == other.SumConnectionsOpened
+            && self.SumConnectiontime == other.SumConnectiontime
+            && self.AvgTimeOpened == other.AvgTimeOpened
+            && self.ServerRndTrips == other.ServerRndTrips
+            && self.BuffersSent == other.BuffersSent
+            && self.BuffersRec == other.BuffersRec
+            && self.BytesSent == other.BytesSent
+            && self.BytesRec == other.BytesRec
+            && self.msExecutionTime == other.msExecutionTime
+            && self.msNetWorkServerTime == other.msNetWorkServerTime
     }
 }
 impl ::core::cmp::Eq for SQLPERF {}
@@ -28513,7 +27923,7 @@ unsafe impl ::windows::core::Abi for SQL_DAY_SECOND_STRUCT {
 }
 impl ::core::cmp::PartialEq for SQL_DAY_SECOND_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQL_DAY_SECOND_STRUCT>()) == 0 }
+        self.day == other.day && self.hour == other.hour && self.minute == other.minute && self.second == other.second && self.fraction == other.fraction
     }
 }
 impl ::core::cmp::Eq for SQL_DAY_SECOND_STRUCT {}
@@ -28538,12 +27948,6 @@ impl ::core::clone::Clone for SQL_INTERVAL_STRUCT {
 unsafe impl ::windows::core::Abi for SQL_INTERVAL_STRUCT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SQL_INTERVAL_STRUCT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQL_INTERVAL_STRUCT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SQL_INTERVAL_STRUCT {}
 impl ::core::default::Default for SQL_INTERVAL_STRUCT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28564,12 +27968,6 @@ impl ::core::clone::Clone for SQL_INTERVAL_STRUCT_0 {
 unsafe impl ::windows::core::Abi for SQL_INTERVAL_STRUCT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SQL_INTERVAL_STRUCT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQL_INTERVAL_STRUCT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SQL_INTERVAL_STRUCT_0 {}
 impl ::core::default::Default for SQL_INTERVAL_STRUCT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28599,7 +27997,7 @@ unsafe impl ::windows::core::Abi for SQL_NUMERIC_STRUCT {
 }
 impl ::core::cmp::PartialEq for SQL_NUMERIC_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQL_NUMERIC_STRUCT>()) == 0 }
+        self.precision == other.precision && self.scale == other.scale && self.sign == other.sign && self.val == other.val
     }
 }
 impl ::core::cmp::Eq for SQL_NUMERIC_STRUCT {}
@@ -28630,7 +28028,7 @@ unsafe impl ::windows::core::Abi for SQL_YEAR_MONTH_STRUCT {
 }
 impl ::core::cmp::PartialEq for SQL_YEAR_MONTH_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SQL_YEAR_MONTH_STRUCT>()) == 0 }
+        self.year == other.year && self.month == other.month
     }
 }
 impl ::core::cmp::Eq for SQL_YEAR_MONTH_STRUCT {}
@@ -28666,7 +28064,7 @@ unsafe impl ::windows::core::Abi for SSERRORINFO {
 }
 impl ::core::cmp::PartialEq for SSERRORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSERRORINFO>()) == 0 }
+        self.pwszMessage == other.pwszMessage && self.pwszServer == other.pwszServer && self.pwszProcedure == other.pwszProcedure && self.lNative == other.lNative && self.bState == other.bState && self.bClass == other.bClass && self.wLineNumber == other.wLineNumber
     }
 }
 impl ::core::cmp::Eq for SSERRORINFO {}
@@ -28694,14 +28092,6 @@ impl ::core::clone::Clone for SSVARIANT {
 unsafe impl ::windows::core::Abi for SSVARIANT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SSVARIANT {
-    fn eq(&self, other: &Self) -> bool {
-        self.vt == other.vt && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.Anonymous == other.Anonymous
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SSVARIANT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SSVARIANT {
     fn default() -> Self {
@@ -28740,14 +28130,6 @@ unsafe impl ::windows::core::Abi for SSVARIANT_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SSVARIANT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSVARIANT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SSVARIANT_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SSVARIANT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -28770,14 +28152,6 @@ impl ::core::clone::Clone for SSVARIANT_0_0 {
 unsafe impl ::windows::core::Abi for SSVARIANT_0_0 {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for SSVARIANT_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        self.dbobj == other.dbobj && self.pUnk == other.pUnk
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for SSVARIANT_0_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::default::Default for SSVARIANT_0_0 {
     fn default() -> Self {
@@ -28814,7 +28188,7 @@ unsafe impl ::windows::core::Abi for SSVARIANT_0_1 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SSVARIANT_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSVARIANT_0_1>()) == 0 }
+        self.sActualLength == other.sActualLength && self.sMaxLength == other.sMaxLength && self.prgbBinaryVal == other.prgbBinaryVal && self.dwReserved == other.dwReserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -28857,7 +28231,7 @@ unsafe impl ::windows::core::Abi for SSVARIANT_0_2 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SSVARIANT_0_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSVARIANT_0_2>()) == 0 }
+        self.sActualLength == other.sActualLength && self.sMaxLength == other.sMaxLength && self.pchCharVal == other.pchCharVal && self.rgbReserved == other.rgbReserved && self.dwReserved == other.dwReserved && self.pwchReserved == other.pwchReserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -28900,7 +28274,7 @@ unsafe impl ::windows::core::Abi for SSVARIANT_0_3 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SSVARIANT_0_3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSVARIANT_0_3>()) == 0 }
+        self.sActualLength == other.sActualLength && self.sMaxLength == other.sMaxLength && self.pwchNCharVal == other.pwchNCharVal && self.rgbReserved == other.rgbReserved && self.dwReserved == other.dwReserved && self.pwchReserved == other.pwchReserved
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -28940,7 +28314,7 @@ unsafe impl ::windows::core::Abi for SSVARIANT_0_4 {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ::core::cmp::PartialEq for SSVARIANT_0_4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SSVARIANT_0_4>()) == 0 }
+        self.dwActualLength == other.dwActualLength && self.rgMetadata == other.rgMetadata && self.pUnknownData == other.pUnknownData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -29088,7 +28462,7 @@ unsafe impl ::windows::core::Abi for SUBSCRIPTIONITEMINFO {
 }
 impl ::core::cmp::PartialEq for SUBSCRIPTIONITEMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SUBSCRIPTIONITEMINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.dwPriority == other.dwPriority && self.ScheduleGroup == other.ScheduleGroup && self.clsidAgent == other.clsidAgent
     }
 }
 impl ::core::cmp::Eq for SUBSCRIPTIONITEMINFO {}
@@ -29113,18 +28487,12 @@ impl ::core::clone::Clone for TEXT_SOURCE {
 }
 impl ::core::fmt::Debug for TEXT_SOURCE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("TEXT_SOURCE").field("pfnFillTextBuffer", &self.pfnFillTextBuffer.map(|f| f as usize)).field("awcBuffer", &self.awcBuffer).field("iEnd", &self.iEnd).field("iCur", &self.iCur).finish()
+        f.debug_struct("TEXT_SOURCE").field("awcBuffer", &self.awcBuffer).field("iEnd", &self.iEnd).field("iCur", &self.iCur).finish()
     }
 }
 unsafe impl ::windows::core::Abi for TEXT_SOURCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TEXT_SOURCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXT_SOURCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TEXT_SOURCE {}
 impl ::core::default::Default for TEXT_SOURCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -29153,7 +28521,7 @@ unsafe impl ::windows::core::Abi for TIMEOUT_INFO {
 }
 impl ::core::cmp::PartialEq for TIMEOUT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMEOUT_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwConnectTimeout == other.dwConnectTimeout && self.dwDataTimeout == other.dwDataTimeout
     }
 }
 impl ::core::cmp::Eq for TIMEOUT_INFO {}
@@ -29189,7 +28557,7 @@ unsafe impl ::windows::core::Abi for TIMESTAMP_STRUCT {
 }
 impl ::core::cmp::PartialEq for TIMESTAMP_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIMESTAMP_STRUCT>()) == 0 }
+        self.year == other.year && self.month == other.month && self.day == other.day && self.hour == other.hour && self.minute == other.minute && self.second == other.second && self.fraction == other.fraction
     }
 }
 impl ::core::cmp::Eq for TIMESTAMP_STRUCT {}
@@ -29221,7 +28589,7 @@ unsafe impl ::windows::core::Abi for TIME_STRUCT {
 }
 impl ::core::cmp::PartialEq for TIME_STRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIME_STRUCT>()) == 0 }
+        self.hour == other.hour && self.minute == other.minute && self.second == other.second
     }
 }
 impl ::core::cmp::Eq for TIME_STRUCT {}
@@ -29258,7 +28626,7 @@ unsafe impl ::windows::core::Abi for VECTORRESTRICTION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ::core::cmp::PartialEq for VECTORRESTRICTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VECTORRESTRICTION>()) == 0 }
+        self.Node == other.Node && self.RankMethod == other.RankMethod
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
@@ -229,7 +229,7 @@ unsafe impl ::windows::core::Abi for WSB_OB_REGISTRATION_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WSB_OB_REGISTRATION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSB_OB_REGISTRATION_INFO>()) == 0 }
+        self.m_wszResourceDLL == other.m_wszResourceDLL && self.m_guidSnapinId == other.m_guidSnapinId && self.m_dwProviderName == other.m_dwProviderName && self.m_dwProviderIcon == other.m_dwProviderIcon && self.m_bSupportsRemoting == other.m_bSupportsRemoting
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -265,7 +265,7 @@ unsafe impl ::windows::core::Abi for WSB_OB_STATUS_ENTRY {
 }
 impl ::core::cmp::PartialEq for WSB_OB_STATUS_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSB_OB_STATUS_ENTRY>()) == 0 }
+        self.m_dwIcon == other.m_dwIcon && self.m_dwStatusEntryName == other.m_dwStatusEntryName && self.m_dwStatusEntryValue == other.m_dwStatusEntryValue && self.m_cValueTypePair == other.m_cValueTypePair && self.m_rgValueTypePair == other.m_rgValueTypePair
     }
 }
 impl ::core::cmp::Eq for WSB_OB_STATUS_ENTRY {}
@@ -296,7 +296,7 @@ unsafe impl ::windows::core::Abi for WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR {
 }
 impl ::core::cmp::PartialEq for WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR>()) == 0 }
+        self.m_wszObStatusEntryPairValue == other.m_wszObStatusEntryPairValue && self.m_ObStatusEntryPairType == other.m_ObStatusEntryPairType
     }
 }
 impl ::core::cmp::Eq for WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR {}
@@ -328,7 +328,7 @@ unsafe impl ::windows::core::Abi for WSB_OB_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for WSB_OB_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WSB_OB_STATUS_INFO>()) == 0 }
+        self.m_guidSnapinId == other.m_guidSnapinId && self.m_cStatusEntry == other.m_cStatusEntry && self.m_rgStatusEntry == other.m_rgStatusEntry
     }
 }
 impl ::core::cmp::Eq for WSB_OB_STATUS_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -1525,7 +1525,7 @@ unsafe impl ::windows::core::Abi for ENUM_SERVICE_STATUSA {
 }
 impl ::core::cmp::PartialEq for ENUM_SERVICE_STATUSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUM_SERVICE_STATUSA>()) == 0 }
+        self.lpServiceName == other.lpServiceName && self.lpDisplayName == other.lpDisplayName && self.ServiceStatus == other.ServiceStatus
     }
 }
 impl ::core::cmp::Eq for ENUM_SERVICE_STATUSA {}
@@ -1557,7 +1557,7 @@ unsafe impl ::windows::core::Abi for ENUM_SERVICE_STATUSW {
 }
 impl ::core::cmp::PartialEq for ENUM_SERVICE_STATUSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUM_SERVICE_STATUSW>()) == 0 }
+        self.lpServiceName == other.lpServiceName && self.lpDisplayName == other.lpDisplayName && self.ServiceStatus == other.ServiceStatus
     }
 }
 impl ::core::cmp::Eq for ENUM_SERVICE_STATUSW {}
@@ -1589,7 +1589,7 @@ unsafe impl ::windows::core::Abi for ENUM_SERVICE_STATUS_PROCESSA {
 }
 impl ::core::cmp::PartialEq for ENUM_SERVICE_STATUS_PROCESSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUM_SERVICE_STATUS_PROCESSA>()) == 0 }
+        self.lpServiceName == other.lpServiceName && self.lpDisplayName == other.lpDisplayName && self.ServiceStatusProcess == other.ServiceStatusProcess
     }
 }
 impl ::core::cmp::Eq for ENUM_SERVICE_STATUS_PROCESSA {}
@@ -1621,7 +1621,7 @@ unsafe impl ::windows::core::Abi for ENUM_SERVICE_STATUS_PROCESSW {
 }
 impl ::core::cmp::PartialEq for ENUM_SERVICE_STATUS_PROCESSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUM_SERVICE_STATUS_PROCESSW>()) == 0 }
+        self.lpServiceName == other.lpServiceName && self.lpDisplayName == other.lpDisplayName && self.ServiceStatusProcess == other.ServiceStatusProcess
     }
 }
 impl ::core::cmp::Eq for ENUM_SERVICE_STATUS_PROCESSW {}
@@ -1659,7 +1659,7 @@ unsafe impl ::windows::core::Abi for QUERY_SERVICE_CONFIGA {
 }
 impl ::core::cmp::PartialEq for QUERY_SERVICE_CONFIGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_SERVICE_CONFIGA>()) == 0 }
+        self.dwServiceType == other.dwServiceType && self.dwStartType == other.dwStartType && self.dwErrorControl == other.dwErrorControl && self.lpBinaryPathName == other.lpBinaryPathName && self.lpLoadOrderGroup == other.lpLoadOrderGroup && self.dwTagId == other.dwTagId && self.lpDependencies == other.lpDependencies && self.lpServiceStartName == other.lpServiceStartName && self.lpDisplayName == other.lpDisplayName
     }
 }
 impl ::core::cmp::Eq for QUERY_SERVICE_CONFIGA {}
@@ -1697,7 +1697,7 @@ unsafe impl ::windows::core::Abi for QUERY_SERVICE_CONFIGW {
 }
 impl ::core::cmp::PartialEq for QUERY_SERVICE_CONFIGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_SERVICE_CONFIGW>()) == 0 }
+        self.dwServiceType == other.dwServiceType && self.dwStartType == other.dwStartType && self.dwErrorControl == other.dwErrorControl && self.lpBinaryPathName == other.lpBinaryPathName && self.lpLoadOrderGroup == other.lpLoadOrderGroup && self.dwTagId == other.dwTagId && self.lpDependencies == other.lpDependencies && self.lpServiceStartName == other.lpServiceStartName && self.lpDisplayName == other.lpDisplayName
     }
 }
 impl ::core::cmp::Eq for QUERY_SERVICE_CONFIGW {}
@@ -1729,7 +1729,7 @@ unsafe impl ::windows::core::Abi for QUERY_SERVICE_LOCK_STATUSA {
 }
 impl ::core::cmp::PartialEq for QUERY_SERVICE_LOCK_STATUSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_SERVICE_LOCK_STATUSA>()) == 0 }
+        self.fIsLocked == other.fIsLocked && self.lpLockOwner == other.lpLockOwner && self.dwLockDuration == other.dwLockDuration
     }
 }
 impl ::core::cmp::Eq for QUERY_SERVICE_LOCK_STATUSA {}
@@ -1761,7 +1761,7 @@ unsafe impl ::windows::core::Abi for QUERY_SERVICE_LOCK_STATUSW {
 }
 impl ::core::cmp::PartialEq for QUERY_SERVICE_LOCK_STATUSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUERY_SERVICE_LOCK_STATUSW>()) == 0 }
+        self.fIsLocked == other.fIsLocked && self.lpLockOwner == other.lpLockOwner && self.dwLockDuration == other.dwLockDuration
     }
 }
 impl ::core::cmp::Eq for QUERY_SERVICE_LOCK_STATUSW {}
@@ -1792,7 +1792,7 @@ unsafe impl ::windows::core::Abi for SC_ACTION {
 }
 impl ::core::cmp::PartialEq for SC_ACTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SC_ACTION>()) == 0 }
+        self.Type == other.Type && self.Delay == other.Delay
     }
 }
 impl ::core::cmp::Eq for SC_ACTION {}
@@ -1824,7 +1824,7 @@ unsafe impl ::windows::core::Abi for SERVICE_CONTROL_STATUS_REASON_PARAMSA {
 }
 impl ::core::cmp::PartialEq for SERVICE_CONTROL_STATUS_REASON_PARAMSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_CONTROL_STATUS_REASON_PARAMSA>()) == 0 }
+        self.dwReason == other.dwReason && self.pszComment == other.pszComment && self.ServiceStatus == other.ServiceStatus
     }
 }
 impl ::core::cmp::Eq for SERVICE_CONTROL_STATUS_REASON_PARAMSA {}
@@ -1856,7 +1856,7 @@ unsafe impl ::windows::core::Abi for SERVICE_CONTROL_STATUS_REASON_PARAMSW {
 }
 impl ::core::cmp::PartialEq for SERVICE_CONTROL_STATUS_REASON_PARAMSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_CONTROL_STATUS_REASON_PARAMSW>()) == 0 }
+        self.dwReason == other.dwReason && self.pszComment == other.pszComment && self.ServiceStatus == other.ServiceStatus
     }
 }
 impl ::core::cmp::Eq for SERVICE_CONTROL_STATUS_REASON_PARAMSW {}
@@ -1879,12 +1879,6 @@ impl ::core::clone::Clone for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
 unsafe impl ::windows::core::Abi for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {}
 impl ::core::default::Default for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1905,12 +1899,6 @@ impl ::core::clone::Clone for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
 unsafe impl ::windows::core::Abi for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {}
 impl ::core::default::Default for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1938,7 +1926,7 @@ unsafe impl ::windows::core::Abi for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITE
 }
 impl ::core::cmp::PartialEq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0_0>()) == 0 }
+        self.DataOffset == other.DataOffset && self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0_0 {}
@@ -1974,7 +1962,7 @@ unsafe impl ::windows::core::Abi for SERVICE_DELAYED_AUTO_START_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVICE_DELAYED_AUTO_START_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_DELAYED_AUTO_START_INFO>()) == 0 }
+        self.fDelayedAutostart == other.fDelayedAutostart
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2006,7 +1994,7 @@ unsafe impl ::windows::core::Abi for SERVICE_DESCRIPTIONA {
 }
 impl ::core::cmp::PartialEq for SERVICE_DESCRIPTIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_DESCRIPTIONA>()) == 0 }
+        self.lpDescription == other.lpDescription
     }
 }
 impl ::core::cmp::Eq for SERVICE_DESCRIPTIONA {}
@@ -2036,7 +2024,7 @@ unsafe impl ::windows::core::Abi for SERVICE_DESCRIPTIONW {
 }
 impl ::core::cmp::PartialEq for SERVICE_DESCRIPTIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_DESCRIPTIONW>()) == 0 }
+        self.lpDescription == other.lpDescription
     }
 }
 impl ::core::cmp::Eq for SERVICE_DESCRIPTIONW {}
@@ -2070,7 +2058,7 @@ unsafe impl ::windows::core::Abi for SERVICE_FAILURE_ACTIONSA {
 }
 impl ::core::cmp::PartialEq for SERVICE_FAILURE_ACTIONSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_FAILURE_ACTIONSA>()) == 0 }
+        self.dwResetPeriod == other.dwResetPeriod && self.lpRebootMsg == other.lpRebootMsg && self.lpCommand == other.lpCommand && self.cActions == other.cActions && self.lpsaActions == other.lpsaActions
     }
 }
 impl ::core::cmp::Eq for SERVICE_FAILURE_ACTIONSA {}
@@ -2104,7 +2092,7 @@ unsafe impl ::windows::core::Abi for SERVICE_FAILURE_ACTIONSW {
 }
 impl ::core::cmp::PartialEq for SERVICE_FAILURE_ACTIONSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_FAILURE_ACTIONSW>()) == 0 }
+        self.dwResetPeriod == other.dwResetPeriod && self.lpRebootMsg == other.lpRebootMsg && self.lpCommand == other.lpCommand && self.cActions == other.cActions && self.lpsaActions == other.lpsaActions
     }
 }
 impl ::core::cmp::Eq for SERVICE_FAILURE_ACTIONSW {}
@@ -2140,7 +2128,7 @@ unsafe impl ::windows::core::Abi for SERVICE_FAILURE_ACTIONS_FLAG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVICE_FAILURE_ACTIONS_FLAG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_FAILURE_ACTIONS_FLAG>()) == 0 }
+        self.fFailureActionsOnNonCrashFailures == other.fFailureActionsOnNonCrashFailures
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2172,7 +2160,7 @@ unsafe impl ::windows::core::Abi for SERVICE_LAUNCH_PROTECTED_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_LAUNCH_PROTECTED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_LAUNCH_PROTECTED_INFO>()) == 0 }
+        self.dwLaunchProtected == other.dwLaunchProtected
     }
 }
 impl ::core::cmp::Eq for SERVICE_LAUNCH_PROTECTED_INFO {}
@@ -2198,18 +2186,12 @@ impl ::core::clone::Clone for SERVICE_NOTIFY_1 {
 }
 impl ::core::fmt::Debug for SERVICE_NOTIFY_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_NOTIFY_1").field("dwVersion", &self.dwVersion).field("pfnNotifyCallback", &self.pfnNotifyCallback.map(|f| f as usize)).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).finish()
+        f.debug_struct("SERVICE_NOTIFY_1").field("dwVersion", &self.dwVersion).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).finish()
     }
 }
 unsafe impl ::windows::core::Abi for SERVICE_NOTIFY_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_NOTIFY_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_NOTIFY_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_NOTIFY_1 {}
 impl ::core::default::Default for SERVICE_NOTIFY_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2234,18 +2216,12 @@ impl ::core::clone::Clone for SERVICE_NOTIFY_2A {
 }
 impl ::core::fmt::Debug for SERVICE_NOTIFY_2A {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_NOTIFY_2A").field("dwVersion", &self.dwVersion).field("pfnNotifyCallback", &self.pfnNotifyCallback.map(|f| f as usize)).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).field("dwNotificationTriggered", &self.dwNotificationTriggered).field("pszServiceNames", &self.pszServiceNames).finish()
+        f.debug_struct("SERVICE_NOTIFY_2A").field("dwVersion", &self.dwVersion).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).field("dwNotificationTriggered", &self.dwNotificationTriggered).field("pszServiceNames", &self.pszServiceNames).finish()
     }
 }
 unsafe impl ::windows::core::Abi for SERVICE_NOTIFY_2A {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_NOTIFY_2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_NOTIFY_2A>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_NOTIFY_2A {}
 impl ::core::default::Default for SERVICE_NOTIFY_2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2270,18 +2246,12 @@ impl ::core::clone::Clone for SERVICE_NOTIFY_2W {
 }
 impl ::core::fmt::Debug for SERVICE_NOTIFY_2W {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_NOTIFY_2W").field("dwVersion", &self.dwVersion).field("pfnNotifyCallback", &self.pfnNotifyCallback.map(|f| f as usize)).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).field("dwNotificationTriggered", &self.dwNotificationTriggered).field("pszServiceNames", &self.pszServiceNames).finish()
+        f.debug_struct("SERVICE_NOTIFY_2W").field("dwVersion", &self.dwVersion).field("pContext", &self.pContext).field("dwNotificationStatus", &self.dwNotificationStatus).field("ServiceStatus", &self.ServiceStatus).field("dwNotificationTriggered", &self.dwNotificationTriggered).field("pszServiceNames", &self.pszServiceNames).finish()
     }
 }
 unsafe impl ::windows::core::Abi for SERVICE_NOTIFY_2W {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_NOTIFY_2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_NOTIFY_2W>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_NOTIFY_2W {}
 impl ::core::default::Default for SERVICE_NOTIFY_2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2315,7 +2285,7 @@ unsafe impl ::windows::core::Abi for SERVICE_PREFERRED_NODE_INFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVICE_PREFERRED_NODE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_PREFERRED_NODE_INFO>()) == 0 }
+        self.usPreferredNode == other.usPreferredNode && self.fDelete == other.fDelete
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2347,7 +2317,7 @@ unsafe impl ::windows::core::Abi for SERVICE_PRESHUTDOWN_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_PRESHUTDOWN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_PRESHUTDOWN_INFO>()) == 0 }
+        self.dwPreshutdownTimeout == other.dwPreshutdownTimeout
     }
 }
 impl ::core::cmp::Eq for SERVICE_PRESHUTDOWN_INFO {}
@@ -2377,7 +2347,7 @@ unsafe impl ::windows::core::Abi for SERVICE_REQUIRED_PRIVILEGES_INFOA {
 }
 impl ::core::cmp::PartialEq for SERVICE_REQUIRED_PRIVILEGES_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_REQUIRED_PRIVILEGES_INFOA>()) == 0 }
+        self.pmszRequiredPrivileges == other.pmszRequiredPrivileges
     }
 }
 impl ::core::cmp::Eq for SERVICE_REQUIRED_PRIVILEGES_INFOA {}
@@ -2407,7 +2377,7 @@ unsafe impl ::windows::core::Abi for SERVICE_REQUIRED_PRIVILEGES_INFOW {
 }
 impl ::core::cmp::PartialEq for SERVICE_REQUIRED_PRIVILEGES_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_REQUIRED_PRIVILEGES_INFOW>()) == 0 }
+        self.pmszRequiredPrivileges == other.pmszRequiredPrivileges
     }
 }
 impl ::core::cmp::Eq for SERVICE_REQUIRED_PRIVILEGES_INFOW {}
@@ -2437,7 +2407,7 @@ unsafe impl ::windows::core::Abi for SERVICE_SID_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_SID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_SID_INFO>()) == 0 }
+        self.dwServiceSidType == other.dwServiceSidType
     }
 }
 impl ::core::cmp::Eq for SERVICE_SID_INFO {}
@@ -2467,7 +2437,7 @@ unsafe impl ::windows::core::Abi for SERVICE_START_REASON {
 }
 impl ::core::cmp::PartialEq for SERVICE_START_REASON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_START_REASON>()) == 0 }
+        self.dwReason == other.dwReason
     }
 }
 impl ::core::cmp::Eq for SERVICE_START_REASON {}
@@ -2503,7 +2473,7 @@ unsafe impl ::windows::core::Abi for SERVICE_STATUS {
 }
 impl ::core::cmp::PartialEq for SERVICE_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_STATUS>()) == 0 }
+        self.dwServiceType == other.dwServiceType && self.dwCurrentState == other.dwCurrentState && self.dwControlsAccepted == other.dwControlsAccepted && self.dwWin32ExitCode == other.dwWin32ExitCode && self.dwServiceSpecificExitCode == other.dwServiceSpecificExitCode && self.dwCheckPoint == other.dwCheckPoint && self.dwWaitHint == other.dwWaitHint
     }
 }
 impl ::core::cmp::Eq for SERVICE_STATUS {}
@@ -2573,7 +2543,7 @@ unsafe impl ::windows::core::Abi for SERVICE_STATUS_PROCESS {
 }
 impl ::core::cmp::PartialEq for SERVICE_STATUS_PROCESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_STATUS_PROCESS>()) == 0 }
+        self.dwServiceType == other.dwServiceType && self.dwCurrentState == other.dwCurrentState && self.dwControlsAccepted == other.dwControlsAccepted && self.dwWin32ExitCode == other.dwWin32ExitCode && self.dwServiceSpecificExitCode == other.dwServiceSpecificExitCode && self.dwCheckPoint == other.dwCheckPoint && self.dwWaitHint == other.dwWaitHint && self.dwProcessId == other.dwProcessId && self.dwServiceFlags == other.dwServiceFlags
     }
 }
 impl ::core::cmp::Eq for SERVICE_STATUS_PROCESS {}
@@ -2596,18 +2566,12 @@ impl ::core::clone::Clone for SERVICE_TABLE_ENTRYA {
 }
 impl ::core::fmt::Debug for SERVICE_TABLE_ENTRYA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_TABLE_ENTRYA").field("lpServiceName", &self.lpServiceName).field("lpServiceProc", &self.lpServiceProc.map(|f| f as usize)).finish()
+        f.debug_struct("SERVICE_TABLE_ENTRYA").field("lpServiceName", &self.lpServiceName).finish()
     }
 }
 unsafe impl ::windows::core::Abi for SERVICE_TABLE_ENTRYA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_TABLE_ENTRYA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TABLE_ENTRYA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_TABLE_ENTRYA {}
 impl ::core::default::Default for SERVICE_TABLE_ENTRYA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2627,18 +2591,12 @@ impl ::core::clone::Clone for SERVICE_TABLE_ENTRYW {
 }
 impl ::core::fmt::Debug for SERVICE_TABLE_ENTRYW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SERVICE_TABLE_ENTRYW").field("lpServiceName", &self.lpServiceName).field("lpServiceProc", &self.lpServiceProc.map(|f| f as usize)).finish()
+        f.debug_struct("SERVICE_TABLE_ENTRYW").field("lpServiceName", &self.lpServiceName).finish()
     }
 }
 unsafe impl ::windows::core::Abi for SERVICE_TABLE_ENTRYW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SERVICE_TABLE_ENTRYW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TABLE_ENTRYW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SERVICE_TABLE_ENTRYW {}
 impl ::core::default::Default for SERVICE_TABLE_ENTRYW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2666,7 +2624,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TIMECHANGE_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_TIMECHANGE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TIMECHANGE_INFO>()) == 0 }
+        self.liNewTime == other.liNewTime && self.liOldTime == other.liOldTime
     }
 }
 impl ::core::cmp::Eq for SERVICE_TIMECHANGE_INFO {}
@@ -2700,7 +2658,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TRIGGER {
 }
 impl ::core::cmp::PartialEq for SERVICE_TRIGGER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TRIGGER>()) == 0 }
+        self.dwTriggerType == other.dwTriggerType && self.dwAction == other.dwAction && self.pTriggerSubtype == other.pTriggerSubtype && self.cDataItems == other.cDataItems && self.pDataItems == other.pDataItems
     }
 }
 impl ::core::cmp::Eq for SERVICE_TRIGGER {}
@@ -2730,7 +2688,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TRIGGER_CUSTOM_STATE_ID {
 }
 impl ::core::cmp::PartialEq for SERVICE_TRIGGER_CUSTOM_STATE_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TRIGGER_CUSTOM_STATE_ID>()) == 0 }
+        self.Data == other.Data
     }
 }
 impl ::core::cmp::Eq for SERVICE_TRIGGER_CUSTOM_STATE_ID {}
@@ -2762,7 +2720,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TRIGGER_INFO {
 }
 impl ::core::cmp::PartialEq for SERVICE_TRIGGER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TRIGGER_INFO>()) == 0 }
+        self.cTriggers == other.cTriggers && self.pTriggers == other.pTriggers && self.pReserved == other.pReserved
     }
 }
 impl ::core::cmp::Eq for SERVICE_TRIGGER_INFO {}
@@ -2794,7 +2752,7 @@ unsafe impl ::windows::core::Abi for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
 }
 impl ::core::cmp::PartialEq for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVICE_TRIGGER_SPECIFIC_DATA_ITEM>()) == 0 }
+        self.dwDataType == other.dwDataType && self.cbData == other.cbData && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {}

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
@@ -838,12 +838,6 @@ impl ::core::clone::Clone for APPLICATION_EVENT_DATA {
 unsafe impl ::windows::core::Abi for APPLICATION_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for APPLICATION_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLICATION_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for APPLICATION_EVENT_DATA {}
 impl ::core::default::Default for APPLICATION_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -866,12 +860,6 @@ impl ::core::clone::Clone for CONTENT_MISSING_EVENT_DATA {
 unsafe impl ::windows::core::Abi for CONTENT_MISSING_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CONTENT_MISSING_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONTENT_MISSING_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CONTENT_MISSING_EVENT_DATA {}
 impl ::core::default::Default for CONTENT_MISSING_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -892,12 +880,6 @@ impl ::core::clone::Clone for DEVICE_USER_CHANGE_EVENT_DATA {
 unsafe impl ::windows::core::Abi for DEVICE_USER_CHANGE_EVENT_DATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DEVICE_USER_CHANGE_EVENT_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_USER_CHANGE_EVENT_DATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DEVICE_USER_CHANGE_EVENT_DATA {}
 impl ::core::default::Default for DEVICE_USER_CHANGE_EVENT_DATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -920,12 +902,6 @@ impl ::core::clone::Clone for EVENT_DATA_HEADER {
 unsafe impl ::windows::core::Abi for EVENT_DATA_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EVENT_DATA_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENT_DATA_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EVENT_DATA_HEADER {}
 impl ::core::default::Default for EVENT_DATA_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -946,12 +922,6 @@ impl ::core::clone::Clone for NEW_EVENT_DATA_AVAILABLE {
 unsafe impl ::windows::core::Abi for NEW_EVENT_DATA_AVAILABLE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NEW_EVENT_DATA_AVAILABLE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEW_EVENT_DATA_AVAILABLE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NEW_EVENT_DATA_AVAILABLE {}
 impl ::core::default::Default for NEW_EVENT_DATA_AVAILABLE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -982,7 +952,7 @@ unsafe impl ::windows::core::Abi for SCF_CONTEXTMENU_EVENT {
 }
 impl ::core::cmp::PartialEq for SCF_CONTEXTMENU_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCF_CONTEXTMENU_EVENT>()) == 0 }
+        self.PreviousPage == other.PreviousPage && self.TargetPage == other.TargetPage && self.PreviousItemId == other.PreviousItemId && self.MenuPage == other.MenuPage && self.MenuItemId == other.MenuItemId
     }
 }
 impl ::core::cmp::Eq for SCF_CONTEXTMENU_EVENT {}
@@ -1013,7 +983,7 @@ unsafe impl ::windows::core::Abi for SCF_EVENT_HEADER {
 }
 impl ::core::cmp::PartialEq for SCF_EVENT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCF_EVENT_HEADER>()) == 0 }
+        self.PreviousPage == other.PreviousPage && self.TargetPage == other.TargetPage
     }
 }
 impl ::core::cmp::Eq for SCF_EVENT_HEADER {}
@@ -1046,7 +1016,7 @@ unsafe impl ::windows::core::Abi for SCF_MENUACTION_EVENT {
 }
 impl ::core::cmp::PartialEq for SCF_MENUACTION_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCF_MENUACTION_EVENT>()) == 0 }
+        self.PreviousPage == other.PreviousPage && self.TargetPage == other.TargetPage && self.Button == other.Button && self.ItemId == other.ItemId
     }
 }
 impl ::core::cmp::Eq for SCF_MENUACTION_EVENT {}
@@ -1078,7 +1048,7 @@ unsafe impl ::windows::core::Abi for SCF_NAVIGATION_EVENT {
 }
 impl ::core::cmp::PartialEq for SCF_NAVIGATION_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCF_NAVIGATION_EVENT>()) == 0 }
+        self.PreviousPage == other.PreviousPage && self.TargetPage == other.TargetPage && self.Button == other.Button
     }
 }
 impl ::core::cmp::Eq for SCF_NAVIGATION_EVENT {}

--- a/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
@@ -548,7 +548,7 @@ unsafe impl ::windows::core::Abi for BSMINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BSMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BSMINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hdesk == other.hdesk && self.hwnd == other.hwnd && self.luid == other.luid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -652,7 +652,7 @@ unsafe impl ::windows::core::Abi for USEROBJECTFLAGS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for USEROBJECTFLAGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USEROBJECTFLAGS>()) == 0 }
+        self.fInherit == other.fInherit && self.fReserved == other.fReserved && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -1578,7 +1578,7 @@ unsafe impl ::windows::core::Abi for CACHE_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for CACHE_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACHE_DESCRIPTOR>()) == 0 }
+        self.Level == other.Level && self.Associativity == other.Associativity && self.LineSize == other.LineSize && self.Size == other.Size && self.Type == other.Type
     }
 }
 impl ::core::cmp::Eq for CACHE_DESCRIPTOR {}
@@ -1608,12 +1608,6 @@ impl ::core::clone::Clone for CACHE_RELATIONSHIP {
 unsafe impl ::windows::core::Abi for CACHE_RELATIONSHIP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CACHE_RELATIONSHIP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACHE_RELATIONSHIP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CACHE_RELATIONSHIP {}
 impl ::core::default::Default for CACHE_RELATIONSHIP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1634,12 +1628,6 @@ impl ::core::clone::Clone for CACHE_RELATIONSHIP_0 {
 unsafe impl ::windows::core::Abi for CACHE_RELATIONSHIP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CACHE_RELATIONSHIP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CACHE_RELATIONSHIP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CACHE_RELATIONSHIP_0 {}
 impl ::core::default::Default for CACHE_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1695,7 +1683,7 @@ unsafe impl ::windows::core::Abi for GROUP_AFFINITY {
 }
 impl ::core::cmp::PartialEq for GROUP_AFFINITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_AFFINITY>()) == 0 }
+        self.Mask == other.Mask && self.Group == other.Group && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for GROUP_AFFINITY {}
@@ -1728,7 +1716,7 @@ unsafe impl ::windows::core::Abi for GROUP_RELATIONSHIP {
 }
 impl ::core::cmp::PartialEq for GROUP_RELATIONSHIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUP_RELATIONSHIP>()) == 0 }
+        self.MaximumGroupCount == other.MaximumGroupCount && self.ActiveGroupCount == other.ActiveGroupCount && self.Reserved == other.Reserved && self.GroupInfo == other.GroupInfo
     }
 }
 impl ::core::cmp::Eq for GROUP_RELATIONSHIP {}
@@ -1765,7 +1753,7 @@ unsafe impl ::windows::core::Abi for MEMORYSTATUS {
 }
 impl ::core::cmp::PartialEq for MEMORYSTATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORYSTATUS>()) == 0 }
+        self.dwLength == other.dwLength && self.dwMemoryLoad == other.dwMemoryLoad && self.dwTotalPhys == other.dwTotalPhys && self.dwAvailPhys == other.dwAvailPhys && self.dwTotalPageFile == other.dwTotalPageFile && self.dwAvailPageFile == other.dwAvailPageFile && self.dwTotalVirtual == other.dwTotalVirtual && self.dwAvailVirtual == other.dwAvailVirtual
     }
 }
 impl ::core::cmp::Eq for MEMORYSTATUS {}
@@ -1803,7 +1791,7 @@ unsafe impl ::windows::core::Abi for MEMORYSTATUSEX {
 }
 impl ::core::cmp::PartialEq for MEMORYSTATUSEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORYSTATUSEX>()) == 0 }
+        self.dwLength == other.dwLength && self.dwMemoryLoad == other.dwMemoryLoad && self.ullTotalPhys == other.ullTotalPhys && self.ullAvailPhys == other.ullAvailPhys && self.ullTotalPageFile == other.ullTotalPageFile && self.ullAvailPageFile == other.ullAvailPageFile && self.ullTotalVirtual == other.ullTotalVirtual && self.ullAvailVirtual == other.ullAvailVirtual && self.ullAvailExtendedVirtual == other.ullAvailExtendedVirtual
     }
 }
 impl ::core::cmp::Eq for MEMORYSTATUSEX {}
@@ -1829,12 +1817,6 @@ impl ::core::clone::Clone for NUMA_NODE_RELATIONSHIP {
 unsafe impl ::windows::core::Abi for NUMA_NODE_RELATIONSHIP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NUMA_NODE_RELATIONSHIP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NUMA_NODE_RELATIONSHIP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NUMA_NODE_RELATIONSHIP {}
 impl ::core::default::Default for NUMA_NODE_RELATIONSHIP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1855,12 +1837,6 @@ impl ::core::clone::Clone for NUMA_NODE_RELATIONSHIP_0 {
 unsafe impl ::windows::core::Abi for NUMA_NODE_RELATIONSHIP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NUMA_NODE_RELATIONSHIP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NUMA_NODE_RELATIONSHIP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NUMA_NODE_RELATIONSHIP_0 {}
 impl ::core::default::Default for NUMA_NODE_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1898,7 +1874,7 @@ unsafe impl ::windows::core::Abi for OSVERSIONINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OSVERSIONINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OSVERSIONINFOA>()) == 0 }
+        self.dwOSVersionInfoSize == other.dwOSVersionInfoSize && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.dwBuildNumber == other.dwBuildNumber && self.dwPlatformId == other.dwPlatformId && self.szCSDVersion == other.szCSDVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1958,7 +1934,7 @@ unsafe impl ::windows::core::Abi for OSVERSIONINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OSVERSIONINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OSVERSIONINFOEXA>()) == 0 }
+        self.dwOSVersionInfoSize == other.dwOSVersionInfoSize && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.dwBuildNumber == other.dwBuildNumber && self.dwPlatformId == other.dwPlatformId && self.szCSDVersion == other.szCSDVersion && self.wServicePackMajor == other.wServicePackMajor && self.wServicePackMinor == other.wServicePackMinor && self.wSuiteMask == other.wSuiteMask && self.wProductType == other.wProductType && self.wReserved == other.wReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2012,7 +1988,7 @@ unsafe impl ::windows::core::Abi for OSVERSIONINFOEXW {
 }
 impl ::core::cmp::PartialEq for OSVERSIONINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OSVERSIONINFOEXW>()) == 0 }
+        self.dwOSVersionInfoSize == other.dwOSVersionInfoSize && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.dwBuildNumber == other.dwBuildNumber && self.dwPlatformId == other.dwPlatformId && self.szCSDVersion == other.szCSDVersion && self.wServicePackMajor == other.wServicePackMajor && self.wServicePackMinor == other.wServicePackMinor && self.wSuiteMask == other.wSuiteMask && self.wProductType == other.wProductType && self.wReserved == other.wReserved
     }
 }
 impl ::core::cmp::Eq for OSVERSIONINFOEXW {}
@@ -2047,7 +2023,7 @@ unsafe impl ::windows::core::Abi for OSVERSIONINFOW {
 }
 impl ::core::cmp::PartialEq for OSVERSIONINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OSVERSIONINFOW>()) == 0 }
+        self.dwOSVersionInfoSize == other.dwOSVersionInfoSize && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.dwBuildNumber == other.dwBuildNumber && self.dwPlatformId == other.dwPlatformId && self.szCSDVersion == other.szCSDVersion
     }
 }
 impl ::core::cmp::Eq for OSVERSIONINFOW {}
@@ -2080,7 +2056,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_GROUP_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_GROUP_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_GROUP_INFO>()) == 0 }
+        self.MaximumProcessorCount == other.MaximumProcessorCount && self.ActiveProcessorCount == other.ActiveProcessorCount && self.Reserved == other.Reserved && self.ActiveProcessorMask == other.ActiveProcessorMask
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_GROUP_INFO {}
@@ -2114,7 +2090,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_RELATIONSHIP {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_RELATIONSHIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_RELATIONSHIP>()) == 0 }
+        self.Flags == other.Flags && self.EfficiencyClass == other.EfficiencyClass && self.Reserved == other.Reserved && self.GroupCount == other.GroupCount && self.GroupMask == other.GroupMask
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_RELATIONSHIP {}
@@ -2139,12 +2115,6 @@ impl ::core::clone::Clone for SYSTEM_CPU_SET_INFORMATION {
 unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION {}
 impl ::core::default::Default for SYSTEM_CPU_SET_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2164,12 +2134,6 @@ impl ::core::clone::Clone for SYSTEM_CPU_SET_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION_0 {}
 impl ::core::default::Default for SYSTEM_CPU_SET_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2198,12 +2162,6 @@ impl ::core::clone::Clone for SYSTEM_CPU_SET_INFORMATION_0_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION_0_0 {}
 impl ::core::default::Default for SYSTEM_CPU_SET_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2224,12 +2182,6 @@ impl ::core::clone::Clone for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION_0_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION_0_0_0 {}
 impl ::core::default::Default for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2256,7 +2208,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {
 }
 impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION_0_0_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {}
@@ -2280,12 +2232,6 @@ impl ::core::clone::Clone for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
 unsafe impl ::windows::core::Abi for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CPU_SET_INFORMATION_0_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_CPU_SET_INFORMATION_0_0_1 {}
 impl ::core::default::Default for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2319,14 +2265,6 @@ unsafe impl ::windows::core::Abi for SYSTEM_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SYSTEM_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SYSTEM_INFO {}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SYSTEM_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2351,14 +2289,6 @@ impl ::core::clone::Clone for SYSTEM_INFO_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::PartialEq for SYSTEM_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl ::core::cmp::Eq for SYSTEM_INFO_0 {}
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::default::Default for SYSTEM_INFO_0 {
     fn default() -> Self {
@@ -2393,7 +2323,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_INFO_0_0 {
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 impl ::core::cmp::PartialEq for SYSTEM_INFO_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_INFO_0_0>()) == 0 }
+        self.wProcessorArchitecture == other.wProcessorArchitecture && self.wReserved == other.wReserved
     }
 }
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -2420,12 +2350,6 @@ impl ::core::clone::Clone for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
 unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {}
 impl ::core::default::Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2448,12 +2372,6 @@ impl ::core::clone::Clone for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {}
 impl ::core::default::Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2480,7 +2398,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
 }
 impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0>()) == 0 }
+        self.NodeNumber == other.NodeNumber
     }
 }
 impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {}
@@ -2510,7 +2428,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
 }
 impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {}
@@ -2535,12 +2453,6 @@ impl ::core::clone::Clone for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
 unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {}
 impl ::core::default::Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2563,12 +2475,6 @@ impl ::core::clone::Clone for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
 unsafe impl ::windows::core::Abi for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {}
 impl ::core::default::Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -2601,7 +2507,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_POOL_ZEROING_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_POOL_ZEROING_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POOL_ZEROING_INFORMATION>()) == 0 }
+        self.PoolZeroingSupportPresent == other.PoolZeroingSupportPresent
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2633,7 +2539,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION>()) == 0 }
+        self.CycleTime == other.CycleTime
     }
 }
 impl ::core::cmp::Eq for SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION {}
@@ -2663,7 +2569,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_IN
 }
 impl ::core::cmp::PartialEq for SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION {}

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -8686,7 +8686,7 @@ unsafe impl ::windows::core::Abi for ANON_OBJECT_HEADER {
 }
 impl ::core::cmp::PartialEq for ANON_OBJECT_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ANON_OBJECT_HEADER>()) == 0 }
+        self.Sig1 == other.Sig1 && self.Sig2 == other.Sig2 && self.Version == other.Version && self.Machine == other.Machine && self.TimeDateStamp == other.TimeDateStamp && self.ClassID == other.ClassID && self.SizeOfData == other.SizeOfData
     }
 }
 impl ::core::cmp::Eq for ANON_OBJECT_HEADER {}
@@ -8742,7 +8742,7 @@ unsafe impl ::windows::core::Abi for ANON_OBJECT_HEADER_BIGOBJ {
 }
 impl ::core::cmp::PartialEq for ANON_OBJECT_HEADER_BIGOBJ {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ANON_OBJECT_HEADER_BIGOBJ>()) == 0 }
+        self.Sig1 == other.Sig1 && self.Sig2 == other.Sig2 && self.Version == other.Version && self.Machine == other.Machine && self.TimeDateStamp == other.TimeDateStamp && self.ClassID == other.ClassID && self.SizeOfData == other.SizeOfData && self.Flags == other.Flags && self.MetaDataSize == other.MetaDataSize && self.MetaDataOffset == other.MetaDataOffset && self.NumberOfSections == other.NumberOfSections && self.PointerToSymbolTable == other.PointerToSymbolTable && self.NumberOfSymbols == other.NumberOfSymbols
     }
 }
 impl ::core::cmp::Eq for ANON_OBJECT_HEADER_BIGOBJ {}
@@ -8781,7 +8781,7 @@ unsafe impl ::windows::core::Abi for ANON_OBJECT_HEADER_V2 {
 }
 impl ::core::cmp::PartialEq for ANON_OBJECT_HEADER_V2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ANON_OBJECT_HEADER_V2>()) == 0 }
+        self.Sig1 == other.Sig1 && self.Sig2 == other.Sig2 && self.Version == other.Version && self.Machine == other.Machine && self.TimeDateStamp == other.TimeDateStamp && self.ClassID == other.ClassID && self.SizeOfData == other.SizeOfData && self.Flags == other.Flags && self.MetaDataSize == other.MetaDataSize && self.MetaDataOffset == other.MetaDataOffset
     }
 }
 impl ::core::cmp::Eq for ANON_OBJECT_HEADER_V2 {}
@@ -8813,7 +8813,7 @@ unsafe impl ::windows::core::Abi for APPLICATIONLAUNCH_SETTING_VALUE {
 }
 impl ::core::cmp::PartialEq for APPLICATIONLAUNCH_SETTING_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLICATIONLAUNCH_SETTING_VALUE>()) == 0 }
+        self.ActivationTime == other.ActivationTime && self.Flags == other.Flags && self.ButtonInstanceID == other.ButtonInstanceID
     }
 }
 impl ::core::cmp::Eq for APPLICATIONLAUNCH_SETTING_VALUE {}
@@ -8845,7 +8845,7 @@ unsafe impl ::windows::core::Abi for COMPONENT_FILTER {
 }
 impl ::core::cmp::PartialEq for COMPONENT_FILTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPONENT_FILTER>()) == 0 }
+        self.ComponentFlags == other.ComponentFlags
     }
 }
 impl ::core::cmp::Eq for COMPONENT_FILTER {}
@@ -8877,7 +8877,7 @@ unsafe impl ::windows::core::Abi for DEVICE_EVENT_BECOMING_READY {
 }
 impl ::core::cmp::PartialEq for DEVICE_EVENT_BECOMING_READY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_EVENT_BECOMING_READY>()) == 0 }
+        self.Version == other.Version && self.Reason == other.Reason && self.Estimated100msToReady == other.Estimated100msToReady
     }
 }
 impl ::core::cmp::Eq for DEVICE_EVENT_BECOMING_READY {}
@@ -8911,7 +8911,7 @@ unsafe impl ::windows::core::Abi for DEVICE_EVENT_EXTERNAL_REQUEST {
 }
 impl ::core::cmp::PartialEq for DEVICE_EVENT_EXTERNAL_REQUEST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_EVENT_EXTERNAL_REQUEST>()) == 0 }
+        self.Version == other.Version && self.DeviceClass == other.DeviceClass && self.ButtonStatus == other.ButtonStatus && self.Request == other.Request && self.SystemTime == other.SystemTime
     }
 }
 impl ::core::cmp::Eq for DEVICE_EVENT_EXTERNAL_REQUEST {}
@@ -8941,7 +8941,7 @@ unsafe impl ::windows::core::Abi for DEVICE_EVENT_GENERIC_DATA {
 }
 impl ::core::cmp::PartialEq for DEVICE_EVENT_GENERIC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_EVENT_GENERIC_DATA>()) == 0 }
+        self.EventNumber == other.EventNumber
     }
 }
 impl ::core::cmp::Eq for DEVICE_EVENT_GENERIC_DATA {}
@@ -8974,7 +8974,7 @@ unsafe impl ::windows::core::Abi for DEVICE_EVENT_MOUNT {
 }
 impl ::core::cmp::PartialEq for DEVICE_EVENT_MOUNT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_EVENT_MOUNT>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags && self.FileSystemNameLength == other.FileSystemNameLength && self.FileSystemNameOffset == other.FileSystemNameOffset
     }
 }
 impl ::core::cmp::Eq for DEVICE_EVENT_MOUNT {}
@@ -9009,7 +9009,7 @@ unsafe impl ::windows::core::Abi for DEVICE_EVENT_RBC_DATA {
 }
 impl ::core::cmp::PartialEq for DEVICE_EVENT_RBC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVICE_EVENT_RBC_DATA>()) == 0 }
+        self.EventNumber == other.EventNumber && self.SenseQualifier == other.SenseQualifier && self.SenseCode == other.SenseCode && self.SenseKey == other.SenseKey && self.Reserved == other.Reserved && self.Information == other.Information
     }
 }
 impl ::core::cmp::Eq for DEVICE_EVENT_RBC_DATA {}
@@ -9049,7 +9049,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_DEVICEINTERFACE_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEV_BROADCAST_DEVICEINTERFACE_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_DEVICEINTERFACE_A>()) == 0 }
+        self.dbcc_size == other.dbcc_size && self.dbcc_devicetype == other.dbcc_devicetype && self.dbcc_reserved == other.dbcc_reserved && self.dbcc_classguid == other.dbcc_classguid && self.dbcc_name == other.dbcc_name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9085,7 +9085,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_DEVICEINTERFACE_W {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_DEVICEINTERFACE_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_DEVICEINTERFACE_W>()) == 0 }
+        self.dbcc_size == other.dbcc_size && self.dbcc_devicetype == other.dbcc_devicetype && self.dbcc_reserved == other.dbcc_reserved && self.dbcc_classguid == other.dbcc_classguid && self.dbcc_name == other.dbcc_name
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_DEVICEINTERFACE_W {}
@@ -9118,7 +9118,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_DEVNODE {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_DEVNODE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_DEVNODE>()) == 0 }
+        self.dbcd_size == other.dbcd_size && self.dbcd_devicetype == other.dbcd_devicetype && self.dbcd_reserved == other.dbcd_reserved && self.dbcd_devnode == other.dbcd_devnode
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_DEVNODE {}
@@ -9161,7 +9161,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_HANDLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEV_BROADCAST_HANDLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_HANDLE>()) == 0 }
+        self.dbch_size == other.dbch_size && self.dbch_devicetype == other.dbch_devicetype && self.dbch_reserved == other.dbch_reserved && self.dbch_handle == other.dbch_handle && self.dbch_hdevnotify == other.dbch_hdevnotify && self.dbch_eventguid == other.dbch_eventguid && self.dbch_nameoffset == other.dbch_nameoffset && self.dbch_data == other.dbch_data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9200,7 +9200,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_HANDLE32 {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_HANDLE32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_HANDLE32>()) == 0 }
+        self.dbch_size == other.dbch_size && self.dbch_devicetype == other.dbch_devicetype && self.dbch_reserved == other.dbch_reserved && self.dbch_handle == other.dbch_handle && self.dbch_hdevnotify == other.dbch_hdevnotify && self.dbch_eventguid == other.dbch_eventguid && self.dbch_nameoffset == other.dbch_nameoffset && self.dbch_data == other.dbch_data
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_HANDLE32 {}
@@ -9237,7 +9237,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_HANDLE64 {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_HANDLE64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_HANDLE64>()) == 0 }
+        self.dbch_size == other.dbch_size && self.dbch_devicetype == other.dbch_devicetype && self.dbch_reserved == other.dbch_reserved && self.dbch_handle == other.dbch_handle && self.dbch_hdevnotify == other.dbch_hdevnotify && self.dbch_eventguid == other.dbch_eventguid && self.dbch_nameoffset == other.dbch_nameoffset && self.dbch_data == other.dbch_data
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_HANDLE64 {}
@@ -9269,7 +9269,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_HDR {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_HDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_HDR>()) == 0 }
+        self.dbch_size == other.dbch_size && self.dbch_devicetype == other.dbch_devicetype && self.dbch_reserved == other.dbch_reserved
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_HDR {}
@@ -9303,7 +9303,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_NET {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_NET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_NET>()) == 0 }
+        self.dbcn_size == other.dbcn_size && self.dbcn_devicetype == other.dbcn_devicetype && self.dbcn_reserved == other.dbcn_reserved && self.dbcn_resource == other.dbcn_resource && self.dbcn_flags == other.dbcn_flags
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_NET {}
@@ -9337,7 +9337,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_OEM {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_OEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_OEM>()) == 0 }
+        self.dbco_size == other.dbco_size && self.dbco_devicetype == other.dbco_devicetype && self.dbco_reserved == other.dbco_reserved && self.dbco_identifier == other.dbco_identifier && self.dbco_suppfunc == other.dbco_suppfunc
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_OEM {}
@@ -9376,7 +9376,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_PORT_A {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEV_BROADCAST_PORT_A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_PORT_A>()) == 0 }
+        self.dbcp_size == other.dbcp_size && self.dbcp_devicetype == other.dbcp_devicetype && self.dbcp_reserved == other.dbcp_reserved && self.dbcp_name == other.dbcp_name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9411,7 +9411,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_PORT_W {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_PORT_W {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_PORT_W>()) == 0 }
+        self.dbcp_size == other.dbcp_size && self.dbcp_devicetype == other.dbcp_devicetype && self.dbcp_reserved == other.dbcp_reserved && self.dbcp_name == other.dbcp_name
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_PORT_W {}
@@ -9445,7 +9445,7 @@ unsafe impl ::windows::core::Abi for DEV_BROADCAST_VOLUME {
 }
 impl ::core::cmp::PartialEq for DEV_BROADCAST_VOLUME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEV_BROADCAST_VOLUME>()) == 0 }
+        self.dbcv_size == other.dbcv_size && self.dbcv_devicetype == other.dbcv_devicetype && self.dbcv_reserved == other.dbcv_reserved && self.dbcv_unitmask == other.dbcv_unitmask && self.dbcv_flags == other.dbcv_flags
     }
 }
 impl ::core::cmp::Eq for DEV_BROADCAST_VOLUME {}
@@ -9475,7 +9475,7 @@ unsafe impl ::windows::core::Abi for DISK_HEALTH_NOTIFICATION_DATA {
 }
 impl ::core::cmp::PartialEq for DISK_HEALTH_NOTIFICATION_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISK_HEALTH_NOTIFICATION_DATA>()) == 0 }
+        self.DeviceGuid == other.DeviceGuid
     }
 }
 impl ::core::cmp::Eq for DISK_HEALTH_NOTIFICATION_DATA {}
@@ -9499,12 +9499,6 @@ impl ::core::clone::Clone for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
 unsafe impl ::windows::core::Abi for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPATCHER_CONTEXT_NONVOLREG_ARM64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {}
 impl ::core::default::Default for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9532,7 +9526,7 @@ unsafe impl ::windows::core::Abi for DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {
 }
 impl ::core::cmp::PartialEq for DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DISPATCHER_CONTEXT_NONVOLREG_ARM64_0>()) == 0 }
+        self.GpNvRegs == other.GpNvRegs && self.FpNvRegs == other.FpNvRegs
     }
 }
 impl ::core::cmp::Eq for DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {}
@@ -9564,7 +9558,7 @@ unsafe impl ::windows::core::Abi for ENLISTMENT_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ENLISTMENT_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENLISTMENT_BASIC_INFORMATION>()) == 0 }
+        self.EnlistmentId == other.EnlistmentId && self.TransactionId == other.TransactionId && self.ResourceManagerId == other.ResourceManagerId
     }
 }
 impl ::core::cmp::Eq for ENLISTMENT_BASIC_INFORMATION {}
@@ -9596,7 +9590,7 @@ unsafe impl ::windows::core::Abi for ENLISTMENT_CRM_INFORMATION {
 }
 impl ::core::cmp::PartialEq for ENLISTMENT_CRM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENLISTMENT_CRM_INFORMATION>()) == 0 }
+        self.CrmTransactionManagerId == other.CrmTransactionManagerId && self.CrmResourceManagerId == other.CrmResourceManagerId && self.CrmEnlistmentId == other.CrmEnlistmentId
     }
 }
 impl ::core::cmp::Eq for ENLISTMENT_CRM_INFORMATION {}
@@ -9625,14 +9619,6 @@ unsafe impl ::windows::core::Abi for GDI_NONREMOTE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for GDI_NONREMOTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GDI_NONREMOTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for GDI_NONREMOTE {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for GDI_NONREMOTE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9657,14 +9643,6 @@ impl ::core::clone::Clone for GDI_NONREMOTE_0 {
 unsafe impl ::windows::core::Abi for GDI_NONREMOTE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for GDI_NONREMOTE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GDI_NONREMOTE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for GDI_NONREMOTE_0 {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for GDI_NONREMOTE_0 {
     fn default() -> Self {
@@ -9692,7 +9670,7 @@ unsafe impl ::windows::core::Abi for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION>()) == 0 }
+        self.DiskNumber == other.DiskNumber
     }
 }
 impl ::core::cmp::Eq for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {}
@@ -9723,7 +9701,7 @@ unsafe impl ::windows::core::Abi for HEAP_OPTIMIZE_RESOURCES_INFORMATION {
 }
 impl ::core::cmp::PartialEq for HEAP_OPTIMIZE_RESOURCES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HEAP_OPTIMIZE_RESOURCES_INFORMATION>()) == 0 }
+        self.Version == other.Version && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for HEAP_OPTIMIZE_RESOURCES_INFORMATION {}
@@ -9754,7 +9732,7 @@ unsafe impl ::windows::core::Abi for HIBERFILE_BUCKET {
 }
 impl ::core::cmp::PartialEq for HIBERFILE_BUCKET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIBERFILE_BUCKET>()) == 0 }
+        self.MaxPhysicalMemory == other.MaxPhysicalMemory && self.PhysicalMemoryPercent == other.PhysicalMemoryPercent
     }
 }
 impl ::core::cmp::Eq for HIBERFILE_BUCKET {}
@@ -9781,12 +9759,6 @@ impl ::core::clone::Clone for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {}
 impl ::core::default::Default for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9817,7 +9789,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {
 }
 impl ::core::cmp::PartialEq for IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY>()) == 0 }
+        self.BeginAddress == other.BeginAddress && self.EndAddress == other.EndAddress && self.ExceptionHandler == other.ExceptionHandler && self.HandlerData == other.HandlerData && self.PrologEndAddress == other.PrologEndAddress
     }
 }
 impl ::core::cmp::Eq for IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {}
@@ -9848,7 +9820,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARCHITECTURE_ENTRY {
 }
 impl ::core::cmp::PartialEq for IMAGE_ARCHITECTURE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARCHITECTURE_ENTRY>()) == 0 }
+        self.FixupInstRVA == other.FixupInstRVA && self.NewInst == other.NewInst
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARCHITECTURE_ENTRY {}
@@ -9879,7 +9851,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARCHITECTURE_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_ARCHITECTURE_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARCHITECTURE_HEADER>()) == 0 }
+        self._bitfield == other._bitfield && self.FirstEntryRVA == other.FirstEntryRVA
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARCHITECTURE_HEADER {}
@@ -9915,7 +9887,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARCHIVE_MEMBER_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_ARCHIVE_MEMBER_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARCHIVE_MEMBER_HEADER>()) == 0 }
+        self.Name == other.Name && self.Date == other.Date && self.UserID == other.UserID && self.GroupID == other.GroupID && self.Mode == other.Mode && self.Size == other.Size && self.EndHeader == other.EndHeader
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARCHIVE_MEMBER_HEADER {}
@@ -9939,12 +9911,6 @@ impl ::core::clone::Clone for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
 unsafe impl ::windows::core::Abi for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {}
 impl ::core::default::Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9971,7 +9937,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 
 }
 impl ::core::cmp::PartialEq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 {}
@@ -9995,12 +9961,6 @@ impl ::core::clone::Clone for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM_RUNTIME_FUNCTION_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {}
 impl ::core::default::Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10021,12 +9981,6 @@ impl ::core::clone::Clone for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
 unsafe impl ::windows::core::Abi for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {}
 impl ::core::default::Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10053,7 +10007,7 @@ unsafe impl ::windows::core::Abi for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {}
@@ -10080,12 +10034,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10106,12 +10054,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_0 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_0 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10138,7 +10080,7 @@ unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_1 {
 }
 impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_1>()) == 0 }
+        self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_1 {}
@@ -10168,12 +10110,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_2 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_2 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10196,12 +10132,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_3 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10222,12 +10152,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_3_0 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3_0 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10254,7 +10178,7 @@ unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3_0_0>()) == 0 }
+        self.Dimension == other.Dimension
     }
 }
 impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3_0_0 {}
@@ -10278,12 +10202,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_3_0_1 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3_0_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3_0_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3_0_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3_0_1 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_3_0_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10304,12 +10222,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_3_1 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3_1 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_3_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10337,7 +10249,7 @@ unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_3_1_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_3_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_3_1_0>()) == 0 }
+        self.Linenumber == other.Linenumber && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_3_1_0 {}
@@ -10364,12 +10276,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_EX {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10390,12 +10296,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_EX_0 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX_0 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_EX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10416,12 +10316,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_EX_1 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX_1 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_EX_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10448,7 +10342,7 @@ unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX_2 {
 }
 impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX_2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX_2>()) == 0 }
+        self.Name == other.Name
     }
 }
 impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX_2 {}
@@ -10479,12 +10373,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_EX_3 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX_3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX_3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX_3 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_EX_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10506,12 +10394,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_EX_4 {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_EX_4 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_EX_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_EX_4>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_EX_4 {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_EX_4 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10534,12 +10416,6 @@ impl ::core::clone::Clone for IMAGE_AUX_SYMBOL_TOKEN_DEF {
 unsafe impl ::windows::core::Abi for IMAGE_AUX_SYMBOL_TOKEN_DEF {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_AUX_SYMBOL_TOKEN_DEF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_AUX_SYMBOL_TOKEN_DEF>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_AUX_SYMBOL_TOKEN_DEF {}
 impl ::core::default::Default for IMAGE_AUX_SYMBOL_TOKEN_DEF {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10567,7 +10443,7 @@ unsafe impl ::windows::core::Abi for IMAGE_BASE_RELOCATION {
 }
 impl ::core::cmp::PartialEq for IMAGE_BASE_RELOCATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_BASE_RELOCATION>()) == 0 }
+        self.VirtualAddress == other.VirtualAddress && self.SizeOfBlock == other.SizeOfBlock
     }
 }
 impl ::core::cmp::Eq for IMAGE_BASE_RELOCATION {}
@@ -10599,7 +10475,7 @@ unsafe impl ::windows::core::Abi for IMAGE_BOUND_FORWARDER_REF {
 }
 impl ::core::cmp::PartialEq for IMAGE_BOUND_FORWARDER_REF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_BOUND_FORWARDER_REF>()) == 0 }
+        self.TimeDateStamp == other.TimeDateStamp && self.OffsetModuleName == other.OffsetModuleName && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for IMAGE_BOUND_FORWARDER_REF {}
@@ -10631,7 +10507,7 @@ unsafe impl ::windows::core::Abi for IMAGE_BOUND_IMPORT_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for IMAGE_BOUND_IMPORT_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_BOUND_IMPORT_DESCRIPTOR>()) == 0 }
+        self.TimeDateStamp == other.TimeDateStamp && self.OffsetModuleName == other.OffsetModuleName && self.NumberOfModuleForwarderRefs == other.NumberOfModuleForwarderRefs
     }
 }
 impl ::core::cmp::Eq for IMAGE_BOUND_IMPORT_DESCRIPTOR {}
@@ -10662,7 +10538,7 @@ unsafe impl ::windows::core::Abi for IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
 }
 impl ::core::cmp::PartialEq for IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_CE_RUNTIME_FUNCTION_ENTRY>()) == 0 }
+        self.FuncStart == other.FuncStart && self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_CE_RUNTIME_FUNCTION_ENTRY {}
@@ -10702,7 +10578,7 @@ unsafe impl ::windows::core::Abi for IMAGE_DEBUG_MISC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGE_DEBUG_MISC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DEBUG_MISC>()) == 0 }
+        self.DataType == other.DataType && self.Length == other.Length && self.Unicode == other.Unicode && self.Reserved == other.Reserved && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10745,12 +10621,6 @@ impl ::core::clone::Clone for IMAGE_DOS_HEADER {
 unsafe impl ::windows::core::Abi for IMAGE_DOS_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DOS_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DOS_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DOS_HEADER {}
 impl ::core::default::Default for IMAGE_DOS_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10771,12 +10641,6 @@ impl ::core::clone::Clone for IMAGE_DYNAMIC_RELOCATION32 {
 unsafe impl ::windows::core::Abi for IMAGE_DYNAMIC_RELOCATION32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DYNAMIC_RELOCATION32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DYNAMIC_RELOCATION32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DYNAMIC_RELOCATION32 {}
 impl ::core::default::Default for IMAGE_DYNAMIC_RELOCATION32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10800,12 +10664,6 @@ impl ::core::clone::Clone for IMAGE_DYNAMIC_RELOCATION32_V2 {
 unsafe impl ::windows::core::Abi for IMAGE_DYNAMIC_RELOCATION32_V2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DYNAMIC_RELOCATION32_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DYNAMIC_RELOCATION32_V2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DYNAMIC_RELOCATION32_V2 {}
 impl ::core::default::Default for IMAGE_DYNAMIC_RELOCATION32_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10826,12 +10684,6 @@ impl ::core::clone::Clone for IMAGE_DYNAMIC_RELOCATION64 {
 unsafe impl ::windows::core::Abi for IMAGE_DYNAMIC_RELOCATION64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DYNAMIC_RELOCATION64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DYNAMIC_RELOCATION64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DYNAMIC_RELOCATION64 {}
 impl ::core::default::Default for IMAGE_DYNAMIC_RELOCATION64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10855,12 +10707,6 @@ impl ::core::clone::Clone for IMAGE_DYNAMIC_RELOCATION64_V2 {
 unsafe impl ::windows::core::Abi for IMAGE_DYNAMIC_RELOCATION64_V2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DYNAMIC_RELOCATION64_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DYNAMIC_RELOCATION64_V2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DYNAMIC_RELOCATION64_V2 {}
 impl ::core::default::Default for IMAGE_DYNAMIC_RELOCATION64_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10888,7 +10734,7 @@ unsafe impl ::windows::core::Abi for IMAGE_DYNAMIC_RELOCATION_TABLE {
 }
 impl ::core::cmp::PartialEq for IMAGE_DYNAMIC_RELOCATION_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DYNAMIC_RELOCATION_TABLE>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for IMAGE_DYNAMIC_RELOCATION_TABLE {}
@@ -10914,12 +10760,6 @@ impl ::core::clone::Clone for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
 unsafe impl ::windows::core::Abi for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {}
 impl ::core::default::Default for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10968,7 +10808,7 @@ unsafe impl ::windows::core::Abi for IMAGE_EXPORT_DIRECTORY {
 }
 impl ::core::cmp::PartialEq for IMAGE_EXPORT_DIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_EXPORT_DIRECTORY>()) == 0 }
+        self.Characteristics == other.Characteristics && self.TimeDateStamp == other.TimeDateStamp && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.Name == other.Name && self.Base == other.Base && self.NumberOfFunctions == other.NumberOfFunctions && self.NumberOfNames == other.NumberOfNames && self.AddressOfFunctions == other.AddressOfFunctions && self.AddressOfNames == other.AddressOfNames && self.AddressOfNameOrdinals == other.AddressOfNameOrdinals
     }
 }
 impl ::core::cmp::Eq for IMAGE_EXPORT_DIRECTORY {}
@@ -11005,7 +10845,7 @@ unsafe impl ::windows::core::Abi for IMAGE_HOT_PATCH_BASE {
 }
 impl ::core::cmp::PartialEq for IMAGE_HOT_PATCH_BASE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_HOT_PATCH_BASE>()) == 0 }
+        self.SequenceNumber == other.SequenceNumber && self.Flags == other.Flags && self.OriginalTimeDateStamp == other.OriginalTimeDateStamp && self.OriginalCheckSum == other.OriginalCheckSum && self.CodeIntegrityInfo == other.CodeIntegrityInfo && self.CodeIntegritySize == other.CodeIntegritySize && self.PatchTable == other.PatchTable && self.BufferOffset == other.BufferOffset
     }
 }
 impl ::core::cmp::Eq for IMAGE_HOT_PATCH_BASE {}
@@ -11036,7 +10876,7 @@ unsafe impl ::windows::core::Abi for IMAGE_HOT_PATCH_HASHES {
 }
 impl ::core::cmp::PartialEq for IMAGE_HOT_PATCH_HASHES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_HOT_PATCH_HASHES>()) == 0 }
+        self.SHA256 == other.SHA256 && self.SHA1 == other.SHA1
     }
 }
 impl ::core::cmp::Eq for IMAGE_HOT_PATCH_HASHES {}
@@ -11072,7 +10912,7 @@ unsafe impl ::windows::core::Abi for IMAGE_HOT_PATCH_INFO {
 }
 impl ::core::cmp::PartialEq for IMAGE_HOT_PATCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_HOT_PATCH_INFO>()) == 0 }
+        self.Version == other.Version && self.Size == other.Size && self.SequenceNumber == other.SequenceNumber && self.BaseImageList == other.BaseImageList && self.BaseImageCount == other.BaseImageCount && self.BufferOffset == other.BufferOffset && self.ExtraPatchSize == other.ExtraPatchSize
     }
 }
 impl ::core::cmp::Eq for IMAGE_HOT_PATCH_INFO {}
@@ -11109,7 +10949,7 @@ unsafe impl ::windows::core::Abi for IMAGE_IMPORT_BY_NAME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGE_IMPORT_BY_NAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_IMPORT_BY_NAME>()) == 0 }
+        self.Hint == other.Hint && self.Name == other.Name
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11134,12 +10974,6 @@ impl ::core::clone::Clone for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
 unsafe impl ::windows::core::Abi for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {}
 impl ::core::default::Default for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11163,12 +10997,6 @@ impl ::core::clone::Clone for IMAGE_IMPORT_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for IMAGE_IMPORT_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_IMPORT_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_IMPORT_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_IMPORT_DESCRIPTOR {}
 impl ::core::default::Default for IMAGE_IMPORT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11189,12 +11017,6 @@ impl ::core::clone::Clone for IMAGE_IMPORT_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for IMAGE_IMPORT_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_IMPORT_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_IMPORT_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_IMPORT_DESCRIPTOR_0 {}
 impl ::core::default::Default for IMAGE_IMPORT_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11214,12 +11036,6 @@ impl ::core::clone::Clone for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
 unsafe impl ::windows::core::Abi for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {}
 impl ::core::default::Default for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11240,12 +11056,6 @@ impl ::core::clone::Clone for IMAGE_LINENUMBER {
 unsafe impl ::windows::core::Abi for IMAGE_LINENUMBER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_LINENUMBER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_LINENUMBER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_LINENUMBER {}
 impl ::core::default::Default for IMAGE_LINENUMBER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11266,12 +11076,6 @@ impl ::core::clone::Clone for IMAGE_LINENUMBER_0 {
 unsafe impl ::windows::core::Abi for IMAGE_LINENUMBER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_LINENUMBER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_LINENUMBER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_LINENUMBER_0 {}
 impl ::core::default::Default for IMAGE_LINENUMBER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11325,14 +11129,6 @@ unsafe impl ::windows::core::Abi for IMAGE_OS2_HEADER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMAGE_OS2_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_OS2_HEADER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMAGE_OS2_HEADER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMAGE_OS2_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11358,14 +11154,6 @@ impl ::core::clone::Clone for IMAGE_POLICY_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_POLICY_ENTRY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMAGE_POLICY_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_POLICY_ENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMAGE_POLICY_ENTRY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMAGE_POLICY_ENTRY {
     fn default() -> Self {
@@ -11402,14 +11190,6 @@ unsafe impl ::windows::core::Abi for IMAGE_POLICY_ENTRY_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMAGE_POLICY_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_POLICY_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMAGE_POLICY_ENTRY_0 {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMAGE_POLICY_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11437,14 +11217,6 @@ unsafe impl ::windows::core::Abi for IMAGE_POLICY_METADATA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMAGE_POLICY_METADATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_POLICY_METADATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMAGE_POLICY_METADATA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMAGE_POLICY_METADATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11471,7 +11243,7 @@ unsafe impl ::windows::core::Abi for IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER>()) == 0 }
+        self.PrologueByteCount == other.PrologueByteCount
     }
 }
 impl ::core::cmp::Eq for IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER {}
@@ -11496,12 +11268,6 @@ impl ::core::clone::Clone for IMAGE_RELOCATION {
 unsafe impl ::windows::core::Abi for IMAGE_RELOCATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RELOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RELOCATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RELOCATION {}
 impl ::core::default::Default for IMAGE_RELOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11522,12 +11288,6 @@ impl ::core::clone::Clone for IMAGE_RELOCATION_0 {
 unsafe impl ::windows::core::Abi for IMAGE_RELOCATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RELOCATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RELOCATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RELOCATION_0 {}
 impl ::core::default::Default for IMAGE_RELOCATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11557,7 +11317,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DATA_ENTRY {
 }
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DATA_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DATA_ENTRY>()) == 0 }
+        self.OffsetToData == other.OffsetToData && self.Size == other.Size && self.CodePage == other.CodePage && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for IMAGE_RESOURCE_DATA_ENTRY {}
@@ -11592,7 +11352,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY {
 }
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY>()) == 0 }
+        self.Characteristics == other.Characteristics && self.TimeDateStamp == other.TimeDateStamp && self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion && self.NumberOfNamedEntries == other.NumberOfNamedEntries && self.NumberOfIdEntries == other.NumberOfIdEntries
     }
 }
 impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY {}
@@ -11616,12 +11376,6 @@ impl ::core::clone::Clone for IMAGE_RESOURCE_DIRECTORY_ENTRY {
 unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_ENTRY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_ENTRY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY_ENTRY {}
 impl ::core::default::Default for IMAGE_RESOURCE_DIRECTORY_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11643,12 +11397,6 @@ impl ::core::clone::Clone for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
 unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_ENTRY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {}
 impl ::core::default::Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11675,7 +11423,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {}
@@ -11699,12 +11447,6 @@ impl ::core::clone::Clone for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
 unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_ENTRY_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {}
 impl ::core::default::Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11731,7 +11473,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {}
@@ -11768,7 +11510,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIRECTORY_STRING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIRECTORY_STRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIRECTORY_STRING>()) == 0 }
+        self.Length == other.Length && self.NameString == other.NameString
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11801,7 +11543,7 @@ unsafe impl ::windows::core::Abi for IMAGE_RESOURCE_DIR_STRING_U {
 }
 impl ::core::cmp::PartialEq for IMAGE_RESOURCE_DIR_STRING_U {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_RESOURCE_DIR_STRING_U>()) == 0 }
+        self.Length == other.Length && self.NameString == other.NameString
     }
 }
 impl ::core::cmp::Eq for IMAGE_RESOURCE_DIR_STRING_U {}
@@ -11857,7 +11599,7 @@ unsafe impl ::windows::core::Abi for IMAGE_SEPARATE_DEBUG_HEADER {
 }
 impl ::core::cmp::PartialEq for IMAGE_SEPARATE_DEBUG_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SEPARATE_DEBUG_HEADER>()) == 0 }
+        self.Signature == other.Signature && self.Flags == other.Flags && self.Machine == other.Machine && self.Characteristics == other.Characteristics && self.TimeDateStamp == other.TimeDateStamp && self.CheckSum == other.CheckSum && self.ImageBase == other.ImageBase && self.SizeOfImage == other.SizeOfImage && self.NumberOfSections == other.NumberOfSections && self.ExportedNamesSize == other.ExportedNamesSize && self.DebugDirectorySize == other.DebugDirectorySize && self.SectionAlignment == other.SectionAlignment && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for IMAGE_SEPARATE_DEBUG_HEADER {}
@@ -11880,12 +11622,6 @@ impl ::core::clone::Clone for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
 unsafe impl ::windows::core::Abi for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {}
 impl ::core::default::Default for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11910,12 +11646,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL {}
 impl ::core::default::Default for IMAGE_SYMBOL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11937,12 +11667,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL_0 {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL_0 {}
 impl ::core::default::Default for IMAGE_SYMBOL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11963,12 +11687,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL_0_0 {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL_0_0 {}
 impl ::core::default::Default for IMAGE_SYMBOL_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11993,12 +11711,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL_EX {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL_EX {}
 impl ::core::default::Default for IMAGE_SYMBOL_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12020,12 +11732,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL_EX_0 {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL_EX_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL_EX_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL_EX_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL_EX_0 {}
 impl ::core::default::Default for IMAGE_SYMBOL_EX_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12046,12 +11752,6 @@ impl ::core::clone::Clone for IMAGE_SYMBOL_EX_0_0 {
 unsafe impl ::windows::core::Abi for IMAGE_SYMBOL_EX_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_SYMBOL_EX_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_SYMBOL_EX_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_SYMBOL_EX_0_0 {}
 impl ::core::default::Default for IMAGE_SYMBOL_EX_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12076,12 +11776,6 @@ impl ::core::clone::Clone for IMAGE_TLS_DIRECTORY32 {
 unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY32 {}
 impl ::core::default::Default for IMAGE_TLS_DIRECTORY32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12102,12 +11796,6 @@ impl ::core::clone::Clone for IMAGE_TLS_DIRECTORY32_0 {
 unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY32_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY32_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY32_0 {}
 impl ::core::default::Default for IMAGE_TLS_DIRECTORY32_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12134,7 +11822,7 @@ unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY32_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY32_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY32_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY32_0_0 {}
@@ -12162,12 +11850,6 @@ impl ::core::clone::Clone for IMAGE_TLS_DIRECTORY64 {
 unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY64 {}
 impl ::core::default::Default for IMAGE_TLS_DIRECTORY64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12188,12 +11870,6 @@ impl ::core::clone::Clone for IMAGE_TLS_DIRECTORY64_0 {
 unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY64_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY64_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY64_0 {}
 impl ::core::default::Default for IMAGE_TLS_DIRECTORY64_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12220,7 +11896,7 @@ unsafe impl ::windows::core::Abi for IMAGE_TLS_DIRECTORY64_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_TLS_DIRECTORY64_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_TLS_DIRECTORY64_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_TLS_DIRECTORY64_0_0 {}
@@ -12293,12 +11969,6 @@ impl ::core::clone::Clone for IMAGE_VXD_HEADER {
 unsafe impl ::windows::core::Abi for IMAGE_VXD_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_VXD_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_VXD_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_VXD_HEADER {}
 impl ::core::default::Default for IMAGE_VXD_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12325,12 +11995,6 @@ impl ::core::clone::Clone for IMPORT_OBJECT_HEADER {
 unsafe impl ::windows::core::Abi for IMPORT_OBJECT_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMPORT_OBJECT_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMPORT_OBJECT_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMPORT_OBJECT_HEADER {}
 impl ::core::default::Default for IMPORT_OBJECT_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12351,12 +12015,6 @@ impl ::core::clone::Clone for IMPORT_OBJECT_HEADER_0 {
 unsafe impl ::windows::core::Abi for IMPORT_OBJECT_HEADER_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMPORT_OBJECT_HEADER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMPORT_OBJECT_HEADER_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMPORT_OBJECT_HEADER_0 {}
 impl ::core::default::Default for IMPORT_OBJECT_HEADER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12395,7 +12053,7 @@ unsafe impl ::windows::core::Abi for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIV
 #[cfg(feature = "Win32_System_JobObjects")]
 impl ::core::cmp::PartialEq for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V1>()) == 0 }
+        self.MaxIops == other.MaxIops && self.MaxBandwidth == other.MaxBandwidth && self.ReservationIops == other.ReservationIops && self.VolumeName == other.VolumeName && self.BaseIoSize == other.BaseIoSize && self.ControlFlags == other.ControlFlags && self.VolumeNameLength == other.VolumeNameLength
     }
 }
 #[cfg(feature = "Win32_System_JobObjects")]
@@ -12424,12 +12082,6 @@ impl ::core::clone::Clone for KERNEL_CET_CONTEXT {
 unsafe impl ::windows::core::Abi for KERNEL_CET_CONTEXT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KERNEL_CET_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERNEL_CET_CONTEXT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KERNEL_CET_CONTEXT {}
 impl ::core::default::Default for KERNEL_CET_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12450,12 +12102,6 @@ impl ::core::clone::Clone for KERNEL_CET_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for KERNEL_CET_CONTEXT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KERNEL_CET_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERNEL_CET_CONTEXT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for KERNEL_CET_CONTEXT_0 {}
 impl ::core::default::Default for KERNEL_CET_CONTEXT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12482,7 +12128,7 @@ unsafe impl ::windows::core::Abi for KERNEL_CET_CONTEXT_0_0 {
 }
 impl ::core::cmp::PartialEq for KERNEL_CET_CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KERNEL_CET_CONTEXT_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for KERNEL_CET_CONTEXT_0_0 {}
@@ -12514,7 +12160,7 @@ unsafe impl ::windows::core::Abi for KTMOBJECT_CURSOR {
 }
 impl ::core::cmp::PartialEq for KTMOBJECT_CURSOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KTMOBJECT_CURSOR>()) == 0 }
+        self.LastQuery == other.LastQuery && self.ObjectIdCount == other.ObjectIdCount && self.ObjectIds == other.ObjectIds
     }
 }
 impl ::core::cmp::Eq for KTMOBJECT_CURSOR {}
@@ -12544,7 +12190,7 @@ unsafe impl ::windows::core::Abi for MAXVERSIONTESTED_INFO {
 }
 impl ::core::cmp::PartialEq for MAXVERSIONTESTED_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAXVERSIONTESTED_INFO>()) == 0 }
+        self.MaxVersionTested == other.MaxVersionTested
     }
 }
 impl ::core::cmp::Eq for MAXVERSIONTESTED_INFO {}
@@ -12576,7 +12222,7 @@ unsafe impl ::windows::core::Abi for MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE
 }
 impl ::core::cmp::PartialEq for MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE>()) == 0 }
+        self.Type == other.Type && self.Reserved == other.Reserved && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE {}
@@ -12612,7 +12258,7 @@ unsafe impl ::windows::core::Abi for MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATI
 }
 impl ::core::cmp::PartialEq for MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset && self.SizeOfInformation == other.SizeOfInformation && self.Flags == other.Flags && self.AttributesOffset == other.AttributesOffset && self.AttributeCount == other.AttributeCount && self.Reserved == other.Reserved && self.TypeId == other.TypeId
     }
 }
 impl ::core::cmp::Eq for MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATION {}
@@ -12643,7 +12289,7 @@ unsafe impl ::windows::core::Abi for NETWORK_APP_INSTANCE_EA {
 }
 impl ::core::cmp::PartialEq for NETWORK_APP_INSTANCE_EA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NETWORK_APP_INSTANCE_EA>()) == 0 }
+        self.AppInstanceID == other.AppInstanceID && self.CsvFlags == other.CsvFlags
     }
 }
 impl ::core::cmp::Eq for NETWORK_APP_INSTANCE_EA {}
@@ -12674,12 +12320,6 @@ impl ::core::clone::Clone for NON_PAGED_DEBUG_INFO {
 unsafe impl ::windows::core::Abi for NON_PAGED_DEBUG_INFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NON_PAGED_DEBUG_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NON_PAGED_DEBUG_INFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NON_PAGED_DEBUG_INFO {}
 impl ::core::default::Default for NON_PAGED_DEBUG_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12706,7 +12346,7 @@ unsafe impl ::windows::core::Abi for NOTIFY_USER_POWER_SETTING {
 }
 impl ::core::cmp::PartialEq for NOTIFY_USER_POWER_SETTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFY_USER_POWER_SETTING>()) == 0 }
+        self.Guid == other.Guid
     }
 }
 impl ::core::cmp::Eq for NOTIFY_USER_POWER_SETTING {}
@@ -12735,12 +12375,6 @@ impl ::core::clone::Clone for NT_TIB32 {
 unsafe impl ::windows::core::Abi for NT_TIB32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NT_TIB32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NT_TIB32 {}
 impl ::core::default::Default for NT_TIB32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12761,12 +12395,6 @@ impl ::core::clone::Clone for NT_TIB32_0 {
 unsafe impl ::windows::core::Abi for NT_TIB32_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NT_TIB32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB32_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NT_TIB32_0 {}
 impl ::core::default::Default for NT_TIB32_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12792,12 +12420,6 @@ impl ::core::clone::Clone for NT_TIB64 {
 unsafe impl ::windows::core::Abi for NT_TIB64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NT_TIB64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NT_TIB64 {}
 impl ::core::default::Default for NT_TIB64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12818,12 +12440,6 @@ impl ::core::clone::Clone for NT_TIB64_0 {
 unsafe impl ::windows::core::Abi for NT_TIB64_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NT_TIB64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_TIB64_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NT_TIB64_0 {}
 impl ::core::default::Default for NT_TIB64_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12852,7 +12468,7 @@ unsafe impl ::windows::core::Abi for PACKEDEVENTINFO {
 }
 impl ::core::cmp::PartialEq for PACKEDEVENTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKEDEVENTINFO>()) == 0 }
+        self.ulSize == other.ulSize && self.ulNumEventsForLogFile == other.ulNumEventsForLogFile && self.ulOffsets == other.ulOffsets
     }
 }
 impl ::core::cmp::Eq for PACKEDEVENTINFO {}
@@ -12883,7 +12499,7 @@ unsafe impl ::windows::core::Abi for POWER_IDLE_RESILIENCY {
 }
 impl ::core::cmp::PartialEq for POWER_IDLE_RESILIENCY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_IDLE_RESILIENCY>()) == 0 }
+        self.CoalescingTimeout == other.CoalescingTimeout && self.IdleResiliencyPeriod == other.IdleResiliencyPeriod
     }
 }
 impl ::core::cmp::Eq for POWER_IDLE_RESILIENCY {}
@@ -12920,7 +12536,7 @@ unsafe impl ::windows::core::Abi for POWER_MONITOR_INVOCATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_MONITOR_INVOCATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_MONITOR_INVOCATION>()) == 0 }
+        self.Console == other.Console && self.RequestReason == other.RequestReason
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12958,7 +12574,7 @@ unsafe impl ::windows::core::Abi for POWER_PLATFORM_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_PLATFORM_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_PLATFORM_INFORMATION>()) == 0 }
+        self.AoAc == other.AoAc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12996,7 +12612,7 @@ unsafe impl ::windows::core::Abi for POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICES>()) == 0 }
+        self.IsAllowed == other.IsAllowed
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13035,7 +12651,7 @@ unsafe impl ::windows::core::Abi for POWER_SESSION_CONNECT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_SESSION_CONNECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_SESSION_CONNECT>()) == 0 }
+        self.Connected == other.Connected && self.Console == other.Console
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13074,7 +12690,7 @@ unsafe impl ::windows::core::Abi for POWER_SESSION_RIT_STATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_SESSION_RIT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_SESSION_RIT_STATE>()) == 0 }
+        self.Active == other.Active && self.LastInputTime == other.LastInputTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13107,7 +12723,7 @@ unsafe impl ::windows::core::Abi for POWER_SESSION_TIMEOUTS {
 }
 impl ::core::cmp::PartialEq for POWER_SESSION_TIMEOUTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_SESSION_TIMEOUTS>()) == 0 }
+        self.InputTimeout == other.InputTimeout && self.DisplayTimeout == other.DisplayTimeout
     }
 }
 impl ::core::cmp::Eq for POWER_SESSION_TIMEOUTS {}
@@ -13145,7 +12761,7 @@ unsafe impl ::windows::core::Abi for POWER_SESSION_WINLOGON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for POWER_SESSION_WINLOGON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_SESSION_WINLOGON>()) == 0 }
+        self.SessionId == other.SessionId && self.Console == other.Console && self.Locked == other.Locked
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13177,7 +12793,7 @@ unsafe impl ::windows::core::Abi for POWER_USER_PRESENCE {
 }
 impl ::core::cmp::PartialEq for POWER_USER_PRESENCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POWER_USER_PRESENCE>()) == 0 }
+        self.UserPresence == other.UserPresence
     }
 }
 impl ::core::cmp::Eq for POWER_USER_PRESENCE {}
@@ -13209,7 +12825,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLESTATE_EVENT {
 }
 impl ::core::cmp::PartialEq for PPM_IDLESTATE_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLESTATE_EVENT>()) == 0 }
+        self.NewState == other.NewState && self.OldState == other.OldState && self.Processors == other.Processors
     }
 }
 impl ::core::cmp::Eq for PPM_IDLESTATE_EVENT {}
@@ -13243,7 +12859,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLE_ACCOUNTING {
 }
 impl ::core::cmp::PartialEq for PPM_IDLE_ACCOUNTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLE_ACCOUNTING>()) == 0 }
+        self.StateCount == other.StateCount && self.TotalTransitions == other.TotalTransitions && self.ResetCount == other.ResetCount && self.StartTime == other.StartTime && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_IDLE_ACCOUNTING {}
@@ -13278,7 +12894,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLE_ACCOUNTING_EX {
 }
 impl ::core::cmp::PartialEq for PPM_IDLE_ACCOUNTING_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLE_ACCOUNTING_EX>()) == 0 }
+        self.StateCount == other.StateCount && self.TotalTransitions == other.TotalTransitions && self.ResetCount == other.ResetCount && self.AbortCount == other.AbortCount && self.StartTime == other.StartTime && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_IDLE_ACCOUNTING_EX {}
@@ -13312,7 +12928,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLE_STATE_ACCOUNTING {
 }
 impl ::core::cmp::PartialEq for PPM_IDLE_STATE_ACCOUNTING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLE_STATE_ACCOUNTING>()) == 0 }
+        self.IdleTransitions == other.IdleTransitions && self.FailedTransitions == other.FailedTransitions && self.InvalidBucketIndex == other.InvalidBucketIndex && self.TotalTime == other.TotalTime && self.IdleTimeBuckets == other.IdleTimeBuckets
     }
 }
 impl ::core::cmp::Eq for PPM_IDLE_STATE_ACCOUNTING {}
@@ -13349,7 +12965,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLE_STATE_ACCOUNTING_EX {
 }
 impl ::core::cmp::PartialEq for PPM_IDLE_STATE_ACCOUNTING_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLE_STATE_ACCOUNTING_EX>()) == 0 }
+        self.TotalTime == other.TotalTime && self.IdleTransitions == other.IdleTransitions && self.FailedTransitions == other.FailedTransitions && self.InvalidBucketIndex == other.InvalidBucketIndex && self.MinTimeUs == other.MinTimeUs && self.MaxTimeUs == other.MaxTimeUs && self.CancelledTransitions == other.CancelledTransitions && self.IdleTimeBuckets == other.IdleTimeBuckets
     }
 }
 impl ::core::cmp::Eq for PPM_IDLE_STATE_ACCOUNTING_EX {}
@@ -13382,7 +12998,7 @@ unsafe impl ::windows::core::Abi for PPM_IDLE_STATE_BUCKET_EX {
 }
 impl ::core::cmp::PartialEq for PPM_IDLE_STATE_BUCKET_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_IDLE_STATE_BUCKET_EX>()) == 0 }
+        self.TotalTimeUs == other.TotalTimeUs && self.MinTimeUs == other.MinTimeUs && self.MaxTimeUs == other.MaxTimeUs && self.Count == other.Count
     }
 }
 impl ::core::cmp::Eq for PPM_IDLE_STATE_BUCKET_EX {}
@@ -13415,7 +13031,7 @@ unsafe impl ::windows::core::Abi for PPM_PERFSTATE_DOMAIN_EVENT {
 }
 impl ::core::cmp::PartialEq for PPM_PERFSTATE_DOMAIN_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_PERFSTATE_DOMAIN_EVENT>()) == 0 }
+        self.State == other.State && self.Latency == other.Latency && self.Speed == other.Speed && self.Processors == other.Processors
     }
 }
 impl ::core::cmp::Eq for PPM_PERFSTATE_DOMAIN_EVENT {}
@@ -13449,7 +13065,7 @@ unsafe impl ::windows::core::Abi for PPM_PERFSTATE_EVENT {
 }
 impl ::core::cmp::PartialEq for PPM_PERFSTATE_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_PERFSTATE_EVENT>()) == 0 }
+        self.State == other.State && self.Status == other.Status && self.Latency == other.Latency && self.Speed == other.Speed && self.Processor == other.Processor
     }
 }
 impl ::core::cmp::Eq for PPM_PERFSTATE_EVENT {}
@@ -13480,7 +13096,7 @@ unsafe impl ::windows::core::Abi for PPM_THERMALCHANGE_EVENT {
 }
 impl ::core::cmp::PartialEq for PPM_THERMALCHANGE_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_THERMALCHANGE_EVENT>()) == 0 }
+        self.ThermalConstraint == other.ThermalConstraint && self.Processors == other.Processors
     }
 }
 impl ::core::cmp::Eq for PPM_THERMALCHANGE_EVENT {}
@@ -13511,7 +13127,7 @@ unsafe impl ::windows::core::Abi for PPM_THERMAL_POLICY_EVENT {
 }
 impl ::core::cmp::PartialEq for PPM_THERMAL_POLICY_EVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_THERMAL_POLICY_EVENT>()) == 0 }
+        self.Mode == other.Mode && self.Processors == other.Processors
     }
 }
 impl ::core::cmp::Eq for PPM_THERMAL_POLICY_EVENT {}
@@ -13551,7 +13167,7 @@ unsafe impl ::windows::core::Abi for PPM_WMI_IDLE_STATE {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_IDLE_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_IDLE_STATE>()) == 0 }
+        self.Latency == other.Latency && self.Power == other.Power && self.TimeCheck == other.TimeCheck && self.PromotePercent == other.PromotePercent && self.DemotePercent == other.DemotePercent && self.StateType == other.StateType && self.Reserved == other.Reserved && self.StateFlags == other.StateFlags && self.Context == other.Context && self.IdleHandler == other.IdleHandler && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_IDLE_STATE {}
@@ -13586,7 +13202,7 @@ unsafe impl ::windows::core::Abi for PPM_WMI_IDLE_STATES {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_IDLE_STATES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_IDLE_STATES>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.TargetState == other.TargetState && self.OldState == other.OldState && self.TargetProcessors == other.TargetProcessors && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_IDLE_STATES {}
@@ -13621,7 +13237,7 @@ unsafe impl ::windows::core::Abi for PPM_WMI_IDLE_STATES_EX {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_IDLE_STATES_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_IDLE_STATES_EX>()) == 0 }
+        self.Type == other.Type && self.Count == other.Count && self.TargetState == other.TargetState && self.OldState == other.OldState && self.TargetProcessors == other.TargetProcessors && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_IDLE_STATES_EX {}
@@ -13653,7 +13269,7 @@ unsafe impl ::windows::core::Abi for PPM_WMI_LEGACY_PERFSTATE {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_LEGACY_PERFSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_LEGACY_PERFSTATE>()) == 0 }
+        self.Frequency == other.Frequency && self.Flags == other.Flags && self.PercentFrequency == other.PercentFrequency
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_LEGACY_PERFSTATE {}
@@ -13711,7 +13327,7 @@ unsafe impl ::windows::core::Abi for PPM_WMI_PERF_STATE {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_PERF_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_PERF_STATE>()) == 0 }
+        self.Frequency == other.Frequency && self.Power == other.Power && self.PercentFrequency == other.PercentFrequency && self.IncreaseLevel == other.IncreaseLevel && self.DecreaseLevel == other.DecreaseLevel && self.Type == other.Type && self.IncreaseTime == other.IncreaseTime && self.DecreaseTime == other.DecreaseTime && self.Control == other.Control && self.Status == other.Status && self.HitCount == other.HitCount && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_PERF_STATE {}
@@ -13783,7 +13399,27 @@ unsafe impl ::windows::core::Abi for PPM_WMI_PERF_STATES {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_PERF_STATES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_PERF_STATES>()) == 0 }
+        self.Count == other.Count
+            && self.MaxFrequency == other.MaxFrequency
+            && self.CurrentState == other.CurrentState
+            && self.MaxPerfState == other.MaxPerfState
+            && self.MinPerfState == other.MinPerfState
+            && self.LowestPerfState == other.LowestPerfState
+            && self.ThermalConstraint == other.ThermalConstraint
+            && self.BusyAdjThreshold == other.BusyAdjThreshold
+            && self.PolicyType == other.PolicyType
+            && self.Type == other.Type
+            && self.Reserved == other.Reserved
+            && self.TimerInterval == other.TimerInterval
+            && self.TargetProcessors == other.TargetProcessors
+            && self.PStateHandler == other.PStateHandler
+            && self.PStateContext == other.PStateContext
+            && self.TStateHandler == other.TStateHandler
+            && self.TStateContext == other.TStateContext
+            && self.FeedbackHandler == other.FeedbackHandler
+            && self.Reserved1 == other.Reserved1
+            && self.Reserved2 == other.Reserved2
+            && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_PERF_STATES {}
@@ -13855,7 +13491,27 @@ unsafe impl ::windows::core::Abi for PPM_WMI_PERF_STATES_EX {
 }
 impl ::core::cmp::PartialEq for PPM_WMI_PERF_STATES_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PPM_WMI_PERF_STATES_EX>()) == 0 }
+        self.Count == other.Count
+            && self.MaxFrequency == other.MaxFrequency
+            && self.CurrentState == other.CurrentState
+            && self.MaxPerfState == other.MaxPerfState
+            && self.MinPerfState == other.MinPerfState
+            && self.LowestPerfState == other.LowestPerfState
+            && self.ThermalConstraint == other.ThermalConstraint
+            && self.BusyAdjThreshold == other.BusyAdjThreshold
+            && self.PolicyType == other.PolicyType
+            && self.Type == other.Type
+            && self.Reserved == other.Reserved
+            && self.TimerInterval == other.TimerInterval
+            && self.TargetProcessors == other.TargetProcessors
+            && self.PStateHandler == other.PStateHandler
+            && self.PStateContext == other.PStateContext
+            && self.TStateHandler == other.TStateHandler
+            && self.TStateContext == other.TStateContext
+            && self.FeedbackHandler == other.FeedbackHandler
+            && self.Reserved1 == other.Reserved1
+            && self.Reserved2 == other.Reserved2
+            && self.State == other.State
     }
 }
 impl ::core::cmp::Eq for PPM_WMI_PERF_STATES_EX {}
@@ -13888,7 +13544,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_IDLESTATE_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_IDLESTATE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_IDLESTATE_INFO>()) == 0 }
+        self.TimeCheck == other.TimeCheck && self.DemotePercent == other.DemotePercent && self.PromotePercent == other.PromotePercent && self.Spare == other.Spare
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_IDLESTATE_INFO {}
@@ -13914,12 +13570,6 @@ impl ::core::clone::Clone for PROCESSOR_IDLESTATE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESSOR_IDLESTATE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESSOR_IDLESTATE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_IDLESTATE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESSOR_IDLESTATE_POLICY {}
 impl ::core::default::Default for PROCESSOR_IDLESTATE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13940,12 +13590,6 @@ impl ::core::clone::Clone for PROCESSOR_IDLESTATE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESSOR_IDLESTATE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESSOR_IDLESTATE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_IDLESTATE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESSOR_IDLESTATE_POLICY_0 {}
 impl ::core::default::Default for PROCESSOR_IDLESTATE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13972,7 +13616,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_IDLESTATE_POLICY_0_0 {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_IDLESTATE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_IDLESTATE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_IDLESTATE_POLICY_0_0 {}
@@ -14004,12 +13648,6 @@ impl ::core::clone::Clone for PROCESSOR_PERFSTATE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESSOR_PERFSTATE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESSOR_PERFSTATE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_PERFSTATE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESSOR_PERFSTATE_POLICY {}
 impl ::core::default::Default for PROCESSOR_PERFSTATE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14030,12 +13668,6 @@ impl ::core::clone::Clone for PROCESSOR_PERFSTATE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESSOR_PERFSTATE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESSOR_PERFSTATE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_PERFSTATE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESSOR_PERFSTATE_POLICY_0 {}
 impl ::core::default::Default for PROCESSOR_PERFSTATE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14056,12 +13688,6 @@ impl ::core::clone::Clone for PROCESSOR_PERFSTATE_POLICY_0_0 {
 unsafe impl ::windows::core::Abi for PROCESSOR_PERFSTATE_POLICY_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESSOR_PERFSTATE_POLICY_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_PERFSTATE_POLICY_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESSOR_PERFSTATE_POLICY_0_0 {}
 impl ::core::default::Default for PROCESSOR_PERFSTATE_POLICY_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14088,7 +13714,7 @@ unsafe impl ::windows::core::Abi for PROCESSOR_PERFSTATE_POLICY_0_0_0 {
 }
 impl ::core::cmp::PartialEq for PROCESSOR_PERFSTATE_POLICY_0_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESSOR_PERFSTATE_POLICY_0_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESSOR_PERFSTATE_POLICY_0_0_0 {}
@@ -14111,12 +13737,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_ASLR_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_ASLR_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_ASLR_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_ASLR_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_ASLR_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_ASLR_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14137,12 +13757,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_ASLR_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_ASLR_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_ASLR_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_ASLR_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_ASLR_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_ASLR_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14169,7 +13783,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_ASLR_POLICY_0_0 {
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_ASLR_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_ASLR_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_ASLR_POLICY_0_0 {}
@@ -14192,12 +13806,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14218,12 +13826,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14250,7 +13852,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0 {}
@@ -14273,12 +13875,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CHILD_PROCESS_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14299,12 +13895,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14331,7 +13921,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0 {}
@@ -14354,12 +13944,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14380,12 +13964,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14412,7 +13990,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLIC
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0 {}
@@ -14441,14 +14019,6 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DEP_POLICY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DEP_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DEP_POLICY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROCESS_MITIGATION_DEP_POLICY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROCESS_MITIGATION_DEP_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14473,14 +14043,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_DEP_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DEP_POLICY_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DEP_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DEP_POLICY_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROCESS_MITIGATION_DEP_POLICY_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROCESS_MITIGATION_DEP_POLICY_0 {
     fn default() -> Self {
@@ -14514,7 +14076,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DEP_POLICY_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DEP_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DEP_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14539,12 +14101,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DYNAMIC_CODE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14565,12 +14121,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14597,7 +14147,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 {}
@@ -14620,12 +14170,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY 
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14646,12 +14190,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14678,7 +14216,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0 {}
@@ -14701,12 +14239,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_FONT_DISABLE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_FONT_DISABLE_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14727,12 +14259,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_FONT_DISABLE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14759,7 +14285,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 {}
@@ -14782,12 +14308,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_IMAGE_LOAD_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14808,12 +14328,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14840,7 +14354,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {}
@@ -14863,12 +14377,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14889,12 +14397,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14921,7 +14423,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLI
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0 {}
@@ -14944,12 +14446,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14970,12 +14466,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15002,7 +14492,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0 {}
@@ -15025,12 +14515,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15051,12 +14535,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15083,7 +14561,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_P
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0 {}
@@ -15106,12 +14584,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15132,12 +14604,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15164,7 +14630,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLI
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0 {}
@@ -15187,12 +14653,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15213,12 +14673,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15245,7 +14699,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLI
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0 {}
@@ -15268,12 +14722,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15294,12 +14742,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15326,7 +14768,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLIC
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0 {}
@@ -15349,12 +14791,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {}
 impl ::core::default::Default for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15375,12 +14811,6 @@ impl ::core::clone::Clone for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
 unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {}
 impl ::core::default::Default for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15407,7 +14837,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY
 }
 impl ::core::cmp::PartialEq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0 {}
@@ -15441,12 +14871,6 @@ impl ::core::clone::Clone for QUOTA_LIMITS_EX {
 unsafe impl ::windows::core::Abi for QUOTA_LIMITS_EX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QUOTA_LIMITS_EX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QUOTA_LIMITS_EX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for QUOTA_LIMITS_EX {}
 impl ::core::default::Default for QUOTA_LIMITS_EX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15467,12 +14891,6 @@ impl ::core::clone::Clone for RATE_QUOTA_LIMIT {
 unsafe impl ::windows::core::Abi for RATE_QUOTA_LIMIT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RATE_QUOTA_LIMIT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RATE_QUOTA_LIMIT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RATE_QUOTA_LIMIT {}
 impl ::core::default::Default for RATE_QUOTA_LIMIT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15499,7 +14917,7 @@ unsafe impl ::windows::core::Abi for RATE_QUOTA_LIMIT_0 {
 }
 impl ::core::cmp::PartialEq for RATE_QUOTA_LIMIT_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RATE_QUOTA_LIMIT_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for RATE_QUOTA_LIMIT_0 {}
@@ -15539,7 +14957,7 @@ unsafe impl ::windows::core::Abi for REARRANGE_FILE_DATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REARRANGE_FILE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REARRANGE_FILE_DATA>()) == 0 }
+        self.SourceStartingOffset == other.SourceStartingOffset && self.TargetOffset == other.TargetOffset && self.SourceFileHandle == other.SourceFileHandle && self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15581,7 +14999,7 @@ unsafe impl ::windows::core::Abi for REARRANGE_FILE_DATA32 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for REARRANGE_FILE_DATA32 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REARRANGE_FILE_DATA32>()) == 0 }
+        self.SourceStartingOffset == other.SourceStartingOffset && self.TargetOffset == other.TargetOffset && self.SourceFileHandle == other.SourceFileHandle && self.Length == other.Length && self.Flags == other.Flags
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -15616,7 +15034,7 @@ unsafe impl ::windows::core::Abi for REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO {
 }
 impl ::core::cmp::PartialEq for REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO>()) == 0 }
+        self.Version == other.Version && self.Accurate == other.Accurate && self.Supported == other.Supported && self.AccurateMask0 == other.AccurateMask0
     }
 }
 impl ::core::cmp::Eq for REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO {}
@@ -15648,7 +15066,7 @@ unsafe impl ::windows::core::Abi for RESOURCEMANAGER_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for RESOURCEMANAGER_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCEMANAGER_BASIC_INFORMATION>()) == 0 }
+        self.ResourceManagerId == other.ResourceManagerId && self.DescriptionLength == other.DescriptionLength && self.Description == other.Description
     }
 }
 impl ::core::cmp::Eq for RESOURCEMANAGER_BASIC_INFORMATION {}
@@ -15685,7 +15103,7 @@ unsafe impl ::windows::core::Abi for RESOURCEMANAGER_COMPLETION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RESOURCEMANAGER_COMPLETION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESOURCEMANAGER_COMPLETION_INFORMATION>()) == 0 }
+        self.IoCompletionPortHandle == other.IoCompletionPortHandle && self.CompletionKey == other.CompletionKey
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15719,7 +15137,7 @@ unsafe impl ::windows::core::Abi for RESUME_PERFORMANCE {
 }
 impl ::core::cmp::PartialEq for RESUME_PERFORMANCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RESUME_PERFORMANCE>()) == 0 }
+        self.PostTimeMs == other.PostTimeMs && self.TotalResumeTimeMs == other.TotalResumeTimeMs && self.ResumeCompleteTimestamp == other.ResumeCompleteTimestamp
     }
 }
 impl ::core::cmp::Eq for RESUME_PERFORMANCE {}
@@ -15750,7 +15168,7 @@ unsafe impl ::windows::core::Abi for RemHBITMAP {
 }
 impl ::core::cmp::PartialEq for RemHBITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHBITMAP>()) == 0 }
+        self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHBITMAP {}
@@ -15781,7 +15199,7 @@ unsafe impl ::windows::core::Abi for RemHBRUSH {
 }
 impl ::core::cmp::PartialEq for RemHBRUSH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHBRUSH>()) == 0 }
+        self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHBRUSH {}
@@ -15812,7 +15230,7 @@ unsafe impl ::windows::core::Abi for RemHENHMETAFILE {
 }
 impl ::core::cmp::PartialEq for RemHENHMETAFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHENHMETAFILE>()) == 0 }
+        self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHENHMETAFILE {}
@@ -15844,7 +15262,7 @@ unsafe impl ::windows::core::Abi for RemHGLOBAL {
 }
 impl ::core::cmp::PartialEq for RemHGLOBAL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHGLOBAL>()) == 0 }
+        self.fNullHGlobal == other.fNullHGlobal && self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHGLOBAL {}
@@ -15878,7 +15296,7 @@ unsafe impl ::windows::core::Abi for RemHMETAFILEPICT {
 }
 impl ::core::cmp::PartialEq for RemHMETAFILEPICT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHMETAFILEPICT>()) == 0 }
+        self.mm == other.mm && self.xExt == other.xExt && self.yExt == other.yExt && self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHMETAFILEPICT {}
@@ -15909,7 +15327,7 @@ unsafe impl ::windows::core::Abi for RemHPALETTE {
 }
 impl ::core::cmp::PartialEq for RemHPALETTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemHPALETTE>()) == 0 }
+        self.cbData == other.cbData && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for RemHPALETTE {}
@@ -15933,12 +15351,6 @@ impl ::core::clone::Clone for RemotableHandle {
 unsafe impl ::windows::core::Abi for RemotableHandle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemotableHandle {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemotableHandle>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RemotableHandle {}
 impl ::core::default::Default for RemotableHandle {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15959,12 +15371,6 @@ impl ::core::clone::Clone for RemotableHandle_0 {
 unsafe impl ::windows::core::Abi for RemotableHandle_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemotableHandle_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RemotableHandle_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RemotableHandle_0 {}
 impl ::core::default::Default for RemotableHandle_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15992,7 +15398,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_AMD64 {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_AMD64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_AMD64>()) == 0 }
+        self.Count == other.Count && self.ScopeRecord == other.ScopeRecord
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_AMD64 {}
@@ -16025,7 +15431,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_AMD64_0 {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_AMD64_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_AMD64_0>()) == 0 }
+        self.BeginAddress == other.BeginAddress && self.EndAddress == other.EndAddress && self.HandlerAddress == other.HandlerAddress && self.JumpTarget == other.JumpTarget
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_AMD64_0 {}
@@ -16056,7 +15462,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_ARM {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_ARM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_ARM>()) == 0 }
+        self.Count == other.Count && self.ScopeRecord == other.ScopeRecord
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_ARM {}
@@ -16089,7 +15495,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_ARM_0 {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_ARM_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_ARM_0>()) == 0 }
+        self.BeginAddress == other.BeginAddress && self.EndAddress == other.EndAddress && self.HandlerAddress == other.HandlerAddress && self.JumpTarget == other.JumpTarget
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_ARM_0 {}
@@ -16120,7 +15526,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_ARM64 {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_ARM64 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_ARM64>()) == 0 }
+        self.Count == other.Count && self.ScopeRecord == other.ScopeRecord
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_ARM64 {}
@@ -16153,7 +15559,7 @@ unsafe impl ::windows::core::Abi for SCOPE_TABLE_ARM64_0 {
 }
 impl ::core::cmp::PartialEq for SCOPE_TABLE_ARM64_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCOPE_TABLE_ARM64_0>()) == 0 }
+        self.BeginAddress == other.BeginAddress && self.EndAddress == other.EndAddress && self.HandlerAddress == other.HandlerAddress && self.JumpTarget == other.JumpTarget
     }
 }
 impl ::core::cmp::Eq for SCOPE_TABLE_ARM64_0 {}
@@ -16188,7 +15594,7 @@ unsafe impl ::windows::core::Abi for SCRUB_DATA_INPUT {
 }
 impl ::core::cmp::PartialEq for SCRUB_DATA_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRUB_DATA_INPUT>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.MaximumIos == other.MaximumIos && self.ObjectId == other.ObjectId && self.Reserved == other.Reserved && self.ResumeContext == other.ResumeContext
     }
 }
 impl ::core::cmp::Eq for SCRUB_DATA_INPUT {}
@@ -16266,7 +15672,30 @@ unsafe impl ::windows::core::Abi for SCRUB_DATA_OUTPUT {
 }
 impl ::core::cmp::PartialEq for SCRUB_DATA_OUTPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRUB_DATA_OUTPUT>()) == 0 }
+        self.Size == other.Size
+            && self.Flags == other.Flags
+            && self.Status == other.Status
+            && self.ErrorFileOffset == other.ErrorFileOffset
+            && self.ErrorLength == other.ErrorLength
+            && self.NumberOfBytesRepaired == other.NumberOfBytesRepaired
+            && self.NumberOfBytesFailed == other.NumberOfBytesFailed
+            && self.InternalFileReference == other.InternalFileReference
+            && self.ResumeContextLength == other.ResumeContextLength
+            && self.ParityExtentDataOffset == other.ParityExtentDataOffset
+            && self.Reserved == other.Reserved
+            && self.NumberOfMetadataBytesProcessed == other.NumberOfMetadataBytesProcessed
+            && self.NumberOfDataBytesProcessed == other.NumberOfDataBytesProcessed
+            && self.TotalNumberOfMetadataBytesInUse == other.TotalNumberOfMetadataBytesInUse
+            && self.TotalNumberOfDataBytesInUse == other.TotalNumberOfDataBytesInUse
+            && self.DataBytesSkippedDueToNoAllocation == other.DataBytesSkippedDueToNoAllocation
+            && self.DataBytesSkippedDueToInvalidRun == other.DataBytesSkippedDueToInvalidRun
+            && self.DataBytesSkippedDueToIntegrityStream == other.DataBytesSkippedDueToIntegrityStream
+            && self.DataBytesSkippedDueToRegionBeingClean == other.DataBytesSkippedDueToRegionBeingClean
+            && self.DataBytesSkippedDueToLockConflict == other.DataBytesSkippedDueToLockConflict
+            && self.DataBytesSkippedDueToNoScrubDataFlag == other.DataBytesSkippedDueToNoScrubDataFlag
+            && self.DataBytesSkippedDueToNoScrubNonIntegrityStreamFlag == other.DataBytesSkippedDueToNoScrubNonIntegrityStreamFlag
+            && self.DataBytesScrubbed == other.DataBytesScrubbed
+            && self.ResumeContext == other.ResumeContext
     }
 }
 impl ::core::cmp::Eq for SCRUB_DATA_OUTPUT {}
@@ -16297,7 +15726,7 @@ unsafe impl ::windows::core::Abi for SCRUB_PARITY_EXTENT {
 }
 impl ::core::cmp::PartialEq for SCRUB_PARITY_EXTENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRUB_PARITY_EXTENT>()) == 0 }
+        self.Offset == other.Offset && self.Length == other.Length
     }
 }
 impl ::core::cmp::Eq for SCRUB_PARITY_EXTENT {}
@@ -16331,7 +15760,7 @@ unsafe impl ::windows::core::Abi for SCRUB_PARITY_EXTENT_DATA {
 }
 impl ::core::cmp::PartialEq for SCRUB_PARITY_EXTENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCRUB_PARITY_EXTENT_DATA>()) == 0 }
+        self.Size == other.Size && self.Flags == other.Flags && self.NumberOfParityExtents == other.NumberOfParityExtents && self.MaximumNumberOfParityExtents == other.MaximumNumberOfParityExtents && self.ParityExtents == other.ParityExtents
     }
 }
 impl ::core::cmp::Eq for SCRUB_PARITY_EXTENT_DATA {}
@@ -16367,7 +15796,7 @@ unsafe impl ::windows::core::Abi for SECURITY_DESCRIPTOR_RELATIVE {
 }
 impl ::core::cmp::PartialEq for SECURITY_DESCRIPTOR_RELATIVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_DESCRIPTOR_RELATIVE>()) == 0 }
+        self.Revision == other.Revision && self.Sbz1 == other.Sbz1 && self.Control == other.Control && self.Owner == other.Owner && self.Group == other.Group && self.Sacl == other.Sacl && self.Dacl == other.Dacl
     }
 }
 impl ::core::cmp::Eq for SECURITY_DESCRIPTOR_RELATIVE {}
@@ -16398,7 +15827,7 @@ unsafe impl ::windows::core::Abi for SECURITY_OBJECT_AI_PARAMS {
 }
 impl ::core::cmp::PartialEq for SECURITY_OBJECT_AI_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SECURITY_OBJECT_AI_PARAMS>()) == 0 }
+        self.Size == other.Size && self.ConstraintMask == other.ConstraintMask
     }
 }
 impl ::core::cmp::Eq for SECURITY_OBJECT_AI_PARAMS {}
@@ -16439,7 +15868,7 @@ unsafe impl ::windows::core::Abi for SERVERSILO_BASIC_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SERVERSILO_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERVERSILO_BASIC_INFORMATION>()) == 0 }
+        self.ServiceSessionId == other.ServiceSessionId && self.State == other.State && self.ExitStatus == other.ExitStatus && self.IsDownlevelContainer == other.IsDownlevelContainer && self.ApiSetSchema == other.ApiSetSchema && self.HostApiSetSchema == other.HostApiSetSchema
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16470,14 +15899,6 @@ unsafe impl ::windows::core::Abi for SE_TOKEN_USER {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for SE_TOKEN_USER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_TOKEN_USER>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for SE_TOKEN_USER {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for SE_TOKEN_USER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16503,14 +15924,6 @@ unsafe impl ::windows::core::Abi for SE_TOKEN_USER_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for SE_TOKEN_USER_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_TOKEN_USER_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for SE_TOKEN_USER_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for SE_TOKEN_USER_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -16535,14 +15948,6 @@ impl ::core::clone::Clone for SE_TOKEN_USER_1 {
 unsafe impl ::windows::core::Abi for SE_TOKEN_USER_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::PartialEq for SE_TOKEN_USER_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SE_TOKEN_USER_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
-impl ::core::cmp::Eq for SE_TOKEN_USER_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ::core::default::Default for SE_TOKEN_USER_1 {
     fn default() -> Self {
@@ -16571,7 +15976,7 @@ unsafe impl ::windows::core::Abi for SHARED_VIRTUAL_DISK_SUPPORT {
 }
 impl ::core::cmp::PartialEq for SHARED_VIRTUAL_DISK_SUPPORT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARED_VIRTUAL_DISK_SUPPORT>()) == 0 }
+        self.SharedVirtualDiskSupport == other.SharedVirtualDiskSupport && self.HandleState == other.HandleState
     }
 }
 impl ::core::cmp::Eq for SHARED_VIRTUAL_DISK_SUPPORT {}
@@ -16603,7 +16008,7 @@ unsafe impl ::windows::core::Abi for SHUFFLE_FILE_DATA {
 }
 impl ::core::cmp::PartialEq for SHUFFLE_FILE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHUFFLE_FILE_DATA>()) == 0 }
+        self.StartingOffset == other.StartingOffset && self.Length == other.Length && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for SHUFFLE_FILE_DATA {}
@@ -16643,7 +16048,7 @@ unsafe impl ::windows::core::Abi for SILOOBJECT_BASIC_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SILOOBJECT_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SILOOBJECT_BASIC_INFORMATION>()) == 0 }
+        self.SiloId == other.SiloId && self.SiloParentId == other.SiloParentId && self.NumberOfProcesses == other.NumberOfProcesses && self.IsInServerSilo == other.IsInServerSilo && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16676,7 +16081,7 @@ unsafe impl ::windows::core::Abi for SUPPORTED_OS_INFO {
 }
 impl ::core::cmp::PartialEq for SUPPORTED_OS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SUPPORTED_OS_INFO>()) == 0 }
+        self.MajorVersion == other.MajorVersion && self.MinorVersion == other.MinorVersion
     }
 }
 impl ::core::cmp::Eq for SUPPORTED_OS_INFO {}
@@ -16708,7 +16113,7 @@ unsafe impl ::windows::core::Abi for TAPE_CREATE_PARTITION {
 }
 impl ::core::cmp::PartialEq for TAPE_CREATE_PARTITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_CREATE_PARTITION>()) == 0 }
+        self.Method == other.Method && self.Count == other.Count && self.Size == other.Size
     }
 }
 impl ::core::cmp::Eq for TAPE_CREATE_PARTITION {}
@@ -16766,7 +16171,7 @@ unsafe impl ::windows::core::Abi for TAPE_GET_DRIVE_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_GET_DRIVE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_GET_DRIVE_PARAMETERS>()) == 0 }
+        self.ECC == other.ECC && self.Compression == other.Compression && self.DataPadding == other.DataPadding && self.ReportSetmarks == other.ReportSetmarks && self.DefaultBlockSize == other.DefaultBlockSize && self.MaximumBlockSize == other.MaximumBlockSize && self.MinimumBlockSize == other.MinimumBlockSize && self.MaximumPartitionCount == other.MaximumPartitionCount && self.FeaturesLow == other.FeaturesLow && self.FeaturesHigh == other.FeaturesHigh && self.EOTWarningZoneSize == other.EOTWarningZoneSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16808,7 +16213,7 @@ unsafe impl ::windows::core::Abi for TAPE_GET_MEDIA_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_GET_MEDIA_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_GET_MEDIA_PARAMETERS>()) == 0 }
+        self.Capacity == other.Capacity && self.Remaining == other.Remaining && self.BlockSize == other.BlockSize && self.PartitionCount == other.PartitionCount && self.WriteProtected == other.WriteProtected
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16850,7 +16255,7 @@ unsafe impl ::windows::core::Abi for TAPE_SET_DRIVE_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TAPE_SET_DRIVE_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_SET_DRIVE_PARAMETERS>()) == 0 }
+        self.ECC == other.ECC && self.Compression == other.Compression && self.DataPadding == other.DataPadding && self.ReportSetmarks == other.ReportSetmarks && self.EOTWarningZoneSize == other.EOTWarningZoneSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16882,7 +16287,7 @@ unsafe impl ::windows::core::Abi for TAPE_SET_MEDIA_PARAMETERS {
 }
 impl ::core::cmp::PartialEq for TAPE_SET_MEDIA_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_SET_MEDIA_PARAMETERS>()) == 0 }
+        self.BlockSize == other.BlockSize
     }
 }
 impl ::core::cmp::Eq for TAPE_SET_MEDIA_PARAMETERS {}
@@ -16914,7 +16319,7 @@ unsafe impl ::windows::core::Abi for TAPE_WMI_OPERATIONS {
 }
 impl ::core::cmp::PartialEq for TAPE_WMI_OPERATIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TAPE_WMI_OPERATIONS>()) == 0 }
+        self.Method == other.Method && self.DataBufferSize == other.DataBufferSize && self.DataBuffer == other.DataBuffer
     }
 }
 impl ::core::cmp::Eq for TAPE_WMI_OPERATIONS {}
@@ -16953,7 +16358,7 @@ unsafe impl ::windows::core::Abi for TOKEN_BNO_ISOLATION_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_BNO_ISOLATION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_BNO_ISOLATION_INFORMATION>()) == 0 }
+        self.IsolationPrefix == other.IsolationPrefix && self.IsolationEnabled == other.IsolationEnabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -16991,7 +16396,7 @@ unsafe impl ::windows::core::Abi for TOKEN_SID_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOKEN_SID_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOKEN_SID_INFORMATION>()) == 0 }
+        self.Sid == other.Sid
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17028,7 +16433,7 @@ unsafe impl ::windows::core::Abi for TRANSACTIONMANAGER_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTIONMANAGER_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTIONMANAGER_BASIC_INFORMATION>()) == 0 }
+        self.TmIdentity == other.TmIdentity && self.VirtualClock == other.VirtualClock
     }
 }
 impl ::core::cmp::Eq for TRANSACTIONMANAGER_BASIC_INFORMATION {}
@@ -17059,7 +16464,7 @@ unsafe impl ::windows::core::Abi for TRANSACTIONMANAGER_LOGPATH_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTIONMANAGER_LOGPATH_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTIONMANAGER_LOGPATH_INFORMATION>()) == 0 }
+        self.LogPathLength == other.LogPathLength && self.LogPath == other.LogPath
     }
 }
 impl ::core::cmp::Eq for TRANSACTIONMANAGER_LOGPATH_INFORMATION {}
@@ -17089,7 +16494,7 @@ unsafe impl ::windows::core::Abi for TRANSACTIONMANAGER_LOG_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTIONMANAGER_LOG_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTIONMANAGER_LOG_INFORMATION>()) == 0 }
+        self.LogIdentity == other.LogIdentity
     }
 }
 impl ::core::cmp::Eq for TRANSACTIONMANAGER_LOG_INFORMATION {}
@@ -17119,7 +16524,7 @@ unsafe impl ::windows::core::Abi for TRANSACTIONMANAGER_OLDEST_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTIONMANAGER_OLDEST_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTIONMANAGER_OLDEST_INFORMATION>()) == 0 }
+        self.OldestTransactionGuid == other.OldestTransactionGuid
     }
 }
 impl ::core::cmp::Eq for TRANSACTIONMANAGER_OLDEST_INFORMATION {}
@@ -17149,7 +16554,7 @@ unsafe impl ::windows::core::Abi for TRANSACTIONMANAGER_RECOVERY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTIONMANAGER_RECOVERY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTIONMANAGER_RECOVERY_INFORMATION>()) == 0 }
+        self.LastRecoveredLsn == other.LastRecoveredLsn
     }
 }
 impl ::core::cmp::Eq for TRANSACTIONMANAGER_RECOVERY_INFORMATION {}
@@ -17181,7 +16586,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_BASIC_INFORMATION>()) == 0 }
+        self.TransactionId == other.TransactionId && self.State == other.State && self.Outcome == other.Outcome
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_BASIC_INFORMATION {}
@@ -17217,7 +16622,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_BIND_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRANSACTION_BIND_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_BIND_INFORMATION>()) == 0 }
+        self.TmHandle == other.TmHandle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17250,7 +16655,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_ENLISTMENTS_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_ENLISTMENTS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_ENLISTMENTS_INFORMATION>()) == 0 }
+        self.NumberOfEnlistments == other.NumberOfEnlistments && self.EnlistmentPair == other.EnlistmentPair
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_ENLISTMENTS_INFORMATION {}
@@ -17281,7 +16686,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_ENLISTMENT_PAIR {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_ENLISTMENT_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_ENLISTMENT_PAIR>()) == 0 }
+        self.EnlistmentId == other.EnlistmentId && self.ResourceManagerId == other.ResourceManagerId
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_ENLISTMENT_PAIR {}
@@ -17311,7 +16716,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_LIST_ENTRY {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_LIST_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_LIST_ENTRY>()) == 0 }
+        self.UOW == other.UOW
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_LIST_ENTRY {}
@@ -17342,7 +16747,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_LIST_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_LIST_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_LIST_INFORMATION>()) == 0 }
+        self.NumberOfTransactions == other.NumberOfTransactions && self.TransactionInformation == other.TransactionInformation
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_LIST_INFORMATION {}
@@ -17377,7 +16782,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_PROPERTIES_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TRANSACTION_PROPERTIES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_PROPERTIES_INFORMATION>()) == 0 }
+        self.IsolationLevel == other.IsolationLevel && self.IsolationFlags == other.IsolationFlags && self.Timeout == other.Timeout && self.Outcome == other.Outcome && self.DescriptionLength == other.DescriptionLength && self.Description == other.Description
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_PROPERTIES_INFORMATION {}
@@ -17407,7 +16812,7 @@ unsafe impl ::windows::core::Abi for TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION
 }
 impl ::core::cmp::PartialEq for TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION>()) == 0 }
+        self.SuperiorEnlistmentPair == other.SuperiorEnlistmentPair
     }
 }
 impl ::core::cmp::Eq for TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION {}
@@ -17439,7 +16844,7 @@ unsafe impl ::windows::core::Abi for UMS_CREATE_THREAD_ATTRIBUTES {
 }
 impl ::core::cmp::PartialEq for UMS_CREATE_THREAD_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UMS_CREATE_THREAD_ATTRIBUTES>()) == 0 }
+        self.UmsVersion == other.UmsVersion && self.UmsContext == other.UmsContext && self.UmsCompletionList == other.UmsCompletionList
     }
 }
 impl ::core::cmp::Eq for UMS_CREATE_THREAD_ATTRIBUTES {}
@@ -17474,7 +16879,7 @@ unsafe impl ::windows::core::Abi for VolLockBroadcast {
 }
 impl ::core::cmp::PartialEq for VolLockBroadcast {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VolLockBroadcast>()) == 0 }
+        self.vlb_dbh == other.vlb_dbh && self.vlb_owner == other.vlb_owner && self.vlb_perms == other.vlb_perms && self.vlb_lockType == other.vlb_lockType && self.vlb_drive == other.vlb_drive && self.vlb_flags == other.vlb_flags
     }
 }
 impl ::core::cmp::Eq for VolLockBroadcast {}
@@ -17505,7 +16910,7 @@ unsafe impl ::windows::core::Abi for XSAVE_CET_U_FORMAT {
 }
 impl ::core::cmp::PartialEq for XSAVE_CET_U_FORMAT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XSAVE_CET_U_FORMAT>()) == 0 }
+        self.Ia32CetUMsr == other.Ia32CetUMsr && self.Ia32Pl3SspMsr == other.Ia32Pl3SspMsr
     }
 }
 impl ::core::cmp::Eq for XSAVE_CET_U_FORMAT {}
@@ -17537,7 +16942,7 @@ unsafe impl ::windows::core::Abi for _DEV_BROADCAST_HEADER {
 }
 impl ::core::cmp::PartialEq for _DEV_BROADCAST_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_DEV_BROADCAST_HEADER>()) == 0 }
+        self.dbcd_size == other.dbcd_size && self.dbcd_devicetype == other.dbcd_devicetype && self.dbcd_reserved == other.dbcd_reserved
     }
 }
 impl ::core::cmp::Eq for _DEV_BROADCAST_HEADER {}
@@ -17574,7 +16979,7 @@ unsafe impl ::windows::core::Abi for _DEV_BROADCAST_USERDEFINED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for _DEV_BROADCAST_USERDEFINED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<_DEV_BROADCAST_USERDEFINED>()) == 0 }
+        self.dbud_dbh == other.dbud_dbh && self.dbud_szName == other.dbud_szName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -17615,7 +17020,7 @@ unsafe impl ::windows::core::Abi for remoteMETAFILEPICT {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for remoteMETAFILEPICT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<remoteMETAFILEPICT>()) == 0 }
+        self.mm == other.mm && self.xExt == other.xExt && self.yExt == other.yExt && self.hMF == other.hMF
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -17654,7 +17059,7 @@ unsafe impl ::windows::core::Abi for userBITMAP {
 }
 impl ::core::cmp::PartialEq for userBITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userBITMAP>()) == 0 }
+        self.bmType == other.bmType && self.bmWidth == other.bmWidth && self.bmHeight == other.bmHeight && self.bmWidthBytes == other.bmWidthBytes && self.bmPlanes == other.bmPlanes && self.bmBitsPixel == other.bmBitsPixel && self.cbSize == other.cbSize && self.pBuffer == other.pBuffer
     }
 }
 impl ::core::cmp::Eq for userBITMAP {}
@@ -17678,12 +17083,6 @@ impl ::core::clone::Clone for userCLIPFORMAT {
 unsafe impl ::windows::core::Abi for userCLIPFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for userCLIPFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userCLIPFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for userCLIPFORMAT {}
 impl ::core::default::Default for userCLIPFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17704,12 +17103,6 @@ impl ::core::clone::Clone for userCLIPFORMAT_0 {
 unsafe impl ::windows::core::Abi for userCLIPFORMAT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for userCLIPFORMAT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userCLIPFORMAT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for userCLIPFORMAT_0 {}
 impl ::core::default::Default for userCLIPFORMAT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17730,12 +17123,6 @@ impl ::core::clone::Clone for userHBITMAP {
 unsafe impl ::windows::core::Abi for userHBITMAP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for userHBITMAP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHBITMAP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for userHBITMAP {}
 impl ::core::default::Default for userHBITMAP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17757,12 +17144,6 @@ impl ::core::clone::Clone for userHBITMAP_0 {
 unsafe impl ::windows::core::Abi for userHBITMAP_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for userHBITMAP_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHBITMAP_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for userHBITMAP_0 {}
 impl ::core::default::Default for userHBITMAP_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17787,14 +17168,6 @@ impl ::core::clone::Clone for userHENHMETAFILE {
 unsafe impl ::windows::core::Abi for userHENHMETAFILE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHENHMETAFILE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHENHMETAFILE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHENHMETAFILE {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHENHMETAFILE {
     fn default() -> Self {
@@ -17822,14 +17195,6 @@ unsafe impl ::windows::core::Abi for userHENHMETAFILE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHENHMETAFILE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHENHMETAFILE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHENHMETAFILE_0 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHENHMETAFILE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17854,14 +17219,6 @@ impl ::core::clone::Clone for userHGLOBAL {
 unsafe impl ::windows::core::Abi for userHGLOBAL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHGLOBAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHGLOBAL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHGLOBAL {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHGLOBAL {
     fn default() -> Self {
@@ -17889,14 +17246,6 @@ unsafe impl ::windows::core::Abi for userHGLOBAL_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHGLOBAL_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHGLOBAL_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHGLOBAL_0 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHGLOBAL_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17921,14 +17270,6 @@ impl ::core::clone::Clone for userHMETAFILE {
 unsafe impl ::windows::core::Abi for userHMETAFILE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHMETAFILE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHMETAFILE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHMETAFILE {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHMETAFILE {
     fn default() -> Self {
@@ -17956,14 +17297,6 @@ unsafe impl ::windows::core::Abi for userHMETAFILE_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHMETAFILE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHMETAFILE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHMETAFILE_0 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHMETAFILE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -17988,14 +17321,6 @@ impl ::core::clone::Clone for userHMETAFILEPICT {
 unsafe impl ::windows::core::Abi for userHMETAFILEPICT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHMETAFILEPICT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHMETAFILEPICT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHMETAFILEPICT {}
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHMETAFILEPICT {
     fn default() -> Self {
@@ -18023,14 +17348,6 @@ unsafe impl ::windows::core::Abi for userHMETAFILEPICT_0 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for userHMETAFILEPICT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHMETAFILEPICT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for userHMETAFILEPICT_0 {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for userHMETAFILEPICT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -18055,14 +17372,6 @@ impl ::core::clone::Clone for userHPALETTE {
 unsafe impl ::windows::core::Abi for userHPALETTE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::PartialEq for userHPALETTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHPALETTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::Eq for userHPALETTE {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::default::Default for userHPALETTE {
     fn default() -> Self {
@@ -18089,14 +17398,6 @@ impl ::core::clone::Clone for userHPALETTE_0 {
 unsafe impl ::windows::core::Abi for userHPALETTE_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::PartialEq for userHPALETTE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<userHPALETTE_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::Eq for userHPALETTE_0 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::default::Default for userHPALETTE_0 {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
@@ -5782,7 +5782,7 @@ unsafe impl ::windows::core::Abi for DAILY {
 }
 impl ::core::cmp::PartialEq for DAILY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DAILY>()) == 0 }
+        self.DaysInterval == other.DaysInterval
     }
 }
 impl ::core::cmp::Eq for DAILY {}
@@ -5813,7 +5813,7 @@ unsafe impl ::windows::core::Abi for MONTHLYDATE {
 }
 impl ::core::cmp::PartialEq for MONTHLYDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONTHLYDATE>()) == 0 }
+        self.rgfDays == other.rgfDays && self.rgfMonths == other.rgfMonths
     }
 }
 impl ::core::cmp::Eq for MONTHLYDATE {}
@@ -5845,7 +5845,7 @@ unsafe impl ::windows::core::Abi for MONTHLYDOW {
 }
 impl ::core::cmp::PartialEq for MONTHLYDOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MONTHLYDOW>()) == 0 }
+        self.wWhichWeek == other.wWhichWeek && self.rgfDaysOfTheWeek == other.rgfDaysOfTheWeek && self.rgfMonths == other.rgfMonths
     }
 }
 impl ::core::cmp::Eq for MONTHLYDOW {}
@@ -5884,12 +5884,6 @@ impl ::core::clone::Clone for TASK_TRIGGER {
 unsafe impl ::windows::core::Abi for TASK_TRIGGER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TASK_TRIGGER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TASK_TRIGGER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TASK_TRIGGER {}
 impl ::core::default::Default for TASK_TRIGGER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5912,12 +5906,6 @@ impl ::core::clone::Clone for TRIGGER_TYPE_UNION {
 unsafe impl ::windows::core::Abi for TRIGGER_TYPE_UNION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TRIGGER_TYPE_UNION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRIGGER_TYPE_UNION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TRIGGER_TYPE_UNION {}
 impl ::core::default::Default for TRIGGER_TYPE_UNION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5945,7 +5933,7 @@ unsafe impl ::windows::core::Abi for WEEKLY {
 }
 impl ::core::cmp::PartialEq for WEEKLY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WEEKLY>()) == 0 }
+        self.WeeksInterval == other.WeeksInterval && self.rgfDaysOfTheWeek == other.rgfDaysOfTheWeek
     }
 }
 impl ::core::cmp::Eq for WEEKLY {}

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -4216,7 +4216,7 @@ unsafe impl ::windows::core::Abi for APP_MEMORY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for APP_MEMORY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APP_MEMORY_INFORMATION>()) == 0 }
+        self.AvailableCommit == other.AvailableCommit && self.PrivateCommitUsage == other.PrivateCommitUsage && self.PeakPrivateCommitUsage == other.PeakPrivateCommitUsage && self.TotalCommitUsage == other.TotalCommitUsage
     }
 }
 impl ::core::cmp::Eq for APP_MEMORY_INFORMATION {}
@@ -4283,7 +4283,7 @@ unsafe impl ::windows::core::Abi for IO_COUNTERS {
 }
 impl ::core::cmp::PartialEq for IO_COUNTERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_COUNTERS>()) == 0 }
+        self.ReadOperationCount == other.ReadOperationCount && self.WriteOperationCount == other.WriteOperationCount && self.OtherOperationCount == other.OtherOperationCount && self.ReadTransferCount == other.ReadTransferCount && self.WriteTransferCount == other.WriteTransferCount && self.OtherTransferCount == other.OtherTransferCount
     }
 }
 impl ::core::cmp::Eq for IO_COUNTERS {}
@@ -4345,7 +4345,7 @@ unsafe impl ::windows::core::Abi for MEMORY_PRIORITY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for MEMORY_PRIORITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEMORY_PRIORITY_INFORMATION>()) == 0 }
+        self.MemoryPriority == other.MemoryPriority
     }
 }
 impl ::core::cmp::Eq for MEMORY_PRIORITY_INFORMATION {}
@@ -4437,7 +4437,6 @@ impl ::core::fmt::Debug for PEB {
             .field("AtlThunkSListPtr32", &self.AtlThunkSListPtr32)
             .field("Reserved9", &self.Reserved9)
             .field("Reserved10", &self.Reserved10)
-            .field("PostProcessInitRoutine", &self.PostProcessInitRoutine.map(|f| f as usize))
             .field("Reserved11", &self.Reserved11)
             .field("Reserved12", &self.Reserved12)
             .field("SessionId", &self.SessionId)
@@ -4448,14 +4447,6 @@ impl ::core::fmt::Debug for PEB {
 unsafe impl ::windows::core::Abi for PEB {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for PEB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEB>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for PEB {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for PEB {
     fn default() -> Self {
@@ -4491,7 +4482,7 @@ unsafe impl ::windows::core::Abi for PEB_LDR_DATA {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for PEB_LDR_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PEB_LDR_DATA>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.InMemoryOrderModuleList == other.InMemoryOrderModuleList
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -4533,7 +4524,7 @@ unsafe impl ::windows::core::Abi for PROCESS_BASIC_INFORMATION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for PROCESS_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_BASIC_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.PebBaseAddress == other.PebBaseAddress && self.Reserved2 == other.Reserved2 && self.UniqueProcessId == other.UniqueProcessId && self.Reserved3 == other.Reserved3
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -4566,7 +4557,7 @@ unsafe impl ::windows::core::Abi for PROCESS_DYNAMIC_EH_CONTINUATION_TARGET {
 }
 impl ::core::cmp::PartialEq for PROCESS_DYNAMIC_EH_CONTINUATION_TARGET {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_DYNAMIC_EH_CONTINUATION_TARGET>()) == 0 }
+        self.TargetAddress == other.TargetAddress && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for PROCESS_DYNAMIC_EH_CONTINUATION_TARGET {}
@@ -4599,7 +4590,7 @@ unsafe impl ::windows::core::Abi for PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INF
 }
 impl ::core::cmp::PartialEq for PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION>()) == 0 }
+        self.NumberOfTargets == other.NumberOfTargets && self.Reserved == other.Reserved && self.Reserved2 == other.Reserved2 && self.Targets == other.Targets
     }
 }
 impl ::core::cmp::Eq for PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION {}
@@ -4631,7 +4622,7 @@ unsafe impl ::windows::core::Abi for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {
 }
 impl ::core::cmp::PartialEq for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE>()) == 0 }
+        self.BaseAddress == other.BaseAddress && self.Size == other.Size && self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {}
@@ -4664,7 +4655,7 @@ unsafe impl ::windows::core::Abi for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INF
 }
 impl ::core::cmp::PartialEq for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INFORMATION>()) == 0 }
+        self.NumberOfRanges == other.NumberOfRanges && self.Reserved == other.Reserved && self.Reserved2 == other.Reserved2 && self.Ranges == other.Ranges
     }
 }
 impl ::core::cmp::Eq for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INFORMATION {}
@@ -4703,7 +4694,7 @@ unsafe impl ::windows::core::Abi for PROCESS_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROCESS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_INFORMATION>()) == 0 }
+        self.hProcess == other.hProcess && self.hThread == other.hThread && self.dwProcessId == other.dwProcessId && self.dwThreadId == other.dwThreadId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4736,7 +4727,7 @@ unsafe impl ::windows::core::Abi for PROCESS_LEAP_SECOND_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESS_LEAP_SECOND_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_LEAP_SECOND_INFO>()) == 0 }
+        self.Flags == other.Flags && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PROCESS_LEAP_SECOND_INFO {}
@@ -4774,7 +4765,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MACHINE_INFORMATION {
 #[cfg(feature = "Win32_System_SystemInformation")]
 impl ::core::cmp::PartialEq for PROCESS_MACHINE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MACHINE_INFORMATION>()) == 0 }
+        self.ProcessMachine == other.ProcessMachine && self.Res0 == other.Res0 && self.MachineAttributes == other.MachineAttributes
     }
 }
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -4809,7 +4800,7 @@ unsafe impl ::windows::core::Abi for PROCESS_MEMORY_EXHAUSTION_INFO {
 }
 impl ::core::cmp::PartialEq for PROCESS_MEMORY_EXHAUSTION_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_MEMORY_EXHAUSTION_INFO>()) == 0 }
+        self.Version == other.Version && self.Reserved == other.Reserved && self.Type == other.Type && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for PROCESS_MEMORY_EXHAUSTION_INFO {}
@@ -4841,7 +4832,7 @@ unsafe impl ::windows::core::Abi for PROCESS_POWER_THROTTLING_STATE {
 }
 impl ::core::cmp::PartialEq for PROCESS_POWER_THROTTLING_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_POWER_THROTTLING_STATE>()) == 0 }
+        self.Version == other.Version && self.ControlMask == other.ControlMask && self.StateMask == other.StateMask
     }
 }
 impl ::core::cmp::Eq for PROCESS_POWER_THROTTLING_STATE {}
@@ -4871,7 +4862,7 @@ unsafe impl ::windows::core::Abi for PROCESS_PROTECTION_LEVEL_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PROCESS_PROTECTION_LEVEL_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROCESS_PROTECTION_LEVEL_INFORMATION>()) == 0 }
+        self.ProtectionLevel == other.ProtectionLevel
     }
 }
 impl ::core::cmp::Eq for PROCESS_PROTECTION_LEVEL_INFORMATION {}
@@ -4928,14 +4919,6 @@ unsafe impl ::windows::core::Abi for REASON_CONTEXT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for REASON_CONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REASON_CONTEXT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for REASON_CONTEXT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for REASON_CONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -4960,14 +4943,6 @@ impl ::core::clone::Clone for REASON_CONTEXT_0 {
 unsafe impl ::windows::core::Abi for REASON_CONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for REASON_CONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REASON_CONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for REASON_CONTEXT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for REASON_CONTEXT_0 {
     fn default() -> Self {
@@ -5004,7 +4979,7 @@ unsafe impl ::windows::core::Abi for REASON_CONTEXT_0_0 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for REASON_CONTEXT_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REASON_CONTEXT_0_0>()) == 0 }
+        self.LocalizedReasonModule == other.LocalizedReasonModule && self.LocalizedReasonId == other.LocalizedReasonId && self.ReasonStringCount == other.ReasonStringCount && self.ReasonStrings == other.ReasonStrings
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5040,7 +5015,7 @@ unsafe impl ::windows::core::Abi for RTL_BARRIER {
 }
 impl ::core::cmp::PartialEq for RTL_BARRIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_BARRIER>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.Reserved3 == other.Reserved3 && self.Reserved4 == other.Reserved4 && self.Reserved5 == other.Reserved5
     }
 }
 impl ::core::cmp::Eq for RTL_BARRIER {}
@@ -5070,7 +5045,7 @@ unsafe impl ::windows::core::Abi for RTL_CONDITION_VARIABLE {
 }
 impl ::core::cmp::PartialEq for RTL_CONDITION_VARIABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_CONDITION_VARIABLE>()) == 0 }
+        self.Ptr == other.Ptr
     }
 }
 impl ::core::cmp::Eq for RTL_CONDITION_VARIABLE {}
@@ -5111,7 +5086,7 @@ unsafe impl ::windows::core::Abi for RTL_CRITICAL_SECTION {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for RTL_CRITICAL_SECTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_CRITICAL_SECTION>()) == 0 }
+        self.DebugInfo == other.DebugInfo && self.LockCount == other.LockCount && self.RecursionCount == other.RecursionCount && self.OwningThread == other.OwningThread && self.LockSemaphore == other.LockSemaphore && self.SpinCount == other.SpinCount
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -5157,7 +5132,7 @@ unsafe impl ::windows::core::Abi for RTL_CRITICAL_SECTION_DEBUG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::cmp::PartialEq for RTL_CRITICAL_SECTION_DEBUG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_CRITICAL_SECTION_DEBUG>()) == 0 }
+        self.Type == other.Type && self.CreatorBackTraceIndex == other.CreatorBackTraceIndex && self.CriticalSection == other.CriticalSection && self.ProcessLocksList == other.ProcessLocksList && self.EntryCount == other.EntryCount && self.ContentionCount == other.ContentionCount && self.Flags == other.Flags && self.CreatorBackTraceIndexHigh == other.CreatorBackTraceIndexHigh && self.SpareWORD == other.SpareWORD
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -5182,12 +5157,6 @@ impl ::core::clone::Clone for RTL_RUN_ONCE {
 unsafe impl ::windows::core::Abi for RTL_RUN_ONCE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RTL_RUN_ONCE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_RUN_ONCE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RTL_RUN_ONCE {}
 impl ::core::default::Default for RTL_RUN_ONCE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5214,7 +5183,7 @@ unsafe impl ::windows::core::Abi for RTL_SRWLOCK {
 }
 impl ::core::cmp::PartialEq for RTL_SRWLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_SRWLOCK>()) == 0 }
+        self.Ptr == other.Ptr
     }
 }
 impl ::core::cmp::Eq for RTL_SRWLOCK {}
@@ -5253,7 +5222,7 @@ unsafe impl ::windows::core::Abi for RTL_USER_PROCESS_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RTL_USER_PROCESS_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RTL_USER_PROCESS_PARAMETERS>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.ImagePathName == other.ImagePathName && self.CommandLine == other.CommandLine
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5327,7 +5296,7 @@ unsafe impl ::windows::core::Abi for STARTUPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STARTUPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTUPINFOA>()) == 0 }
+        self.cb == other.cb && self.lpReserved == other.lpReserved && self.lpDesktop == other.lpDesktop && self.lpTitle == other.lpTitle && self.dwX == other.dwX && self.dwY == other.dwY && self.dwXSize == other.dwXSize && self.dwYSize == other.dwYSize && self.dwXCountChars == other.dwXCountChars && self.dwYCountChars == other.dwYCountChars && self.dwFillAttribute == other.dwFillAttribute && self.dwFlags == other.dwFlags && self.wShowWindow == other.wShowWindow && self.cbReserved2 == other.cbReserved2 && self.lpReserved2 == other.lpReserved2 && self.hStdInput == other.hStdInput && self.hStdOutput == other.hStdOutput && self.hStdError == other.hStdError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5366,7 +5335,7 @@ unsafe impl ::windows::core::Abi for STARTUPINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STARTUPINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTUPINFOEXA>()) == 0 }
+        self.StartupInfo == other.StartupInfo && self.lpAttributeList == other.lpAttributeList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5405,7 +5374,7 @@ unsafe impl ::windows::core::Abi for STARTUPINFOEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STARTUPINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTUPINFOEXW>()) == 0 }
+        self.StartupInfo == other.StartupInfo && self.lpAttributeList == other.lpAttributeList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5479,7 +5448,7 @@ unsafe impl ::windows::core::Abi for STARTUPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STARTUPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STARTUPINFOW>()) == 0 }
+        self.cb == other.cb && self.lpReserved == other.lpReserved && self.lpDesktop == other.lpDesktop && self.lpTitle == other.lpTitle && self.dwX == other.dwX && self.dwY == other.dwY && self.dwXSize == other.dwXSize && self.dwYSize == other.dwYSize && self.dwXCountChars == other.dwXCountChars && self.dwYCountChars == other.dwYCountChars && self.dwFillAttribute == other.dwFillAttribute && self.dwFlags == other.dwFlags && self.wShowWindow == other.wShowWindow && self.cbReserved2 == other.cbReserved2 && self.lpReserved2 == other.lpReserved2 && self.hStdInput == other.hStdInput && self.hStdOutput == other.hStdOutput && self.hStdError == other.hStdError
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5513,7 +5482,7 @@ unsafe impl ::windows::core::Abi for THREAD_POWER_THROTTLING_STATE {
 }
 impl ::core::cmp::PartialEq for THREAD_POWER_THROTTLING_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THREAD_POWER_THROTTLING_STATE>()) == 0 }
+        self.Version == other.Version && self.ControlMask == other.ControlMask && self.StateMask == other.StateMask
     }
 }
 impl ::core::cmp::Eq for THREAD_POWER_THROTTLING_STATE {}
@@ -5545,12 +5514,6 @@ impl ::core::clone::Clone for TP_CALLBACK_ENVIRON_V3 {
 unsafe impl ::windows::core::Abi for TP_CALLBACK_ENVIRON_V3 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TP_CALLBACK_ENVIRON_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TP_CALLBACK_ENVIRON_V3>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TP_CALLBACK_ENVIRON_V3 {}
 impl ::core::default::Default for TP_CALLBACK_ENVIRON_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5573,12 +5536,6 @@ impl ::core::clone::Clone for TP_CALLBACK_ENVIRON_V3_1 {
 unsafe impl ::windows::core::Abi for TP_CALLBACK_ENVIRON_V3_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TP_CALLBACK_ENVIRON_V3_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TP_CALLBACK_ENVIRON_V3_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TP_CALLBACK_ENVIRON_V3_1 {}
 impl ::core::default::Default for TP_CALLBACK_ENVIRON_V3_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5605,7 +5562,7 @@ unsafe impl ::windows::core::Abi for TP_CALLBACK_ENVIRON_V3_1_0 {
 }
 impl ::core::cmp::PartialEq for TP_CALLBACK_ENVIRON_V3_1_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TP_CALLBACK_ENVIRON_V3_1_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for TP_CALLBACK_ENVIRON_V3_1_0 {}
@@ -5640,7 +5597,7 @@ unsafe impl ::windows::core::Abi for TP_POOL_STACK_INFORMATION {
 }
 impl ::core::cmp::PartialEq for TP_POOL_STACK_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TP_POOL_STACK_INFORMATION>()) == 0 }
+        self.StackReserve == other.StackReserve && self.StackCommit == other.StackCommit
     }
 }
 impl ::core::cmp::Eq for TP_POOL_STACK_INFORMATION {}
@@ -5707,21 +5664,13 @@ impl ::core::clone::Clone for UMS_SCHEDULER_STARTUP_INFO {
 #[cfg(feature = "Win32_System_SystemServices")]
 impl ::core::fmt::Debug for UMS_SCHEDULER_STARTUP_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("UMS_SCHEDULER_STARTUP_INFO").field("UmsVersion", &self.UmsVersion).field("CompletionList", &self.CompletionList).field("SchedulerProc", &self.SchedulerProc.map(|f| f as usize)).field("SchedulerParam", &self.SchedulerParam).finish()
+        f.debug_struct("UMS_SCHEDULER_STARTUP_INFO").field("UmsVersion", &self.UmsVersion).field("CompletionList", &self.CompletionList).field("SchedulerParam", &self.SchedulerParam).finish()
     }
 }
 #[cfg(feature = "Win32_System_SystemServices")]
 unsafe impl ::windows::core::Abi for UMS_SCHEDULER_STARTUP_INFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::PartialEq for UMS_SCHEDULER_STARTUP_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UMS_SCHEDULER_STARTUP_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_SystemServices")]
-impl ::core::cmp::Eq for UMS_SCHEDULER_STARTUP_INFO {}
 #[cfg(feature = "Win32_System_SystemServices")]
 impl ::core::default::Default for UMS_SCHEDULER_STARTUP_INFO {
     fn default() -> Self {
@@ -5743,12 +5692,6 @@ impl ::core::clone::Clone for UMS_SYSTEM_THREAD_INFORMATION {
 unsafe impl ::windows::core::Abi for UMS_SYSTEM_THREAD_INFORMATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UMS_SYSTEM_THREAD_INFORMATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UMS_SYSTEM_THREAD_INFORMATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UMS_SYSTEM_THREAD_INFORMATION {}
 impl ::core::default::Default for UMS_SYSTEM_THREAD_INFORMATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5769,12 +5712,6 @@ impl ::core::clone::Clone for UMS_SYSTEM_THREAD_INFORMATION_0 {
 unsafe impl ::windows::core::Abi for UMS_SYSTEM_THREAD_INFORMATION_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UMS_SYSTEM_THREAD_INFORMATION_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UMS_SYSTEM_THREAD_INFORMATION_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UMS_SYSTEM_THREAD_INFORMATION_0 {}
 impl ::core::default::Default for UMS_SYSTEM_THREAD_INFORMATION_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5801,7 +5738,7 @@ unsafe impl ::windows::core::Abi for UMS_SYSTEM_THREAD_INFORMATION_0_0 {
 }
 impl ::core::cmp::PartialEq for UMS_SYSTEM_THREAD_INFORMATION_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UMS_SYSTEM_THREAD_INFORMATION_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for UMS_SYSTEM_THREAD_INFORMATION_0_0 {}

--- a/crates/libs/windows/src/Windows/Win32/System/Time/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Time/mod.rs
@@ -158,7 +158,7 @@ unsafe impl ::windows::core::Abi for DYNAMIC_TIME_ZONE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DYNAMIC_TIME_ZONE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DYNAMIC_TIME_ZONE_INFORMATION>()) == 0 }
+        self.Bias == other.Bias && self.StandardName == other.StandardName && self.StandardDate == other.StandardDate && self.StandardBias == other.StandardBias && self.DaylightName == other.DaylightName && self.DaylightDate == other.DaylightDate && self.DaylightBias == other.DaylightBias && self.TimeZoneKeyName == other.TimeZoneKeyName && self.DynamicDaylightTimeDisabled == other.DynamicDaylightTimeDisabled
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -202,7 +202,7 @@ unsafe impl ::windows::core::Abi for TIME_ZONE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TIME_ZONE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TIME_ZONE_INFORMATION>()) == 0 }
+        self.Bias == other.Bias && self.StandardName == other.StandardName && self.StandardDate == other.StandardDate && self.StandardBias == other.StandardBias && self.DaylightName == other.DaylightName && self.DaylightDate == other.DaylightDate && self.DaylightBias == other.DaylightBias
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/TpmBaseServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TpmBaseServices/mod.rs
@@ -219,7 +219,7 @@ unsafe impl ::windows::core::Abi for TBS_CONTEXT_PARAMS {
 }
 impl ::core::cmp::PartialEq for TBS_CONTEXT_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBS_CONTEXT_PARAMS>()) == 0 }
+        self.version == other.version
     }
 }
 impl ::core::cmp::Eq for TBS_CONTEXT_PARAMS {}
@@ -243,12 +243,6 @@ impl ::core::clone::Clone for TBS_CONTEXT_PARAMS2 {
 unsafe impl ::windows::core::Abi for TBS_CONTEXT_PARAMS2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TBS_CONTEXT_PARAMS2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBS_CONTEXT_PARAMS2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TBS_CONTEXT_PARAMS2 {}
 impl ::core::default::Default for TBS_CONTEXT_PARAMS2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -269,12 +263,6 @@ impl ::core::clone::Clone for TBS_CONTEXT_PARAMS2_0 {
 unsafe impl ::windows::core::Abi for TBS_CONTEXT_PARAMS2_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TBS_CONTEXT_PARAMS2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBS_CONTEXT_PARAMS2_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TBS_CONTEXT_PARAMS2_0 {}
 impl ::core::default::Default for TBS_CONTEXT_PARAMS2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -301,7 +289,7 @@ unsafe impl ::windows::core::Abi for TBS_CONTEXT_PARAMS2_0_0 {
 }
 impl ::core::cmp::PartialEq for TBS_CONTEXT_PARAMS2_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBS_CONTEXT_PARAMS2_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for TBS_CONTEXT_PARAMS2_0_0 {}
@@ -334,7 +322,7 @@ unsafe impl ::windows::core::Abi for TPM_DEVICE_INFO {
 }
 impl ::core::cmp::PartialEq for TPM_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TPM_DEVICE_INFO>()) == 0 }
+        self.structVersion == other.structVersion && self.tpmVersion == other.tpmVersion && self.tpmInterfaceType == other.tpmInterfaceType && self.tpmImpRevision == other.tpmImpRevision
     }
 }
 impl ::core::cmp::Eq for TPM_DEVICE_INFO {}
@@ -365,7 +353,7 @@ unsafe impl ::windows::core::Abi for TPM_WNF_PROVISIONING {
 }
 impl ::core::cmp::PartialEq for TPM_WNF_PROVISIONING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TPM_WNF_PROVISIONING>()) == 0 }
+        self.status == other.status && self.message == other.message
     }
 }
 impl ::core::cmp::Eq for TPM_WNF_PROVISIONING {}

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
@@ -167,7 +167,7 @@ unsafe impl ::windows::core::Abi for OSUpdateAssessment {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OSUpdateAssessment {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OSUpdateAssessment>()) == 0 }
+        self.isEndOfSupport == other.isEndOfSupport && self.assessmentForCurrent == other.assessmentForCurrent && self.assessmentForUpToDate == other.assessmentForUpToDate && self.securityStatus == other.securityStatus && self.assessmentTime == other.assessmentTime && self.releaseInfoTime == other.releaseInfoTime && self.currentOSBuild == other.currentOSBuild && self.currentOSReleaseTime == other.currentOSReleaseTime && self.upToDateOSBuild == other.upToDateOSBuild && self.upToDateOSReleaseTime == other.upToDateOSReleaseTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -201,7 +201,7 @@ unsafe impl ::windows::core::Abi for UpdateAssessment {
 }
 impl ::core::cmp::PartialEq for UpdateAssessment {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UpdateAssessment>()) == 0 }
+        self.status == other.status && self.impact == other.impact && self.daysOutOfDate == other.daysOutOfDate
     }
 }
 impl ::core::cmp::Eq for UpdateAssessment {}

--- a/crates/libs/windows/src/Windows/Win32/System/UserAccessLogging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UserAccessLogging/mod.rs
@@ -61,7 +61,7 @@ unsafe impl ::windows::core::Abi for UAL_DATA_BLOB {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl ::core::cmp::PartialEq for UAL_DATA_BLOB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UAL_DATA_BLOB>()) == 0 }
+        self.Size == other.Size && self.RoleGuid == other.RoleGuid && self.TenantId == other.TenantId && self.Address == other.Address && self.UserName == other.UserName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]

--- a/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -217,14 +217,6 @@ unsafe impl ::windows::core::Abi for GLOBALENTRY {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GLOBALENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GLOBALENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GLOBALENTRY {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GLOBALENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -260,7 +252,7 @@ unsafe impl ::windows::core::Abi for IMAGE_NOTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMAGE_NOTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_NOTE>()) == 0 }
+        self.Module == other.Module && self.FileName == other.FileName && self.hModule == other.hModule && self.hTask == other.hTask
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -294,14 +286,6 @@ impl ::core::clone::Clone for MODULEENTRY {
 unsafe impl ::windows::core::Abi for MODULEENTRY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MODULEENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODULEENTRY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MODULEENTRY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MODULEENTRY {
     fn default() -> Self {
@@ -341,7 +325,7 @@ unsafe impl ::windows::core::Abi for SEGMENT_NOTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SEGMENT_NOTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SEGMENT_NOTE>()) == 0 }
+        self.Selector1 == other.Selector1 && self.Selector2 == other.Selector2 && self.Segment == other.Segment && self.Module == other.Module && self.FileName == other.FileName && self.Type == other.Type && self.Length == other.Length
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -381,7 +365,7 @@ unsafe impl ::windows::core::Abi for TEMP_BP_NOTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TEMP_BP_NOTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEMP_BP_NOTE>()) == 0 }
+        self.Seg == other.Seg && self.Offset == other.Offset && self.bPM == other.bPM
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -475,7 +459,7 @@ unsafe impl ::windows::core::Abi for VDMCONTEXT {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for VDMCONTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMCONTEXT>()) == 0 }
+        self.ContextFlags == other.ContextFlags && self.Dr0 == other.Dr0 && self.Dr1 == other.Dr1 && self.Dr2 == other.Dr2 && self.Dr3 == other.Dr3 && self.Dr6 == other.Dr6 && self.Dr7 == other.Dr7 && self.FloatSave == other.FloatSave && self.SegGs == other.SegGs && self.SegFs == other.SegFs && self.SegEs == other.SegEs && self.SegDs == other.SegDs && self.Edi == other.Edi && self.Esi == other.Esi && self.Ebx == other.Ebx && self.Edx == other.Edx && self.Ecx == other.Ecx && self.Eax == other.Eax && self.Ebp == other.Ebp && self.Eip == other.Eip && self.SegCs == other.SegCs && self.EFlags == other.EFlags && self.Esp == other.Esp && self.SegSs == other.SegSs && self.ExtendedRegisters == other.ExtendedRegisters
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -563,7 +547,7 @@ unsafe impl ::windows::core::Abi for VDMCONTEXT_WITHOUT_XSAVE {
 #[cfg(feature = "Win32_System_Kernel")]
 impl ::core::cmp::PartialEq for VDMCONTEXT_WITHOUT_XSAVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMCONTEXT_WITHOUT_XSAVE>()) == 0 }
+        self.ContextFlags == other.ContextFlags && self.Dr0 == other.Dr0 && self.Dr1 == other.Dr1 && self.Dr2 == other.Dr2 && self.Dr3 == other.Dr3 && self.Dr6 == other.Dr6 && self.Dr7 == other.Dr7 && self.FloatSave == other.FloatSave && self.SegGs == other.SegGs && self.SegFs == other.SegFs && self.SegEs == other.SegEs && self.SegDs == other.SegDs && self.Edi == other.Edi && self.Esi == other.Esi && self.Ebx == other.Ebx && self.Edx == other.Edx && self.Ecx == other.Ecx && self.Eax == other.Eax && self.Ebp == other.Ebp && self.Eip == other.Eip && self.SegCs == other.SegCs && self.EFlags == other.EFlags && self.Esp == other.Esp && self.SegSs == other.SegSs
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
@@ -595,14 +579,6 @@ unsafe impl ::windows::core::Abi for VDMLDT_ENTRY {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for VDMLDT_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMLDT_ENTRY>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for VDMLDT_ENTRY {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for VDMLDT_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -627,14 +603,6 @@ impl ::core::clone::Clone for VDMLDT_ENTRY_0 {
 unsafe impl ::windows::core::Abi for VDMLDT_ENTRY_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for VDMLDT_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMLDT_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for VDMLDT_ENTRY_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for VDMLDT_ENTRY_0 {
     fn default() -> Self {
@@ -668,7 +636,7 @@ unsafe impl ::windows::core::Abi for VDMLDT_ENTRY_0_0 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for VDMLDT_ENTRY_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMLDT_ENTRY_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -709,7 +677,7 @@ unsafe impl ::windows::core::Abi for VDMLDT_ENTRY_0_1 {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for VDMLDT_ENTRY_0_1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDMLDT_ENTRY_0_1>()) == 0 }
+        self.BaseMid == other.BaseMid && self.Flags1 == other.Flags1 && self.Flags2 == other.Flags2 && self.BaseHi == other.BaseHi
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -752,7 +720,7 @@ unsafe impl ::windows::core::Abi for VDM_SEGINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for VDM_SEGINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VDM_SEGINFO>()) == 0 }
+        self.Selector == other.Selector && self.SegNumber == other.SegNumber && self.Length == other.Length && self.Type == other.Type && self.ModuleName == other.ModuleName && self.FileName == other.FileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
@@ -99,7 +99,7 @@ unsafe impl ::windows::core::Abi for PDF_RENDER_PARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ::core::cmp::PartialEq for PDF_RENDER_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PDF_RENDER_PARAMS>()) == 0 }
+        self.SourceRect == other.SourceRect && self.DestinationWidth == other.DestinationWidth && self.DestinationHeight == other.DestinationHeight && self.BackgroundColor == other.BackgroundColor && self.IgnoreHighContrast == other.IgnoreHighContrast
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2833,7 +2833,7 @@ unsafe impl ::windows::core::Abi for DispatcherQueueOptions {
 }
 impl ::core::cmp::PartialEq for DispatcherQueueOptions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DispatcherQueueOptions>()) == 0 }
+        self.dwSize == other.dwSize && self.threadType == other.threadType && self.apartmentType == other.apartmentType
     }
 }
 impl ::core::cmp::Eq for DispatcherQueueOptions {}
@@ -2863,7 +2863,7 @@ unsafe impl ::windows::core::Abi for EventRegistrationToken {
 }
 impl ::core::cmp::PartialEq for EventRegistrationToken {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EventRegistrationToken>()) == 0 }
+        self.value == other.value
     }
 }
 impl ::core::cmp::Eq for EventRegistrationToken {}
@@ -2929,7 +2929,7 @@ unsafe impl ::windows::core::Abi for HSTRING_HEADER {
 }
 impl ::core::cmp::PartialEq for HSTRING_HEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HSTRING_HEADER>()) == 0 }
+        self.flags == other.flags && self.length == other.length && self.padding1 == other.padding1 && self.padding2 == other.padding2 && self.data == other.data
     }
 }
 impl ::core::cmp::Eq for HSTRING_HEADER {}
@@ -2993,7 +2993,7 @@ unsafe impl ::windows::core::Abi for ServerInformation {
 }
 impl ::core::cmp::PartialEq for ServerInformation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ServerInformation>()) == 0 }
+        self.dwServerPid == other.dwServerPid && self.dwServerTid == other.dwServerTid && self.ui64ServerAddress == other.ui64ServerAddress
     }
 }
 impl ::core::cmp::Eq for ServerInformation {}

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -4509,7 +4509,7 @@ unsafe impl ::windows::core::Abi for ACTCTX_SECTION_KEYED_DATA_2600 {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ACTCTX_SECTION_KEYED_DATA_2600 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTCTX_SECTION_KEYED_DATA_2600>()) == 0 }
+        self.cbSize == other.cbSize && self.ulDataFormatVersion == other.ulDataFormatVersion && self.lpData == other.lpData && self.ulLength == other.ulLength && self.lpSectionGlobalData == other.lpSectionGlobalData && self.ulSectionGlobalDataLength == other.ulSectionGlobalDataLength && self.lpSectionBase == other.lpSectionBase && self.ulSectionTotalLength == other.ulSectionTotalLength && self.hActCtx == other.hActCtx && self.ulAssemblyRosterIndex == other.ulAssemblyRosterIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4545,7 +4545,7 @@ unsafe impl ::windows::core::Abi for ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA
 }
 impl ::core::cmp::PartialEq for ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA>()) == 0 }
+        self.lpInformation == other.lpInformation && self.lpSectionBase == other.lpSectionBase && self.ulSectionLength == other.ulSectionLength && self.lpSectionGlobalDataBase == other.lpSectionGlobalDataBase && self.ulSectionGlobalDataLength == other.ulSectionGlobalDataLength
     }
 }
 impl ::core::cmp::Eq for ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA {}
@@ -4582,7 +4582,7 @@ unsafe impl ::windows::core::Abi for ACTIVATION_CONTEXT_BASIC_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ACTIVATION_CONTEXT_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACTIVATION_CONTEXT_BASIC_INFORMATION>()) == 0 }
+        self.hActCtx == other.hActCtx && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4624,7 +4624,7 @@ unsafe impl ::windows::core::Abi for CABINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CABINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINFOA>()) == 0 }
+        self.pszCab == other.pszCab && self.pszInf == other.pszInf && self.pszSection == other.pszSection && self.szSrcPath == other.szSrcPath && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4660,7 +4660,7 @@ unsafe impl ::windows::core::Abi for CABINFOW {
 }
 impl ::core::cmp::PartialEq for CABINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINFOW>()) == 0 }
+        self.pszCab == other.pszCab && self.pszInf == other.pszInf && self.pszSection == other.pszSection && self.szSrcPath == other.szSrcPath && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for CABINFOW {}
@@ -4697,7 +4697,7 @@ unsafe impl ::windows::core::Abi for CLIENT_ID {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLIENT_ID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIENT_ID>()) == 0 }
+        self.UniqueProcess == other.UniqueProcess && self.UniqueThread == other.UniqueThread
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4730,7 +4730,7 @@ unsafe impl ::windows::core::Abi for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {
 }
 impl ::core::cmp::PartialEq for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG>()) == 0 }
+        self.Size == other.Size && self.TriggerId == other.TriggerId
     }
 }
 impl ::core::cmp::Eq for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {}
@@ -4765,7 +4765,7 @@ unsafe impl ::windows::core::Abi for DATETIME {
 }
 impl ::core::cmp::PartialEq for DATETIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATETIME>()) == 0 }
+        self.year == other.year && self.month == other.month && self.day == other.day && self.hour == other.hour && self.min == other.min && self.sec == other.sec
     }
 }
 impl ::core::cmp::Eq for DATETIME {}
@@ -4799,7 +4799,7 @@ unsafe impl ::windows::core::Abi for DCICMD {
 }
 impl ::core::cmp::PartialEq for DCICMD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCICMD>()) == 0 }
+        self.dwCommand == other.dwCommand && self.dwParam1 == other.dwParam1 && self.dwParam2 == other.dwParam2 && self.dwVersion == other.dwVersion && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for DCICMD {}
@@ -4836,7 +4836,7 @@ unsafe impl ::windows::core::Abi for DCICREATEINPUT {
 }
 impl ::core::cmp::PartialEq for DCICREATEINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCICREATEINPUT>()) == 0 }
+        self.cmd == other.cmd && self.dwCompression == other.dwCompression && self.dwMask == other.dwMask && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.dwDCICaps == other.dwDCICaps && self.dwBitCount == other.dwBitCount && self.lpSurface == other.lpSurface
     }
 }
 impl ::core::cmp::Eq for DCICREATEINPUT {}
@@ -4876,7 +4876,7 @@ unsafe impl ::windows::core::Abi for DCIENUMINPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DCIENUMINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCIENUMINPUT>()) == 0 }
+        self.cmd == other.cmd && self.rSrc == other.rSrc && self.rDst == other.rDst && self.EnumCallback == other.EnumCallback && self.lpContext == other.lpContext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -4911,7 +4911,7 @@ unsafe impl ::windows::core::Abi for DCIOFFSCREEN {
 }
 impl ::core::cmp::PartialEq for DCIOFFSCREEN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCIOFFSCREEN>()) == 0 }
+        self.dciInfo == other.dciInfo && self.Draw == other.Draw && self.SetClipList == other.SetClipList && self.SetDestination == other.SetDestination
     }
 }
 impl ::core::cmp::Eq for DCIOFFSCREEN {}
@@ -4943,7 +4943,7 @@ unsafe impl ::windows::core::Abi for DCIOVERLAY {
 }
 impl ::core::cmp::PartialEq for DCIOVERLAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCIOVERLAY>()) == 0 }
+        self.dciInfo == other.dciInfo && self.dwChromakeyValue == other.dwChromakeyValue && self.dwChromakeyMask == other.dwChromakeyMask
     }
 }
 impl ::core::cmp::Eq for DCIOVERLAY {}
@@ -5007,7 +5007,7 @@ unsafe impl ::windows::core::Abi for DCISURFACEINFO {
 }
 impl ::core::cmp::PartialEq for DCISURFACEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DCISURFACEINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwDCICaps == other.dwDCICaps && self.dwCompression == other.dwCompression && self.dwMask == other.dwMask && self.dwWidth == other.dwWidth && self.dwHeight == other.dwHeight && self.lStride == other.lStride && self.dwBitCount == other.dwBitCount && self.dwOffSurface == other.dwOffSurface && self.wSelSurface == other.wSelSurface && self.wReserved == other.wReserved && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2 && self.dwReserved3 == other.dwReserved3 && self.BeginAccess == other.BeginAccess && self.EndAccess == other.EndAccess && self.DestroySurface == other.DestroySurface
     }
 }
 impl ::core::cmp::Eq for DCISURFACEINFO {}
@@ -5042,14 +5042,6 @@ unsafe impl ::windows::core::Abi for DELAYLOAD_INFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DELAYLOAD_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELAYLOAD_INFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DELAYLOAD_INFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DELAYLOAD_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5081,14 +5073,6 @@ unsafe impl ::windows::core::Abi for DELAYLOAD_INFO {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DELAYLOAD_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELAYLOAD_INFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DELAYLOAD_INFO {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for DELAYLOAD_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5109,12 +5093,6 @@ impl ::core::clone::Clone for DELAYLOAD_PROC_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for DELAYLOAD_PROC_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DELAYLOAD_PROC_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELAYLOAD_PROC_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DELAYLOAD_PROC_DESCRIPTOR {}
 impl ::core::default::Default for DELAYLOAD_PROC_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5135,12 +5113,6 @@ impl ::core::clone::Clone for DELAYLOAD_PROC_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for DELAYLOAD_PROC_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DELAYLOAD_PROC_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELAYLOAD_PROC_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DELAYLOAD_PROC_DESCRIPTOR_0 {}
 impl ::core::default::Default for DELAYLOAD_PROC_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5195,7 +5167,7 @@ unsafe impl ::windows::core::Abi for FEATURE_ERROR {
 }
 impl ::core::cmp::PartialEq for FEATURE_ERROR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FEATURE_ERROR>()) == 0 }
+        self.hr == other.hr && self.lineNumber == other.lineNumber && self.file == other.file && self.process == other.process && self.module == other.module && self.callerReturnAddressOffset == other.callerReturnAddressOffset && self.callerModule == other.callerModule && self.message == other.message && self.originLineNumber == other.originLineNumber && self.originFile == other.originFile && self.originModule == other.originModule && self.originCallerReturnAddressOffset == other.originCallerReturnAddressOffset && self.originCallerModule == other.originCallerModule && self.originName == other.originName
     }
 }
 impl ::core::cmp::Eq for FEATURE_ERROR {}
@@ -5289,7 +5261,7 @@ unsafe impl ::windows::core::Abi for FILE_CASE_SENSITIVE_INFO {
 }
 impl ::core::cmp::PartialEq for FILE_CASE_SENSITIVE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_CASE_SENSITIVE_INFO>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FILE_CASE_SENSITIVE_INFO {}
@@ -5319,7 +5291,7 @@ unsafe impl ::windows::core::Abi for FILE_DISPOSITION_INFO_EX {
 }
 impl ::core::cmp::PartialEq for FILE_DISPOSITION_INFO_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_DISPOSITION_INFO_EX>()) == 0 }
+        self.Flags == other.Flags
     }
 }
 impl ::core::cmp::Eq for FILE_DISPOSITION_INFO_EX {}
@@ -5389,7 +5361,7 @@ unsafe impl ::windows::core::Abi for HW_PROFILE_INFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HW_PROFILE_INFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HW_PROFILE_INFOA>()) == 0 }
+        self.dwDockInfo == other.dwDockInfo && self.szHwProfileGuid == other.szHwProfileGuid && self.szHwProfileName == other.szHwProfileName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5423,7 +5395,7 @@ unsafe impl ::windows::core::Abi for HW_PROFILE_INFOW {
 }
 impl ::core::cmp::PartialEq for HW_PROFILE_INFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HW_PROFILE_INFOW>()) == 0 }
+        self.dwDockInfo == other.dwDockInfo && self.szHwProfileGuid == other.szHwProfileGuid && self.szHwProfileName == other.szHwProfileName
     }
 }
 impl ::core::cmp::Eq for HW_PROFILE_INFOW {}
@@ -5453,12 +5425,6 @@ impl ::core::clone::Clone for IMAGE_DELAYLOAD_DESCRIPTOR {
 unsafe impl ::windows::core::Abi for IMAGE_DELAYLOAD_DESCRIPTOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DELAYLOAD_DESCRIPTOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DELAYLOAD_DESCRIPTOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DELAYLOAD_DESCRIPTOR {}
 impl ::core::default::Default for IMAGE_DELAYLOAD_DESCRIPTOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5479,12 +5445,6 @@ impl ::core::clone::Clone for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
 unsafe impl ::windows::core::Abi for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DELAYLOAD_DESCRIPTOR_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_DELAYLOAD_DESCRIPTOR_0 {}
 impl ::core::default::Default for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5511,7 +5471,7 @@ unsafe impl ::windows::core::Abi for IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {
 }
 impl ::core::cmp::PartialEq for IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_DELAYLOAD_DESCRIPTOR_0_0>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {}
@@ -5534,12 +5494,6 @@ impl ::core::clone::Clone for IMAGE_THUNK_DATA32 {
 unsafe impl ::windows::core::Abi for IMAGE_THUNK_DATA32 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_THUNK_DATA32 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_THUNK_DATA32>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_THUNK_DATA32 {}
 impl ::core::default::Default for IMAGE_THUNK_DATA32 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5562,12 +5516,6 @@ impl ::core::clone::Clone for IMAGE_THUNK_DATA32_0 {
 unsafe impl ::windows::core::Abi for IMAGE_THUNK_DATA32_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_THUNK_DATA32_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_THUNK_DATA32_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_THUNK_DATA32_0 {}
 impl ::core::default::Default for IMAGE_THUNK_DATA32_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5587,12 +5535,6 @@ impl ::core::clone::Clone for IMAGE_THUNK_DATA64 {
 unsafe impl ::windows::core::Abi for IMAGE_THUNK_DATA64 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_THUNK_DATA64 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_THUNK_DATA64>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_THUNK_DATA64 {}
 impl ::core::default::Default for IMAGE_THUNK_DATA64 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5615,12 +5557,6 @@ impl ::core::clone::Clone for IMAGE_THUNK_DATA64_0 {
 unsafe impl ::windows::core::Abi for IMAGE_THUNK_DATA64_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMAGE_THUNK_DATA64_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGE_THUNK_DATA64_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMAGE_THUNK_DATA64_0 {}
 impl ::core::default::Default for IMAGE_THUNK_DATA64_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5658,7 +5594,7 @@ unsafe impl ::windows::core::Abi for IMEPROA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMEPROA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEPROA>()) == 0 }
+        self.hWnd == other.hWnd && self.InstDate == other.InstDate && self.wVersion == other.wVersion && self.szDescription == other.szDescription && self.szName == other.szName && self.szOptions == other.szOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5701,7 +5637,7 @@ unsafe impl ::windows::core::Abi for IMEPROW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMEPROW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEPROW>()) == 0 }
+        self.hWnd == other.hWnd && self.InstDate == other.InstDate && self.wVersion == other.wVersion && self.szDescription == other.szDescription && self.szName == other.szName && self.szOptions == other.szOptions
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5746,7 +5682,7 @@ unsafe impl ::windows::core::Abi for IMESTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMESTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMESTRUCT>()) == 0 }
+        self.fnc == other.fnc && self.wParam == other.wParam && self.wCount == other.wCount && self.dchSource == other.dchSource && self.dchDest == other.dchDest && self.lParam1 == other.lParam1 && self.lParam2 == other.lParam2 && self.lParam3 == other.lParam3
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5777,14 +5713,6 @@ unsafe impl ::windows::core::Abi for IO_STATUS_BLOCK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IO_STATUS_BLOCK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_STATUS_BLOCK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IO_STATUS_BLOCK {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IO_STATUS_BLOCK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -5809,14 +5737,6 @@ impl ::core::clone::Clone for IO_STATUS_BLOCK_0 {
 unsafe impl ::windows::core::Abi for IO_STATUS_BLOCK_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IO_STATUS_BLOCK_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IO_STATUS_BLOCK_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IO_STATUS_BLOCK_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IO_STATUS_BLOCK_0 {
     fn default() -> Self {
@@ -5874,7 +5794,7 @@ unsafe impl ::windows::core::Abi for JAVA_TRUST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for JAVA_TRUST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JAVA_TRUST>()) == 0 }
+        self.cbSize == other.cbSize && self.flag == other.flag && self.fAllActiveXPermissions == other.fAllActiveXPermissions && self.fAllPermissions == other.fAllPermissions && self.dwEncodingType == other.dwEncodingType && self.pbJavaPermissions == other.pbJavaPermissions && self.cbJavaPermissions == other.cbJavaPermissions && self.pbSigner == other.pbSigner && self.cbSigner == other.cbSigner && self.pwszZone == other.pwszZone && self.guidZone == other.guidZone && self.hVerify == other.hVerify
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5912,7 +5832,7 @@ unsafe impl ::windows::core::Abi for JIT_DEBUG_INFO {
 }
 impl ::core::cmp::PartialEq for JIT_DEBUG_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JIT_DEBUG_INFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwProcessorArchitecture == other.dwProcessorArchitecture && self.dwThreadID == other.dwThreadID && self.dwReserved0 == other.dwReserved0 && self.lpExceptionAddress == other.lpExceptionAddress && self.lpExceptionRecord == other.lpExceptionRecord && self.lpContextRecord == other.lpContextRecord
     }
 }
 impl ::core::cmp::Eq for JIT_DEBUG_INFO {}
@@ -5951,7 +5871,7 @@ unsafe impl ::windows::core::Abi for KEY_VALUE_ENTRY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for KEY_VALUE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEY_VALUE_ENTRY>()) == 0 }
+        self.ValueName == other.ValueName && self.DataLength == other.DataLength && self.DataOffset == other.DataOffset && self.Type == other.Type
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5990,14 +5910,6 @@ unsafe impl ::windows::core::Abi for LDR_DATA_TABLE_ENTRY {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for LDR_DATA_TABLE_ENTRY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDR_DATA_TABLE_ENTRY>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for LDR_DATA_TABLE_ENTRY {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for LDR_DATA_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6022,14 +5934,6 @@ impl ::core::clone::Clone for LDR_DATA_TABLE_ENTRY_0 {
 unsafe impl ::windows::core::Abi for LDR_DATA_TABLE_ENTRY_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::PartialEq for LDR_DATA_TABLE_ENTRY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LDR_DATA_TABLE_ENTRY_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
-impl ::core::cmp::Eq for LDR_DATA_TABLE_ENTRY_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl ::core::default::Default for LDR_DATA_TABLE_ENTRY_0 {
     fn default() -> Self {
@@ -6068,7 +5972,7 @@ unsafe impl ::windows::core::Abi for OBJECT_ATTRIBUTES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for OBJECT_ATTRIBUTES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECT_ATTRIBUTES>()) == 0 }
+        self.Length == other.Length && self.RootDirectory == other.RootDirectory && self.ObjectName == other.ObjectName && self.Attributes == other.Attributes && self.SecurityDescriptor == other.SecurityDescriptor && self.SecurityQualityOfService == other.SecurityQualityOfService
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6113,7 +6017,7 @@ unsafe impl ::windows::core::Abi for PERUSERSECTIONA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERUSERSECTIONA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERUSERSECTIONA>()) == 0 }
+        self.szGUID == other.szGUID && self.szDispName == other.szDispName && self.szLocale == other.szLocale && self.szStub == other.szStub && self.szVersion == other.szVersion && self.szCompID == other.szCompID && self.dwIsInstalled == other.dwIsInstalled && self.bRollback == other.bRollback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6158,7 +6062,7 @@ unsafe impl ::windows::core::Abi for PERUSERSECTIONW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PERUSERSECTIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERUSERSECTIONW>()) == 0 }
+        self.szGUID == other.szGUID && self.szDispName == other.szDispName && self.szLocale == other.szLocale && self.szStub == other.szStub && self.szVersion == other.szVersion && self.szCompID == other.szCompID && self.dwIsInstalled == other.dwIsInstalled && self.bRollback == other.bRollback
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6194,7 +6098,7 @@ unsafe impl ::windows::core::Abi for PUBLIC_OBJECT_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for PUBLIC_OBJECT_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBLIC_OBJECT_BASIC_INFORMATION>()) == 0 }
+        self.Attributes == other.Attributes && self.GrantedAccess == other.GrantedAccess && self.HandleCount == other.HandleCount && self.PointerCount == other.PointerCount && self.Reserved == other.Reserved
     }
 }
 impl ::core::cmp::Eq for PUBLIC_OBJECT_BASIC_INFORMATION {}
@@ -6231,7 +6135,7 @@ unsafe impl ::windows::core::Abi for PUBLIC_OBJECT_TYPE_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PUBLIC_OBJECT_TYPE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBLIC_OBJECT_TYPE_INFORMATION>()) == 0 }
+        self.TypeName == other.TypeName && self.Reserved == other.Reserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6264,7 +6168,7 @@ unsafe impl ::windows::core::Abi for STRENTRYA {
 }
 impl ::core::cmp::PartialEq for STRENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRENTRYA>()) == 0 }
+        self.pszName == other.pszName && self.pszValue == other.pszValue
     }
 }
 impl ::core::cmp::Eq for STRENTRYA {}
@@ -6295,7 +6199,7 @@ unsafe impl ::windows::core::Abi for STRENTRYW {
 }
 impl ::core::cmp::PartialEq for STRENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRENTRYW>()) == 0 }
+        self.pszName == other.pszName && self.pszValue == other.pszValue
     }
 }
 impl ::core::cmp::Eq for STRENTRYW {}
@@ -6329,7 +6233,7 @@ unsafe impl ::windows::core::Abi for STRINGEXSTRUCT {
 }
 impl ::core::cmp::PartialEq for STRINGEXSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRINGEXSTRUCT>()) == 0 }
+        self.dwSize == other.dwSize && self.uDeterminePos == other.uDeterminePos && self.uDetermineDelimPos == other.uDetermineDelimPos && self.uYomiPos == other.uYomiPos && self.uYomiDelimPos == other.uYomiDelimPos
     }
 }
 impl ::core::cmp::Eq for STRINGEXSTRUCT {}
@@ -6360,7 +6264,7 @@ unsafe impl ::windows::core::Abi for STRTABLEA {
 }
 impl ::core::cmp::PartialEq for STRTABLEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRTABLEA>()) == 0 }
+        self.cEntries == other.cEntries && self.pse == other.pse
     }
 }
 impl ::core::cmp::Eq for STRTABLEA {}
@@ -6391,7 +6295,7 @@ unsafe impl ::windows::core::Abi for STRTABLEW {
 }
 impl ::core::cmp::PartialEq for STRTABLEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRTABLEW>()) == 0 }
+        self.cEntries == other.cEntries && self.pse == other.pse
     }
 }
 impl ::core::cmp::Eq for STRTABLEW {}
@@ -6423,7 +6327,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_BASIC_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_BASIC_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_BASIC_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.NumberOfProcessors == other.NumberOfProcessors
     }
 }
 impl ::core::cmp::Eq for SYSTEM_BASIC_INFORMATION {}
@@ -6454,7 +6358,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_CODEINTEGRITY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_CODEINTEGRITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_CODEINTEGRITY_INFORMATION>()) == 0 }
+        self.Length == other.Length && self.CodeIntegrityOptions == other.CodeIntegrityOptions
     }
 }
 impl ::core::cmp::Eq for SYSTEM_CODEINTEGRITY_INFORMATION {}
@@ -6484,7 +6388,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_EXCEPTION_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_EXCEPTION_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_EXCEPTION_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_EXCEPTION_INFORMATION {}
@@ -6514,7 +6418,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_INTERRUPT_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_INTERRUPT_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_INTERRUPT_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_INTERRUPT_INFORMATION {}
@@ -6544,7 +6448,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_LOOKASIDE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_LOOKASIDE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_LOOKASIDE_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_LOOKASIDE_INFORMATION {}
@@ -6574,7 +6478,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_PERFORMANCE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_PERFORMANCE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_PERFORMANCE_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_PERFORMANCE_INFORMATION {}
@@ -6605,7 +6509,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_POLICY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_POLICY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_POLICY_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for SYSTEM_POLICY_INFORMATION {}
@@ -6639,7 +6543,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION>()) == 0 }
+        self.IdleTime == other.IdleTime && self.KernelTime == other.KernelTime && self.UserTime == other.UserTime && self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2
     }
 }
 impl ::core::cmp::Eq for SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {}
@@ -6721,7 +6625,29 @@ unsafe impl ::windows::core::Abi for SYSTEM_PROCESS_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_PROCESS_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_PROCESS_INFORMATION>()) == 0 }
+        self.NextEntryOffset == other.NextEntryOffset
+            && self.NumberOfThreads == other.NumberOfThreads
+            && self.Reserved1 == other.Reserved1
+            && self.ImageName == other.ImageName
+            && self.BasePriority == other.BasePriority
+            && self.UniqueProcessId == other.UniqueProcessId
+            && self.Reserved2 == other.Reserved2
+            && self.HandleCount == other.HandleCount
+            && self.SessionId == other.SessionId
+            && self.Reserved3 == other.Reserved3
+            && self.PeakVirtualSize == other.PeakVirtualSize
+            && self.VirtualSize == other.VirtualSize
+            && self.Reserved4 == other.Reserved4
+            && self.PeakWorkingSetSize == other.PeakWorkingSetSize
+            && self.WorkingSetSize == other.WorkingSetSize
+            && self.Reserved5 == other.Reserved5
+            && self.QuotaPagedPoolUsage == other.QuotaPagedPoolUsage
+            && self.Reserved6 == other.Reserved6
+            && self.QuotaNonPagedPoolUsage == other.QuotaNonPagedPoolUsage
+            && self.PagefileUsage == other.PagefileUsage
+            && self.PeakPagefileUsage == other.PeakPagefileUsage
+            && self.PrivatePageCount == other.PrivatePageCount
+            && self.Reserved7 == other.Reserved7
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6755,7 +6681,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_REGISTRY_QUOTA_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_REGISTRY_QUOTA_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_REGISTRY_QUOTA_INFORMATION>()) == 0 }
+        self.RegistryQuotaAllowed == other.RegistryQuotaAllowed && self.RegistryQuotaUsed == other.RegistryQuotaUsed && self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_REGISTRY_QUOTA_INFORMATION {}
@@ -6799,7 +6725,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_THREAD_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYSTEM_THREAD_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_THREAD_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1 && self.Reserved2 == other.Reserved2 && self.StartAddress == other.StartAddress && self.ClientId == other.ClientId && self.Priority == other.Priority && self.BasePriority == other.BasePriority && self.Reserved3 == other.Reserved3 && self.ThreadState == other.ThreadState && self.WaitReason == other.WaitReason
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6831,7 +6757,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_TIMEOFDAY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for SYSTEM_TIMEOFDAY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_TIMEOFDAY_INFORMATION>()) == 0 }
+        self.Reserved1 == other.Reserved1
     }
 }
 impl ::core::cmp::Eq for SYSTEM_TIMEOFDAY_INFORMATION {}
@@ -6868,7 +6794,7 @@ unsafe impl ::windows::core::Abi for TCP_REQUEST_QUERY_INFORMATION_EX32_XP {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for TCP_REQUEST_QUERY_INFORMATION_EX32_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_REQUEST_QUERY_INFORMATION_EX32_XP>()) == 0 }
+        self.ID == other.ID && self.Context == other.Context
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -6901,7 +6827,7 @@ unsafe impl ::windows::core::Abi for TCP_REQUEST_QUERY_INFORMATION_EX_W2K {
 }
 impl ::core::cmp::PartialEq for TCP_REQUEST_QUERY_INFORMATION_EX_W2K {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_REQUEST_QUERY_INFORMATION_EX_W2K>()) == 0 }
+        self.ID == other.ID && self.Context == other.Context
     }
 }
 impl ::core::cmp::Eq for TCP_REQUEST_QUERY_INFORMATION_EX_W2K {}
@@ -6932,7 +6858,7 @@ unsafe impl ::windows::core::Abi for TCP_REQUEST_QUERY_INFORMATION_EX_XP {
 }
 impl ::core::cmp::PartialEq for TCP_REQUEST_QUERY_INFORMATION_EX_XP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_REQUEST_QUERY_INFORMATION_EX_XP>()) == 0 }
+        self.ID == other.ID && self.Context == other.Context
     }
 }
 impl ::core::cmp::Eq for TCP_REQUEST_QUERY_INFORMATION_EX_XP {}
@@ -6964,7 +6890,7 @@ unsafe impl ::windows::core::Abi for TCP_REQUEST_SET_INFORMATION_EX {
 }
 impl ::core::cmp::PartialEq for TCP_REQUEST_SET_INFORMATION_EX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCP_REQUEST_SET_INFORMATION_EX>()) == 0 }
+        self.ID == other.ID && self.BufferSize == other.BufferSize && self.Buffer == other.Buffer
     }
 }
 impl ::core::cmp::Eq for TCP_REQUEST_SET_INFORMATION_EX {}
@@ -6995,7 +6921,7 @@ unsafe impl ::windows::core::Abi for TDIEntityID {
 }
 impl ::core::cmp::PartialEq for TDIEntityID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TDIEntityID>()) == 0 }
+        self.tei_entity == other.tei_entity && self.tei_instance == other.tei_instance
     }
 }
 impl ::core::cmp::Eq for TDIEntityID {}
@@ -7028,7 +6954,7 @@ unsafe impl ::windows::core::Abi for TDIObjectID {
 }
 impl ::core::cmp::PartialEq for TDIObjectID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TDIObjectID>()) == 0 }
+        self.toi_entity == other.toi_entity && self.toi_class == other.toi_class && self.toi_type == other.toi_type && self.toi_id == other.toi_id
     }
 }
 impl ::core::cmp::Eq for TDIObjectID {}
@@ -7057,12 +6983,6 @@ impl ::core::clone::Clone for TDI_TL_IO_CONTROL_ENDPOINT {
 unsafe impl ::windows::core::Abi for TDI_TL_IO_CONTROL_ENDPOINT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TDI_TL_IO_CONTROL_ENDPOINT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TDI_TL_IO_CONTROL_ENDPOINT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TDI_TL_IO_CONTROL_ENDPOINT {}
 impl ::core::default::Default for TDI_TL_IO_CONTROL_ENDPOINT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7083,12 +7003,6 @@ impl ::core::clone::Clone for TDI_TL_IO_CONTROL_ENDPOINT_0 {
 unsafe impl ::windows::core::Abi for TDI_TL_IO_CONTROL_ENDPOINT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TDI_TL_IO_CONTROL_ENDPOINT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TDI_TL_IO_CONTROL_ENDPOINT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TDI_TL_IO_CONTROL_ENDPOINT_0 {}
 impl ::core::default::Default for TDI_TL_IO_CONTROL_ENDPOINT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7121,7 +7035,7 @@ unsafe impl ::windows::core::Abi for THREAD_NAME_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for THREAD_NAME_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THREAD_NAME_INFORMATION>()) == 0 }
+        self.ThreadName == other.ThreadName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7181,7 +7095,7 @@ unsafe impl ::windows::core::Abi for UNDETERMINESTRUCT {
 }
 impl ::core::cmp::PartialEq for UNDETERMINESTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UNDETERMINESTRUCT>()) == 0 }
+        self.dwSize == other.dwSize && self.uDefIMESize == other.uDefIMESize && self.uDefIMEPos == other.uDefIMEPos && self.uUndetTextLen == other.uUndetTextLen && self.uUndetTextPos == other.uUndetTextPos && self.uUndetAttrPos == other.uUndetAttrPos && self.uCursorPos == other.uCursorPos && self.uDeltaStart == other.uDeltaStart && self.uDetermineTextLen == other.uDetermineTextLen && self.uDetermineTextPos == other.uDetermineTextPos && self.uDetermineDelimPos == other.uDetermineDelimPos && self.uYomiTextLen == other.uYomiTextLen && self.uYomiTextPos == other.uYomiTextPos && self.uYomiDelimPos == other.uYomiDelimPos
     }
 }
 impl ::core::cmp::Eq for UNDETERMINESTRUCT {}
@@ -7213,7 +7127,7 @@ unsafe impl ::windows::core::Abi for WINSTATIONINFORMATIONW {
 }
 impl ::core::cmp::PartialEq for WINSTATIONINFORMATIONW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINSTATIONINFORMATIONW>()) == 0 }
+        self.Reserved2 == other.Reserved2 && self.LogonId == other.LogonId && self.Reserved3 == other.Reserved3
     }
 }
 impl ::core::cmp::Eq for WINSTATIONINFORMATIONW {}
@@ -7246,7 +7160,7 @@ unsafe impl ::windows::core::Abi for WLDP_DEVICE_SECURITY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for WLDP_DEVICE_SECURITY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLDP_DEVICE_SECURITY_INFORMATION>()) == 0 }
+        self.UnlockIdSize == other.UnlockIdSize && self.UnlockId == other.UnlockId && self.ManufacturerIDLength == other.ManufacturerIDLength && self.ManufacturerID == other.ManufacturerID
     }
 }
 impl ::core::cmp::Eq for WLDP_DEVICE_SECURITY_INFORMATION {}
@@ -7285,7 +7199,7 @@ unsafe impl ::windows::core::Abi for WLDP_HOST_INFORMATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WLDP_HOST_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WLDP_HOST_INFORMATION>()) == 0 }
+        self.dwRevision == other.dwRevision && self.dwHostId == other.dwHostId && self.szSource == other.szSource && self.hSource == other.hSource
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
@@ -5464,7 +5464,7 @@ unsafe impl ::windows::core::Abi for ID_PARAMETERS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ID_PARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ID_PARAMETERS>()) == 0 }
+        self.dwSize == other.dwSize && self.replicaId == other.replicaId && self.itemId == other.itemId && self.changeUnitId == other.changeUnitId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5503,7 +5503,7 @@ unsafe impl ::windows::core::Abi for ID_PARAMETER_PAIR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ID_PARAMETER_PAIR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ID_PARAMETER_PAIR>()) == 0 }
+        self.fIsVariable == other.fIsVariable && self.cbIdSize == other.cbIdSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5542,7 +5542,7 @@ unsafe impl ::windows::core::Abi for SYNC_FILTER_CHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SYNC_FILTER_CHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNC_FILTER_CHANGE>()) == 0 }
+        self.fMoveIn == other.fMoveIn && self.moveVersion == other.moveVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5575,7 +5575,7 @@ unsafe impl ::windows::core::Abi for SYNC_RANGE {
 }
 impl ::core::cmp::PartialEq for SYNC_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNC_RANGE>()) == 0 }
+        self.pbClosedLowerBound == other.pbClosedLowerBound && self.pbClosedUpperBound == other.pbClosedUpperBound
     }
 }
 impl ::core::cmp::Eq for SYNC_RANGE {}
@@ -5606,7 +5606,7 @@ unsafe impl ::windows::core::Abi for SYNC_SESSION_STATISTICS {
 }
 impl ::core::cmp::PartialEq for SYNC_SESSION_STATISTICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNC_SESSION_STATISTICS>()) == 0 }
+        self.dwChangesApplied == other.dwChangesApplied && self.dwChangesFailed == other.dwChangesFailed
     }
 }
 impl ::core::cmp::Eq for SYNC_SESSION_STATISTICS {}
@@ -5637,7 +5637,7 @@ unsafe impl ::windows::core::Abi for SYNC_TIME {
 }
 impl ::core::cmp::PartialEq for SYNC_TIME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNC_TIME>()) == 0 }
+        self.dwDate == other.dwDate && self.dwTime == other.dwTime
     }
 }
 impl ::core::cmp::Eq for SYNC_TIME {}
@@ -5668,7 +5668,7 @@ unsafe impl ::windows::core::Abi for SYNC_VERSION {
 }
 impl ::core::cmp::PartialEq for SYNC_VERSION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNC_VERSION>()) == 0 }
+        self.dwLastUpdatingReplicaKey == other.dwLastUpdatingReplicaKey && self.ullTickCount == other.ullTickCount
     }
 }
 impl ::core::cmp::Eq for SYNC_VERSION {}
@@ -5710,7 +5710,7 @@ unsafe impl ::windows::core::Abi for SyncProviderConfigUIConfiguration {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SyncProviderConfigUIConfiguration {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SyncProviderConfigUIConfiguration>()) == 0 }
+        self.dwVersion == other.dwVersion && self.guidInstanceId == other.guidInstanceId && self.clsidConfigUI == other.clsidConfigUI && self.guidContentType == other.guidContentType && self.dwCapabilities == other.dwCapabilities && self.dwSupportedArchitecture == other.dwSupportedArchitecture && self.fIsGlobal == other.fIsGlobal
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -5748,7 +5748,7 @@ unsafe impl ::windows::core::Abi for SyncProviderConfiguration {
 }
 impl ::core::cmp::PartialEq for SyncProviderConfiguration {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SyncProviderConfiguration>()) == 0 }
+        self.dwVersion == other.dwVersion && self.guidInstanceId == other.guidInstanceId && self.clsidProvider == other.clsidProvider && self.guidConfigUIInstanceId == other.guidConfigUIInstanceId && self.guidContentType == other.guidContentType && self.dwCapabilities == other.dwCapabilities && self.dwSupportedArchitecture == other.dwSupportedArchitecture
     }
 }
 impl ::core::cmp::Eq for SyncProviderConfiguration {}

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -9780,7 +9780,7 @@ unsafe impl ::windows::core::Abi for MI_Application {
 }
 impl ::core::cmp::PartialEq for MI_Application {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Application>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_Application {}
@@ -9832,7 +9832,7 @@ unsafe impl ::windows::core::Abi for MI_ApplicationFT {
 }
 impl ::core::cmp::PartialEq for MI_ApplicationFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ApplicationFT>()) == 0 }
+        self.Close == other.Close && self.NewSession == other.NewSession && self.NewHostedProvider == other.NewHostedProvider && self.NewInstance == other.NewInstance && self.NewDestinationOptions == other.NewDestinationOptions && self.NewOperationOptions == other.NewOperationOptions && self.NewSubscriptionDeliveryOptions == other.NewSubscriptionDeliveryOptions && self.NewSerializer == other.NewSerializer && self.NewDeserializer == other.NewDeserializer && self.NewInstanceFromClass == other.NewInstanceFromClass && self.NewClass == other.NewClass
     }
 }
 impl ::core::cmp::Eq for MI_ApplicationFT {}
@@ -9863,7 +9863,7 @@ unsafe impl ::windows::core::Abi for MI_Array {
 }
 impl ::core::cmp::PartialEq for MI_Array {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Array>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Array {}
@@ -9895,7 +9895,7 @@ unsafe impl ::windows::core::Abi for MI_ArrayField {
 }
 impl ::core::cmp::PartialEq for MI_ArrayField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ArrayField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ArrayField {}
@@ -9926,7 +9926,7 @@ unsafe impl ::windows::core::Abi for MI_BooleanA {
 }
 impl ::core::cmp::PartialEq for MI_BooleanA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_BooleanA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_BooleanA {}
@@ -9958,7 +9958,7 @@ unsafe impl ::windows::core::Abi for MI_BooleanAField {
 }
 impl ::core::cmp::PartialEq for MI_BooleanAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_BooleanAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_BooleanAField {}
@@ -9990,7 +9990,7 @@ unsafe impl ::windows::core::Abi for MI_BooleanField {
 }
 impl ::core::cmp::PartialEq for MI_BooleanField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_BooleanField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_BooleanField {}
@@ -10021,7 +10021,7 @@ unsafe impl ::windows::core::Abi for MI_Char16A {
 }
 impl ::core::cmp::PartialEq for MI_Char16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Char16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Char16A {}
@@ -10053,7 +10053,7 @@ unsafe impl ::windows::core::Abi for MI_Char16AField {
 }
 impl ::core::cmp::PartialEq for MI_Char16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Char16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Char16AField {}
@@ -10085,7 +10085,7 @@ unsafe impl ::windows::core::Abi for MI_Char16Field {
 }
 impl ::core::cmp::PartialEq for MI_Char16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Char16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Char16Field {}
@@ -10119,7 +10119,7 @@ unsafe impl ::windows::core::Abi for MI_Class {
 }
 impl ::core::cmp::PartialEq for MI_Class {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Class>()) == 0 }
+        self.ft == other.ft && self.classDecl == other.classDecl && self.namespaceName == other.namespaceName && self.serverName == other.serverName && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for MI_Class {}
@@ -10179,7 +10179,7 @@ unsafe impl ::windows::core::Abi for MI_ClassDecl {
 }
 impl ::core::cmp::PartialEq for MI_ClassDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ClassDecl>()) == 0 }
+        self.flags == other.flags && self.code == other.code && self.name == other.name && self.qualifiers == other.qualifiers && self.numQualifiers == other.numQualifiers && self.properties == other.properties && self.numProperties == other.numProperties && self.size == other.size && self.superClass == other.superClass && self.superClassDecl == other.superClassDecl && self.methods == other.methods && self.numMethods == other.numMethods && self.schema == other.schema && self.providerFT == other.providerFT && self.owningClass == other.owningClass
     }
 }
 impl ::core::cmp::Eq for MI_ClassDecl {}
@@ -10237,7 +10237,7 @@ unsafe impl ::windows::core::Abi for MI_ClassFT {
 }
 impl ::core::cmp::PartialEq for MI_ClassFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ClassFT>()) == 0 }
+        self.GetClassNameA == other.GetClassNameA && self.GetNameSpace == other.GetNameSpace && self.GetServerName == other.GetServerName && self.GetElementCount == other.GetElementCount && self.GetElement == other.GetElement && self.GetElementAt == other.GetElementAt && self.GetClassQualifierSet == other.GetClassQualifierSet && self.GetMethodCount == other.GetMethodCount && self.GetMethodAt == other.GetMethodAt && self.GetMethod == other.GetMethod && self.GetParentClassName == other.GetParentClassName && self.GetParentClass == other.GetParentClass && self.Delete == other.Delete && self.Clone == other.Clone
     }
 }
 impl ::core::cmp::Eq for MI_ClassFT {}
@@ -10287,7 +10287,7 @@ unsafe impl ::windows::core::Abi for MI_ClientFT_V1 {
 }
 impl ::core::cmp::PartialEq for MI_ClientFT_V1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ClientFT_V1>()) == 0 }
+        self.applicationFT == other.applicationFT && self.sessionFT == other.sessionFT && self.operationFT == other.operationFT && self.hostedProviderFT == other.hostedProviderFT && self.serializerFT == other.serializerFT && self.deserializerFT == other.deserializerFT && self.subscribeDeliveryOptionsFT == other.subscribeDeliveryOptionsFT && self.destinationOptionsFT == other.destinationOptionsFT && self.operationOptionsFT == other.operationOptionsFT && self.utilitiesFT == other.utilitiesFT
     }
 }
 impl ::core::cmp::Eq for MI_ClientFT_V1 {}
@@ -10318,7 +10318,7 @@ unsafe impl ::windows::core::Abi for MI_ConstBooleanA {
 }
 impl ::core::cmp::PartialEq for MI_ConstBooleanA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstBooleanA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstBooleanA {}
@@ -10350,7 +10350,7 @@ unsafe impl ::windows::core::Abi for MI_ConstBooleanAField {
 }
 impl ::core::cmp::PartialEq for MI_ConstBooleanAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstBooleanAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstBooleanAField {}
@@ -10382,7 +10382,7 @@ unsafe impl ::windows::core::Abi for MI_ConstBooleanField {
 }
 impl ::core::cmp::PartialEq for MI_ConstBooleanField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstBooleanField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstBooleanField {}
@@ -10413,7 +10413,7 @@ unsafe impl ::windows::core::Abi for MI_ConstChar16A {
 }
 impl ::core::cmp::PartialEq for MI_ConstChar16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstChar16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstChar16A {}
@@ -10445,7 +10445,7 @@ unsafe impl ::windows::core::Abi for MI_ConstChar16AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstChar16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstChar16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstChar16AField {}
@@ -10477,7 +10477,7 @@ unsafe impl ::windows::core::Abi for MI_ConstChar16Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstChar16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstChar16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstChar16Field {}
@@ -10508,7 +10508,7 @@ unsafe impl ::windows::core::Abi for MI_ConstDatetimeA {
 }
 impl ::core::cmp::PartialEq for MI_ConstDatetimeA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstDatetimeA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstDatetimeA {}
@@ -10540,7 +10540,7 @@ unsafe impl ::windows::core::Abi for MI_ConstDatetimeAField {
 }
 impl ::core::cmp::PartialEq for MI_ConstDatetimeAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstDatetimeAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstDatetimeAField {}
@@ -10565,12 +10565,6 @@ impl ::core::clone::Clone for MI_ConstDatetimeField {
 unsafe impl ::windows::core::Abi for MI_ConstDatetimeField {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_ConstDatetimeField {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstDatetimeField>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_ConstDatetimeField {}
 impl ::core::default::Default for MI_ConstDatetimeField {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10598,7 +10592,7 @@ unsafe impl ::windows::core::Abi for MI_ConstInstanceA {
 }
 impl ::core::cmp::PartialEq for MI_ConstInstanceA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstInstanceA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstInstanceA {}
@@ -10630,7 +10624,7 @@ unsafe impl ::windows::core::Abi for MI_ConstInstanceAField {
 }
 impl ::core::cmp::PartialEq for MI_ConstInstanceAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstInstanceAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstInstanceAField {}
@@ -10662,7 +10656,7 @@ unsafe impl ::windows::core::Abi for MI_ConstInstanceField {
 }
 impl ::core::cmp::PartialEq for MI_ConstInstanceField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstInstanceField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstInstanceField {}
@@ -10693,7 +10687,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal32A {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal32A {}
@@ -10725,7 +10719,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal32AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal32AField {}
@@ -10757,7 +10751,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal32Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal32Field {}
@@ -10788,7 +10782,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal64A {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal64A {}
@@ -10820,7 +10814,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal64AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal64AField {}
@@ -10852,7 +10846,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReal64Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstReal64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReal64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReal64Field {}
@@ -10883,7 +10877,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReferenceA {
 }
 impl ::core::cmp::PartialEq for MI_ConstReferenceA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReferenceA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstReferenceA {}
@@ -10915,7 +10909,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReferenceAField {
 }
 impl ::core::cmp::PartialEq for MI_ConstReferenceAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReferenceAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReferenceAField {}
@@ -10947,7 +10941,7 @@ unsafe impl ::windows::core::Abi for MI_ConstReferenceField {
 }
 impl ::core::cmp::PartialEq for MI_ConstReferenceField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstReferenceField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstReferenceField {}
@@ -10978,7 +10972,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint16A {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint16A {}
@@ -11010,7 +11004,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint16AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint16AField {}
@@ -11042,7 +11036,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint16Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint16Field {}
@@ -11073,7 +11067,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint32A {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint32A {}
@@ -11105,7 +11099,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint32AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint32AField {}
@@ -11137,7 +11131,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint32Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint32Field {}
@@ -11168,7 +11162,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint64A {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint64A {}
@@ -11200,7 +11194,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint64AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint64AField {}
@@ -11232,7 +11226,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint64Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint64Field {}
@@ -11263,7 +11257,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint8A {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint8A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint8A {}
@@ -11295,7 +11289,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint8AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint8AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint8AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint8AField {}
@@ -11327,7 +11321,7 @@ unsafe impl ::windows::core::Abi for MI_ConstSint8Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstSint8Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstSint8Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstSint8Field {}
@@ -11358,7 +11352,7 @@ unsafe impl ::windows::core::Abi for MI_ConstStringA {
 }
 impl ::core::cmp::PartialEq for MI_ConstStringA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstStringA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstStringA {}
@@ -11390,7 +11384,7 @@ unsafe impl ::windows::core::Abi for MI_ConstStringAField {
 }
 impl ::core::cmp::PartialEq for MI_ConstStringAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstStringAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstStringAField {}
@@ -11422,7 +11416,7 @@ unsafe impl ::windows::core::Abi for MI_ConstStringField {
 }
 impl ::core::cmp::PartialEq for MI_ConstStringField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstStringField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstStringField {}
@@ -11453,7 +11447,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint16A {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint16A {}
@@ -11485,7 +11479,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint16AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint16AField {}
@@ -11517,7 +11511,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint16Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint16Field {}
@@ -11548,7 +11542,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint32A {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint32A {}
@@ -11580,7 +11574,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint32AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint32AField {}
@@ -11612,7 +11606,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint32Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint32Field {}
@@ -11643,7 +11637,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint64A {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint64A {}
@@ -11675,7 +11669,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint64AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint64AField {}
@@ -11707,7 +11701,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint64Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint64Field {}
@@ -11738,7 +11732,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint8A {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint8A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint8A {}
@@ -11770,7 +11764,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint8AField {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint8AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint8AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint8AField {}
@@ -11802,7 +11796,7 @@ unsafe impl ::windows::core::Abi for MI_ConstUint8Field {
 }
 impl ::core::cmp::PartialEq for MI_ConstUint8Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ConstUint8Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ConstUint8Field {}
@@ -11833,7 +11827,7 @@ unsafe impl ::windows::core::Abi for MI_Context {
 }
 impl ::core::cmp::PartialEq for MI_Context {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Context>()) == 0 }
+        self.ft == other.ft && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for MI_Context {}
@@ -11923,7 +11917,36 @@ unsafe impl ::windows::core::Abi for MI_ContextFT {
 }
 impl ::core::cmp::PartialEq for MI_ContextFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ContextFT>()) == 0 }
+        self.PostResult == other.PostResult
+            && self.PostInstance == other.PostInstance
+            && self.PostIndication == other.PostIndication
+            && self.ConstructInstance == other.ConstructInstance
+            && self.ConstructParameters == other.ConstructParameters
+            && self.NewInstance == other.NewInstance
+            && self.NewDynamicInstance == other.NewDynamicInstance
+            && self.NewParameters == other.NewParameters
+            && self.Canceled == other.Canceled
+            && self.GetLocale == other.GetLocale
+            && self.RegisterCancel == other.RegisterCancel
+            && self.RequestUnload == other.RequestUnload
+            && self.RefuseUnload == other.RefuseUnload
+            && self.GetLocalSession == other.GetLocalSession
+            && self.SetStringOption == other.SetStringOption
+            && self.GetStringOption == other.GetStringOption
+            && self.GetNumberOption == other.GetNumberOption
+            && self.GetCustomOption == other.GetCustomOption
+            && self.GetCustomOptionCount == other.GetCustomOptionCount
+            && self.GetCustomOptionAt == other.GetCustomOptionAt
+            && self.WriteMessage == other.WriteMessage
+            && self.WriteProgress == other.WriteProgress
+            && self.WriteStreamParameter == other.WriteStreamParameter
+            && self.WriteCimError == other.WriteCimError
+            && self.PromptUser == other.PromptUser
+            && self.ShouldProcess == other.ShouldProcess
+            && self.ShouldContinue == other.ShouldContinue
+            && self.PostError == other.PostError
+            && self.PostCimError == other.PostCimError
+            && self.WriteError == other.WriteError
     }
 }
 impl ::core::cmp::Eq for MI_ContextFT {}
@@ -11947,12 +11970,6 @@ impl ::core::clone::Clone for MI_Datetime {
 unsafe impl ::windows::core::Abi for MI_Datetime {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_Datetime {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Datetime>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_Datetime {}
 impl ::core::default::Default for MI_Datetime {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11973,12 +11990,6 @@ impl ::core::clone::Clone for MI_Datetime_0 {
 unsafe impl ::windows::core::Abi for MI_Datetime_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_Datetime_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Datetime_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_Datetime_0 {}
 impl ::core::default::Default for MI_Datetime_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12006,7 +12017,7 @@ unsafe impl ::windows::core::Abi for MI_DatetimeA {
 }
 impl ::core::cmp::PartialEq for MI_DatetimeA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DatetimeA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_DatetimeA {}
@@ -12038,7 +12049,7 @@ unsafe impl ::windows::core::Abi for MI_DatetimeAField {
 }
 impl ::core::cmp::PartialEq for MI_DatetimeAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DatetimeAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_DatetimeAField {}
@@ -12063,12 +12074,6 @@ impl ::core::clone::Clone for MI_DatetimeField {
 unsafe impl ::windows::core::Abi for MI_DatetimeField {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_DatetimeField {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DatetimeField>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_DatetimeField {}
 impl ::core::default::Default for MI_DatetimeField {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12096,7 +12101,7 @@ unsafe impl ::windows::core::Abi for MI_Deserializer {
 }
 impl ::core::cmp::PartialEq for MI_Deserializer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Deserializer>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2
     }
 }
 impl ::core::cmp::Eq for MI_Deserializer {}
@@ -12131,7 +12136,7 @@ unsafe impl ::windows::core::Abi for MI_DeserializerFT {
 }
 impl ::core::cmp::PartialEq for MI_DeserializerFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DeserializerFT>()) == 0 }
+        self.Close == other.Close && self.DeserializeClass == other.DeserializeClass && self.Class_GetClassName == other.Class_GetClassName && self.Class_GetParentClassName == other.Class_GetParentClassName && self.DeserializeInstance == other.DeserializeInstance && self.Instance_GetClassName == other.Instance_GetClassName
     }
 }
 impl ::core::cmp::Eq for MI_DeserializerFT {}
@@ -12163,7 +12168,7 @@ unsafe impl ::windows::core::Abi for MI_DestinationOptions {
 }
 impl ::core::cmp::PartialEq for MI_DestinationOptions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DestinationOptions>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_DestinationOptions {}
@@ -12223,7 +12228,7 @@ unsafe impl ::windows::core::Abi for MI_DestinationOptionsFT {
 }
 impl ::core::cmp::PartialEq for MI_DestinationOptionsFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_DestinationOptionsFT>()) == 0 }
+        self.Delete == other.Delete && self.SetString == other.SetString && self.SetNumber == other.SetNumber && self.AddCredentials == other.AddCredentials && self.GetString == other.GetString && self.GetNumber == other.GetNumber && self.GetOptionCount == other.GetOptionCount && self.GetOptionAt == other.GetOptionAt && self.GetOption == other.GetOption && self.GetCredentialsCount == other.GetCredentialsCount && self.GetCredentialsAt == other.GetCredentialsAt && self.GetCredentialsPasswordAt == other.GetCredentialsPasswordAt && self.Clone == other.Clone && self.SetInterval == other.SetInterval && self.GetInterval == other.GetInterval
     }
 }
 impl ::core::cmp::Eq for MI_DestinationOptionsFT {}
@@ -12257,7 +12262,7 @@ unsafe impl ::windows::core::Abi for MI_FeatureDecl {
 }
 impl ::core::cmp::PartialEq for MI_FeatureDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_FeatureDecl>()) == 0 }
+        self.flags == other.flags && self.code == other.code && self.name == other.name && self.qualifiers == other.qualifiers && self.numQualifiers == other.numQualifiers
     }
 }
 impl ::core::cmp::Eq for MI_FeatureDecl {}
@@ -12288,7 +12293,7 @@ unsafe impl ::windows::core::Abi for MI_Filter {
 }
 impl ::core::cmp::PartialEq for MI_Filter {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Filter>()) == 0 }
+        self.ft == other.ft && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for MI_Filter {}
@@ -12319,7 +12324,7 @@ unsafe impl ::windows::core::Abi for MI_FilterFT {
 }
 impl ::core::cmp::PartialEq for MI_FilterFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_FilterFT>()) == 0 }
+        self.Evaluate == other.Evaluate && self.GetExpression == other.GetExpression
     }
 }
 impl ::core::cmp::Eq for MI_FilterFT {}
@@ -12351,7 +12356,7 @@ unsafe impl ::windows::core::Abi for MI_HostedProvider {
 }
 impl ::core::cmp::PartialEq for MI_HostedProvider {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_HostedProvider>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_HostedProvider {}
@@ -12382,7 +12387,7 @@ unsafe impl ::windows::core::Abi for MI_HostedProviderFT {
 }
 impl ::core::cmp::PartialEq for MI_HostedProviderFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_HostedProviderFT>()) == 0 }
+        self.Close == other.Close && self.GetApplication == other.GetApplication
     }
 }
 impl ::core::cmp::Eq for MI_HostedProviderFT {}
@@ -12416,7 +12421,7 @@ unsafe impl ::windows::core::Abi for MI_Instance {
 }
 impl ::core::cmp::PartialEq for MI_Instance {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Instance>()) == 0 }
+        self.ft == other.ft && self.classDecl == other.classDecl && self.serverName == other.serverName && self.nameSpace == other.nameSpace && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for MI_Instance {}
@@ -12447,7 +12452,7 @@ unsafe impl ::windows::core::Abi for MI_InstanceA {
 }
 impl ::core::cmp::PartialEq for MI_InstanceA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_InstanceA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_InstanceA {}
@@ -12479,7 +12484,7 @@ unsafe impl ::windows::core::Abi for MI_InstanceAField {
 }
 impl ::core::cmp::PartialEq for MI_InstanceAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_InstanceAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_InstanceAField {}
@@ -12510,7 +12515,7 @@ unsafe impl ::windows::core::Abi for MI_InstanceExFT {
 }
 impl ::core::cmp::PartialEq for MI_InstanceExFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_InstanceExFT>()) == 0 }
+        self.parent == other.parent && self.Normalize == other.Normalize
     }
 }
 impl ::core::cmp::Eq for MI_InstanceExFT {}
@@ -12576,7 +12581,7 @@ unsafe impl ::windows::core::Abi for MI_InstanceFT {
 }
 impl ::core::cmp::PartialEq for MI_InstanceFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_InstanceFT>()) == 0 }
+        self.Clone == other.Clone && self.Destruct == other.Destruct && self.Delete == other.Delete && self.IsA == other.IsA && self.GetClassNameA == other.GetClassNameA && self.SetNameSpace == other.SetNameSpace && self.GetNameSpace == other.GetNameSpace && self.GetElementCount == other.GetElementCount && self.AddElement == other.AddElement && self.SetElement == other.SetElement && self.SetElementAt == other.SetElementAt && self.GetElement == other.GetElement && self.GetElementAt == other.GetElementAt && self.ClearElement == other.ClearElement && self.ClearElementAt == other.ClearElementAt && self.GetServerName == other.GetServerName && self.SetServerName == other.SetServerName && self.GetClass == other.GetClass
     }
 }
 impl ::core::cmp::Eq for MI_InstanceFT {}
@@ -12608,7 +12613,7 @@ unsafe impl ::windows::core::Abi for MI_InstanceField {
 }
 impl ::core::cmp::PartialEq for MI_InstanceField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_InstanceField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_InstanceField {}
@@ -12645,7 +12650,7 @@ unsafe impl ::windows::core::Abi for MI_Interval {
 }
 impl ::core::cmp::PartialEq for MI_Interval {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Interval>()) == 0 }
+        self.days == other.days && self.hours == other.hours && self.minutes == other.minutes && self.seconds == other.seconds && self.microseconds == other.microseconds && self.__padding1 == other.__padding1 && self.__padding2 == other.__padding2 && self.__padding3 == other.__padding3
     }
 }
 impl ::core::cmp::Eq for MI_Interval {}
@@ -12679,32 +12684,12 @@ impl ::core::clone::Clone for MI_MethodDecl {
 }
 impl ::core::fmt::Debug for MI_MethodDecl {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MI_MethodDecl")
-            .field("flags", &self.flags)
-            .field("code", &self.code)
-            .field("name", &self.name)
-            .field("qualifiers", &self.qualifiers)
-            .field("numQualifiers", &self.numQualifiers)
-            .field("parameters", &self.parameters)
-            .field("numParameters", &self.numParameters)
-            .field("size", &self.size)
-            .field("returnType", &self.returnType)
-            .field("origin", &self.origin)
-            .field("propagator", &self.propagator)
-            .field("schema", &self.schema)
-            .field("function", &self.function.map(|f| f as usize))
-            .finish()
+        f.debug_struct("MI_MethodDecl").field("flags", &self.flags).field("code", &self.code).field("name", &self.name).field("qualifiers", &self.qualifiers).field("numQualifiers", &self.numQualifiers).field("parameters", &self.parameters).field("numParameters", &self.numParameters).field("size", &self.size).field("returnType", &self.returnType).field("origin", &self.origin).field("propagator", &self.propagator).field("schema", &self.schema).finish()
     }
 }
 unsafe impl ::windows::core::Abi for MI_MethodDecl {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_MethodDecl {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_MethodDecl>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_MethodDecl {}
 impl ::core::default::Default for MI_MethodDecl {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12730,18 +12715,12 @@ impl ::core::clone::Clone for MI_Module {
 }
 impl ::core::fmt::Debug for MI_Module {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MI_Module").field("version", &self.version).field("generatorVersion", &self.generatorVersion).field("flags", &self.flags).field("charSize", &self.charSize).field("schemaDecl", &self.schemaDecl).field("Load", &self.Load.map(|f| f as usize)).field("Unload", &self.Unload.map(|f| f as usize)).field("dynamicProviderFT", &self.dynamicProviderFT).finish()
+        f.debug_struct("MI_Module").field("version", &self.version).field("generatorVersion", &self.generatorVersion).field("flags", &self.flags).field("charSize", &self.charSize).field("schemaDecl", &self.schemaDecl).field("dynamicProviderFT", &self.dynamicProviderFT).finish()
     }
 }
 unsafe impl ::windows::core::Abi for MI_Module {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_Module {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Module>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_Module {}
 impl ::core::default::Default for MI_Module {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12777,7 +12756,7 @@ unsafe impl ::windows::core::Abi for MI_ObjectDecl {
 }
 impl ::core::cmp::PartialEq for MI_ObjectDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ObjectDecl>()) == 0 }
+        self.flags == other.flags && self.code == other.code && self.name == other.name && self.qualifiers == other.qualifiers && self.numQualifiers == other.numQualifiers && self.properties == other.properties && self.numProperties == other.numProperties && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ObjectDecl {}
@@ -12809,7 +12788,7 @@ unsafe impl ::windows::core::Abi for MI_Operation {
 }
 impl ::core::cmp::PartialEq for MI_Operation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Operation>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_Operation {}
@@ -12839,28 +12818,12 @@ impl ::core::clone::Clone for MI_OperationCallbacks {
 }
 impl ::core::fmt::Debug for MI_OperationCallbacks {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MI_OperationCallbacks")
-            .field("callbackContext", &self.callbackContext)
-            .field("promptUser", &self.promptUser.map(|f| f as usize))
-            .field("writeError", &self.writeError.map(|f| f as usize))
-            .field("writeMessage", &self.writeMessage.map(|f| f as usize))
-            .field("writeProgress", &self.writeProgress.map(|f| f as usize))
-            .field("instanceResult", &self.instanceResult.map(|f| f as usize))
-            .field("indicationResult", &self.indicationResult.map(|f| f as usize))
-            .field("classResult", &self.classResult.map(|f| f as usize))
-            .field("streamedParameterResult", &self.streamedParameterResult.map(|f| f as usize))
-            .finish()
+        f.debug_struct("MI_OperationCallbacks").field("callbackContext", &self.callbackContext).finish()
     }
 }
 unsafe impl ::windows::core::Abi for MI_OperationCallbacks {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_OperationCallbacks {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_OperationCallbacks>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_OperationCallbacks {}
 impl ::core::default::Default for MI_OperationCallbacks {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12892,7 +12855,7 @@ unsafe impl ::windows::core::Abi for MI_OperationFT {
 }
 impl ::core::cmp::PartialEq for MI_OperationFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_OperationFT>()) == 0 }
+        self.Close == other.Close && self.Cancel == other.Cancel && self.GetSession == other.GetSession && self.GetInstance == other.GetInstance && self.GetIndication == other.GetIndication && self.GetClass == other.GetClass
     }
 }
 impl ::core::cmp::Eq for MI_OperationFT {}
@@ -12924,7 +12887,7 @@ unsafe impl ::windows::core::Abi for MI_OperationOptions {
 }
 impl ::core::cmp::PartialEq for MI_OperationOptions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_OperationOptions>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_OperationOptions {}
@@ -12980,7 +12943,7 @@ unsafe impl ::windows::core::Abi for MI_OperationOptionsFT {
 }
 impl ::core::cmp::PartialEq for MI_OperationOptionsFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_OperationOptionsFT>()) == 0 }
+        self.Delete == other.Delete && self.SetString == other.SetString && self.SetNumber == other.SetNumber && self.SetCustomOption == other.SetCustomOption && self.GetString == other.GetString && self.GetNumber == other.GetNumber && self.GetOptionCount == other.GetOptionCount && self.GetOptionAt == other.GetOptionAt && self.GetOption == other.GetOption && self.GetEnabledChannels == other.GetEnabledChannels && self.Clone == other.Clone && self.SetInterval == other.SetInterval && self.GetInterval == other.GetInterval
     }
 }
 impl ::core::cmp::Eq for MI_OperationOptionsFT {}
@@ -13018,7 +12981,7 @@ unsafe impl ::windows::core::Abi for MI_ParameterDecl {
 }
 impl ::core::cmp::PartialEq for MI_ParameterDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ParameterDecl>()) == 0 }
+        self.flags == other.flags && self.code == other.code && self.name == other.name && self.qualifiers == other.qualifiers && self.numQualifiers == other.numQualifiers && self.r#type == other.r#type && self.className == other.className && self.subscript == other.subscript && self.offset == other.offset
     }
 }
 impl ::core::cmp::Eq for MI_ParameterDecl {}
@@ -13050,7 +13013,7 @@ unsafe impl ::windows::core::Abi for MI_ParameterSet {
 }
 impl ::core::cmp::PartialEq for MI_ParameterSet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ParameterSet>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_ParameterSet {}
@@ -13083,7 +13046,7 @@ unsafe impl ::windows::core::Abi for MI_ParameterSetFT {
 }
 impl ::core::cmp::PartialEq for MI_ParameterSetFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ParameterSetFT>()) == 0 }
+        self.GetMethodReturnType == other.GetMethodReturnType && self.GetParameterCount == other.GetParameterCount && self.GetParameterAt == other.GetParameterAt && self.GetParameter == other.GetParameter
     }
 }
 impl ::core::cmp::Eq for MI_ParameterSetFT {}
@@ -13124,7 +13087,7 @@ unsafe impl ::windows::core::Abi for MI_PropertyDecl {
 }
 impl ::core::cmp::PartialEq for MI_PropertyDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_PropertyDecl>()) == 0 }
+        self.flags == other.flags && self.code == other.code && self.name == other.name && self.qualifiers == other.qualifiers && self.numQualifiers == other.numQualifiers && self.r#type == other.r#type && self.className == other.className && self.subscript == other.subscript && self.offset == other.offset && self.origin == other.origin && self.propagator == other.propagator && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for MI_PropertyDecl {}
@@ -13155,7 +13118,7 @@ unsafe impl ::windows::core::Abi for MI_PropertySet {
 }
 impl ::core::cmp::PartialEq for MI_PropertySet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_PropertySet>()) == 0 }
+        self.ft == other.ft && self.reserved == other.reserved
     }
 }
 impl ::core::cmp::Eq for MI_PropertySet {}
@@ -13192,7 +13155,7 @@ unsafe impl ::windows::core::Abi for MI_PropertySetFT {
 }
 impl ::core::cmp::PartialEq for MI_PropertySetFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_PropertySetFT>()) == 0 }
+        self.GetElementCount == other.GetElementCount && self.ContainsElement == other.ContainsElement && self.AddElement == other.AddElement && self.GetElementAt == other.GetElementAt && self.Clear == other.Clear && self.Destruct == other.Destruct && self.Delete == other.Delete && self.Clone == other.Clone
     }
 }
 impl ::core::cmp::Eq for MI_PropertySetFT {}
@@ -13227,33 +13190,12 @@ impl ::core::clone::Clone for MI_ProviderFT {
 }
 impl ::core::fmt::Debug for MI_ProviderFT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MI_ProviderFT")
-            .field("Load", &self.Load.map(|f| f as usize))
-            .field("Unload", &self.Unload.map(|f| f as usize))
-            .field("GetInstance", &self.GetInstance.map(|f| f as usize))
-            .field("EnumerateInstances", &self.EnumerateInstances.map(|f| f as usize))
-            .field("CreateInstance", &self.CreateInstance.map(|f| f as usize))
-            .field("ModifyInstance", &self.ModifyInstance.map(|f| f as usize))
-            .field("DeleteInstance", &self.DeleteInstance.map(|f| f as usize))
-            .field("AssociatorInstances", &self.AssociatorInstances.map(|f| f as usize))
-            .field("ReferenceInstances", &self.ReferenceInstances.map(|f| f as usize))
-            .field("EnableIndications", &self.EnableIndications.map(|f| f as usize))
-            .field("DisableIndications", &self.DisableIndications.map(|f| f as usize))
-            .field("Subscribe", &self.Subscribe.map(|f| f as usize))
-            .field("Unsubscribe", &self.Unsubscribe.map(|f| f as usize))
-            .field("Invoke", &self.Invoke.map(|f| f as usize))
-            .finish()
+        f.debug_struct("MI_ProviderFT").finish()
     }
 }
 unsafe impl ::windows::core::Abi for MI_ProviderFT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_ProviderFT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ProviderFT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_ProviderFT {}
 impl ::core::default::Default for MI_ProviderFT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -13283,7 +13225,7 @@ unsafe impl ::windows::core::Abi for MI_Qualifier {
 }
 impl ::core::cmp::PartialEq for MI_Qualifier {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Qualifier>()) == 0 }
+        self.name == other.name && self.r#type == other.r#type && self.flavor == other.flavor && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for MI_Qualifier {}
@@ -13318,7 +13260,7 @@ unsafe impl ::windows::core::Abi for MI_QualifierDecl {
 }
 impl ::core::cmp::PartialEq for MI_QualifierDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_QualifierDecl>()) == 0 }
+        self.name == other.name && self.r#type == other.r#type && self.scope == other.scope && self.flavor == other.flavor && self.subscript == other.subscript && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for MI_QualifierDecl {}
@@ -13350,7 +13292,7 @@ unsafe impl ::windows::core::Abi for MI_QualifierSet {
 }
 impl ::core::cmp::PartialEq for MI_QualifierSet {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_QualifierSet>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_QualifierSet {}
@@ -13382,7 +13324,7 @@ unsafe impl ::windows::core::Abi for MI_QualifierSetFT {
 }
 impl ::core::cmp::PartialEq for MI_QualifierSetFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_QualifierSetFT>()) == 0 }
+        self.GetQualifierCount == other.GetQualifierCount && self.GetQualifierAt == other.GetQualifierAt && self.GetQualifier == other.GetQualifier
     }
 }
 impl ::core::cmp::Eq for MI_QualifierSetFT {}
@@ -13413,7 +13355,7 @@ unsafe impl ::windows::core::Abi for MI_Real32A {
 }
 impl ::core::cmp::PartialEq for MI_Real32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Real32A {}
@@ -13445,7 +13387,7 @@ unsafe impl ::windows::core::Abi for MI_Real32AField {
 }
 impl ::core::cmp::PartialEq for MI_Real32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Real32AField {}
@@ -13477,7 +13419,7 @@ unsafe impl ::windows::core::Abi for MI_Real32Field {
 }
 impl ::core::cmp::PartialEq for MI_Real32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Real32Field {}
@@ -13508,7 +13450,7 @@ unsafe impl ::windows::core::Abi for MI_Real64A {
 }
 impl ::core::cmp::PartialEq for MI_Real64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Real64A {}
@@ -13540,7 +13482,7 @@ unsafe impl ::windows::core::Abi for MI_Real64AField {
 }
 impl ::core::cmp::PartialEq for MI_Real64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Real64AField {}
@@ -13572,7 +13514,7 @@ unsafe impl ::windows::core::Abi for MI_Real64Field {
 }
 impl ::core::cmp::PartialEq for MI_Real64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Real64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Real64Field {}
@@ -13603,7 +13545,7 @@ unsafe impl ::windows::core::Abi for MI_ReferenceA {
 }
 impl ::core::cmp::PartialEq for MI_ReferenceA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ReferenceA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_ReferenceA {}
@@ -13635,7 +13577,7 @@ unsafe impl ::windows::core::Abi for MI_ReferenceAField {
 }
 impl ::core::cmp::PartialEq for MI_ReferenceAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ReferenceAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ReferenceAField {}
@@ -13667,7 +13609,7 @@ unsafe impl ::windows::core::Abi for MI_ReferenceField {
 }
 impl ::core::cmp::PartialEq for MI_ReferenceField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ReferenceField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_ReferenceField {}
@@ -13700,7 +13642,7 @@ unsafe impl ::windows::core::Abi for MI_SchemaDecl {
 }
 impl ::core::cmp::PartialEq for MI_SchemaDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SchemaDecl>()) == 0 }
+        self.qualifierDecls == other.qualifierDecls && self.numQualifierDecls == other.numQualifierDecls && self.classDecls == other.classDecls && self.numClassDecls == other.numClassDecls
     }
 }
 impl ::core::cmp::Eq for MI_SchemaDecl {}
@@ -13731,7 +13673,7 @@ unsafe impl ::windows::core::Abi for MI_Serializer {
 }
 impl ::core::cmp::PartialEq for MI_Serializer {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Serializer>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2
     }
 }
 impl ::core::cmp::Eq for MI_Serializer {}
@@ -13763,7 +13705,7 @@ unsafe impl ::windows::core::Abi for MI_SerializerFT {
 }
 impl ::core::cmp::PartialEq for MI_SerializerFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SerializerFT>()) == 0 }
+        self.Close == other.Close && self.SerializeClass == other.SerializeClass && self.SerializeInstance == other.SerializeInstance
     }
 }
 impl ::core::cmp::Eq for MI_SerializerFT {}
@@ -13797,7 +13739,7 @@ unsafe impl ::windows::core::Abi for MI_Server {
 }
 impl ::core::cmp::PartialEq for MI_Server {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Server>()) == 0 }
+        self.serverFT == other.serverFT && self.contextFT == other.contextFT && self.instanceFT == other.instanceFT && self.propertySetFT == other.propertySetFT && self.filterFT == other.filterFT
     }
 }
 impl ::core::cmp::Eq for MI_Server {}
@@ -13828,7 +13770,7 @@ unsafe impl ::windows::core::Abi for MI_ServerFT {
 }
 impl ::core::cmp::PartialEq for MI_ServerFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_ServerFT>()) == 0 }
+        self.GetVersion == other.GetVersion && self.GetSystemName == other.GetSystemName
     }
 }
 impl ::core::cmp::Eq for MI_ServerFT {}
@@ -13860,7 +13802,7 @@ unsafe impl ::windows::core::Abi for MI_Session {
 }
 impl ::core::cmp::PartialEq for MI_Session {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Session>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_Session {}
@@ -13892,7 +13834,7 @@ unsafe impl ::windows::core::Abi for MI_SessionCallbacks {
 }
 impl ::core::cmp::PartialEq for MI_SessionCallbacks {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SessionCallbacks>()) == 0 }
+        self.callbackContext == other.callbackContext && self.writeMessage == other.writeMessage && self.writeError == other.writeError
     }
 }
 impl ::core::cmp::Eq for MI_SessionCallbacks {}
@@ -13952,7 +13894,7 @@ unsafe impl ::windows::core::Abi for MI_SessionFT {
 }
 impl ::core::cmp::PartialEq for MI_SessionFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SessionFT>()) == 0 }
+        self.Close == other.Close && self.GetApplication == other.GetApplication && self.GetInstance == other.GetInstance && self.ModifyInstance == other.ModifyInstance && self.CreateInstance == other.CreateInstance && self.DeleteInstance == other.DeleteInstance && self.Invoke == other.Invoke && self.EnumerateInstances == other.EnumerateInstances && self.QueryInstances == other.QueryInstances && self.AssociatorInstances == other.AssociatorInstances && self.ReferenceInstances == other.ReferenceInstances && self.Subscribe == other.Subscribe && self.GetClass == other.GetClass && self.EnumerateClasses == other.EnumerateClasses && self.TestConnection == other.TestConnection
     }
 }
 impl ::core::cmp::Eq for MI_SessionFT {}
@@ -13983,7 +13925,7 @@ unsafe impl ::windows::core::Abi for MI_Sint16A {
 }
 impl ::core::cmp::PartialEq for MI_Sint16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Sint16A {}
@@ -14015,7 +13957,7 @@ unsafe impl ::windows::core::Abi for MI_Sint16AField {
 }
 impl ::core::cmp::PartialEq for MI_Sint16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint16AField {}
@@ -14047,7 +13989,7 @@ unsafe impl ::windows::core::Abi for MI_Sint16Field {
 }
 impl ::core::cmp::PartialEq for MI_Sint16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint16Field {}
@@ -14078,7 +14020,7 @@ unsafe impl ::windows::core::Abi for MI_Sint32A {
 }
 impl ::core::cmp::PartialEq for MI_Sint32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Sint32A {}
@@ -14110,7 +14052,7 @@ unsafe impl ::windows::core::Abi for MI_Sint32AField {
 }
 impl ::core::cmp::PartialEq for MI_Sint32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint32AField {}
@@ -14142,7 +14084,7 @@ unsafe impl ::windows::core::Abi for MI_Sint32Field {
 }
 impl ::core::cmp::PartialEq for MI_Sint32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint32Field {}
@@ -14173,7 +14115,7 @@ unsafe impl ::windows::core::Abi for MI_Sint64A {
 }
 impl ::core::cmp::PartialEq for MI_Sint64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Sint64A {}
@@ -14205,7 +14147,7 @@ unsafe impl ::windows::core::Abi for MI_Sint64AField {
 }
 impl ::core::cmp::PartialEq for MI_Sint64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint64AField {}
@@ -14237,7 +14179,7 @@ unsafe impl ::windows::core::Abi for MI_Sint64Field {
 }
 impl ::core::cmp::PartialEq for MI_Sint64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint64Field {}
@@ -14268,7 +14210,7 @@ unsafe impl ::windows::core::Abi for MI_Sint8A {
 }
 impl ::core::cmp::PartialEq for MI_Sint8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint8A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Sint8A {}
@@ -14300,7 +14242,7 @@ unsafe impl ::windows::core::Abi for MI_Sint8AField {
 }
 impl ::core::cmp::PartialEq for MI_Sint8AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint8AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint8AField {}
@@ -14332,7 +14274,7 @@ unsafe impl ::windows::core::Abi for MI_Sint8Field {
 }
 impl ::core::cmp::PartialEq for MI_Sint8Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Sint8Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Sint8Field {}
@@ -14363,7 +14305,7 @@ unsafe impl ::windows::core::Abi for MI_StringA {
 }
 impl ::core::cmp::PartialEq for MI_StringA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_StringA>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_StringA {}
@@ -14395,7 +14337,7 @@ unsafe impl ::windows::core::Abi for MI_StringAField {
 }
 impl ::core::cmp::PartialEq for MI_StringAField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_StringAField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_StringAField {}
@@ -14427,7 +14369,7 @@ unsafe impl ::windows::core::Abi for MI_StringField {
 }
 impl ::core::cmp::PartialEq for MI_StringField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_StringField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_StringField {}
@@ -14459,7 +14401,7 @@ unsafe impl ::windows::core::Abi for MI_SubscriptionDeliveryOptions {
 }
 impl ::core::cmp::PartialEq for MI_SubscriptionDeliveryOptions {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SubscriptionDeliveryOptions>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2 && self.ft == other.ft
     }
 }
 impl ::core::cmp::Eq for MI_SubscriptionDeliveryOptions {}
@@ -14523,7 +14465,7 @@ unsafe impl ::windows::core::Abi for MI_SubscriptionDeliveryOptionsFT {
 }
 impl ::core::cmp::PartialEq for MI_SubscriptionDeliveryOptionsFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_SubscriptionDeliveryOptionsFT>()) == 0 }
+        self.SetString == other.SetString && self.SetNumber == other.SetNumber && self.SetDateTime == other.SetDateTime && self.SetInterval == other.SetInterval && self.AddCredentials == other.AddCredentials && self.Delete == other.Delete && self.GetString == other.GetString && self.GetNumber == other.GetNumber && self.GetDateTime == other.GetDateTime && self.GetInterval == other.GetInterval && self.GetOptionCount == other.GetOptionCount && self.GetOptionAt == other.GetOptionAt && self.GetOption == other.GetOption && self.GetCredentialsCount == other.GetCredentialsCount && self.GetCredentialsAt == other.GetCredentialsAt && self.GetCredentialsPasswordAt == other.GetCredentialsPasswordAt && self.Clone == other.Clone
     }
 }
 impl ::core::cmp::Eq for MI_SubscriptionDeliveryOptionsFT {}
@@ -14560,7 +14502,7 @@ unsafe impl ::windows::core::Abi for MI_Timestamp {
 }
 impl ::core::cmp::PartialEq for MI_Timestamp {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Timestamp>()) == 0 }
+        self.year == other.year && self.month == other.month && self.day == other.day && self.hour == other.hour && self.minute == other.minute && self.second == other.second && self.microseconds == other.microseconds && self.utc == other.utc
     }
 }
 impl ::core::cmp::Eq for MI_Timestamp {}
@@ -14591,7 +14533,7 @@ unsafe impl ::windows::core::Abi for MI_Uint16A {
 }
 impl ::core::cmp::PartialEq for MI_Uint16A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint16A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Uint16A {}
@@ -14623,7 +14565,7 @@ unsafe impl ::windows::core::Abi for MI_Uint16AField {
 }
 impl ::core::cmp::PartialEq for MI_Uint16AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint16AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint16AField {}
@@ -14655,7 +14597,7 @@ unsafe impl ::windows::core::Abi for MI_Uint16Field {
 }
 impl ::core::cmp::PartialEq for MI_Uint16Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint16Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint16Field {}
@@ -14686,7 +14628,7 @@ unsafe impl ::windows::core::Abi for MI_Uint32A {
 }
 impl ::core::cmp::PartialEq for MI_Uint32A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint32A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Uint32A {}
@@ -14718,7 +14660,7 @@ unsafe impl ::windows::core::Abi for MI_Uint32AField {
 }
 impl ::core::cmp::PartialEq for MI_Uint32AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint32AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint32AField {}
@@ -14750,7 +14692,7 @@ unsafe impl ::windows::core::Abi for MI_Uint32Field {
 }
 impl ::core::cmp::PartialEq for MI_Uint32Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint32Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint32Field {}
@@ -14781,7 +14723,7 @@ unsafe impl ::windows::core::Abi for MI_Uint64A {
 }
 impl ::core::cmp::PartialEq for MI_Uint64A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint64A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Uint64A {}
@@ -14813,7 +14755,7 @@ unsafe impl ::windows::core::Abi for MI_Uint64AField {
 }
 impl ::core::cmp::PartialEq for MI_Uint64AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint64AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint64AField {}
@@ -14845,7 +14787,7 @@ unsafe impl ::windows::core::Abi for MI_Uint64Field {
 }
 impl ::core::cmp::PartialEq for MI_Uint64Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint64Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint64Field {}
@@ -14876,7 +14818,7 @@ unsafe impl ::windows::core::Abi for MI_Uint8A {
 }
 impl ::core::cmp::PartialEq for MI_Uint8A {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint8A>()) == 0 }
+        self.data == other.data && self.size == other.size
     }
 }
 impl ::core::cmp::Eq for MI_Uint8A {}
@@ -14908,7 +14850,7 @@ unsafe impl ::windows::core::Abi for MI_Uint8AField {
 }
 impl ::core::cmp::PartialEq for MI_Uint8AField {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint8AField>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint8AField {}
@@ -14940,7 +14882,7 @@ unsafe impl ::windows::core::Abi for MI_Uint8Field {
 }
 impl ::core::cmp::PartialEq for MI_Uint8Field {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Uint8Field>()) == 0 }
+        self.value == other.value && self.exists == other.exists && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for MI_Uint8Field {}
@@ -14964,12 +14906,6 @@ impl ::core::clone::Clone for MI_UserCredentials {
 unsafe impl ::windows::core::Abi for MI_UserCredentials {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_UserCredentials {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_UserCredentials>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_UserCredentials {}
 impl ::core::default::Default for MI_UserCredentials {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14990,12 +14926,6 @@ impl ::core::clone::Clone for MI_UserCredentials_0 {
 unsafe impl ::windows::core::Abi for MI_UserCredentials_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_UserCredentials_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_UserCredentials_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_UserCredentials_0 {}
 impl ::core::default::Default for MI_UserCredentials_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15024,7 +14954,7 @@ unsafe impl ::windows::core::Abi for MI_UsernamePasswordCreds {
 }
 impl ::core::cmp::PartialEq for MI_UsernamePasswordCreds {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_UsernamePasswordCreds>()) == 0 }
+        self.domain == other.domain && self.username == other.username && self.password == other.password
     }
 }
 impl ::core::cmp::Eq for MI_UsernamePasswordCreds {}
@@ -15055,7 +14985,7 @@ unsafe impl ::windows::core::Abi for MI_UtilitiesFT {
 }
 impl ::core::cmp::PartialEq for MI_UtilitiesFT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_UtilitiesFT>()) == 0 }
+        self.MapErrorToMiErrorCategory == other.MapErrorToMiErrorCategory && self.CimErrorFromErrorCode == other.CimErrorFromErrorCode
     }
 }
 impl ::core::cmp::Eq for MI_UtilitiesFT {}
@@ -15110,12 +15040,6 @@ impl ::core::clone::Clone for MI_Value {
 unsafe impl ::windows::core::Abi for MI_Value {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MI_Value {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MI_Value>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MI_Value {}
 impl ::core::default::Default for MI_Value {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15154,7 +15078,7 @@ unsafe impl ::windows::core::Abi for SWbemAnalysisMatrix {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SWbemAnalysisMatrix {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemAnalysisMatrix>()) == 0 }
+        self.m_uVersion == other.m_uVersion && self.m_uMatrixType == other.m_uMatrixType && self.m_pszProperty == other.m_pszProperty && self.m_uPropertyType == other.m_uPropertyType && self.m_uEntries == other.m_uEntries && self.m_pValues == other.m_pValues && self.m_pbTruthTable == other.m_pbTruthTable
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15195,7 +15119,7 @@ unsafe impl ::windows::core::Abi for SWbemAnalysisMatrixList {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SWbemAnalysisMatrixList {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemAnalysisMatrixList>()) == 0 }
+        self.m_uVersion == other.m_uVersion && self.m_uMatrixType == other.m_uMatrixType && self.m_uNumMatrices == other.m_uNumMatrices && self.m_pMatrices == other.m_pMatrices
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15305,7 +15229,7 @@ unsafe impl ::windows::core::Abi for SWbemQueryQualifiedName {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SWbemQueryQualifiedName {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemQueryQualifiedName>()) == 0 }
+        self.m_uVersion == other.m_uVersion && self.m_uTokenType == other.m_uTokenType && self.m_uNameListSize == other.m_uNameListSize && self.m_ppszNameList == other.m_ppszNameList && self.m_bArraysUsed == other.m_bArraysUsed && self.m_pbArrayElUsed == other.m_pbArrayElUsed && self.m_puArrayIndex == other.m_puArrayIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15340,14 +15264,6 @@ impl ::core::clone::Clone for SWbemRpnConst {
 unsafe impl ::windows::core::Abi for SWbemRpnConst {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SWbemRpnConst {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemRpnConst>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SWbemRpnConst {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SWbemRpnConst {
     fn default() -> Self {
@@ -15417,7 +15333,24 @@ unsafe impl ::windows::core::Abi for SWbemRpnEncodedQuery {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SWbemRpnEncodedQuery {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemRpnEncodedQuery>()) == 0 }
+        self.m_uVersion == other.m_uVersion
+            && self.m_uTokenType == other.m_uTokenType
+            && self.m_uParsedFeatureMask == other.m_uParsedFeatureMask
+            && self.m_uDetectedArraySize == other.m_uDetectedArraySize
+            && self.m_puDetectedFeatures == other.m_puDetectedFeatures
+            && self.m_uSelectListSize == other.m_uSelectListSize
+            && self.m_ppSelectList == other.m_ppSelectList
+            && self.m_uFromTargetType == other.m_uFromTargetType
+            && self.m_pszOptionalFromPath == other.m_pszOptionalFromPath
+            && self.m_uFromListSize == other.m_uFromListSize
+            && self.m_ppszFromList == other.m_ppszFromList
+            && self.m_uWhereClauseSize == other.m_uWhereClauseSize
+            && self.m_ppRpnWhereClause == other.m_ppRpnWhereClause
+            && self.m_dblWithinPolling == other.m_dblWithinPolling
+            && self.m_dblWithinWindow == other.m_dblWithinWindow
+            && self.m_uOrderByListSize == other.m_uOrderByListSize
+            && self.m_ppszOrderByList == other.m_ppszOrderByList
+            && self.m_uOrderDirectionEl == other.m_uOrderDirectionEl
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -15458,14 +15391,6 @@ unsafe impl ::windows::core::Abi for SWbemRpnQueryToken {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SWbemRpnQueryToken {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemRpnQueryToken>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SWbemRpnQueryToken {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SWbemRpnQueryToken {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -15494,7 +15419,7 @@ unsafe impl ::windows::core::Abi for SWbemRpnTokenList {
 }
 impl ::core::cmp::PartialEq for SWbemRpnTokenList {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SWbemRpnTokenList>()) == 0 }
+        self.m_uVersion == other.m_uVersion && self.m_uTokenType == other.m_uTokenType && self.m_uNumTokens == other.m_uNumTokens
     }
 }
 impl ::core::cmp::Eq for SWbemRpnTokenList {}
@@ -15529,7 +15454,7 @@ unsafe impl ::windows::core::Abi for WBEM_COMPILE_STATUS_INFO {
 }
 impl ::core::cmp::PartialEq for WBEM_COMPILE_STATUS_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WBEM_COMPILE_STATUS_INFO>()) == 0 }
+        self.lPhaseError == other.lPhaseError && self.hRes == other.hRes && self.ObjectNum == other.ObjectNum && self.FirstLine == other.FirstLine && self.LastLine == other.LastLine && self.dwOutFlags == other.dwOutFlags
     }
 }
 impl ::core::cmp::Eq for WBEM_COMPILE_STATUS_INFO {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -21101,7 +21101,7 @@ unsafe impl ::windows::core::Abi for ACCESSTIMEOUT {
 }
 impl ::core::cmp::PartialEq for ACCESSTIMEOUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCESSTIMEOUT>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iTimeOutMSec == other.iTimeOutMSec
     }
 }
 impl ::core::cmp::Eq for ACCESSTIMEOUT {}
@@ -21166,7 +21166,7 @@ unsafe impl ::windows::core::Abi for FILTERKEYS {
 }
 impl ::core::cmp::PartialEq for FILTERKEYS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILTERKEYS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iWaitMSec == other.iWaitMSec && self.iDelayMSec == other.iDelayMSec && self.iRepeatMSec == other.iRepeatMSec && self.iBounceMSec == other.iBounceMSec
     }
 }
 impl ::core::cmp::Eq for FILTERKEYS {}
@@ -21198,7 +21198,7 @@ unsafe impl ::windows::core::Abi for HIGHCONTRASTA {
 }
 impl ::core::cmp::PartialEq for HIGHCONTRASTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIGHCONTRASTA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpszDefaultScheme == other.lpszDefaultScheme
     }
 }
 impl ::core::cmp::Eq for HIGHCONTRASTA {}
@@ -21230,7 +21230,7 @@ unsafe impl ::windows::core::Abi for HIGHCONTRASTW {
 }
 impl ::core::cmp::PartialEq for HIGHCONTRASTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HIGHCONTRASTW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpszDefaultScheme == other.lpszDefaultScheme
     }
 }
 impl ::core::cmp::Eq for HIGHCONTRASTW {}
@@ -21426,7 +21426,7 @@ unsafe impl ::windows::core::Abi for MOUSEKEYS {
 }
 impl ::core::cmp::PartialEq for MOUSEKEYS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSEKEYS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iMaxSpeed == other.iMaxSpeed && self.iTimeToMaxSpeed == other.iTimeToMaxSpeed && self.iCtrlSpeed == other.iCtrlSpeed && self.dwReserved1 == other.dwReserved1 && self.dwReserved2 == other.dwReserved2
     }
 }
 impl ::core::cmp::Eq for MOUSEKEYS {}
@@ -21458,7 +21458,7 @@ unsafe impl ::windows::core::Abi for MSAAMENUINFO {
 }
 impl ::core::cmp::PartialEq for MSAAMENUINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSAAMENUINFO>()) == 0 }
+        self.dwMSAASignature == other.dwMSAASignature && self.cchWText == other.cchWText && self.pszWText == other.pszWText
     }
 }
 impl ::core::cmp::Eq for MSAAMENUINFO {}
@@ -21494,7 +21494,7 @@ unsafe impl ::windows::core::Abi for SERIALKEYSA {
 }
 impl ::core::cmp::PartialEq for SERIALKEYSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERIALKEYSA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpszActivePort == other.lpszActivePort && self.lpszPort == other.lpszPort && self.iBaudRate == other.iBaudRate && self.iPortState == other.iPortState && self.iActive == other.iActive
     }
 }
 impl ::core::cmp::Eq for SERIALKEYSA {}
@@ -21530,7 +21530,7 @@ unsafe impl ::windows::core::Abi for SERIALKEYSW {
 }
 impl ::core::cmp::PartialEq for SERIALKEYSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SERIALKEYSW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.lpszActivePort == other.lpszActivePort && self.lpszPort == other.lpszPort && self.iBaudRate == other.iBaudRate && self.iPortState == other.iPortState && self.iActive == other.iActive
     }
 }
 impl ::core::cmp::Eq for SERIALKEYSW {}
@@ -21584,7 +21584,7 @@ unsafe impl ::windows::core::Abi for SOUNDSENTRYA {
 }
 impl ::core::cmp::PartialEq for SOUNDSENTRYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOUNDSENTRYA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iFSTextEffect == other.iFSTextEffect && self.iFSTextEffectMSec == other.iFSTextEffectMSec && self.iFSTextEffectColorBits == other.iFSTextEffectColorBits && self.iFSGrafEffect == other.iFSGrafEffect && self.iFSGrafEffectMSec == other.iFSGrafEffectMSec && self.iFSGrafEffectColor == other.iFSGrafEffectColor && self.iWindowsEffect == other.iWindowsEffect && self.iWindowsEffectMSec == other.iWindowsEffectMSec && self.lpszWindowsEffectDLL == other.lpszWindowsEffectDLL && self.iWindowsEffectOrdinal == other.iWindowsEffectOrdinal
     }
 }
 impl ::core::cmp::Eq for SOUNDSENTRYA {}
@@ -21638,7 +21638,7 @@ unsafe impl ::windows::core::Abi for SOUNDSENTRYW {
 }
 impl ::core::cmp::PartialEq for SOUNDSENTRYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOUNDSENTRYW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iFSTextEffect == other.iFSTextEffect && self.iFSTextEffectMSec == other.iFSTextEffectMSec && self.iFSTextEffectColorBits == other.iFSTextEffectColorBits && self.iFSGrafEffect == other.iFSGrafEffect && self.iFSGrafEffectMSec == other.iFSGrafEffectMSec && self.iFSGrafEffectColor == other.iFSGrafEffectColor && self.iWindowsEffect == other.iWindowsEffect && self.iWindowsEffectMSec == other.iWindowsEffectMSec && self.lpszWindowsEffectDLL == other.lpszWindowsEffectDLL && self.iWindowsEffectOrdinal == other.iWindowsEffectOrdinal
     }
 }
 impl ::core::cmp::Eq for SOUNDSENTRYW {}
@@ -21669,7 +21669,7 @@ unsafe impl ::windows::core::Abi for STICKYKEYS {
 }
 impl ::core::cmp::PartialEq for STICKYKEYS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STICKYKEYS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for STICKYKEYS {}
@@ -21700,7 +21700,7 @@ unsafe impl ::windows::core::Abi for TOGGLEKEYS {
 }
 impl ::core::cmp::PartialEq for TOGGLEKEYS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOGGLEKEYS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for TOGGLEKEYS {}
@@ -21731,7 +21731,7 @@ unsafe impl ::windows::core::Abi for UIAutomationEventInfo {
 }
 impl ::core::cmp::PartialEq for UIAutomationEventInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UIAutomationEventInfo>()) == 0 }
+        self.guid == other.guid && self.pProgrammaticName == other.pProgrammaticName
     }
 }
 impl ::core::cmp::Eq for UIAutomationEventInfo {}
@@ -21772,7 +21772,7 @@ unsafe impl ::windows::core::Abi for UIAutomationMethodInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for UIAutomationMethodInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UIAutomationMethodInfo>()) == 0 }
+        self.pProgrammaticName == other.pProgrammaticName && self.doSetFocus == other.doSetFocus && self.cInParameters == other.cInParameters && self.cOutParameters == other.cOutParameters && self.pParameterTypes == other.pParameterTypes && self.pParameterNames == other.pParameterNames
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21805,7 +21805,7 @@ unsafe impl ::windows::core::Abi for UIAutomationParameter {
 }
 impl ::core::cmp::PartialEq for UIAutomationParameter {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UIAutomationParameter>()) == 0 }
+        self.r#type == other.r#type && self.pData == other.pData
     }
 }
 impl ::core::cmp::Eq for UIAutomationParameter {}
@@ -21907,7 +21907,7 @@ unsafe impl ::windows::core::Abi for UIAutomationPropertyInfo {
 }
 impl ::core::cmp::PartialEq for UIAutomationPropertyInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UIAutomationPropertyInfo>()) == 0 }
+        self.guid == other.guid && self.pProgrammaticName == other.pProgrammaticName && self.r#type == other.r#type
     }
 }
 impl ::core::cmp::Eq for UIAutomationPropertyInfo {}
@@ -21939,7 +21939,7 @@ unsafe impl ::windows::core::Abi for UiaAndOrCondition {
 }
 impl ::core::cmp::PartialEq for UiaAndOrCondition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaAndOrCondition>()) == 0 }
+        self.ConditionType == other.ConditionType && self.ppConditions == other.ppConditions && self.cConditions == other.cConditions
     }
 }
 impl ::core::cmp::Eq for UiaAndOrCondition {}
@@ -21972,7 +21972,7 @@ unsafe impl ::windows::core::Abi for UiaAsyncContentLoadedEventArgs {
 }
 impl ::core::cmp::PartialEq for UiaAsyncContentLoadedEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaAsyncContentLoadedEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId && self.AsyncContentLoadedState == other.AsyncContentLoadedState && self.PercentComplete == other.PercentComplete
     }
 }
 impl ::core::cmp::Eq for UiaAsyncContentLoadedEventArgs {}
@@ -22008,7 +22008,7 @@ unsafe impl ::windows::core::Abi for UiaCacheRequest {
 }
 impl ::core::cmp::PartialEq for UiaCacheRequest {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaCacheRequest>()) == 0 }
+        self.pViewCondition == other.pViewCondition && self.Scope == other.Scope && self.pProperties == other.pProperties && self.cProperties == other.cProperties && self.pPatterns == other.pPatterns && self.cPatterns == other.cPatterns && self.automationElementMode == other.automationElementMode
     }
 }
 impl ::core::cmp::Eq for UiaCacheRequest {}
@@ -22035,14 +22035,6 @@ impl ::core::clone::Clone for UiaChangeInfo {
 unsafe impl ::windows::core::Abi for UiaChangeInfo {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for UiaChangeInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.uiaId == other.uiaId && self.payload == other.payload && self.extraInfo == other.extraInfo
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for UiaChangeInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for UiaChangeInfo {
     fn default() -> Self {
@@ -22079,7 +22071,7 @@ unsafe impl ::windows::core::Abi for UiaChangesEventArgs {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::cmp::PartialEq for UiaChangesEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaChangesEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId && self.EventIdCount == other.EventIdCount && self.pUiaChanges == other.pUiaChanges
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -22111,7 +22103,7 @@ unsafe impl ::windows::core::Abi for UiaCondition {
 }
 impl ::core::cmp::PartialEq for UiaCondition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaCondition>()) == 0 }
+        self.ConditionType == other.ConditionType
     }
 }
 impl ::core::cmp::Eq for UiaCondition {}
@@ -22142,7 +22134,7 @@ unsafe impl ::windows::core::Abi for UiaEventArgs {
 }
 impl ::core::cmp::PartialEq for UiaEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId
     }
 }
 impl ::core::cmp::Eq for UiaEventArgs {}
@@ -22181,7 +22173,7 @@ unsafe impl ::windows::core::Abi for UiaFindParams {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for UiaFindParams {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaFindParams>()) == 0 }
+        self.MaxDepth == other.MaxDepth && self.FindFirst == other.FindFirst && self.ExcludeRoot == other.ExcludeRoot && self.pFindCondition == other.pFindCondition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22214,7 +22206,7 @@ unsafe impl ::windows::core::Abi for UiaNotCondition {
 }
 impl ::core::cmp::PartialEq for UiaNotCondition {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaNotCondition>()) == 0 }
+        self.ConditionType == other.ConditionType && self.pCondition == other.pCondition
     }
 }
 impl ::core::cmp::Eq for UiaNotCondition {}
@@ -22245,7 +22237,7 @@ unsafe impl ::windows::core::Abi for UiaPoint {
 }
 impl ::core::cmp::PartialEq for UiaPoint {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaPoint>()) == 0 }
+        self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for UiaPoint {}
@@ -22275,14 +22267,6 @@ unsafe impl ::windows::core::Abi for UiaPropertyChangedEventArgs {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for UiaPropertyChangedEventArgs {
-    fn eq(&self, other: &Self) -> bool {
-        self.Type == other.Type && self.EventId == other.EventId && self.PropertyId == other.PropertyId && self.OldValue == other.OldValue && self.NewValue == other.NewValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for UiaPropertyChangedEventArgs {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for UiaPropertyChangedEventArgs {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -22307,14 +22291,6 @@ impl ::core::clone::Clone for UiaPropertyCondition {
 unsafe impl ::windows::core::Abi for UiaPropertyCondition {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for UiaPropertyCondition {
-    fn eq(&self, other: &Self) -> bool {
-        self.ConditionType == other.ConditionType && self.PropertyId == other.PropertyId && self.Value == other.Value && self.Flags == other.Flags
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for UiaPropertyCondition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for UiaPropertyCondition {
     fn default() -> Self {
@@ -22345,7 +22321,7 @@ unsafe impl ::windows::core::Abi for UiaRect {
 }
 impl ::core::cmp::PartialEq for UiaRect {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaRect>()) == 0 }
+        self.left == other.left && self.top == other.top && self.width == other.width && self.height == other.height
     }
 }
 impl ::core::cmp::Eq for UiaRect {}
@@ -22379,7 +22355,7 @@ unsafe impl ::windows::core::Abi for UiaStructureChangedEventArgs {
 }
 impl ::core::cmp::PartialEq for UiaStructureChangedEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaStructureChangedEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId && self.StructureChangeType == other.StructureChangeType && self.pRuntimeId == other.pRuntimeId && self.cRuntimeIdLen == other.cRuntimeIdLen
     }
 }
 impl ::core::cmp::Eq for UiaStructureChangedEventArgs {}
@@ -22418,7 +22394,7 @@ unsafe impl ::windows::core::Abi for UiaTextEditTextChangedEventArgs {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for UiaTextEditTextChangedEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaTextEditTextChangedEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId && self.TextEditChangeType == other.TextEditChangeType && self.pTextChange == other.pTextChange
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -22453,7 +22429,7 @@ unsafe impl ::windows::core::Abi for UiaWindowClosedEventArgs {
 }
 impl ::core::cmp::PartialEq for UiaWindowClosedEventArgs {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UiaWindowClosedEventArgs>()) == 0 }
+        self.Type == other.Type && self.EventId == other.EventId && self.pRuntimeId == other.pRuntimeId && self.cRuntimeIdLen == other.cRuntimeIdLen
     }
 }
 impl ::core::cmp::Eq for UiaWindowClosedEventArgs {}

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -1778,7 +1778,7 @@ unsafe impl ::windows::core::Abi for BlackInformation {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BlackInformation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BlackInformation>()) == 0 }
+        self.fBlackOnly == other.fBlackOnly && self.blackWeight == other.blackWeight
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1813,7 +1813,7 @@ unsafe impl ::windows::core::Abi for CMYKCOLOR {
 }
 impl ::core::cmp::PartialEq for CMYKCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMYKCOLOR>()) == 0 }
+        self.cyan == other.cyan && self.magenta == other.magenta && self.yellow == other.yellow && self.black == other.black
     }
 }
 impl ::core::cmp::Eq for CMYKCOLOR {}
@@ -1845,12 +1845,6 @@ impl ::core::clone::Clone for COLOR {
 unsafe impl ::windows::core::Abi for COLOR {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for COLOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLOR>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for COLOR {}
 impl ::core::default::Default for COLOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1878,7 +1872,7 @@ unsafe impl ::windows::core::Abi for COLOR_0 {
 }
 impl ::core::cmp::PartialEq for COLOR_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLOR_0>()) == 0 }
+        self.reserved1 == other.reserved1 && self.reserved2 == other.reserved2
     }
 }
 impl ::core::cmp::Eq for COLOR_0 {}
@@ -1938,9 +1932,7 @@ impl ::core::fmt::Debug for COLORMATCHSETUPA {
             .field("ccPrinterProfile", &self.ccPrinterProfile)
             .field("pTargetProfile", &self.pTargetProfile)
             .field("ccTargetProfile", &self.ccTargetProfile)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lParam", &self.lParam)
-            .field("lpfnApplyCallback", &self.lpfnApplyCallback.map(|f| f as usize))
             .field("lParamApplyCallback", &self.lParamApplyCallback)
             .finish()
     }
@@ -1949,14 +1941,6 @@ impl ::core::fmt::Debug for COLORMATCHSETUPA {
 unsafe impl ::windows::core::Abi for COLORMATCHSETUPA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for COLORMATCHSETUPA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORMATCHSETUPA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for COLORMATCHSETUPA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for COLORMATCHSETUPA {
     fn default() -> Self {
@@ -2014,9 +1998,7 @@ impl ::core::fmt::Debug for COLORMATCHSETUPW {
             .field("ccPrinterProfile", &self.ccPrinterProfile)
             .field("pTargetProfile", &self.pTargetProfile)
             .field("ccTargetProfile", &self.ccTargetProfile)
-            .field("lpfnHook", &self.lpfnHook.map(|f| f as usize))
             .field("lParam", &self.lParam)
-            .field("lpfnApplyCallback", &self.lpfnApplyCallback.map(|f| f as usize))
             .field("lParamApplyCallback", &self.lParamApplyCallback)
             .finish()
     }
@@ -2025,14 +2007,6 @@ impl ::core::fmt::Debug for COLORMATCHSETUPW {
 unsafe impl ::windows::core::Abi for COLORMATCHSETUPW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for COLORMATCHSETUPW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORMATCHSETUPW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for COLORMATCHSETUPW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for COLORMATCHSETUPW {
     fn default() -> Self {
@@ -2068,7 +2042,7 @@ unsafe impl ::windows::core::Abi for EMRCREATECOLORSPACE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for EMRCREATECOLORSPACE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATECOLORSPACE>()) == 0 }
+        self.emr == other.emr && self.ihCS == other.ihCS && self.lcs == other.lcs
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -2111,7 +2085,7 @@ unsafe impl ::windows::core::Abi for EMRCREATECOLORSPACEW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for EMRCREATECOLORSPACEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EMRCREATECOLORSPACEW>()) == 0 }
+        self.emr == other.emr && self.ihCS == other.ihCS && self.lcs == other.lcs && self.dwFlags == other.dwFlags && self.cbData == other.cbData && self.Data == other.Data
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2183,7 +2157,26 @@ unsafe impl ::windows::core::Abi for ENUMTYPEA {
 }
 impl ::core::cmp::PartialEq for ENUMTYPEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMTYPEA>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwVersion == other.dwVersion
+            && self.dwFields == other.dwFields
+            && self.pDeviceName == other.pDeviceName
+            && self.dwMediaType == other.dwMediaType
+            && self.dwDitheringMode == other.dwDitheringMode
+            && self.dwResolution == other.dwResolution
+            && self.dwCMMType == other.dwCMMType
+            && self.dwClass == other.dwClass
+            && self.dwDataColorSpace == other.dwDataColorSpace
+            && self.dwConnectionSpace == other.dwConnectionSpace
+            && self.dwSignature == other.dwSignature
+            && self.dwPlatform == other.dwPlatform
+            && self.dwProfileFlags == other.dwProfileFlags
+            && self.dwManufacturer == other.dwManufacturer
+            && self.dwModel == other.dwModel
+            && self.dwAttributes == other.dwAttributes
+            && self.dwRenderingIntent == other.dwRenderingIntent
+            && self.dwCreator == other.dwCreator
+            && self.dwDeviceClass == other.dwDeviceClass
     }
 }
 impl ::core::cmp::Eq for ENUMTYPEA {}
@@ -2253,7 +2246,26 @@ unsafe impl ::windows::core::Abi for ENUMTYPEW {
 }
 impl ::core::cmp::PartialEq for ENUMTYPEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENUMTYPEW>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwVersion == other.dwVersion
+            && self.dwFields == other.dwFields
+            && self.pDeviceName == other.pDeviceName
+            && self.dwMediaType == other.dwMediaType
+            && self.dwDitheringMode == other.dwDitheringMode
+            && self.dwResolution == other.dwResolution
+            && self.dwCMMType == other.dwCMMType
+            && self.dwClass == other.dwClass
+            && self.dwDataColorSpace == other.dwDataColorSpace
+            && self.dwConnectionSpace == other.dwConnectionSpace
+            && self.dwSignature == other.dwSignature
+            && self.dwPlatform == other.dwPlatform
+            && self.dwProfileFlags == other.dwProfileFlags
+            && self.dwManufacturer == other.dwManufacturer
+            && self.dwModel == other.dwModel
+            && self.dwAttributes == other.dwAttributes
+            && self.dwRenderingIntent == other.dwRenderingIntent
+            && self.dwCreator == other.dwCreator
+            && self.dwDeviceClass == other.dwDeviceClass
     }
 }
 impl ::core::cmp::Eq for ENUMTYPEW {}
@@ -2285,7 +2297,7 @@ unsafe impl ::windows::core::Abi for GENERIC3CHANNEL {
 }
 impl ::core::cmp::PartialEq for GENERIC3CHANNEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GENERIC3CHANNEL>()) == 0 }
+        self.ch1 == other.ch1 && self.ch2 == other.ch2 && self.ch3 == other.ch3
     }
 }
 impl ::core::cmp::Eq for GENERIC3CHANNEL {}
@@ -2315,7 +2327,7 @@ unsafe impl ::windows::core::Abi for GRAYCOLOR {
 }
 impl ::core::cmp::PartialEq for GRAYCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GRAYCOLOR>()) == 0 }
+        self.gray == other.gray
     }
 }
 impl ::core::cmp::Eq for GRAYCOLOR {}
@@ -2350,7 +2362,7 @@ unsafe impl ::windows::core::Abi for GamutBoundaryDescription {
 }
 impl ::core::cmp::PartialEq for GamutBoundaryDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GamutBoundaryDescription>()) == 0 }
+        self.pPrimaries == other.pPrimaries && self.cNeutralSamples == other.cNeutralSamples && self.pNeutralSamples == other.pNeutralSamples && self.pReferenceShell == other.pReferenceShell && self.pPlausibleShell == other.pPlausibleShell && self.pPossibleShell == other.pPossibleShell
     }
 }
 impl ::core::cmp::Eq for GamutBoundaryDescription {}
@@ -2385,7 +2397,7 @@ unsafe impl ::windows::core::Abi for GamutShell {
 }
 impl ::core::cmp::PartialEq for GamutShell {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GamutShell>()) == 0 }
+        self.JMin == other.JMin && self.JMax == other.JMax && self.cVertices == other.cVertices && self.cTriangles == other.cTriangles && self.pVertices == other.pVertices && self.pTriangles == other.pTriangles
     }
 }
 impl ::core::cmp::Eq for GamutShell {}
@@ -2415,7 +2427,7 @@ unsafe impl ::windows::core::Abi for GamutShellTriangle {
 }
 impl ::core::cmp::PartialEq for GamutShellTriangle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GamutShellTriangle>()) == 0 }
+        self.aVertexIndex == other.aVertexIndex
     }
 }
 impl ::core::cmp::Eq for GamutShellTriangle {}
@@ -2477,7 +2489,7 @@ unsafe impl ::windows::core::Abi for HiFiCOLOR {
 }
 impl ::core::cmp::PartialEq for HiFiCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HiFiCOLOR>()) == 0 }
+        self.channel == other.channel
     }
 }
 impl ::core::cmp::Eq for HiFiCOLOR {}
@@ -2509,7 +2521,7 @@ unsafe impl ::windows::core::Abi for JChColorF {
 }
 impl ::core::cmp::PartialEq for JChColorF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JChColorF>()) == 0 }
+        self.J == other.J && self.C == other.C && self.h == other.h
     }
 }
 impl ::core::cmp::Eq for JChColorF {}
@@ -2541,7 +2553,7 @@ unsafe impl ::windows::core::Abi for JabColorF {
 }
 impl ::core::cmp::PartialEq for JabColorF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<JabColorF>()) == 0 }
+        self.J == other.J && self.a == other.a && self.b == other.b
     }
 }
 impl ::core::cmp::Eq for JabColorF {}
@@ -2586,7 +2598,7 @@ unsafe impl ::windows::core::Abi for LOGCOLORSPACEA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for LOGCOLORSPACEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGCOLORSPACEA>()) == 0 }
+        self.lcsSignature == other.lcsSignature && self.lcsVersion == other.lcsVersion && self.lcsSize == other.lcsSize && self.lcsCSType == other.lcsCSType && self.lcsIntent == other.lcsIntent && self.lcsEndpoints == other.lcsEndpoints && self.lcsGammaRed == other.lcsGammaRed && self.lcsGammaGreen == other.lcsGammaGreen && self.lcsGammaBlue == other.lcsGammaBlue && self.lcsFilename == other.lcsFilename
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -2633,7 +2645,7 @@ unsafe impl ::windows::core::Abi for LOGCOLORSPACEW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for LOGCOLORSPACEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LOGCOLORSPACEW>()) == 0 }
+        self.lcsSignature == other.lcsSignature && self.lcsVersion == other.lcsVersion && self.lcsSize == other.lcsSize && self.lcsCSType == other.lcsCSType && self.lcsIntent == other.lcsIntent && self.lcsEndpoints == other.lcsEndpoints && self.lcsGammaRed == other.lcsGammaRed && self.lcsGammaGreen == other.lcsGammaGreen && self.lcsGammaBlue == other.lcsGammaBlue && self.lcsFilename == other.lcsFilename
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2667,7 +2679,7 @@ unsafe impl ::windows::core::Abi for LabCOLOR {
 }
 impl ::core::cmp::PartialEq for LabCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LabCOLOR>()) == 0 }
+        self.L == other.L && self.a == other.a && self.b == other.b
     }
 }
 impl ::core::cmp::Eq for LabCOLOR {}
@@ -2697,7 +2709,7 @@ unsafe impl ::windows::core::Abi for NAMEDCOLOR {
 }
 impl ::core::cmp::PartialEq for NAMEDCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAMEDCOLOR>()) == 0 }
+        self.dwIndex == other.dwIndex
     }
 }
 impl ::core::cmp::Eq for NAMEDCOLOR {}
@@ -2731,7 +2743,7 @@ unsafe impl ::windows::core::Abi for NAMED_PROFILE_INFO {
 }
 impl ::core::cmp::PartialEq for NAMED_PROFILE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NAMED_PROFILE_INFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwCount == other.dwCount && self.dwCountDevCoordinates == other.dwCountDevCoordinates && self.szPrefix == other.szPrefix && self.szSuffix == other.szSuffix
     }
 }
 impl ::core::cmp::Eq for NAMED_PROFILE_INFO {}
@@ -2763,7 +2775,7 @@ unsafe impl ::windows::core::Abi for PROFILE {
 }
 impl ::core::cmp::PartialEq for PROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILE>()) == 0 }
+        self.dwType == other.dwType && self.pProfileData == other.pProfileData && self.cbDataSize == other.cbDataSize
     }
 }
 impl ::core::cmp::Eq for PROFILE {}
@@ -2833,7 +2845,7 @@ unsafe impl ::windows::core::Abi for PROFILEHEADER {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for PROFILEHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILEHEADER>()) == 0 }
+        self.phSize == other.phSize && self.phCMMType == other.phCMMType && self.phVersion == other.phVersion && self.phClass == other.phClass && self.phDataColorSpace == other.phDataColorSpace && self.phConnectionSpace == other.phConnectionSpace && self.phDateTime == other.phDateTime && self.phSignature == other.phSignature && self.phPlatform == other.phPlatform && self.phProfileFlags == other.phProfileFlags && self.phManufacturer == other.phManufacturer && self.phModel == other.phModel && self.phAttributes == other.phAttributes && self.phRenderingIntent == other.phRenderingIntent && self.phIlluminant == other.phIlluminant && self.phCreator == other.phCreator && self.phReserved == other.phReserved
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2872,7 +2884,7 @@ unsafe impl ::windows::core::Abi for PrimaryJabColors {
 }
 impl ::core::cmp::PartialEq for PrimaryJabColors {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrimaryJabColors>()) == 0 }
+        self.red == other.red && self.yellow == other.yellow && self.green == other.green && self.cyan == other.cyan && self.blue == other.blue && self.magenta == other.magenta && self.black == other.black && self.white == other.white
     }
 }
 impl ::core::cmp::Eq for PrimaryJabColors {}
@@ -2909,7 +2921,7 @@ unsafe impl ::windows::core::Abi for PrimaryXYZColors {
 }
 impl ::core::cmp::PartialEq for PrimaryXYZColors {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PrimaryXYZColors>()) == 0 }
+        self.red == other.red && self.yellow == other.yellow && self.green == other.green && self.cyan == other.cyan && self.blue == other.blue && self.magenta == other.magenta && self.black == other.black && self.white == other.white
     }
 }
 impl ::core::cmp::Eq for PrimaryXYZColors {}
@@ -2941,7 +2953,7 @@ unsafe impl ::windows::core::Abi for RGBCOLOR {
 }
 impl ::core::cmp::PartialEq for RGBCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RGBCOLOR>()) == 0 }
+        self.red == other.red && self.green == other.green && self.blue == other.blue
     }
 }
 impl ::core::cmp::Eq for RGBCOLOR {}
@@ -2981,7 +2993,7 @@ unsafe impl ::windows::core::Abi for WCS_DEVICE_MHC2_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCS_DEVICE_MHC2_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCS_DEVICE_MHC2_CAPABILITIES>()) == 0 }
+        self.Size == other.Size && self.SupportsMhc2 == other.SupportsMhc2 && self.RegammaLutEntryCount == other.RegammaLutEntryCount && self.CscXyzMatrixRows == other.CscXyzMatrixRows && self.CscXyzMatrixColumns == other.CscXyzMatrixColumns
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3020,7 +3032,7 @@ unsafe impl ::windows::core::Abi for WCS_DEVICE_VCGT_CAPABILITIES {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WCS_DEVICE_VCGT_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WCS_DEVICE_VCGT_CAPABILITIES>()) == 0 }
+        self.Size == other.Size && self.SupportsVcgt == other.SupportsVcgt
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -3054,7 +3066,7 @@ unsafe impl ::windows::core::Abi for XYZCOLOR {
 }
 impl ::core::cmp::PartialEq for XYZCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XYZCOLOR>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z
     }
 }
 impl ::core::cmp::Eq for XYZCOLOR {}
@@ -3086,7 +3098,7 @@ unsafe impl ::windows::core::Abi for XYZColorF {
 }
 impl ::core::cmp::PartialEq for XYZColorF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XYZColorF>()) == 0 }
+        self.X == other.X && self.Y == other.Y && self.Z == other.Z
     }
 }
 impl ::core::cmp::Eq for XYZColorF {}
@@ -3118,7 +3130,7 @@ unsafe impl ::windows::core::Abi for YxyCOLOR {
 }
 impl ::core::cmp::PartialEq for YxyCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<YxyCOLOR>()) == 0 }
+        self.Y == other.Y && self.x == other.x && self.y == other.y
     }
 }
 impl ::core::cmp::Eq for YxyCOLOR {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -1297,16 +1297,6 @@ unsafe impl ::windows::core::Abi for CHOOSECOLORA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHOOSECOLORA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSECOLORA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHOOSECOLORA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHOOSECOLORA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1344,16 +1334,6 @@ unsafe impl ::windows::core::Abi for CHOOSECOLORA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHOOSECOLORA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSECOLORA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHOOSECOLORA {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHOOSECOLORA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1391,16 +1371,6 @@ unsafe impl ::windows::core::Abi for CHOOSECOLORW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHOOSECOLORW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSECOLORW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHOOSECOLORW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHOOSECOLORW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1438,16 +1408,6 @@ unsafe impl ::windows::core::Abi for CHOOSECOLORW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CHOOSECOLORW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSECOLORW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CHOOSECOLORW {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CHOOSECOLORW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1492,16 +1452,6 @@ unsafe impl ::windows::core::Abi for CHOOSEFONTA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHOOSEFONTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSEFONTA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHOOSEFONTA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHOOSEFONTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1546,16 +1496,6 @@ unsafe impl ::windows::core::Abi for CHOOSEFONTA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHOOSEFONTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSEFONTA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHOOSEFONTA {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHOOSEFONTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1600,16 +1540,6 @@ unsafe impl ::windows::core::Abi for CHOOSEFONTW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHOOSEFONTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSEFONTW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHOOSEFONTW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHOOSEFONTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1654,16 +1584,6 @@ unsafe impl ::windows::core::Abi for CHOOSEFONTW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHOOSEFONTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHOOSEFONTW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHOOSEFONTW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHOOSEFONTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1691,14 +1611,6 @@ unsafe impl ::windows::core::Abi for DEVNAMES {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for DEVNAMES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVNAMES>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for DEVNAMES {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for DEVNAMES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1725,14 +1637,6 @@ impl ::core::clone::Clone for DEVNAMES {
 unsafe impl ::windows::core::Abi for DEVNAMES {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for DEVNAMES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEVNAMES>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for DEVNAMES {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for DEVNAMES {
     fn default() -> Self {
@@ -1771,16 +1675,6 @@ impl ::core::clone::Clone for FINDREPLACEA {
 unsafe impl ::windows::core::Abi for FINDREPLACEA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FINDREPLACEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDREPLACEA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FINDREPLACEA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FINDREPLACEA {
@@ -1820,16 +1714,6 @@ impl ::core::clone::Clone for FINDREPLACEA {
 unsafe impl ::windows::core::Abi for FINDREPLACEA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FINDREPLACEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDREPLACEA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FINDREPLACEA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FINDREPLACEA {
@@ -1869,16 +1753,6 @@ impl ::core::clone::Clone for FINDREPLACEW {
 unsafe impl ::windows::core::Abi for FINDREPLACEW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FINDREPLACEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDREPLACEW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FINDREPLACEW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FINDREPLACEW {
@@ -1918,16 +1792,6 @@ impl ::core::clone::Clone for FINDREPLACEW {
 unsafe impl ::windows::core::Abi for FINDREPLACEW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FINDREPLACEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDREPLACEW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FINDREPLACEW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FINDREPLACEW {
@@ -1959,16 +1823,6 @@ impl ::core::clone::Clone for OFNOTIFYA {
 unsafe impl ::windows::core::Abi for OFNOTIFYA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYA {
@@ -2000,16 +1854,6 @@ impl ::core::clone::Clone for OFNOTIFYA {
 unsafe impl ::windows::core::Abi for OFNOTIFYA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYA {
@@ -2042,16 +1886,6 @@ impl ::core::clone::Clone for OFNOTIFYEXA {
 unsafe impl ::windows::core::Abi for OFNOTIFYEXA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYEXA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYEXA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYEXA {
@@ -2084,16 +1918,6 @@ impl ::core::clone::Clone for OFNOTIFYEXA {
 unsafe impl ::windows::core::Abi for OFNOTIFYEXA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYEXA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYEXA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYEXA {
@@ -2126,16 +1950,6 @@ impl ::core::clone::Clone for OFNOTIFYEXW {
 unsafe impl ::windows::core::Abi for OFNOTIFYEXW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYEXW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYEXW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYEXW {
@@ -2168,16 +1982,6 @@ impl ::core::clone::Clone for OFNOTIFYEXW {
 unsafe impl ::windows::core::Abi for OFNOTIFYEXW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYEXW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYEXW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYEXW {
@@ -2209,16 +2013,6 @@ impl ::core::clone::Clone for OFNOTIFYW {
 unsafe impl ::windows::core::Abi for OFNOTIFYW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYW {
@@ -2250,16 +2044,6 @@ impl ::core::clone::Clone for OFNOTIFYW {
 unsafe impl ::windows::core::Abi for OFNOTIFYW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OFNOTIFYW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OFNOTIFYW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OFNOTIFYW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OFNOTIFYW {
@@ -2311,16 +2095,6 @@ impl ::core::clone::Clone for OPENFILENAMEA {
 unsafe impl ::windows::core::Abi for OPENFILENAMEA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAMEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAMEA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAMEA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAMEA {
@@ -2372,16 +2146,6 @@ impl ::core::clone::Clone for OPENFILENAMEA {
 unsafe impl ::windows::core::Abi for OPENFILENAMEA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAMEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAMEA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAMEA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAMEA {
@@ -2433,16 +2197,6 @@ impl ::core::clone::Clone for OPENFILENAMEW {
 unsafe impl ::windows::core::Abi for OPENFILENAMEW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAMEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAMEW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAMEW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAMEW {
@@ -2494,16 +2248,6 @@ impl ::core::clone::Clone for OPENFILENAMEW {
 unsafe impl ::windows::core::Abi for OPENFILENAMEW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAMEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAMEW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAMEW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAMEW {
@@ -2552,16 +2296,6 @@ impl ::core::clone::Clone for OPENFILENAME_NT4A {
 unsafe impl ::windows::core::Abi for OPENFILENAME_NT4A {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAME_NT4A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAME_NT4A>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAME_NT4A {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAME_NT4A {
@@ -2610,16 +2344,6 @@ impl ::core::clone::Clone for OPENFILENAME_NT4A {
 unsafe impl ::windows::core::Abi for OPENFILENAME_NT4A {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAME_NT4A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAME_NT4A>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAME_NT4A {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAME_NT4A {
@@ -2668,16 +2392,6 @@ impl ::core::clone::Clone for OPENFILENAME_NT4W {
 unsafe impl ::windows::core::Abi for OPENFILENAME_NT4W {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAME_NT4W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAME_NT4W>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAME_NT4W {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAME_NT4W {
@@ -2726,16 +2440,6 @@ impl ::core::clone::Clone for OPENFILENAME_NT4W {
 unsafe impl ::windows::core::Abi for OPENFILENAME_NT4W {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPENFILENAME_NT4W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENFILENAME_NT4W>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPENFILENAME_NT4W {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPENFILENAME_NT4W {
@@ -2778,16 +2482,6 @@ impl ::core::clone::Clone for PAGESETUPDLGA {
 unsafe impl ::windows::core::Abi for PAGESETUPDLGA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PAGESETUPDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGESETUPDLGA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PAGESETUPDLGA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PAGESETUPDLGA {
@@ -2830,16 +2524,6 @@ impl ::core::clone::Clone for PAGESETUPDLGA {
 unsafe impl ::windows::core::Abi for PAGESETUPDLGA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PAGESETUPDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGESETUPDLGA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PAGESETUPDLGA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PAGESETUPDLGA {
@@ -2882,16 +2566,6 @@ impl ::core::clone::Clone for PAGESETUPDLGW {
 unsafe impl ::windows::core::Abi for PAGESETUPDLGW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PAGESETUPDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGESETUPDLGW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PAGESETUPDLGW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PAGESETUPDLGW {
@@ -2934,16 +2608,6 @@ impl ::core::clone::Clone for PAGESETUPDLGW {
 unsafe impl ::windows::core::Abi for PAGESETUPDLGW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PAGESETUPDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PAGESETUPDLGW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PAGESETUPDLGW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PAGESETUPDLGW {
@@ -2991,16 +2655,6 @@ impl ::core::clone::Clone for PRINTDLGA {
 unsafe impl ::windows::core::Abi for PRINTDLGA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGA {
@@ -3048,16 +2702,6 @@ impl ::core::clone::Clone for PRINTDLGA {
 unsafe impl ::windows::core::Abi for PRINTDLGA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGA {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGA {
@@ -3128,36 +2772,6 @@ unsafe impl ::windows::core::Abi for PRINTDLGEXA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGEXA {
-    fn eq(&self, other: &Self) -> bool {
-        self.lStructSize == other.lStructSize
-            && self.hwndOwner == other.hwndOwner
-            && self.hDevMode == other.hDevMode
-            && self.hDevNames == other.hDevNames
-            && self.hDC == other.hDC
-            && self.Flags == other.Flags
-            && self.Flags2 == other.Flags2
-            && self.ExclusionFlags == other.ExclusionFlags
-            && self.nPageRanges == other.nPageRanges
-            && self.nMaxPageRanges == other.nMaxPageRanges
-            && self.lpPageRanges == other.lpPageRanges
-            && self.nMinPage == other.nMinPage
-            && self.nMaxPage == other.nMaxPage
-            && self.nCopies == other.nCopies
-            && self.hInstance == other.hInstance
-            && self.lpPrintTemplateName == other.lpPrintTemplateName
-            && self.lpCallback == other.lpCallback
-            && self.nPropertyPages == other.nPropertyPages
-            && self.lphPropertyPages == other.lphPropertyPages
-            && self.nStartPage == other.nStartPage
-            && self.dwResultAction == other.dwResultAction
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGEXA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGEXA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3195,16 +2809,6 @@ pub struct PRINTDLGEXA {
 unsafe impl ::windows::core::Abi for PRINTDLGEXA {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGEXA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGEXA {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGEXA {
@@ -3275,36 +2879,6 @@ unsafe impl ::windows::core::Abi for PRINTDLGEXW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGEXW {
-    fn eq(&self, other: &Self) -> bool {
-        self.lStructSize == other.lStructSize
-            && self.hwndOwner == other.hwndOwner
-            && self.hDevMode == other.hDevMode
-            && self.hDevNames == other.hDevNames
-            && self.hDC == other.hDC
-            && self.Flags == other.Flags
-            && self.Flags2 == other.Flags2
-            && self.ExclusionFlags == other.ExclusionFlags
-            && self.nPageRanges == other.nPageRanges
-            && self.nMaxPageRanges == other.nMaxPageRanges
-            && self.lpPageRanges == other.lpPageRanges
-            && self.nMinPage == other.nMinPage
-            && self.nMaxPage == other.nMaxPage
-            && self.nCopies == other.nCopies
-            && self.hInstance == other.hInstance
-            && self.lpPrintTemplateName == other.lpPrintTemplateName
-            && self.lpCallback == other.lpCallback
-            && self.nPropertyPages == other.nPropertyPages
-            && self.lphPropertyPages == other.lphPropertyPages
-            && self.nStartPage == other.nStartPage
-            && self.dwResultAction == other.dwResultAction
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGEXW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGEXW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3344,16 +2918,6 @@ unsafe impl ::windows::core::Abi for PRINTDLGEXW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGEXW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGEXW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGEXW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3401,16 +2965,6 @@ unsafe impl ::windows::core::Abi for PRINTDLGW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3458,16 +3012,6 @@ unsafe impl ::windows::core::Abi for PRINTDLGW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for PRINTDLGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTDLGW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for PRINTDLGW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for PRINTDLGW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3493,14 +3037,6 @@ unsafe impl ::windows::core::Abi for PRINTPAGERANGE {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for PRINTPAGERANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPAGERANGE>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for PRINTPAGERANGE {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for PRINTPAGERANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -3525,14 +3061,6 @@ impl ::core::clone::Clone for PRINTPAGERANGE {
 unsafe impl ::windows::core::Abi for PRINTPAGERANGE {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for PRINTPAGERANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PRINTPAGERANGE>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for PRINTPAGERANGE {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for PRINTPAGERANGE {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -9488,7 +9488,7 @@ unsafe impl ::windows::core::Abi for BIDIOPTIONS {
 }
 impl ::core::cmp::PartialEq for BIDIOPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BIDIOPTIONS>()) == 0 }
+        self.cbSize == other.cbSize && self.wMask == other.wMask && self.wEffects == other.wEffects
     }
 }
 impl ::core::cmp::Eq for BIDIOPTIONS {}
@@ -9517,14 +9517,6 @@ unsafe impl ::windows::core::Abi for CARET_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::PartialEq for CARET_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CARET_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl ::core::cmp::Eq for CARET_INFO {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::default::Default for CARET_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9552,7 +9544,7 @@ unsafe impl ::windows::core::Abi for CHANGENOTIFY {
 }
 impl ::core::cmp::PartialEq for CHANGENOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGENOTIFY>()) == 0 }
+        self.dwChangeType == other.dwChangeType && self.pvCookieData == other.pvCookieData
     }
 }
 impl ::core::cmp::Eq for CHANGENOTIFY {}
@@ -9591,14 +9583,6 @@ unsafe impl ::windows::core::Abi for CHARFORMAT2A {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHARFORMAT2A {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMAT2A>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHARFORMAT2A {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHARFORMAT2A {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9623,14 +9607,6 @@ impl ::core::clone::Clone for CHARFORMAT2A_0 {
 unsafe impl ::windows::core::Abi for CHARFORMAT2A_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHARFORMAT2A_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMAT2A_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHARFORMAT2A_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHARFORMAT2A_0 {
     fn default() -> Self {
@@ -9667,14 +9643,6 @@ unsafe impl ::windows::core::Abi for CHARFORMAT2W {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHARFORMAT2W {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMAT2W>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHARFORMAT2W {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHARFORMAT2W {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9699,14 +9667,6 @@ impl ::core::clone::Clone for CHARFORMAT2W_0 {
 unsafe impl ::windows::core::Abi for CHARFORMAT2W_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CHARFORMAT2W_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMAT2W_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CHARFORMAT2W_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CHARFORMAT2W_0 {
     fn default() -> Self {
@@ -9748,7 +9708,7 @@ unsafe impl ::windows::core::Abi for CHARFORMATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for CHARFORMATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMATA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.dwEffects == other.dwEffects && self.yHeight == other.yHeight && self.yOffset == other.yOffset && self.crTextColor == other.crTextColor && self.bCharSet == other.bCharSet && self.bPitchAndFamily == other.bPitchAndFamily && self.szFaceName == other.szFaceName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9794,7 +9754,7 @@ unsafe impl ::windows::core::Abi for CHARFORMATW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for CHARFORMATW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARFORMATW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.dwEffects == other.dwEffects && self.yHeight == other.yHeight && self.yOffset == other.yOffset && self.crTextColor == other.crTextColor && self.bCharSet == other.bCharSet && self.bPitchAndFamily == other.bPitchAndFamily && self.szFaceName == other.szFaceName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -9827,7 +9787,7 @@ unsafe impl ::windows::core::Abi for CHARRANGE {
 }
 impl ::core::cmp::PartialEq for CHARRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARRANGE>()) == 0 }
+        self.cpMin == other.cpMin && self.cpMax == other.cpMax
     }
 }
 impl ::core::cmp::Eq for CHARRANGE {}
@@ -9855,14 +9815,6 @@ impl ::core::clone::Clone for CLIPBOARDFORMAT {
 unsafe impl ::windows::core::Abi for CLIPBOARDFORMAT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for CLIPBOARDFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIPBOARDFORMAT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for CLIPBOARDFORMAT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for CLIPBOARDFORMAT {
     fn default() -> Self {
@@ -9898,7 +9850,7 @@ unsafe impl ::windows::core::Abi for COMPCOLOR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMPCOLOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPCOLOR>()) == 0 }
+        self.crText == other.crText && self.crBackground == other.crBackground && self.dwEffects == other.dwEffects
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -9925,12 +9877,6 @@ impl ::core::clone::Clone for EDITSTREAM {
 unsafe impl ::windows::core::Abi for EDITSTREAM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EDITSTREAM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EDITSTREAM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EDITSTREAM {}
 impl ::core::default::Default for EDITSTREAM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9957,14 +9903,6 @@ unsafe impl ::windows::core::Abi for ENCORRECTTEXT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENCORRECTTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENCORRECTTEXT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENCORRECTTEXT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENCORRECTTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -9989,14 +9927,6 @@ impl ::core::clone::Clone for ENDCOMPOSITIONNOTIFY {
 unsafe impl ::windows::core::Abi for ENDCOMPOSITIONNOTIFY {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENDCOMPOSITIONNOTIFY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENDCOMPOSITIONNOTIFY>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENDCOMPOSITIONNOTIFY {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENDCOMPOSITIONNOTIFY {
     fn default() -> Self {
@@ -10024,14 +9954,6 @@ impl ::core::clone::Clone for ENDROPFILES {
 unsafe impl ::windows::core::Abi for ENDROPFILES {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENDROPFILES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENDROPFILES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENDROPFILES {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENDROPFILES {
     fn default() -> Self {
@@ -10061,14 +9983,6 @@ unsafe impl ::windows::core::Abi for ENLINK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENLINK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENLINK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENLINK {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENLINK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10093,14 +10007,6 @@ impl ::core::clone::Clone for ENLOWFIRTF {
 unsafe impl ::windows::core::Abi for ENLOWFIRTF {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENLOWFIRTF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENLOWFIRTF>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENLOWFIRTF {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENLOWFIRTF {
     fn default() -> Self {
@@ -10128,14 +10034,6 @@ impl ::core::clone::Clone for ENOLEOPFAILED {
 unsafe impl ::windows::core::Abi for ENOLEOPFAILED {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENOLEOPFAILED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENOLEOPFAILED>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENOLEOPFAILED {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENOLEOPFAILED {
     fn default() -> Self {
@@ -10165,14 +10063,6 @@ unsafe impl ::windows::core::Abi for ENPROTECTED {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENPROTECTED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENPROTECTED>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENPROTECTED {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENPROTECTED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10199,14 +10089,6 @@ unsafe impl ::windows::core::Abi for ENSAVECLIPBOARD {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for ENSAVECLIPBOARD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ENSAVECLIPBOARD>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for ENSAVECLIPBOARD {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for ENSAVECLIPBOARD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10227,12 +10109,6 @@ impl ::core::clone::Clone for FINDTEXTA {
 unsafe impl ::windows::core::Abi for FINDTEXTA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FINDTEXTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDTEXTA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FINDTEXTA {}
 impl ::core::default::Default for FINDTEXTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10254,12 +10130,6 @@ impl ::core::clone::Clone for FINDTEXTEXA {
 unsafe impl ::windows::core::Abi for FINDTEXTEXA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FINDTEXTEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDTEXTEXA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FINDTEXTEXA {}
 impl ::core::default::Default for FINDTEXTEXA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10281,12 +10151,6 @@ impl ::core::clone::Clone for FINDTEXTEXW {
 unsafe impl ::windows::core::Abi for FINDTEXTEXW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FINDTEXTEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDTEXTEXW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FINDTEXTEXW {}
 impl ::core::default::Default for FINDTEXTEXW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10307,12 +10171,6 @@ impl ::core::clone::Clone for FINDTEXTW {
 unsafe impl ::windows::core::Abi for FINDTEXTW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FINDTEXTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FINDTEXTW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FINDTEXTW {}
 impl ::core::default::Default for FINDTEXTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10341,14 +10199,6 @@ unsafe impl ::windows::core::Abi for FORMATRANGE {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for FORMATRANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FORMATRANGE>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for FORMATRANGE {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for FORMATRANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10376,14 +10226,6 @@ unsafe impl ::windows::core::Abi for GETCONTEXTMENUEX {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GETCONTEXTMENUEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GETCONTEXTMENUEX>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GETCONTEXTMENUEX {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GETCONTEXTMENUEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10407,12 +10249,6 @@ impl ::core::clone::Clone for GETTEXTEX {
 unsafe impl ::windows::core::Abi for GETTEXTEX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GETTEXTEX {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GETTEXTEX>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for GETTEXTEX {}
 impl ::core::default::Default for GETTEXTEX {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10440,7 +10276,7 @@ unsafe impl ::windows::core::Abi for GETTEXTLENGTHEX {
 }
 impl ::core::cmp::PartialEq for GETTEXTLENGTHEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GETTEXTLENGTHEX>()) == 0 }
+        self.flags == other.flags && self.codepage == other.codepage
     }
 }
 impl ::core::cmp::Eq for GETTEXTLENGTHEX {}
@@ -10469,14 +10305,6 @@ unsafe impl ::windows::core::Abi for GROUPTYPINGCHANGE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for GROUPTYPINGCHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GROUPTYPINGCHANGE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for GROUPTYPINGCHANGE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for GROUPTYPINGCHANGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10498,12 +10326,6 @@ impl ::core::clone::Clone for HYPHENATEINFO {
 unsafe impl ::windows::core::Abi for HYPHENATEINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HYPHENATEINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYPHENATEINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for HYPHENATEINFO {}
 impl ::core::default::Default for HYPHENATEINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10532,7 +10354,7 @@ unsafe impl ::windows::core::Abi for HYPHRESULT {
 }
 impl ::core::cmp::PartialEq for HYPHRESULT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HYPHRESULT>()) == 0 }
+        self.khyph == other.khyph && self.ichHyph == other.ichHyph && self.chHyph == other.chHyph
     }
 }
 impl ::core::cmp::Eq for HYPHRESULT {}
@@ -10563,7 +10385,7 @@ unsafe impl ::windows::core::Abi for IMECOMPTEXT {
 }
 impl ::core::cmp::PartialEq for IMECOMPTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMECOMPTEXT>()) == 0 }
+        self.cb == other.cb && self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for IMECOMPTEXT {}
@@ -10594,14 +10416,6 @@ unsafe impl ::windows::core::Abi for MSGFILTER {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for MSGFILTER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSGFILTER>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for MSGFILTER {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for MSGFILTER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10627,14 +10441,6 @@ impl ::core::clone::Clone for OBJECTPOSITIONS {
 unsafe impl ::windows::core::Abi for OBJECTPOSITIONS {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OBJECTPOSITIONS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OBJECTPOSITIONS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OBJECTPOSITIONS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OBJECTPOSITIONS {
     fn default() -> Self {
@@ -10664,12 +10470,6 @@ impl ::core::clone::Clone for PARAFORMAT {
 unsafe impl ::windows::core::Abi for PARAFORMAT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PARAFORMAT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAFORMAT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PARAFORMAT {}
 impl ::core::default::Default for PARAFORMAT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10690,12 +10490,6 @@ impl ::core::clone::Clone for PARAFORMAT_0 {
 unsafe impl ::windows::core::Abi for PARAFORMAT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PARAFORMAT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAFORMAT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PARAFORMAT_0 {}
 impl ::core::default::Default for PARAFORMAT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10729,12 +10523,6 @@ impl ::core::clone::Clone for PARAFORMAT2 {
 unsafe impl ::windows::core::Abi for PARAFORMAT2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PARAFORMAT2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARAFORMAT2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PARAFORMAT2 {}
 impl ::core::default::Default for PARAFORMAT2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10755,12 +10543,6 @@ impl ::core::clone::Clone for PUNCTUATION {
 unsafe impl ::windows::core::Abi for PUNCTUATION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PUNCTUATION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUNCTUATION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for PUNCTUATION {}
 impl ::core::default::Default for PUNCTUATION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10842,14 +10624,6 @@ unsafe impl ::windows::core::Abi for REPASTESPECIAL {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::PartialEq for REPASTESPECIAL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REPASTESPECIAL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::cmp::Eq for REPASTESPECIAL {}
-#[cfg(feature = "Win32_System_Com")]
 impl ::core::default::Default for REPASTESPECIAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10875,14 +10649,6 @@ unsafe impl ::windows::core::Abi for REQRESIZE {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for REQRESIZE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REQRESIZE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for REQRESIZE {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for REQRESIZE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -10903,14 +10669,6 @@ pub struct RICHEDIT_IMAGE_PARAMETERS {
 unsafe impl ::windows::core::Abi for RICHEDIT_IMAGE_PARAMETERS {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
-impl ::core::cmp::PartialEq for RICHEDIT_IMAGE_PARAMETERS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RICHEDIT_IMAGE_PARAMETERS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
-impl ::core::cmp::Eq for RICHEDIT_IMAGE_PARAMETERS {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl ::core::default::Default for RICHEDIT_IMAGE_PARAMETERS {
     fn default() -> Self {
@@ -10937,14 +10695,6 @@ impl ::core::clone::Clone for SELCHANGE {
 unsafe impl ::windows::core::Abi for SELCHANGE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SELCHANGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SELCHANGE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SELCHANGE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SELCHANGE {
     fn default() -> Self {
@@ -10973,7 +10723,7 @@ unsafe impl ::windows::core::Abi for SETTEXTEX {
 }
 impl ::core::cmp::PartialEq for SETTEXTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SETTEXTEX>()) == 0 }
+        self.flags == other.flags && self.codepage == other.codepage
     }
 }
 impl ::core::cmp::Eq for SETTEXTEX {}
@@ -11035,7 +10785,7 @@ unsafe impl ::windows::core::Abi for TABLECELLPARMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TABLECELLPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TABLECELLPARMS>()) == 0 }
+        self.dxWidth == other.dxWidth && self._bitfield == other._bitfield && self.wShading == other.wShading && self.dxBrdrLeft == other.dxBrdrLeft && self.dyBrdrTop == other.dyBrdrTop && self.dxBrdrRight == other.dxBrdrRight && self.dyBrdrBottom == other.dyBrdrBottom && self.crBrdrLeft == other.crBrdrLeft && self.crBrdrTop == other.crBrdrTop && self.crBrdrRight == other.crBrdrRight && self.crBrdrBottom == other.crBrdrBottom && self.crBackPat == other.crBackPat && self.crForePat == other.crForePat
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11077,7 +10827,7 @@ unsafe impl ::windows::core::Abi for TABLEROWPARMS {
 }
 impl ::core::cmp::PartialEq for TABLEROWPARMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TABLEROWPARMS>()) == 0 }
+        self.cbRow == other.cbRow && self.cbCell == other.cbCell && self.cCell == other.cCell && self.cRow == other.cRow && self.dxCellMargin == other.dxCellMargin && self.dxIndent == other.dxIndent && self.dyHeight == other.dyHeight && self._bitfield == other._bitfield && self.cpStartRow == other.cpStartRow && self.bTableLevel == other.bTableLevel && self.iCell == other.iCell
     }
 }
 impl ::core::cmp::Eq for TABLEROWPARMS {}
@@ -11101,12 +10851,6 @@ impl ::core::clone::Clone for TEXTRANGEA {
 unsafe impl ::windows::core::Abi for TEXTRANGEA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TEXTRANGEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXTRANGEA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TEXTRANGEA {}
 impl ::core::default::Default for TEXTRANGEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11127,12 +10871,6 @@ impl ::core::clone::Clone for TEXTRANGEW {
 unsafe impl ::windows::core::Abi for TEXTRANGEW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TEXTRANGEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TEXTRANGEW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TEXTRANGEW {}
 impl ::core::default::Default for TEXTRANGEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -19188,7 +19188,7 @@ unsafe impl ::windows::core::Abi for BP_ANIMATIONPARAMS {
 }
 impl ::core::cmp::PartialEq for BP_ANIMATIONPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BP_ANIMATIONPARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.style == other.style && self.dwDuration == other.dwDuration
     }
 }
 impl ::core::cmp::Eq for BP_ANIMATIONPARAMS {}
@@ -19227,7 +19227,7 @@ unsafe impl ::windows::core::Abi for BP_PAINTPARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for BP_PAINTPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BP_PAINTPARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.prcExclude == other.prcExclude && self.pBlendFunction == other.pBlendFunction
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -19267,7 +19267,7 @@ unsafe impl ::windows::core::Abi for BUTTON_IMAGELIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BUTTON_IMAGELIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUTTON_IMAGELIST>()) == 0 }
+        self.himl == other.himl && self.margin == other.margin && self.uAlign == other.uAlign
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19308,7 +19308,7 @@ unsafe impl ::windows::core::Abi for BUTTON_SPLITINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for BUTTON_SPLITINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BUTTON_SPLITINFO>()) == 0 }
+        self.mask == other.mask && self.himlGlyph == other.himlGlyph && self.uSplitStyle == other.uSplitStyle && self.size == other.size
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19362,8 +19362,6 @@ impl ::core::fmt::Debug for CCINFOA {
             .field("szTextDefault", &self.szTextDefault)
             .field("cStyleFlags", &self.cStyleFlags)
             .field("aStyleFlags", &self.aStyleFlags)
-            .field("lpfnStyle", &self.lpfnStyle.map(|f| f as usize))
-            .field("lpfnSizeToText", &self.lpfnSizeToText.map(|f| f as usize))
             .field("dwReserved1", &self.dwReserved1)
             .field("dwReserved2", &self.dwReserved2)
             .finish()
@@ -19373,14 +19371,6 @@ impl ::core::fmt::Debug for CCINFOA {
 unsafe impl ::windows::core::Abi for CCINFOA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CCINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCINFOA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CCINFOA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CCINFOA {
     fn default() -> Self {
@@ -19430,8 +19420,6 @@ impl ::core::fmt::Debug for CCINFOW {
             .field("cStyleFlags", &self.cStyleFlags)
             .field("aStyleFlags", &self.aStyleFlags)
             .field("szTextDefault", &self.szTextDefault)
-            .field("lpfnStyle", &self.lpfnStyle.map(|f| f as usize))
-            .field("lpfnSizeToText", &self.lpfnSizeToText.map(|f| f as usize))
             .field("dwReserved1", &self.dwReserved1)
             .field("dwReserved2", &self.dwReserved2)
             .finish()
@@ -19441,14 +19429,6 @@ impl ::core::fmt::Debug for CCINFOW {
 unsafe impl ::windows::core::Abi for CCINFOW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for CCINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCINFOW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for CCINFOW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for CCINFOW {
     fn default() -> Self {
@@ -19486,7 +19466,7 @@ unsafe impl ::windows::core::Abi for CCSTYLEA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CCSTYLEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCSTYLEA>()) == 0 }
+        self.flStyle == other.flStyle && self.flExtStyle == other.flExtStyle && self.szText == other.szText && self.lgid == other.lgid && self.wReserved1 == other.wReserved1
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19520,7 +19500,7 @@ unsafe impl ::windows::core::Abi for CCSTYLEFLAGA {
 }
 impl ::core::cmp::PartialEq for CCSTYLEFLAGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCSTYLEFLAGA>()) == 0 }
+        self.flStyle == other.flStyle && self.flStyleMask == other.flStyleMask && self.pszStyle == other.pszStyle
     }
 }
 impl ::core::cmp::Eq for CCSTYLEFLAGA {}
@@ -19552,7 +19532,7 @@ unsafe impl ::windows::core::Abi for CCSTYLEFLAGW {
 }
 impl ::core::cmp::PartialEq for CCSTYLEFLAGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCSTYLEFLAGW>()) == 0 }
+        self.flStyle == other.flStyle && self.flStyleMask == other.flStyleMask && self.pszStyle == other.pszStyle
     }
 }
 impl ::core::cmp::Eq for CCSTYLEFLAGW {}
@@ -19586,7 +19566,7 @@ unsafe impl ::windows::core::Abi for CCSTYLEW {
 }
 impl ::core::cmp::PartialEq for CCSTYLEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CCSTYLEW>()) == 0 }
+        self.flStyle == other.flStyle && self.flExtStyle == other.flExtStyle && self.szText == other.szText && self.lgid == other.lgid && self.wReserved1 == other.wReserved1
     }
 }
 impl ::core::cmp::Eq for CCSTYLEW {}
@@ -19623,7 +19603,7 @@ unsafe impl ::windows::core::Abi for COLORMAP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COLORMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORMAP>()) == 0 }
+        self.from == other.from && self.to == other.to
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19663,7 +19643,7 @@ unsafe impl ::windows::core::Abi for COLORSCHEME {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COLORSCHEME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COLORSCHEME>()) == 0 }
+        self.dwSize == other.dwSize && self.clrBtnHighlight == other.clrBtnHighlight && self.clrBtnShadow == other.clrBtnShadow
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19709,7 +19689,7 @@ unsafe impl ::windows::core::Abi for COMBOBOXEXITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMBOBOXEXITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMBOBOXEXITEMA>()) == 0 }
+        self.mask == other.mask && self.iItem == other.iItem && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.iOverlay == other.iOverlay && self.iIndent == other.iIndent && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19755,7 +19735,7 @@ unsafe impl ::windows::core::Abi for COMBOBOXEXITEMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMBOBOXEXITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMBOBOXEXITEMW>()) == 0 }
+        self.mask == other.mask && self.iItem == other.iItem && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.iOverlay == other.iOverlay && self.iIndent == other.iIndent && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19799,7 +19779,7 @@ unsafe impl ::windows::core::Abi for COMBOBOXINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMBOBOXINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMBOBOXINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcItem == other.rcItem && self.rcButton == other.rcButton && self.stateButton == other.stateButton && self.hwndCombo == other.hwndCombo && self.hwndItem == other.hwndItem && self.hwndList == other.hwndList
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19844,7 +19824,7 @@ unsafe impl ::windows::core::Abi for COMPAREITEMSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMPAREITEMSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPAREITEMSTRUCT>()) == 0 }
+        self.CtlType == other.CtlType && self.CtlID == other.CtlID && self.hwndItem == other.hwndItem && self.itemID1 == other.itemID1 && self.itemData1 == other.itemData1 && self.itemID2 == other.itemID2 && self.itemData2 == other.itemData2 && self.dwLocaleId == other.dwLocaleId
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19889,7 +19869,7 @@ unsafe impl ::windows::core::Abi for DATETIMEPICKERINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DATETIMEPICKERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATETIMEPICKERINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcCheck == other.rcCheck && self.stateCheck == other.stateCheck && self.rcButton == other.rcButton && self.stateButton == other.stateButton && self.hwndEdit == other.hwndEdit && self.hwndUD == other.hwndUD && self.hwndDropDown == other.hwndDropDown
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19931,7 +19911,7 @@ unsafe impl ::windows::core::Abi for DELETEITEMSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DELETEITEMSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELETEITEMSTRUCT>()) == 0 }
+        self.CtlType == other.CtlType && self.CtlID == other.CtlID && self.itemID == other.itemID && self.hwndItem == other.hwndItem && self.itemData == other.itemData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -19964,7 +19944,7 @@ unsafe impl ::windows::core::Abi for DPASTREAMINFO {
 }
 impl ::core::cmp::PartialEq for DPASTREAMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DPASTREAMINFO>()) == 0 }
+        self.iPos == other.iPos && self.pvItem == other.pvItem
     }
 }
 impl ::core::cmp::Eq for DPASTREAMINFO {}
@@ -20002,7 +19982,7 @@ unsafe impl ::windows::core::Abi for DRAGLISTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DRAGLISTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAGLISTINFO>()) == 0 }
+        self.uNotification == other.uNotification && self.hWnd == other.hWnd && self.ptCursor == other.ptCursor
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20048,7 +20028,7 @@ unsafe impl ::windows::core::Abi for DRAWITEMSTRUCT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for DRAWITEMSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAWITEMSTRUCT>()) == 0 }
+        self.CtlType == other.CtlType && self.CtlID == other.CtlID && self.itemID == other.itemID && self.itemAction == other.itemAction && self.itemState == other.itemState && self.hwndItem == other.hwndItem && self.hDC == other.hDC && self.rcItem == other.rcItem && self.itemData == other.itemData
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -20088,7 +20068,7 @@ unsafe impl ::windows::core::Abi for DTBGOPTS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DTBGOPTS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTBGOPTS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.rcClip == other.rcClip
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20144,7 +20124,6 @@ impl ::core::fmt::Debug for DTTOPTS {
             .field("iStateId", &self.iStateId)
             .field("fApplyOverlay", &self.fApplyOverlay)
             .field("iGlowSize", &self.iGlowSize)
-            .field("pfnDrawTextCallback", &self.pfnDrawTextCallback.map(|f| f as usize))
             .field("lParam", &self.lParam)
             .finish()
     }
@@ -20153,14 +20132,6 @@ impl ::core::fmt::Debug for DTTOPTS {
 unsafe impl ::windows::core::Abi for DTTOPTS {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for DTTOPTS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DTTOPTS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for DTTOPTS {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for DTTOPTS {
     fn default() -> Self {
@@ -20191,7 +20162,7 @@ unsafe impl ::windows::core::Abi for EDITBALLOONTIP {
 }
 impl ::core::cmp::PartialEq for EDITBALLOONTIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EDITBALLOONTIP>()) == 0 }
+        self.cbStruct == other.cbStruct && self.pszTitle == other.pszTitle && self.pszText == other.pszText && self.ttiIcon == other.ttiIcon
     }
 }
 impl ::core::cmp::Eq for EDITBALLOONTIP {}
@@ -20229,7 +20200,7 @@ unsafe impl ::windows::core::Abi for HDHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HDHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.flags == other.flags && self.iItem == other.iItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20278,7 +20249,7 @@ unsafe impl ::windows::core::Abi for HDITEMA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for HDITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDITEMA>()) == 0 }
+        self.mask == other.mask && self.cxy == other.cxy && self.pszText == other.pszText && self.hbm == other.hbm && self.cchTextMax == other.cchTextMax && self.fmt == other.fmt && self.lParam == other.lParam && self.iImage == other.iImage && self.iOrder == other.iOrder && self.r#type == other.r#type && self.pvFilter == other.pvFilter && self.state == other.state
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -20327,7 +20298,7 @@ unsafe impl ::windows::core::Abi for HDITEMW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for HDITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDITEMW>()) == 0 }
+        self.mask == other.mask && self.cxy == other.cxy && self.pszText == other.pszText && self.hbm == other.hbm && self.cchTextMax == other.cchTextMax && self.fmt == other.fmt && self.lParam == other.lParam && self.iImage == other.iImage && self.iOrder == other.iOrder && self.r#type == other.r#type && self.pvFilter == other.pvFilter && self.state == other.state
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -20366,7 +20337,7 @@ unsafe impl ::windows::core::Abi for HDLAYOUT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for HDLAYOUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HDLAYOUT>()) == 0 }
+        self.prc == other.prc && self.pwpos == other.pwpos
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -20463,7 +20434,7 @@ unsafe impl ::windows::core::Abi for HD_TEXTFILTERA {
 }
 impl ::core::cmp::PartialEq for HD_TEXTFILTERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HD_TEXTFILTERA>()) == 0 }
+        self.pszText == other.pszText && self.cchTextMax == other.cchTextMax
     }
 }
 impl ::core::cmp::Eq for HD_TEXTFILTERA {}
@@ -20494,7 +20465,7 @@ unsafe impl ::windows::core::Abi for HD_TEXTFILTERW {
 }
 impl ::core::cmp::PartialEq for HD_TEXTFILTERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HD_TEXTFILTERW>()) == 0 }
+        self.pszText == other.pszText && self.cchTextMax == other.cchTextMax
     }
 }
 impl ::core::cmp::Eq for HD_TEXTFILTERW {}
@@ -20689,7 +20660,7 @@ unsafe impl ::windows::core::Abi for IMAGEINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for IMAGEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGEINFO>()) == 0 }
+        self.hbmImage == other.hbmImage && self.hbmMask == other.hbmMask && self.Unused1 == other.Unused1 && self.Unused2 == other.Unused2 && self.rcImage == other.rcImage
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -20761,7 +20732,7 @@ unsafe impl ::windows::core::Abi for IMAGELISTDRAWPARAMS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for IMAGELISTDRAWPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGELISTDRAWPARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.himl == other.himl && self.i == other.i && self.hdcDst == other.hdcDst && self.x == other.x && self.y == other.y && self.cx == other.cx && self.cy == other.cy && self.xBitmap == other.xBitmap && self.yBitmap == other.yBitmap && self.rgbBk == other.rgbBk && self.rgbFg == other.rgbFg && self.fStyle == other.fStyle && self.dwRop == other.dwRop && self.fState == other.fState && self.Frame == other.Frame && self.crEffect == other.crEffect
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -20796,7 +20767,7 @@ unsafe impl ::windows::core::Abi for IMAGELISTSTATS {
 }
 impl ::core::cmp::PartialEq for IMAGELISTSTATS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMAGELISTSTATS>()) == 0 }
+        self.cbSize == other.cbSize && self.cAlloc == other.cAlloc && self.cUsed == other.cUsed && self.cStandby == other.cStandby
     }
 }
 impl ::core::cmp::Eq for IMAGELISTSTATS {}
@@ -20827,7 +20798,7 @@ unsafe impl ::windows::core::Abi for INITCOMMONCONTROLSEX {
 }
 impl ::core::cmp::PartialEq for INITCOMMONCONTROLSEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INITCOMMONCONTROLSEX>()) == 0 }
+        self.dwSize == other.dwSize && self.dwICC == other.dwICC
     }
 }
 impl ::core::cmp::Eq for INITCOMMONCONTROLSEX {}
@@ -20858,7 +20829,7 @@ unsafe impl ::windows::core::Abi for INTLIST {
 }
 impl ::core::cmp::PartialEq for INTLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTLIST>()) == 0 }
+        self.iValueCount == other.iValueCount && self.iValues == other.iValues
     }
 }
 impl ::core::cmp::Eq for INTLIST {}
@@ -20895,7 +20866,7 @@ unsafe impl ::windows::core::Abi for LHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -20932,7 +20903,7 @@ unsafe impl ::windows::core::Abi for LITEM {
 }
 impl ::core::cmp::PartialEq for LITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LITEM>()) == 0 }
+        self.mask == other.mask && self.iLink == other.iLink && self.state == other.state && self.stateMask == other.stateMask && self.szID == other.szID && self.szUrl == other.szUrl
     }
 }
 impl ::core::cmp::Eq for LITEM {}
@@ -20973,7 +20944,7 @@ unsafe impl ::windows::core::Abi for LVBKIMAGEA {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for LVBKIMAGEA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVBKIMAGEA>()) == 0 }
+        self.ulFlags == other.ulFlags && self.hbm == other.hbm && self.pszImage == other.pszImage && self.cchImageMax == other.cchImageMax && self.xOffsetPercent == other.xOffsetPercent && self.yOffsetPercent == other.yOffsetPercent
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -21016,7 +20987,7 @@ unsafe impl ::windows::core::Abi for LVBKIMAGEW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for LVBKIMAGEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVBKIMAGEW>()) == 0 }
+        self.ulFlags == other.ulFlags && self.hbm == other.hbm && self.pszImage == other.pszImage && self.cchImageMax == other.cchImageMax && self.xOffsetPercent == other.xOffsetPercent && self.yOffsetPercent == other.yOffsetPercent
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -21058,7 +21029,7 @@ unsafe impl ::windows::core::Abi for LVCOLUMNA {
 }
 impl ::core::cmp::PartialEq for LVCOLUMNA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVCOLUMNA>()) == 0 }
+        self.mask == other.mask && self.fmt == other.fmt && self.cx == other.cx && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iSubItem == other.iSubItem && self.iImage == other.iImage && self.iOrder == other.iOrder && self.cxMin == other.cxMin && self.cxDefault == other.cxDefault && self.cxIdeal == other.cxIdeal
     }
 }
 impl ::core::cmp::Eq for LVCOLUMNA {}
@@ -21098,7 +21069,7 @@ unsafe impl ::windows::core::Abi for LVCOLUMNW {
 }
 impl ::core::cmp::PartialEq for LVCOLUMNW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVCOLUMNW>()) == 0 }
+        self.mask == other.mask && self.fmt == other.fmt && self.cx == other.cx && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iSubItem == other.iSubItem && self.iImage == other.iImage && self.iOrder == other.iOrder && self.cxMin == other.cxMin && self.cxDefault == other.cxDefault && self.cxIdeal == other.cxIdeal
     }
 }
 impl ::core::cmp::Eq for LVCOLUMNW {}
@@ -21138,7 +21109,7 @@ unsafe impl ::windows::core::Abi for LVFINDINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVFINDINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVFINDINFOA>()) == 0 }
+        self.flags == other.flags && self.psz == other.psz && self.lParam == other.lParam && self.pt == other.pt && self.vkDirection == other.vkDirection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21180,7 +21151,7 @@ unsafe impl ::windows::core::Abi for LVFINDINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVFINDINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVFINDINFOW>()) == 0 }
+        self.flags == other.flags && self.psz == other.psz && self.lParam == other.lParam && self.pt == other.pt && self.vkDirection == other.vkDirection
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21215,7 +21186,7 @@ unsafe impl ::windows::core::Abi for LVFOOTERINFO {
 }
 impl ::core::cmp::PartialEq for LVFOOTERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVFOOTERINFO>()) == 0 }
+        self.mask == other.mask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.cItems == other.cItems
     }
 }
 impl ::core::cmp::Eq for LVFOOTERINFO {}
@@ -21250,7 +21221,7 @@ unsafe impl ::windows::core::Abi for LVFOOTERITEM {
 }
 impl ::core::cmp::PartialEq for LVFOOTERITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVFOOTERITEM>()) == 0 }
+        self.mask == other.mask && self.iItem == other.iItem && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.state == other.state && self.stateMask == other.stateMask
     }
 }
 impl ::core::cmp::Eq for LVFOOTERITEM {}
@@ -21328,7 +21299,30 @@ unsafe impl ::windows::core::Abi for LVGROUP {
 }
 impl ::core::cmp::PartialEq for LVGROUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVGROUP>()) == 0 }
+        self.cbSize == other.cbSize
+            && self.mask == other.mask
+            && self.pszHeader == other.pszHeader
+            && self.cchHeader == other.cchHeader
+            && self.pszFooter == other.pszFooter
+            && self.cchFooter == other.cchFooter
+            && self.iGroupId == other.iGroupId
+            && self.stateMask == other.stateMask
+            && self.state == other.state
+            && self.uAlign == other.uAlign
+            && self.pszSubtitle == other.pszSubtitle
+            && self.cchSubtitle == other.cchSubtitle
+            && self.pszTask == other.pszTask
+            && self.cchTask == other.cchTask
+            && self.pszDescriptionTop == other.pszDescriptionTop
+            && self.cchDescriptionTop == other.cchDescriptionTop
+            && self.pszDescriptionBottom == other.pszDescriptionBottom
+            && self.cchDescriptionBottom == other.cchDescriptionBottom
+            && self.iTitleImage == other.iTitleImage
+            && self.iExtendedImage == other.iExtendedImage
+            && self.iFirstItem == other.iFirstItem
+            && self.cItems == other.cItems
+            && self.pszSubsetTitle == other.pszSubsetTitle
+            && self.cchSubsetTitle == other.cchSubsetTitle
     }
 }
 impl ::core::cmp::Eq for LVGROUP {}
@@ -21375,7 +21369,7 @@ unsafe impl ::windows::core::Abi for LVGROUPMETRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVGROUPMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVGROUPMETRICS>()) == 0 }
+        self.cbSize == other.cbSize && self.mask == other.mask && self.Left == other.Left && self.Top == other.Top && self.Right == other.Right && self.Bottom == other.Bottom && self.crLeft == other.crLeft && self.crTop == other.crTop && self.crRight == other.crRight && self.crBottom == other.crBottom && self.crHeader == other.crHeader && self.crFooter == other.crFooter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21417,7 +21411,7 @@ unsafe impl ::windows::core::Abi for LVHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.flags == other.flags && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.iGroup == other.iGroup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21443,18 +21437,12 @@ impl ::core::clone::Clone for LVINSERTGROUPSORTED {
 }
 impl ::core::fmt::Debug for LVINSERTGROUPSORTED {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("LVINSERTGROUPSORTED").field("pfnGroupCompare", &self.pfnGroupCompare.map(|f| f as usize)).field("pvData", &self.pvData).field("lvGroup", &self.lvGroup).finish()
+        f.debug_struct("LVINSERTGROUPSORTED").field("pvData", &self.pvData).field("lvGroup", &self.lvGroup).finish()
     }
 }
 unsafe impl ::windows::core::Abi for LVINSERTGROUPSORTED {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LVINSERTGROUPSORTED {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVINSERTGROUPSORTED>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for LVINSERTGROUPSORTED {}
 impl ::core::default::Default for LVINSERTGROUPSORTED {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -21484,7 +21472,7 @@ unsafe impl ::windows::core::Abi for LVINSERTMARK {
 }
 impl ::core::cmp::PartialEq for LVINSERTMARK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVINSERTMARK>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.iItem == other.iItem && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for LVINSERTMARK {}
@@ -21550,7 +21538,7 @@ unsafe impl ::windows::core::Abi for LVITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVITEMA>()) == 0 }
+        self.mask == other.mask && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam && self.iIndent == other.iIndent && self.iGroupId == other.iGroupId && self.cColumns == other.cColumns && self.puColumns == other.puColumns && self.piColFmt == other.piColFmt && self.iGroup == other.iGroup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21583,7 +21571,7 @@ unsafe impl ::windows::core::Abi for LVITEMINDEX {
 }
 impl ::core::cmp::PartialEq for LVITEMINDEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVITEMINDEX>()) == 0 }
+        self.iItem == other.iItem && self.iGroup == other.iGroup
     }
 }
 impl ::core::cmp::Eq for LVITEMINDEX {}
@@ -21649,7 +21637,7 @@ unsafe impl ::windows::core::Abi for LVITEMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVITEMW>()) == 0 }
+        self.mask == other.mask && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam && self.iIndent == other.iIndent && self.iGroupId == other.iGroupId && self.cColumns == other.cColumns && self.puColumns == other.puColumns && self.piColFmt == other.piColFmt && self.iGroup == other.iGroup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21685,7 +21673,7 @@ unsafe impl ::windows::core::Abi for LVSETINFOTIP {
 }
 impl ::core::cmp::PartialEq for LVSETINFOTIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVSETINFOTIP>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.pszText == other.pszText && self.iItem == other.iItem && self.iSubItem == other.iSubItem
     }
 }
 impl ::core::cmp::Eq for LVSETINFOTIP {}
@@ -21719,7 +21707,7 @@ unsafe impl ::windows::core::Abi for LVTILEINFO {
 }
 impl ::core::cmp::PartialEq for LVTILEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVTILEINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.iItem == other.iItem && self.cColumns == other.cColumns && self.puColumns == other.puColumns && self.piColFmt == other.piColFmt
     }
 }
 impl ::core::cmp::Eq for LVTILEINFO {}
@@ -21760,7 +21748,7 @@ unsafe impl ::windows::core::Abi for LVTILEVIEWINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LVTILEVIEWINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LVTILEVIEWINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.dwFlags == other.dwFlags && self.sizeTile == other.sizeTile && self.cLines == other.cLines && self.rcLabelMargin == other.rcLabelMargin
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21795,7 +21783,7 @@ unsafe impl ::windows::core::Abi for MARGINS {
 }
 impl ::core::cmp::PartialEq for MARGINS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MARGINS>()) == 0 }
+        self.cxLeftWidth == other.cxLeftWidth && self.cxRightWidth == other.cxRightWidth && self.cyTopHeight == other.cyTopHeight && self.cyBottomHeight == other.cyBottomHeight
     }
 }
 impl ::core::cmp::Eq for MARGINS {}
@@ -21842,7 +21830,7 @@ unsafe impl ::windows::core::Abi for MCGRIDINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MCGRIDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCGRIDINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwPart == other.dwPart && self.dwFlags == other.dwFlags && self.iCalendar == other.iCalendar && self.iRow == other.iRow && self.iCol == other.iCol && self.bSelected == other.bSelected && self.stStart == other.stStart && self.stEnd == other.stEnd && self.rc == other.rc && self.pszName == other.pszName && self.cchName == other.cchName
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21887,7 +21875,7 @@ unsafe impl ::windows::core::Abi for MCHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MCHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MCHITTESTINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.pt == other.pt && self.uHit == other.uHit && self.st == other.st && self.rc == other.rc && self.iOffset == other.iOffset && self.iRow == other.iRow && self.iCol == other.iCol
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -21924,7 +21912,7 @@ unsafe impl ::windows::core::Abi for MEASUREITEMSTRUCT {
 }
 impl ::core::cmp::PartialEq for MEASUREITEMSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MEASUREITEMSTRUCT>()) == 0 }
+        self.CtlType == other.CtlType && self.CtlID == other.CtlID && self.itemID == other.itemID && self.itemWidth == other.itemWidth && self.itemHeight == other.itemHeight && self.itemData == other.itemData
     }
 }
 impl ::core::cmp::Eq for MEASUREITEMSTRUCT {}
@@ -21961,7 +21949,7 @@ unsafe impl ::windows::core::Abi for NMBCDROPDOWN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMBCDROPDOWN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMBCDROPDOWN>()) == 0 }
+        self.hdr == other.hdr && self.rcButton == other.rcButton
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22000,7 +21988,7 @@ unsafe impl ::windows::core::Abi for NMBCHOTITEM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMBCHOTITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMBCHOTITEM>()) == 0 }
+        self.hdr == other.hdr && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22040,7 +22028,7 @@ unsafe impl ::windows::core::Abi for NMCBEDRAGBEGINA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCBEDRAGBEGINA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCBEDRAGBEGINA>()) == 0 }
+        self.hdr == other.hdr && self.iItemid == other.iItemid && self.szText == other.szText
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22080,7 +22068,7 @@ unsafe impl ::windows::core::Abi for NMCBEDRAGBEGINW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCBEDRAGBEGINW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCBEDRAGBEGINW>()) == 0 }
+        self.hdr == other.hdr && self.iItemid == other.iItemid && self.szText == other.szText
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22122,7 +22110,7 @@ unsafe impl ::windows::core::Abi for NMCBEENDEDITA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCBEENDEDITA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCBEENDEDITA>()) == 0 }
+        self.hdr == other.hdr && self.fChanged == other.fChanged && self.iNewSelection == other.iNewSelection && self.szText == other.szText && self.iWhy == other.iWhy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22164,7 +22152,7 @@ unsafe impl ::windows::core::Abi for NMCBEENDEDITW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCBEENDEDITW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCBEENDEDITW>()) == 0 }
+        self.hdr == other.hdr && self.fChanged == other.fChanged && self.iNewSelection == other.iNewSelection && self.szText == other.szText && self.iWhy == other.iWhy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22205,7 +22193,7 @@ unsafe impl ::windows::core::Abi for NMCHAR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCHAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCHAR>()) == 0 }
+        self.hdr == other.hdr && self.ch == other.ch && self.dwItemPrev == other.dwItemPrev && self.dwItemNext == other.dwItemNext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22244,7 +22232,7 @@ unsafe impl ::windows::core::Abi for NMCOMBOBOXEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCOMBOBOXEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCOMBOBOXEXA>()) == 0 }
+        self.hdr == other.hdr && self.ceItem == other.ceItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22283,7 +22271,7 @@ unsafe impl ::windows::core::Abi for NMCOMBOBOXEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCOMBOBOXEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCOMBOBOXEXW>()) == 0 }
+        self.hdr == other.hdr && self.ceItem == other.ceItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22327,7 +22315,7 @@ unsafe impl ::windows::core::Abi for NMCUSTOMDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMCUSTOMDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCUSTOMDRAW>()) == 0 }
+        self.hdr == other.hdr && self.dwDrawStage == other.dwDrawStage && self.hdc == other.hdc && self.rc == other.rc && self.dwItemSpec == other.dwItemSpec && self.uItemState == other.uItemState && self.lItemlParam == other.lItemlParam
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -22368,7 +22356,7 @@ unsafe impl ::windows::core::Abi for NMCUSTOMSPLITRECTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMCUSTOMSPLITRECTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCUSTOMSPLITRECTINFO>()) == 0 }
+        self.hdr == other.hdr && self.rcClient == other.rcClient && self.rcButton == other.rcButton && self.rcSplit == other.rcSplit
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22412,7 +22400,7 @@ unsafe impl ::windows::core::Abi for NMCUSTOMTEXT {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMCUSTOMTEXT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMCUSTOMTEXT>()) == 0 }
+        self.hdr == other.hdr && self.hDC == other.hDC && self.lpString == other.lpString && self.nCount == other.nCount && self.lpRect == other.lpRect && self.uFormat == other.uFormat && self.fLink == other.fLink
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -22452,7 +22440,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMECHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMECHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMECHANGE>()) == 0 }
+        self.nmhdr == other.nmhdr && self.dwFlags == other.dwFlags && self.st == other.st
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22494,7 +22482,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEFORMATA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEFORMATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEFORMATA>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszFormat == other.pszFormat && self.st == other.st && self.pszDisplay == other.pszDisplay && self.szDisplay == other.szDisplay
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22534,7 +22522,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEFORMATQUERYA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEFORMATQUERYA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEFORMATQUERYA>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszFormat == other.pszFormat && self.szMax == other.szMax
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22574,7 +22562,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEFORMATQUERYW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEFORMATQUERYW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEFORMATQUERYW>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszFormat == other.pszFormat && self.szMax == other.szMax
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22616,7 +22604,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEFORMATW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEFORMATW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEFORMATW>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszFormat == other.pszFormat && self.st == other.st && self.pszDisplay == other.pszDisplay && self.szDisplay == other.szDisplay
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22657,7 +22645,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMESTRINGA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMESTRINGA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMESTRINGA>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszUserString == other.pszUserString && self.st == other.st && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22698,7 +22686,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMESTRINGW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMESTRINGW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMESTRINGW>()) == 0 }
+        self.nmhdr == other.nmhdr && self.pszUserString == other.pszUserString && self.st == other.st && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22739,7 +22727,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEWMKEYDOWNA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEWMKEYDOWNA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEWMKEYDOWNA>()) == 0 }
+        self.nmhdr == other.nmhdr && self.nVirtKey == other.nVirtKey && self.pszFormat == other.pszFormat && self.st == other.st
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22780,7 +22768,7 @@ unsafe impl ::windows::core::Abi for NMDATETIMEWMKEYDOWNW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDATETIMEWMKEYDOWNW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDATETIMEWMKEYDOWNW>()) == 0 }
+        self.nmhdr == other.nmhdr && self.nVirtKey == other.nVirtKey && self.pszFormat == other.pszFormat && self.st == other.st
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22821,7 +22809,7 @@ unsafe impl ::windows::core::Abi for NMDAYSTATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMDAYSTATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMDAYSTATE>()) == 0 }
+        self.nmhdr == other.nmhdr && self.stStart == other.stStart && self.cDayState == other.cDayState && self.prgDayState == other.prgDayState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22865,7 +22853,7 @@ unsafe impl ::windows::core::Abi for NMHDDISPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMHDDISPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHDDISPINFOA>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.mask == other.mask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22909,7 +22897,7 @@ unsafe impl ::windows::core::Abi for NMHDDISPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMHDDISPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHDDISPINFOW>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.mask == other.mask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22949,7 +22937,7 @@ unsafe impl ::windows::core::Abi for NMHDFILTERBTNCLICK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMHDFILTERBTNCLICK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHDFILTERBTNCLICK>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.rc == other.rc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -22989,7 +22977,7 @@ unsafe impl ::windows::core::Abi for NMHDR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMHDR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHDR>()) == 0 }
+        self.hwndFrom == other.hwndFrom && self.idFrom == other.idFrom && self.code == other.code
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23030,7 +23018,7 @@ unsafe impl ::windows::core::Abi for NMHEADERA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMHEADERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHEADERA>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.iButton == other.iButton && self.pitem == other.pitem
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -23071,7 +23059,7 @@ unsafe impl ::windows::core::Abi for NMHEADERW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMHEADERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMHEADERW>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.iButton == other.iButton && self.pitem == other.pitem
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -23111,7 +23099,7 @@ unsafe impl ::windows::core::Abi for NMIPADDRESS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMIPADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMIPADDRESS>()) == 0 }
+        self.hdr == other.hdr && self.iField == other.iField && self.iValue == other.iValue
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23157,7 +23145,7 @@ unsafe impl ::windows::core::Abi for NMITEMACTIVATE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMITEMACTIVATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMITEMACTIVATE>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.uNewState == other.uNewState && self.uOldState == other.uOldState && self.uChanged == other.uChanged && self.ptAction == other.ptAction && self.lParam == other.lParam && self.uKeyFlags == other.uKeyFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23197,7 +23185,7 @@ unsafe impl ::windows::core::Abi for NMKEY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMKEY>()) == 0 }
+        self.hdr == other.hdr && self.nVKey == other.nVKey && self.uFlags == other.uFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23236,7 +23224,7 @@ unsafe impl ::windows::core::Abi for NMLINK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLINK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLINK>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23281,7 +23269,7 @@ unsafe impl ::windows::core::Abi for NMLISTVIEW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLISTVIEW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLISTVIEW>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.uNewState == other.uNewState && self.uOldState == other.uOldState && self.uChanged == other.uChanged && self.ptAction == other.ptAction && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23321,7 +23309,7 @@ unsafe impl ::windows::core::Abi for NMLVCACHEHINT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVCACHEHINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVCACHEHINT>()) == 0 }
+        self.hdr == other.hdr && self.iFrom == other.iFrom && self.iTo == other.iTo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23370,7 +23358,7 @@ unsafe impl ::windows::core::Abi for NMLVCUSTOMDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMLVCUSTOMDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVCUSTOMDRAW>()) == 0 }
+        self.nmcd == other.nmcd && self.clrText == other.clrText && self.clrTextBk == other.clrTextBk && self.iSubItem == other.iSubItem && self.dwItemType == other.dwItemType && self.clrFace == other.clrFace && self.iIconEffect == other.iIconEffect && self.iIconPhase == other.iIconPhase && self.iPartId == other.iPartId && self.iStateId == other.iStateId && self.rcText == other.rcText && self.uAlign == other.uAlign
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -23409,7 +23397,7 @@ unsafe impl ::windows::core::Abi for NMLVDISPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVDISPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVDISPINFOA>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23448,7 +23436,7 @@ unsafe impl ::windows::core::Abi for NMLVDISPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVDISPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVDISPINFOW>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23488,7 +23476,7 @@ unsafe impl ::windows::core::Abi for NMLVEMPTYMARKUP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVEMPTYMARKUP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVEMPTYMARKUP>()) == 0 }
+        self.hdr == other.hdr && self.dwFlags == other.dwFlags && self.szMarkup == other.szMarkup
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23528,7 +23516,7 @@ unsafe impl ::windows::core::Abi for NMLVFINDITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVFINDITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVFINDITEMA>()) == 0 }
+        self.hdr == other.hdr && self.iStart == other.iStart && self.lvfi == other.lvfi
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23568,7 +23556,7 @@ unsafe impl ::windows::core::Abi for NMLVFINDITEMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVFINDITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVFINDITEMW>()) == 0 }
+        self.hdr == other.hdr && self.iStart == other.iStart && self.lvfi == other.lvfi
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23612,7 +23600,7 @@ unsafe impl ::windows::core::Abi for NMLVGETINFOTIPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVGETINFOTIPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVGETINFOTIPA>()) == 0 }
+        self.hdr == other.hdr && self.dwFlags == other.dwFlags && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23656,7 +23644,7 @@ unsafe impl ::windows::core::Abi for NMLVGETINFOTIPW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVGETINFOTIPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVGETINFOTIPW>()) == 0 }
+        self.hdr == other.hdr && self.dwFlags == other.dwFlags && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iItem == other.iItem && self.iSubItem == other.iSubItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23687,14 +23675,6 @@ impl ::core::clone::Clone for NMLVKEYDOWN {
 unsafe impl ::windows::core::Abi for NMLVKEYDOWN {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NMLVKEYDOWN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVKEYDOWN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NMLVKEYDOWN {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NMLVKEYDOWN {
     fn default() -> Self {
@@ -23731,7 +23711,7 @@ unsafe impl ::windows::core::Abi for NMLVLINK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVLINK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVLINK>()) == 0 }
+        self.hdr == other.hdr && self.link == other.link && self.iItem == other.iItem && self.iSubItem == other.iSubItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23773,7 +23753,7 @@ unsafe impl ::windows::core::Abi for NMLVODSTATECHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVODSTATECHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVODSTATECHANGE>()) == 0 }
+        self.hdr == other.hdr && self.iFrom == other.iFrom && self.iTo == other.iTo && self.uNewState == other.uNewState && self.uOldState == other.uOldState
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23813,7 +23793,7 @@ unsafe impl ::windows::core::Abi for NMLVSCROLL {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMLVSCROLL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMLVSCROLL>()) == 0 }
+        self.hdr == other.hdr && self.dx == other.dx && self.dy == other.dy
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23855,7 +23835,7 @@ unsafe impl ::windows::core::Abi for NMMOUSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMMOUSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMMOUSE>()) == 0 }
+        self.hdr == other.hdr && self.dwItemSpec == other.dwItemSpec && self.dwItemData == other.dwItemData && self.pt == other.pt && self.dwHitInfo == other.dwHitInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23898,7 +23878,7 @@ unsafe impl ::windows::core::Abi for NMOBJECTNOTIFY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMOBJECTNOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMOBJECTNOTIFY>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.piid == other.piid && self.pObject == other.pObject && self.hResult == other.hResult && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23939,7 +23919,7 @@ unsafe impl ::windows::core::Abi for NMPGCALCSIZE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMPGCALCSIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMPGCALCSIZE>()) == 0 }
+        self.hdr == other.hdr && self.dwFlag == other.dwFlag && self.iWidth == other.iWidth && self.iHeight == other.iHeight
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -23980,7 +23960,7 @@ unsafe impl ::windows::core::Abi for NMPGHOTITEM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMPGHOTITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMPGHOTITEM>()) == 0 }
+        self.hdr == other.hdr && self.idOld == other.idOld && self.idNew == other.idNew && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24015,14 +23995,6 @@ impl ::core::clone::Clone for NMPGSCROLL {
 unsafe impl ::windows::core::Abi for NMPGSCROLL {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NMPGSCROLL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMPGSCROLL>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NMPGSCROLL {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NMPGSCROLL {
     fn default() -> Self {
@@ -24059,7 +24031,7 @@ unsafe impl ::windows::core::Abi for NMRBAUTOSIZE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMRBAUTOSIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMRBAUTOSIZE>()) == 0 }
+        self.hdr == other.hdr && self.fChanged == other.fChanged && self.rcTarget == other.rcTarget && self.rcActual == other.rcActual
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24102,7 +24074,7 @@ unsafe impl ::windows::core::Abi for NMREBAR {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMREBAR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMREBAR>()) == 0 }
+        self.hdr == other.hdr && self.dwMask == other.dwMask && self.uBand == other.uBand && self.fStyle == other.fStyle && self.wID == other.wID && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24146,7 +24118,7 @@ unsafe impl ::windows::core::Abi for NMREBARAUTOBREAK {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMREBARAUTOBREAK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMREBARAUTOBREAK>()) == 0 }
+        self.hdr == other.hdr && self.uBand == other.uBand && self.wID == other.wID && self.lParam == other.lParam && self.uMsg == other.uMsg && self.fStyleCurrent == other.fStyleCurrent && self.fAutoBreak == other.fAutoBreak
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24189,7 +24161,7 @@ unsafe impl ::windows::core::Abi for NMREBARCHEVRON {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMREBARCHEVRON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMREBARCHEVRON>()) == 0 }
+        self.hdr == other.hdr && self.uBand == other.uBand && self.wID == other.wID && self.lParam == other.lParam && self.rc == other.rc && self.lParamNM == other.lParamNM
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24231,7 +24203,7 @@ unsafe impl ::windows::core::Abi for NMREBARCHILDSIZE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMREBARCHILDSIZE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMREBARCHILDSIZE>()) == 0 }
+        self.hdr == other.hdr && self.uBand == other.uBand && self.wID == other.wID && self.rcChild == other.rcChild && self.rcBand == other.rcBand
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24270,7 +24242,7 @@ unsafe impl ::windows::core::Abi for NMREBARSPLITTER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMREBARSPLITTER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMREBARSPLITTER>()) == 0 }
+        self.hdr == other.hdr && self.rcSizing == other.rcSizing
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24311,7 +24283,7 @@ unsafe impl ::windows::core::Abi for NMSEARCHWEB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMSEARCHWEB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMSEARCHWEB>()) == 0 }
+        self.hdr == other.hdr && self.entrypoint == other.entrypoint && self.hasQueryText == other.hasQueryText && self.invokeSucceeded == other.invokeSucceeded
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24351,7 +24323,7 @@ unsafe impl ::windows::core::Abi for NMSELCHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMSELCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMSELCHANGE>()) == 0 }
+        self.nmhdr == other.nmhdr && self.stSelStart == other.stSelStart && self.stSelEnd == other.stSelEnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24417,7 +24389,7 @@ unsafe impl ::windows::core::Abi for NMTBCUSTOMDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMTBCUSTOMDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBCUSTOMDRAW>()) == 0 }
+        self.nmcd == other.nmcd && self.hbrMonoDither == other.hbrMonoDither && self.hbrLines == other.hbrLines && self.hpenLines == other.hpenLines && self.clrText == other.clrText && self.clrMark == other.clrMark && self.clrTextHighlight == other.clrTextHighlight && self.clrBtnFace == other.clrBtnFace && self.clrBtnHighlight == other.clrBtnHighlight && self.clrHighlightHotTrack == other.clrHighlightHotTrack && self.rcText == other.rcText && self.nStringBkMode == other.nStringBkMode && self.nHLStringBkMode == other.nHLStringBkMode && self.iListGap == other.iListGap
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -24461,7 +24433,7 @@ unsafe impl ::windows::core::Abi for NMTBDISPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBDISPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBDISPINFOA>()) == 0 }
+        self.hdr == other.hdr && self.dwMask == other.dwMask && self.idCommand == other.idCommand && self.lParam == other.lParam && self.iImage == other.iImage && self.pszText == other.pszText && self.cchText == other.cchText
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24505,7 +24477,7 @@ unsafe impl ::windows::core::Abi for NMTBDISPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBDISPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBDISPINFOW>()) == 0 }
+        self.hdr == other.hdr && self.dwMask == other.dwMask && self.idCommand == other.idCommand && self.lParam == other.lParam && self.iImage == other.iImage && self.pszText == other.pszText && self.cchText == other.cchText
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24547,7 +24519,7 @@ unsafe impl ::windows::core::Abi for NMTBGETINFOTIPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBGETINFOTIPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBGETINFOTIPA>()) == 0 }
+        self.hdr == other.hdr && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iItem == other.iItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24589,7 +24561,7 @@ unsafe impl ::windows::core::Abi for NMTBGETINFOTIPW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBGETINFOTIPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBGETINFOTIPW>()) == 0 }
+        self.hdr == other.hdr && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iItem == other.iItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24630,7 +24602,7 @@ unsafe impl ::windows::core::Abi for NMTBHOTITEM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBHOTITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBHOTITEM>()) == 0 }
+        self.hdr == other.hdr && self.idOld == other.idOld && self.idNew == other.idNew && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24675,7 +24647,7 @@ unsafe impl ::windows::core::Abi for NMTBRESTORE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBRESTORE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBRESTORE>()) == 0 }
+        self.hdr == other.hdr && self.pData == other.pData && self.pCurrent == other.pCurrent && self.cbData == other.cbData && self.iItem == other.iItem && self.cButtons == other.cButtons && self.cbBytesPerRecord == other.cbBytesPerRecord && self.tbButton == other.tbButton
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24719,7 +24691,7 @@ unsafe impl ::windows::core::Abi for NMTBSAVE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTBSAVE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTBSAVE>()) == 0 }
+        self.hdr == other.hdr && self.pData == other.pData && self.pCurrent == other.pCurrent && self.cbData == other.cbData && self.iItem == other.iItem && self.cButtons == other.cButtons && self.tbButton == other.tbButton
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24750,14 +24722,6 @@ impl ::core::clone::Clone for NMTCKEYDOWN {
 unsafe impl ::windows::core::Abi for NMTCKEYDOWN {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NMTCKEYDOWN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTCKEYDOWN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NMTCKEYDOWN {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NMTCKEYDOWN {
     fn default() -> Self {
@@ -24796,7 +24760,7 @@ unsafe impl ::windows::core::Abi for NMTOOLBARA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTOOLBARA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTOOLBARA>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.tbButton == other.tbButton && self.cchText == other.cchText && self.pszText == other.pszText && self.rcButton == other.rcButton
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24839,7 +24803,7 @@ unsafe impl ::windows::core::Abi for NMTOOLBARW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTOOLBARW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTOOLBARW>()) == 0 }
+        self.hdr == other.hdr && self.iItem == other.iItem && self.tbButton == other.tbButton && self.cchText == other.cchText && self.pszText == other.pszText && self.rcButton == other.rcButton
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24878,7 +24842,7 @@ unsafe impl ::windows::core::Abi for NMTOOLTIPSCREATED {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTOOLTIPSCREATED {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTOOLTIPSCREATED>()) == 0 }
+        self.hdr == other.hdr && self.hwndToolTips == other.hwndToolTips
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24918,7 +24882,7 @@ unsafe impl ::windows::core::Abi for NMTRBTHUMBPOSCHANGING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTRBTHUMBPOSCHANGING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTRBTHUMBPOSCHANGING>()) == 0 }
+        self.hdr == other.hdr && self.dwPos == other.dwPos && self.nReason == other.nReason
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -24960,7 +24924,7 @@ unsafe impl ::windows::core::Abi for NMTREEVIEWA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTREEVIEWA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTREEVIEWA>()) == 0 }
+        self.hdr == other.hdr && self.action == other.action && self.itemOld == other.itemOld && self.itemNew == other.itemNew && self.ptDrag == other.ptDrag
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25002,7 +24966,7 @@ unsafe impl ::windows::core::Abi for NMTREEVIEWW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTREEVIEWW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTREEVIEWW>()) == 0 }
+        self.hdr == other.hdr && self.action == other.action && self.itemOld == other.itemOld && self.itemNew == other.itemNew && self.ptDrag == other.ptDrag
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25041,7 +25005,7 @@ unsafe impl ::windows::core::Abi for NMTTCUSTOMDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMTTCUSTOMDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTTCUSTOMDRAW>()) == 0 }
+        self.nmcd == other.nmcd && self.uDrawFlags == other.uDrawFlags
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -25084,7 +25048,7 @@ unsafe impl ::windows::core::Abi for NMTTDISPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTTDISPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTTDISPINFOA>()) == 0 }
+        self.hdr == other.hdr && self.lpszText == other.lpszText && self.szText == other.szText && self.hinst == other.hinst && self.uFlags == other.uFlags && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25127,7 +25091,7 @@ unsafe impl ::windows::core::Abi for NMTTDISPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTTDISPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTTDISPINFOW>()) == 0 }
+        self.hdr == other.hdr && self.lpszText == other.lpszText && self.szText == other.szText && self.hinst == other.hinst && self.uFlags == other.uFlags && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25171,7 +25135,7 @@ unsafe impl ::windows::core::Abi for NMTVASYNCDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMTVASYNCDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVASYNCDRAW>()) == 0 }
+        self.hdr == other.hdr && self.pimldp == other.pimldp && self.hr == other.hr && self.hItem == other.hItem && self.lParam == other.lParam && self.dwRetFlags == other.dwRetFlags && self.iRetImageIndex == other.iRetImageIndex
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -25212,7 +25176,7 @@ unsafe impl ::windows::core::Abi for NMTVCUSTOMDRAW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NMTVCUSTOMDRAW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVCUSTOMDRAW>()) == 0 }
+        self.nmcd == other.nmcd && self.clrText == other.clrText && self.clrTextBk == other.clrTextBk && self.iLevel == other.iLevel
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -25251,7 +25215,7 @@ unsafe impl ::windows::core::Abi for NMTVDISPINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVDISPINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVDISPINFOA>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25290,7 +25254,7 @@ unsafe impl ::windows::core::Abi for NMTVDISPINFOEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVDISPINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVDISPINFOEXA>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25329,7 +25293,7 @@ unsafe impl ::windows::core::Abi for NMTVDISPINFOEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVDISPINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVDISPINFOEXW>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25368,7 +25332,7 @@ unsafe impl ::windows::core::Abi for NMTVDISPINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVDISPINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVDISPINFOW>()) == 0 }
+        self.hdr == other.hdr && self.item == other.item
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25410,7 +25374,7 @@ unsafe impl ::windows::core::Abi for NMTVGETINFOTIPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVGETINFOTIPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVGETINFOTIPA>()) == 0 }
+        self.hdr == other.hdr && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.hItem == other.hItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25452,7 +25416,7 @@ unsafe impl ::windows::core::Abi for NMTVGETINFOTIPW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVGETINFOTIPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVGETINFOTIPW>()) == 0 }
+        self.hdr == other.hdr && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.hItem == other.hItem && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25495,7 +25459,7 @@ unsafe impl ::windows::core::Abi for NMTVITEMCHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVITEMCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVITEMCHANGE>()) == 0 }
+        self.hdr == other.hdr && self.uChanged == other.uChanged && self.hItem == other.hItem && self.uStateNew == other.uStateNew && self.uStateOld == other.uStateOld && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25526,14 +25490,6 @@ impl ::core::clone::Clone for NMTVKEYDOWN {
 unsafe impl ::windows::core::Abi for NMTVKEYDOWN {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NMTVKEYDOWN {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVKEYDOWN>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NMTVKEYDOWN {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NMTVKEYDOWN {
     fn default() -> Self {
@@ -25570,7 +25526,7 @@ unsafe impl ::windows::core::Abi for NMTVSTATEIMAGECHANGING {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMTVSTATEIMAGECHANGING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMTVSTATEIMAGECHANGING>()) == 0 }
+        self.hdr == other.hdr && self.hti == other.hti && self.iOldStateImageIndex == other.iOldStateImageIndex && self.iNewStateImageIndex == other.iNewStateImageIndex
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25610,7 +25566,7 @@ unsafe impl ::windows::core::Abi for NMUPDOWN {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMUPDOWN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMUPDOWN>()) == 0 }
+        self.hdr == other.hdr && self.iPos == other.iPos && self.iDelta == other.iDelta
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25650,7 +25606,7 @@ unsafe impl ::windows::core::Abi for NMVIEWCHANGE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NMVIEWCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NMVIEWCHANGE>()) == 0 }
+        self.nmhdr == other.nmhdr && self.dwOldView == other.dwOldView && self.dwNewView == other.dwNewView
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -25683,7 +25639,7 @@ unsafe impl ::windows::core::Abi for PBRANGE {
 }
 impl ::core::cmp::PartialEq for PBRANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PBRANGE>()) == 0 }
+        self.iLow == other.iLow && self.iHigh == other.iHigh
     }
 }
 impl ::core::cmp::Eq for PBRANGE {}
@@ -25714,7 +25670,7 @@ unsafe impl ::windows::core::Abi for POINTER_DEVICE_CURSOR_INFO {
 }
 impl ::core::cmp::PartialEq for POINTER_DEVICE_CURSOR_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_DEVICE_CURSOR_INFO>()) == 0 }
+        self.cursorId == other.cursorId && self.cursor == other.cursor
     }
 }
 impl ::core::cmp::Eq for POINTER_DEVICE_CURSOR_INFO {}
@@ -25756,7 +25712,7 @@ unsafe impl ::windows::core::Abi for POINTER_DEVICE_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for POINTER_DEVICE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_DEVICE_INFO>()) == 0 }
+        self.displayOrientation == other.displayOrientation && self.device == other.device && self.pointerDeviceType == other.pointerDeviceType && self.monitor == other.monitor && self.startingCursorId == other.startingCursorId && self.maxActiveContacts == other.maxActiveContacts && self.productString == other.productString
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -25795,7 +25751,7 @@ unsafe impl ::windows::core::Abi for POINTER_DEVICE_PROPERTY {
 }
 impl ::core::cmp::PartialEq for POINTER_DEVICE_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_DEVICE_PROPERTY>()) == 0 }
+        self.logicalMin == other.logicalMin && self.logicalMax == other.logicalMax && self.physicalMin == other.physicalMin && self.physicalMax == other.physicalMax && self.unit == other.unit && self.unitExponent == other.unitExponent && self.usagePageId == other.usagePageId && self.usageId == other.usageId
     }
 }
 impl ::core::cmp::Eq for POINTER_DEVICE_PROPERTY {}
@@ -25824,14 +25780,6 @@ unsafe impl ::windows::core::Abi for POINTER_TYPE_INFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for POINTER_TYPE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_TYPE_INFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for POINTER_TYPE_INFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for POINTER_TYPE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25856,14 +25804,6 @@ impl ::core::clone::Clone for POINTER_TYPE_INFO_0 {
 unsafe impl ::windows::core::Abi for POINTER_TYPE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for POINTER_TYPE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_TYPE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for POINTER_TYPE_INFO_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for POINTER_TYPE_INFO_0 {
     fn default() -> Self {
@@ -25898,14 +25838,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25930,14 +25862,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERA_V1_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V1_0 {
     fn default() -> Self {
@@ -25964,14 +25888,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V1_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V1_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -25996,14 +25912,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERA_V1_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V1_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V1_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V1_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V1_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V1_2 {
     fn default() -> Self {
@@ -26041,14 +25949,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26073,14 +25973,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERA_V2_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2_0 {
     fn default() -> Self {
@@ -26107,14 +25999,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26139,14 +26023,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERA_V2_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2_2 {
     fn default() -> Self {
@@ -26173,14 +26049,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2_3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2_3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26205,14 +26073,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERA_V2_4 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERA_V2_4 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERA_V2_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERA_V2_4>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERA_V2_4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERA_V2_4 {
     fn default() -> Self {
@@ -26247,14 +26107,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26279,14 +26131,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERW_V1_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V1_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V1_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V1_0 {
     fn default() -> Self {
@@ -26313,14 +26157,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V1_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V1_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V1_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26345,14 +26181,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERW_V1_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V1_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V1_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V1_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V1_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V1_2 {
     fn default() -> Self {
@@ -26390,14 +26218,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26422,14 +26242,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERW_V2_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2_0 {
     fn default() -> Self {
@@ -26456,14 +26268,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26488,14 +26292,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERW_V2_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2_2 {
     fn default() -> Self {
@@ -26522,14 +26318,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2_3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2_3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2_3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2_3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2_3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26554,14 +26342,6 @@ impl ::core::clone::Clone for PROPSHEETHEADERW_V2_4 {
 unsafe impl ::windows::core::Abi for PROPSHEETHEADERW_V2_4 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETHEADERW_V2_4 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETHEADERW_V2_4>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETHEADERW_V2_4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETHEADERW_V2_4 {
     fn default() -> Self {
@@ -26600,14 +26380,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26632,14 +26404,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEA_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_0 {
     fn default() -> Self {
@@ -26666,14 +26430,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26698,14 +26454,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEA_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_2 {
     fn default() -> Self {
@@ -26740,14 +26488,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26773,14 +26513,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V1_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V1_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26805,14 +26537,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEA_V1_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V1_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V1_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V1_1 {
     fn default() -> Self {
@@ -26849,14 +26573,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26882,14 +26598,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26914,14 +26622,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEA_V2_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V2_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V2_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V2_1 {
     fn default() -> Self {
@@ -26959,14 +26659,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -26992,14 +26684,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V3_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V3_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V3_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27024,14 +26708,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEA_V3_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEA_V3_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEA_V3_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEA_V3_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEA_V3_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEA_V3_1 {
     fn default() -> Self {
@@ -27070,14 +26746,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27102,14 +26770,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEW_0 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_0 {
     fn default() -> Self {
@@ -27136,14 +26796,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27168,14 +26820,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEW_2 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_2 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_2 {
     fn default() -> Self {
@@ -27210,14 +26854,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27243,14 +26879,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V1_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V1_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V1_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V1_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V1_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27275,14 +26903,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEW_V1_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V1_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V1_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V1_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V1_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V1_1 {
     fn default() -> Self {
@@ -27319,14 +26939,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V2 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V2>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V2 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27352,14 +26964,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V2_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V2_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V2_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V2_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27384,14 +26988,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEW_V2_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V2_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V2_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V2_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V2_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V2_1 {
     fn default() -> Self {
@@ -27429,14 +27025,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V3 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V3 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V3>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V3 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V3 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27462,14 +27050,6 @@ unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V3_0 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V3_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V3_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V3_0 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V3_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27494,14 +27074,6 @@ impl ::core::clone::Clone for PROPSHEETPAGEW_V3_1 {
 unsafe impl ::windows::core::Abi for PROPSHEETPAGEW_V3_1 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for PROPSHEETPAGEW_V3_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPSHEETPAGEW_V3_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for PROPSHEETPAGEW_V3_1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for PROPSHEETPAGEW_V3_1 {
     fn default() -> Self {
@@ -27536,7 +27108,7 @@ unsafe impl ::windows::core::Abi for PSHNOTIFY {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PSHNOTIFY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PSHNOTIFY>()) == 0 }
+        self.hdr == other.hdr && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27576,7 +27148,7 @@ unsafe impl ::windows::core::Abi for RBHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RBHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RBHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.flags == other.flags && self.iBand == other.iBand
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -27658,7 +27230,7 @@ unsafe impl ::windows::core::Abi for REBARBANDINFOA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for REBARBANDINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REBARBANDINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.fStyle == other.fStyle && self.clrFore == other.clrFore && self.clrBack == other.clrBack && self.lpText == other.lpText && self.cch == other.cch && self.iImage == other.iImage && self.hwndChild == other.hwndChild && self.cxMinChild == other.cxMinChild && self.cyMinChild == other.cyMinChild && self.cx == other.cx && self.hbmBack == other.hbmBack && self.wID == other.wID && self.cyChild == other.cyChild && self.cyMaxChild == other.cyMaxChild && self.cyIntegral == other.cyIntegral && self.cxIdeal == other.cxIdeal && self.lParam == other.lParam && self.cxHeader == other.cxHeader && self.rcChevronLocation == other.rcChevronLocation && self.uChevronState == other.uChevronState
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -27740,7 +27312,7 @@ unsafe impl ::windows::core::Abi for REBARBANDINFOW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for REBARBANDINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REBARBANDINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.fStyle == other.fStyle && self.clrFore == other.clrFore && self.clrBack == other.clrBack && self.lpText == other.lpText && self.cch == other.cch && self.iImage == other.iImage && self.hwndChild == other.hwndChild && self.cxMinChild == other.cxMinChild && self.cyMinChild == other.cyMinChild && self.cx == other.cx && self.hbmBack == other.hbmBack && self.wID == other.wID && self.cyChild == other.cyChild && self.cyMaxChild == other.cyMaxChild && self.cyIntegral == other.cyIntegral && self.cxIdeal == other.cxIdeal && self.lParam == other.lParam && self.cxHeader == other.cxHeader && self.rcChevronLocation == other.rcChevronLocation && self.uChevronState == other.uChevronState
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -27774,7 +27346,7 @@ unsafe impl ::windows::core::Abi for REBARINFO {
 }
 impl ::core::cmp::PartialEq for REBARINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REBARINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.himl == other.himl
     }
 }
 impl ::core::cmp::Eq for REBARINFO {}
@@ -27825,14 +27397,6 @@ unsafe impl ::windows::core::Abi for TASKDIALOGCONFIG {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for TASKDIALOGCONFIG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TASKDIALOGCONFIG>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for TASKDIALOGCONFIG {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for TASKDIALOGCONFIG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27857,14 +27421,6 @@ impl ::core::clone::Clone for TASKDIALOGCONFIG_0 {
 unsafe impl ::windows::core::Abi for TASKDIALOGCONFIG_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for TASKDIALOGCONFIG_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TASKDIALOGCONFIG_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for TASKDIALOGCONFIG_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for TASKDIALOGCONFIG_0 {
     fn default() -> Self {
@@ -27891,14 +27447,6 @@ unsafe impl ::windows::core::Abi for TASKDIALOGCONFIG_1 {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for TASKDIALOGCONFIG_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TASKDIALOGCONFIG_1>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for TASKDIALOGCONFIG_1 {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for TASKDIALOGCONFIG_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27919,12 +27467,6 @@ impl ::core::clone::Clone for TASKDIALOG_BUTTON {
 unsafe impl ::windows::core::Abi for TASKDIALOG_BUTTON {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TASKDIALOG_BUTTON {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TASKDIALOG_BUTTON>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TASKDIALOG_BUTTON {}
 impl ::core::default::Default for TASKDIALOG_BUTTON {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -27955,7 +27497,7 @@ unsafe impl ::windows::core::Abi for TA_CUBIC_BEZIER {
 }
 impl ::core::cmp::PartialEq for TA_CUBIC_BEZIER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_CUBIC_BEZIER>()) == 0 }
+        self.header == other.header && self.rX0 == other.rX0 && self.rY0 == other.rY0 && self.rX1 == other.rX1 && self.rY1 == other.rY1
     }
 }
 impl ::core::cmp::Eq for TA_CUBIC_BEZIER {}
@@ -27985,7 +27527,7 @@ unsafe impl ::windows::core::Abi for TA_TIMINGFUNCTION {
 }
 impl ::core::cmp::PartialEq for TA_TIMINGFUNCTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_TIMINGFUNCTION>()) == 0 }
+        self.eTimingFunctionType == other.eTimingFunctionType
     }
 }
 impl ::core::cmp::Eq for TA_TIMINGFUNCTION {}
@@ -28019,7 +27561,7 @@ unsafe impl ::windows::core::Abi for TA_TRANSFORM {
 }
 impl ::core::cmp::PartialEq for TA_TRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_TRANSFORM>()) == 0 }
+        self.eTransformType == other.eTransformType && self.dwTimingFunctionId == other.dwTimingFunctionId && self.dwStartTime == other.dwStartTime && self.dwDurationTime == other.dwDurationTime && self.eFlags == other.eFlags
     }
 }
 impl ::core::cmp::Eq for TA_TRANSFORM {}
@@ -28055,7 +27597,7 @@ unsafe impl ::windows::core::Abi for TA_TRANSFORM_2D {
 }
 impl ::core::cmp::PartialEq for TA_TRANSFORM_2D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_TRANSFORM_2D>()) == 0 }
+        self.header == other.header && self.rX == other.rX && self.rY == other.rY && self.rInitialX == other.rInitialX && self.rInitialY == other.rInitialY && self.rOriginX == other.rOriginX && self.rOriginY == other.rOriginY
     }
 }
 impl ::core::cmp::Eq for TA_TRANSFORM_2D {}
@@ -28093,7 +27635,7 @@ unsafe impl ::windows::core::Abi for TA_TRANSFORM_CLIP {
 }
 impl ::core::cmp::PartialEq for TA_TRANSFORM_CLIP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_TRANSFORM_CLIP>()) == 0 }
+        self.header == other.header && self.rLeft == other.rLeft && self.rTop == other.rTop && self.rRight == other.rRight && self.rBottom == other.rBottom && self.rInitialLeft == other.rInitialLeft && self.rInitialTop == other.rInitialTop && self.rInitialRight == other.rInitialRight && self.rInitialBottom == other.rInitialBottom
     }
 }
 impl ::core::cmp::Eq for TA_TRANSFORM_CLIP {}
@@ -28125,7 +27667,7 @@ unsafe impl ::windows::core::Abi for TA_TRANSFORM_OPACITY {
 }
 impl ::core::cmp::PartialEq for TA_TRANSFORM_OPACITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TA_TRANSFORM_OPACITY>()) == 0 }
+        self.header == other.header && self.rOpacity == other.rOpacity && self.rInitialOpacity == other.rInitialOpacity
     }
 }
 impl ::core::cmp::Eq for TA_TRANSFORM_OPACITY {}
@@ -28162,7 +27704,7 @@ unsafe impl ::windows::core::Abi for TBADDBITMAP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TBADDBITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBADDBITMAP>()) == 0 }
+        self.hInst == other.hInst && self.nID == other.nID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28206,7 +27748,7 @@ unsafe impl ::windows::core::Abi for TBBUTTON {
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::cmp::PartialEq for TBBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBBUTTON>()) == 0 }
+        self.iBitmap == other.iBitmap && self.idCommand == other.idCommand && self.fsState == other.fsState && self.fsStyle == other.fsStyle && self.bReserved == other.bReserved && self.dwData == other.dwData && self.iString == other.iString
     }
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -28250,7 +27792,7 @@ unsafe impl ::windows::core::Abi for TBBUTTON {
 #[cfg(target_arch = "x86")]
 impl ::core::cmp::PartialEq for TBBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBBUTTON>()) == 0 }
+        self.iBitmap == other.iBitmap && self.idCommand == other.idCommand && self.fsState == other.fsState && self.fsStyle == other.fsStyle && self.bReserved == other.bReserved && self.dwData == other.dwData && self.iString == other.iString
     }
 }
 #[cfg(target_arch = "x86")]
@@ -28291,7 +27833,7 @@ unsafe impl ::windows::core::Abi for TBBUTTONINFOA {
 }
 impl ::core::cmp::PartialEq for TBBUTTONINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBBUTTONINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.idCommand == other.idCommand && self.iImage == other.iImage && self.fsState == other.fsState && self.fsStyle == other.fsStyle && self.cx == other.cx && self.lParam == other.lParam && self.pszText == other.pszText && self.cchText == other.cchText
     }
 }
 impl ::core::cmp::Eq for TBBUTTONINFOA {}
@@ -28330,7 +27872,7 @@ unsafe impl ::windows::core::Abi for TBBUTTONINFOW {
 }
 impl ::core::cmp::PartialEq for TBBUTTONINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBBUTTONINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.idCommand == other.idCommand && self.iImage == other.iImage && self.fsState == other.fsState && self.fsStyle == other.fsStyle && self.cx == other.cx && self.lParam == other.lParam && self.pszText == other.pszText && self.cchText == other.cchText
     }
 }
 impl ::core::cmp::Eq for TBBUTTONINFOW {}
@@ -28361,7 +27903,7 @@ unsafe impl ::windows::core::Abi for TBINSERTMARK {
 }
 impl ::core::cmp::PartialEq for TBINSERTMARK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBINSERTMARK>()) == 0 }
+        self.iButton == other.iButton && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for TBINSERTMARK {}
@@ -28398,7 +27940,7 @@ unsafe impl ::windows::core::Abi for TBMETRICS {
 }
 impl ::core::cmp::PartialEq for TBMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBMETRICS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.cxPad == other.cxPad && self.cyPad == other.cyPad && self.cxBarPad == other.cxBarPad && self.cyBarPad == other.cyBarPad && self.cxButtonSpacing == other.cxButtonSpacing && self.cyButtonSpacing == other.cyButtonSpacing
     }
 }
 impl ::core::cmp::Eq for TBMETRICS {}
@@ -28438,7 +27980,7 @@ unsafe impl ::windows::core::Abi for TBREPLACEBITMAP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TBREPLACEBITMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBREPLACEBITMAP>()) == 0 }
+        self.hInstOld == other.hInstOld && self.nIDOld == other.nIDOld && self.hInstNew == other.hInstNew && self.nIDNew == other.nIDNew && self.nButtons == other.nButtons
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28478,7 +28020,7 @@ unsafe impl ::windows::core::Abi for TBSAVEPARAMSA {
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::cmp::PartialEq for TBSAVEPARAMSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBSAVEPARAMSA>()) == 0 }
+        self.hkr == other.hkr && self.pszSubKey == other.pszSubKey && self.pszValueName == other.pszValueName
     }
 }
 #[cfg(feature = "Win32_System_Registry")]
@@ -28518,7 +28060,7 @@ unsafe impl ::windows::core::Abi for TBSAVEPARAMSW {
 #[cfg(feature = "Win32_System_Registry")]
 impl ::core::cmp::PartialEq for TBSAVEPARAMSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBSAVEPARAMSW>()) == 0 }
+        self.hkr == other.hkr && self.pszSubKey == other.pszSubKey && self.pszValueName == other.pszValueName
     }
 }
 #[cfg(feature = "Win32_System_Registry")]
@@ -28557,7 +28099,7 @@ unsafe impl ::windows::core::Abi for TCHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.flags == other.flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28601,7 +28143,7 @@ unsafe impl ::windows::core::Abi for TCITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCITEMA>()) == 0 }
+        self.mask == other.mask && self.dwState == other.dwState && self.dwStateMask == other.dwStateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28638,7 +28180,7 @@ unsafe impl ::windows::core::Abi for TCITEMHEADERA {
 }
 impl ::core::cmp::PartialEq for TCITEMHEADERA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCITEMHEADERA>()) == 0 }
+        self.mask == other.mask && self.lpReserved1 == other.lpReserved1 && self.lpReserved2 == other.lpReserved2 && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage
     }
 }
 impl ::core::cmp::Eq for TCITEMHEADERA {}
@@ -28673,7 +28215,7 @@ unsafe impl ::windows::core::Abi for TCITEMHEADERW {
 }
 impl ::core::cmp::PartialEq for TCITEMHEADERW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCITEMHEADERW>()) == 0 }
+        self.mask == other.mask && self.lpReserved1 == other.lpReserved1 && self.lpReserved2 == other.lpReserved2 && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage
     }
 }
 impl ::core::cmp::Eq for TCITEMHEADERW {}
@@ -28715,7 +28257,7 @@ unsafe impl ::windows::core::Abi for TCITEMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TCITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TCITEMW>()) == 0 }
+        self.mask == other.mask && self.dwState == other.dwState && self.dwStateMask == other.dwStateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28757,7 +28299,7 @@ unsafe impl ::windows::core::Abi for TOUCH_HIT_TESTING_INPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOUCH_HIT_TESTING_INPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOUCH_HIT_TESTING_INPUT>()) == 0 }
+        self.pointerId == other.pointerId && self.point == other.point && self.boundingBox == other.boundingBox && self.nonOccludedBoundingBox == other.nonOccludedBoundingBox && self.orientation == other.orientation
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28796,7 +28338,7 @@ unsafe impl ::windows::core::Abi for TOUCH_HIT_TESTING_PROXIMITY_EVALUATION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOUCH_HIT_TESTING_PROXIMITY_EVALUATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOUCH_HIT_TESTING_PROXIMITY_EVALUATION>()) == 0 }
+        self.score == other.score && self.adjustedPoint == other.adjustedPoint
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28831,7 +28373,7 @@ unsafe impl ::windows::core::Abi for TTGETTITLE {
 }
 impl ::core::cmp::PartialEq for TTGETTITLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTGETTITLE>()) == 0 }
+        self.dwSize == other.dwSize && self.uTitleBitmap == other.uTitleBitmap && self.cch == other.cch && self.pszTitle == other.pszTitle
     }
 }
 impl ::core::cmp::Eq for TTGETTITLE {}
@@ -28869,7 +28411,7 @@ unsafe impl ::windows::core::Abi for TTHITTESTINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TTHITTESTINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTHITTESTINFOA>()) == 0 }
+        self.hwnd == other.hwnd && self.pt == other.pt && self.ti == other.ti
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28909,7 +28451,7 @@ unsafe impl ::windows::core::Abi for TTHITTESTINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TTHITTESTINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTHITTESTINFOW>()) == 0 }
+        self.hwnd == other.hwnd && self.pt == other.pt && self.ti == other.ti
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -28955,7 +28497,7 @@ unsafe impl ::windows::core::Abi for TTTOOLINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TTTOOLINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTTOOLINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.uFlags == other.uFlags && self.hwnd == other.hwnd && self.uId == other.uId && self.rect == other.rect && self.hinst == other.hinst && self.lpszText == other.lpszText && self.lParam == other.lParam && self.lpReserved == other.lpReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29001,7 +28543,7 @@ unsafe impl ::windows::core::Abi for TTTOOLINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TTTOOLINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TTTOOLINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.uFlags == other.uFlags && self.hwnd == other.hwnd && self.uId == other.uId && self.rect == other.rect && self.hinst == other.hinst && self.lpszText == other.lpszText && self.lParam == other.lParam && self.lpReserved == other.lpReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29041,7 +28583,7 @@ unsafe impl ::windows::core::Abi for TVGETITEMPARTRECTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVGETITEMPARTRECTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVGETITEMPARTRECTINFO>()) == 0 }
+        self.hti == other.hti && self.prc == other.prc && self.partID == other.partID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29081,7 +28623,7 @@ unsafe impl ::windows::core::Abi for TVHITTESTINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVHITTESTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVHITTESTINFO>()) == 0 }
+        self.pt == other.pt && self.flags == other.flags && self.hItem == other.hItem
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29113,14 +28655,6 @@ unsafe impl ::windows::core::Abi for TVINSERTSTRUCTA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TVINSERTSTRUCTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVINSERTSTRUCTA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TVINSERTSTRUCTA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TVINSERTSTRUCTA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -29145,14 +28679,6 @@ impl ::core::clone::Clone for TVINSERTSTRUCTA_0 {
 unsafe impl ::windows::core::Abi for TVINSERTSTRUCTA_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TVINSERTSTRUCTA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVINSERTSTRUCTA_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TVINSERTSTRUCTA_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TVINSERTSTRUCTA_0 {
     fn default() -> Self {
@@ -29180,14 +28706,6 @@ unsafe impl ::windows::core::Abi for TVINSERTSTRUCTW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TVINSERTSTRUCTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVINSERTSTRUCTW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TVINSERTSTRUCTW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TVINSERTSTRUCTW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -29212,14 +28730,6 @@ impl ::core::clone::Clone for TVINSERTSTRUCTW_0 {
 unsafe impl ::windows::core::Abi for TVINSERTSTRUCTW_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TVINSERTSTRUCTW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVINSERTSTRUCTW_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TVINSERTSTRUCTW_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TVINSERTSTRUCTW_0 {
     fn default() -> Self {
@@ -29262,7 +28772,7 @@ unsafe impl ::windows::core::Abi for TVITEMA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVITEMA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVITEMA>()) == 0 }
+        self.mask == other.mask && self.hItem == other.hItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.cChildren == other.cChildren && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29330,7 +28840,7 @@ unsafe impl ::windows::core::Abi for TVITEMEXA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVITEMEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVITEMEXA>()) == 0 }
+        self.mask == other.mask && self.hItem == other.hItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.cChildren == other.cChildren && self.lParam == other.lParam && self.iIntegral == other.iIntegral && self.uStateEx == other.uStateEx && self.hwnd == other.hwnd && self.iExpandedImage == other.iExpandedImage && self.iReserved == other.iReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29398,7 +28908,7 @@ unsafe impl ::windows::core::Abi for TVITEMEXW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVITEMEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVITEMEXW>()) == 0 }
+        self.mask == other.mask && self.hItem == other.hItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.cChildren == other.cChildren && self.lParam == other.lParam && self.iIntegral == other.iIntegral && self.uStateEx == other.uStateEx && self.hwnd == other.hwnd && self.iExpandedImage == other.iExpandedImage && self.iReserved == other.iReserved
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29445,7 +28955,7 @@ unsafe impl ::windows::core::Abi for TVITEMW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TVITEMW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVITEMW>()) == 0 }
+        self.mask == other.mask && self.hItem == other.hItem && self.state == other.state && self.stateMask == other.stateMask && self.pszText == other.pszText && self.cchTextMax == other.cchTextMax && self.iImage == other.iImage && self.iSelectedImage == other.iSelectedImage && self.cChildren == other.cChildren && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -29475,21 +28985,13 @@ impl ::core::clone::Clone for TVSORTCB {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::fmt::Debug for TVSORTCB {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("TVSORTCB").field("hParent", &self.hParent).field("lpfnCompare", &self.lpfnCompare.map(|f| f as usize)).field("lParam", &self.lParam).finish()
+        f.debug_struct("TVSORTCB").field("hParent", &self.hParent).field("lParam", &self.lParam).finish()
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 unsafe impl ::windows::core::Abi for TVSORTCB {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TVSORTCB {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TVSORTCB>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TVSORTCB {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TVSORTCB {
     fn default() -> Self {
@@ -29518,7 +29020,7 @@ unsafe impl ::windows::core::Abi for UDACCEL {
 }
 impl ::core::cmp::PartialEq for UDACCEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UDACCEL>()) == 0 }
+        self.nSec == other.nSec && self.nInc == other.nInc
     }
 }
 impl ::core::cmp::Eq for UDACCEL {}
@@ -29557,7 +29059,7 @@ unsafe impl ::windows::core::Abi for USAGE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for USAGE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<USAGE_PROPERTIES>()) == 0 }
+        self.level == other.level && self.page == other.page && self.usage == other.usage && self.logicalMinimum == other.logicalMinimum && self.logicalMaximum == other.logicalMaximum && self.unit == other.unit && self.exponent == other.exponent && self.count == other.count && self.physicalMinimum == other.physicalMinimum && self.physicalMaximum == other.physicalMaximum
     }
 }
 impl ::core::cmp::Eq for USAGE_PROPERTIES {}
@@ -29588,7 +29090,7 @@ unsafe impl ::windows::core::Abi for WTA_OPTIONS {
 }
 impl ::core::cmp::PartialEq for WTA_OPTIONS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTA_OPTIONS>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwMask == other.dwMask
     }
 }
 impl ::core::cmp::Eq for WTA_OPTIONS {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -5935,7 +5935,7 @@ unsafe impl ::windows::core::Abi for APPLETIDLIST {
 }
 impl ::core::cmp::PartialEq for APPLETIDLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLETIDLIST>()) == 0 }
+        self.count == other.count && self.pIIDList == other.pIIDList
     }
 }
 impl ::core::cmp::Eq for APPLETIDLIST {}
@@ -5968,7 +5968,7 @@ unsafe impl ::windows::core::Abi for APPLYCANDEXPARAM {
 }
 impl ::core::cmp::PartialEq for APPLYCANDEXPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPLYCANDEXPARAM>()) == 0 }
+        self.dwSize == other.dwSize && self.lpwstrDisplay == other.lpwstrDisplay && self.lpwstrReading == other.lpwstrReading && self.dwReserved == other.dwReserved
     }
 }
 impl ::core::cmp::Eq for APPLYCANDEXPARAM {}
@@ -6007,7 +6007,7 @@ unsafe impl ::windows::core::Abi for CANDIDATEFORM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CANDIDATEFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CANDIDATEFORM>()) == 0 }
+        self.dwIndex == other.dwIndex && self.dwStyle == other.dwStyle && self.ptCurrentPos == other.ptCurrentPos && self.rcArea == other.rcArea
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6043,7 +6043,7 @@ unsafe impl ::windows::core::Abi for CANDIDATEINFO {
 }
 impl ::core::cmp::PartialEq for CANDIDATEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CANDIDATEINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCount == other.dwCount && self.dwOffset == other.dwOffset && self.dwPrivateSize == other.dwPrivateSize && self.dwPrivateOffset == other.dwPrivateOffset
     }
 }
 impl ::core::cmp::Eq for CANDIDATEINFO {}
@@ -6079,7 +6079,7 @@ unsafe impl ::windows::core::Abi for CANDIDATELIST {
 }
 impl ::core::cmp::PartialEq for CANDIDATELIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CANDIDATELIST>()) == 0 }
+        self.dwSize == other.dwSize && self.dwStyle == other.dwStyle && self.dwCount == other.dwCount && self.dwSelection == other.dwSelection && self.dwPageStart == other.dwPageStart && self.dwPageSize == other.dwPageSize && self.dwOffset == other.dwOffset
     }
 }
 impl ::core::cmp::Eq for CANDIDATELIST {}
@@ -6117,7 +6117,7 @@ unsafe impl ::windows::core::Abi for COMPOSITIONFORM {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for COMPOSITIONFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITIONFORM>()) == 0 }
+        self.dwStyle == other.dwStyle && self.ptCurrentPos == other.ptCurrentPos && self.rcArea == other.rcArea
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6199,7 +6199,31 @@ unsafe impl ::windows::core::Abi for COMPOSITIONSTRING {
 }
 impl ::core::cmp::PartialEq for COMPOSITIONSTRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMPOSITIONSTRING>()) == 0 }
+        self.dwSize == other.dwSize
+            && self.dwCompReadAttrLen == other.dwCompReadAttrLen
+            && self.dwCompReadAttrOffset == other.dwCompReadAttrOffset
+            && self.dwCompReadClauseLen == other.dwCompReadClauseLen
+            && self.dwCompReadClauseOffset == other.dwCompReadClauseOffset
+            && self.dwCompReadStrLen == other.dwCompReadStrLen
+            && self.dwCompReadStrOffset == other.dwCompReadStrOffset
+            && self.dwCompAttrLen == other.dwCompAttrLen
+            && self.dwCompAttrOffset == other.dwCompAttrOffset
+            && self.dwCompClauseLen == other.dwCompClauseLen
+            && self.dwCompClauseOffset == other.dwCompClauseOffset
+            && self.dwCompStrLen == other.dwCompStrLen
+            && self.dwCompStrOffset == other.dwCompStrOffset
+            && self.dwCursorPos == other.dwCursorPos
+            && self.dwDeltaStart == other.dwDeltaStart
+            && self.dwResultReadClauseLen == other.dwResultReadClauseLen
+            && self.dwResultReadClauseOffset == other.dwResultReadClauseOffset
+            && self.dwResultReadStrLen == other.dwResultReadStrLen
+            && self.dwResultReadStrOffset == other.dwResultReadStrOffset
+            && self.dwResultClauseLen == other.dwResultClauseLen
+            && self.dwResultClauseOffset == other.dwResultClauseOffset
+            && self.dwResultStrLen == other.dwResultStrLen
+            && self.dwResultStrOffset == other.dwResultStrOffset
+            && self.dwPrivateSize == other.dwPrivateSize
+            && self.dwPrivateOffset == other.dwPrivateOffset
     }
 }
 impl ::core::cmp::Eq for COMPOSITIONSTRING {}
@@ -6235,7 +6259,7 @@ unsafe impl ::windows::core::Abi for GUIDELINE {
 }
 impl ::core::cmp::PartialEq for GUIDELINE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUIDELINE>()) == 0 }
+        self.dwSize == other.dwSize && self.dwLevel == other.dwLevel && self.dwIndex == other.dwIndex && self.dwStrLen == other.dwStrLen && self.dwStrOffset == other.dwStrOffset && self.dwPrivateSize == other.dwPrivateSize && self.dwPrivateOffset == other.dwPrivateOffset
     }
 }
 impl ::core::cmp::Eq for GUIDELINE {}
@@ -6279,7 +6303,7 @@ unsafe impl ::windows::core::Abi for IMEAPPLETCFG {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for IMEAPPLETCFG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEAPPLETCFG>()) == 0 }
+        self.dwConfig == other.dwConfig && self.wchTitle == other.wchTitle && self.wchTitleFontFace == other.wchTitleFontFace && self.dwCharSet == other.dwCharSet && self.iCategory == other.iCategory && self.hIcon == other.hIcon && self.langID == other.langID && self.dummy == other.dummy && self.lReserved1 == other.lReserved1
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -6326,7 +6350,7 @@ unsafe impl ::windows::core::Abi for IMEAPPLETUI {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMEAPPLETUI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEAPPLETUI>()) == 0 }
+        self.hwnd == other.hwnd && self.dwStyle == other.dwStyle && self.width == other.width && self.height == other.height && self.minWidth == other.minWidth && self.minHeight == other.minHeight && self.maxWidth == other.maxWidth && self.maxHeight == other.maxHeight && self.lReserved1 == other.lReserved1 && self.lReserved2 == other.lReserved2
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6359,7 +6383,7 @@ unsafe impl ::windows::core::Abi for IMECHARINFO {
 }
 impl ::core::cmp::PartialEq for IMECHARINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMECHARINFO>()) == 0 }
+        self.wch == other.wch && self.dwCharInfo == other.dwCharInfo
     }
 }
 impl ::core::cmp::Eq for IMECHARINFO {}
@@ -6399,7 +6423,7 @@ unsafe impl ::windows::core::Abi for IMECHARPOSITION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for IMECHARPOSITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMECHARPOSITION>()) == 0 }
+        self.dwSize == other.dwSize && self.dwCharPos == other.dwCharPos && self.pt == other.pt && self.cLineHeight == other.cLineHeight && self.rcDocument == other.rcDocument
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -6436,7 +6460,7 @@ unsafe impl ::windows::core::Abi for IMECOMPOSITIONSTRINGINFO {
 }
 impl ::core::cmp::PartialEq for IMECOMPOSITIONSTRINGINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMECOMPOSITIONSTRINGINFO>()) == 0 }
+        self.iCompStrLen == other.iCompStrLen && self.iCaretPos == other.iCaretPos && self.iEditStart == other.iEditStart && self.iEditLen == other.iEditLen && self.iTargetStart == other.iTargetStart && self.iTargetLen == other.iTargetLen
     }
 }
 impl ::core::cmp::Eq for IMECOMPOSITIONSTRINGINFO {}
@@ -6467,14 +6491,6 @@ unsafe impl ::windows::core::Abi for IMEDLG {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMEDLG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEDLG>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMEDLG {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMEDLG {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6496,12 +6512,6 @@ impl ::core::clone::Clone for IMEDP {
 unsafe impl ::windows::core::Abi for IMEDP {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEDP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEDP>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEDP {}
 impl ::core::default::Default for IMEDP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6530,7 +6540,7 @@ unsafe impl ::windows::core::Abi for IMEFAREASTINFO {
 }
 impl ::core::cmp::PartialEq for IMEFAREASTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEFAREASTINFO>()) == 0 }
+        self.dwSize == other.dwSize && self.dwType == other.dwType && self.dwData == other.dwData
     }
 }
 impl ::core::cmp::Eq for IMEFAREASTINFO {}
@@ -6566,7 +6576,7 @@ unsafe impl ::windows::core::Abi for IMEINFO {
 }
 impl ::core::cmp::PartialEq for IMEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEINFO>()) == 0 }
+        self.dwPrivateDataSize == other.dwPrivateDataSize && self.fdwProperty == other.fdwProperty && self.fdwConversionCaps == other.fdwConversionCaps && self.fdwSentenceCaps == other.fdwSentenceCaps && self.fdwUICaps == other.fdwUICaps && self.fdwSCSCaps == other.fdwSCSCaps && self.fdwSelectCaps == other.fdwSelectCaps
     }
 }
 impl ::core::cmp::Eq for IMEINFO {}
@@ -6598,7 +6608,7 @@ unsafe impl ::windows::core::Abi for IMEITEM {
 }
 impl ::core::cmp::PartialEq for IMEITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEITEM>()) == 0 }
+        self.cbSize == other.cbSize && self.iType == other.iType && self.lpItemData == other.lpItemData
     }
 }
 impl ::core::cmp::Eq for IMEITEM {}
@@ -6629,7 +6639,7 @@ unsafe impl ::windows::core::Abi for IMEITEMCANDIDATE {
 }
 impl ::core::cmp::PartialEq for IMEITEMCANDIDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEITEMCANDIDATE>()) == 0 }
+        self.uCount == other.uCount && self.imeItem == other.imeItem
     }
 }
 impl ::core::cmp::Eq for IMEITEMCANDIDATE {}
@@ -6660,14 +6670,6 @@ unsafe impl ::windows::core::Abi for IMEKMS {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::PartialEq for IMEKMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMS>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::Eq for IMEKMS {}
-#[cfg(feature = "Win32_Globalization")]
 impl ::core::default::Default for IMEKMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6690,12 +6692,6 @@ impl ::core::clone::Clone for IMEKMSFUNCDESC {
 unsafe impl ::windows::core::Abi for IMEKMSFUNCDESC {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEKMSFUNCDESC {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSFUNCDESC>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEKMSFUNCDESC {}
 impl ::core::default::Default for IMEKMSFUNCDESC {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6720,14 +6716,6 @@ impl ::core::clone::Clone for IMEKMSINIT {
 unsafe impl ::windows::core::Abi for IMEKMSINIT {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMEKMSINIT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSINIT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMEKMSINIT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMEKMSINIT {
     fn default() -> Self {
@@ -6755,14 +6743,6 @@ unsafe impl ::windows::core::Abi for IMEKMSINVK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::PartialEq for IMEKMSINVK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSINVK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::Eq for IMEKMSINVK {}
-#[cfg(feature = "Win32_Globalization")]
 impl ::core::default::Default for IMEKMSINVK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6786,12 +6766,6 @@ impl ::core::clone::Clone for IMEKMSKEY {
 unsafe impl ::windows::core::Abi for IMEKMSKEY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEKMSKEY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSKEY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEKMSKEY {}
 impl ::core::default::Default for IMEKMSKEY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6812,12 +6786,6 @@ impl ::core::clone::Clone for IMEKMSKEY_0 {
 unsafe impl ::windows::core::Abi for IMEKMSKEY_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEKMSKEY_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSKEY_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEKMSKEY_0 {}
 impl ::core::default::Default for IMEKMSKEY_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6838,12 +6806,6 @@ impl ::core::clone::Clone for IMEKMSKEY_1 {
 unsafe impl ::windows::core::Abi for IMEKMSKEY_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEKMSKEY_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSKEY_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEKMSKEY_1 {}
 impl ::core::default::Default for IMEKMSKEY_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6874,14 +6836,6 @@ unsafe impl ::windows::core::Abi for IMEKMSKMP {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::PartialEq for IMEKMSKMP {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSKMP>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Globalization")]
-impl ::core::cmp::Eq for IMEKMSKMP {}
-#[cfg(feature = "Win32_Globalization")]
 impl ::core::default::Default for IMEKMSKMP {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -6907,14 +6861,6 @@ impl ::core::clone::Clone for IMEKMSNTFY {
 unsafe impl ::windows::core::Abi for IMEKMSNTFY {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization"))]
-impl ::core::cmp::PartialEq for IMEKMSNTFY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEKMSNTFY>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization"))]
-impl ::core::cmp::Eq for IMEKMSNTFY {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization"))]
 impl ::core::default::Default for IMEKMSNTFY {
     fn default() -> Self {
@@ -6956,7 +6902,7 @@ unsafe impl ::windows::core::Abi for IMEMENUITEMINFOA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for IMEMENUITEMINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEMENUITEMINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.fType == other.fType && self.fState == other.fState && self.wID == other.wID && self.hbmpChecked == other.hbmpChecked && self.hbmpUnchecked == other.hbmpUnchecked && self.dwItemData == other.dwItemData && self.szString == other.szString && self.hbmpItem == other.hbmpItem
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -7002,7 +6948,7 @@ unsafe impl ::windows::core::Abi for IMEMENUITEMINFOW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for IMEMENUITEMINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEMENUITEMINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.fType == other.fType && self.fState == other.fState && self.wID == other.wID && self.hbmpChecked == other.hbmpChecked && self.hbmpUnchecked == other.hbmpUnchecked && self.dwItemData == other.dwItemData && self.szString == other.szString && self.hbmpItem == other.hbmpItem
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7036,14 +6982,6 @@ unsafe impl ::windows::core::Abi for IMESHF {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for IMESHF {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMESHF>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for IMESHF {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for IMESHF {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7071,7 +7009,7 @@ unsafe impl ::windows::core::Abi for IMESTRINGCANDIDATE {
 }
 impl ::core::cmp::PartialEq for IMESTRINGCANDIDATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMESTRINGCANDIDATE>()) == 0 }
+        self.uCount == other.uCount && self.lpwstr == other.lpwstr
     }
 }
 impl ::core::cmp::Eq for IMESTRINGCANDIDATE {}
@@ -7106,7 +7044,7 @@ unsafe impl ::windows::core::Abi for IMESTRINGCANDIDATEINFO {
 }
 impl ::core::cmp::PartialEq for IMESTRINGCANDIDATEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMESTRINGCANDIDATEINFO>()) == 0 }
+        self.dwFarEastId == other.dwFarEastId && self.lpFarEastInfo == other.lpFarEastInfo && self.fInfoMask == other.fInfoMask && self.iSelIndex == other.iSelIndex && self.uCount == other.uCount && self.lpwstr == other.lpwstr
     }
 }
 impl ::core::cmp::Eq for IMESTRINGCANDIDATEINFO {}
@@ -7137,7 +7075,7 @@ unsafe impl ::windows::core::Abi for IMESTRINGINFO {
 }
 impl ::core::cmp::PartialEq for IMESTRINGINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMESTRINGINFO>()) == 0 }
+        self.dwFarEastId == other.dwFarEastId && self.lpwstr == other.lpwstr
     }
 }
 impl ::core::cmp::Eq for IMESTRINGINFO {}
@@ -7166,12 +7104,6 @@ impl ::core::clone::Clone for IMEWRD {
 unsafe impl ::windows::core::Abi for IMEWRD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEWRD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEWRD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEWRD {}
 impl ::core::default::Default for IMEWRD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7192,12 +7124,6 @@ impl ::core::clone::Clone for IMEWRD_0 {
 unsafe impl ::windows::core::Abi for IMEWRD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEWRD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEWRD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEWRD_0 {}
 impl ::core::default::Default for IMEWRD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7218,12 +7144,6 @@ impl ::core::clone::Clone for IMEWRD_0_0 {
 unsafe impl ::windows::core::Abi for IMEWRD_0_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IMEWRD_0_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IMEWRD_0_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for IMEWRD_0_0 {}
 impl ::core::default::Default for IMEWRD_0_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7264,14 +7184,6 @@ unsafe impl ::windows::core::Abi for INPUTCONTEXT {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for INPUTCONTEXT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUTCONTEXT>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for INPUTCONTEXT {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for INPUTCONTEXT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7296,14 +7208,6 @@ impl ::core::clone::Clone for INPUTCONTEXT_0 {
 unsafe impl ::windows::core::Abi for INPUTCONTEXT_0 {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for INPUTCONTEXT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUTCONTEXT_0>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for INPUTCONTEXT_0 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for INPUTCONTEXT_0 {
     fn default() -> Self {
@@ -7336,12 +7240,6 @@ impl ::core::clone::Clone for MORRSLT {
 unsafe impl ::windows::core::Abi for MORRSLT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MORRSLT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MORRSLT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MORRSLT {}
 impl ::core::default::Default for MORRSLT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7362,12 +7260,6 @@ impl ::core::clone::Clone for MORRSLT_0 {
 unsafe impl ::windows::core::Abi for MORRSLT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MORRSLT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MORRSLT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MORRSLT_0 {}
 impl ::core::default::Default for MORRSLT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7388,12 +7280,6 @@ impl ::core::clone::Clone for MORRSLT_1 {
 unsafe impl ::windows::core::Abi for MORRSLT_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MORRSLT_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MORRSLT_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MORRSLT_1 {}
 impl ::core::default::Default for MORRSLT_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7414,12 +7300,6 @@ impl ::core::clone::Clone for MORRSLT_2 {
 unsafe impl ::windows::core::Abi for MORRSLT_2 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MORRSLT_2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MORRSLT_2>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for MORRSLT_2 {}
 impl ::core::default::Default for MORRSLT_2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7440,12 +7320,6 @@ impl ::core::clone::Clone for POSTBL {
 unsafe impl ::windows::core::Abi for POSTBL {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for POSTBL {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POSTBL>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for POSTBL {}
 impl ::core::default::Default for POSTBL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7479,7 +7353,7 @@ unsafe impl ::windows::core::Abi for RECONVERTSTRING {
 }
 impl ::core::cmp::PartialEq for RECONVERTSTRING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECONVERTSTRING>()) == 0 }
+        self.dwSize == other.dwSize && self.dwVersion == other.dwVersion && self.dwStrLen == other.dwStrLen && self.dwStrOffset == other.dwStrOffset && self.dwCompStrLen == other.dwCompStrLen && self.dwCompStrOffset == other.dwCompStrOffset && self.dwTargetStrLen == other.dwTargetStrLen && self.dwTargetStrOffset == other.dwTargetStrOffset
     }
 }
 impl ::core::cmp::Eq for RECONVERTSTRING {}
@@ -7510,7 +7384,7 @@ unsafe impl ::windows::core::Abi for REGISTERWORDA {
 }
 impl ::core::cmp::PartialEq for REGISTERWORDA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REGISTERWORDA>()) == 0 }
+        self.lpReading == other.lpReading && self.lpWord == other.lpWord
     }
 }
 impl ::core::cmp::Eq for REGISTERWORDA {}
@@ -7541,7 +7415,7 @@ unsafe impl ::windows::core::Abi for REGISTERWORDW {
 }
 impl ::core::cmp::PartialEq for REGISTERWORDW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<REGISTERWORDW>()) == 0 }
+        self.lpReading == other.lpReading && self.lpWord == other.lpWord
     }
 }
 impl ::core::cmp::Eq for REGISTERWORDW {}
@@ -7572,7 +7446,7 @@ unsafe impl ::windows::core::Abi for SOFTKBDDATA {
 }
 impl ::core::cmp::PartialEq for SOFTKBDDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SOFTKBDDATA>()) == 0 }
+        self.uCount == other.uCount && self.wCode == other.wCode
     }
 }
 impl ::core::cmp::Eq for SOFTKBDDATA {}
@@ -7609,7 +7483,7 @@ unsafe impl ::windows::core::Abi for STYLEBUFA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for STYLEBUFA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STYLEBUFA>()) == 0 }
+        self.dwStyle == other.dwStyle && self.szDescription == other.szDescription
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7642,7 +7516,7 @@ unsafe impl ::windows::core::Abi for STYLEBUFW {
 }
 impl ::core::cmp::PartialEq for STYLEBUFW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STYLEBUFW>()) == 0 }
+        self.dwStyle == other.dwStyle && self.szDescription == other.szDescription
     }
 }
 impl ::core::cmp::Eq for STYLEBUFW {}
@@ -7680,7 +7554,7 @@ unsafe impl ::windows::core::Abi for TRANSMSG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRANSMSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMSG>()) == 0 }
+        self.message == other.message && self.wParam == other.wParam && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7719,7 +7593,7 @@ unsafe impl ::windows::core::Abi for TRANSMSGLIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRANSMSGLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRANSMSGLIST>()) == 0 }
+        self.uMsgCount == other.uMsgCount && self.TransMsg == other.TransMsg
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -7751,12 +7625,6 @@ impl ::core::clone::Clone for WDD {
 unsafe impl ::windows::core::Abi for WDD {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WDD {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDD>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WDD {}
 impl ::core::default::Default for WDD {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7777,12 +7645,6 @@ impl ::core::clone::Clone for WDD_0 {
 unsafe impl ::windows::core::Abi for WDD_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WDD_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDD_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WDD_0 {}
 impl ::core::default::Default for WDD_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -7803,12 +7665,6 @@ impl ::core::clone::Clone for WDD_1 {
 unsafe impl ::windows::core::Abi for WDD_1 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WDD_1 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WDD_1>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for WDD_1 {}
 impl ::core::default::Default for WDD_1 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
@@ -1574,7 +1574,7 @@ unsafe impl ::windows::core::Abi for DEADKEY {
 }
 impl ::core::cmp::PartialEq for DEADKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEADKEY>()) == 0 }
+        self.dwBoth == other.dwBoth && self.wchComposed == other.wchComposed && self.uFlags == other.uFlags
     }
 }
 impl ::core::cmp::Eq for DEADKEY {}
@@ -1606,7 +1606,7 @@ unsafe impl ::windows::core::Abi for HARDWAREINPUT {
 }
 impl ::core::cmp::PartialEq for HARDWAREINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HARDWAREINPUT>()) == 0 }
+        self.uMsg == other.uMsg && self.wParamL == other.wParamL && self.wParamH == other.wParamH
     }
 }
 impl ::core::cmp::Eq for HARDWAREINPUT {}
@@ -1630,12 +1630,6 @@ impl ::core::clone::Clone for INPUT {
 unsafe impl ::windows::core::Abi for INPUT {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INPUT {}
 impl ::core::default::Default for INPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1657,12 +1651,6 @@ impl ::core::clone::Clone for INPUT_0 {
 unsafe impl ::windows::core::Abi for INPUT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INPUT_0 {}
 impl ::core::default::Default for INPUT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1694,7 +1682,7 @@ unsafe impl ::windows::core::Abi for KBDNLSTABLES {
 }
 impl ::core::cmp::PartialEq for KBDNLSTABLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBDNLSTABLES>()) == 0 }
+        self.OEMIdentifier == other.OEMIdentifier && self.LayoutInformation == other.LayoutInformation && self.NumOfVkToF == other.NumOfVkToF && self.pVkToF == other.pVkToF && self.NumOfMouseVKey == other.NumOfMouseVKey && self.pusMouseVKey == other.pusMouseVKey
     }
 }
 impl ::core::cmp::Eq for KBDNLSTABLES {}
@@ -1756,7 +1744,7 @@ unsafe impl ::windows::core::Abi for KBDTABLES {
 }
 impl ::core::cmp::PartialEq for KBDTABLES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBDTABLES>()) == 0 }
+        self.pCharModifiers == other.pCharModifiers && self.pVkToWcharTable == other.pVkToWcharTable && self.pDeadKey == other.pDeadKey && self.pKeyNames == other.pKeyNames && self.pKeyNamesExt == other.pKeyNamesExt && self.pKeyNamesDead == other.pKeyNamesDead && self.pusVSCtoVK == other.pusVSCtoVK && self.bMaxVSCtoVK == other.bMaxVSCtoVK && self.pVSCtoVK_E0 == other.pVSCtoVK_E0 && self.pVSCtoVK_E1 == other.pVSCtoVK_E1 && self.fLocaleFlags == other.fLocaleFlags && self.nLgMax == other.nLgMax && self.cbLgEntry == other.cbLgEntry && self.pLigature == other.pLigature && self.dwType == other.dwType && self.dwSubType == other.dwSubType
     }
 }
 impl ::core::cmp::Eq for KBDTABLES {}
@@ -1788,7 +1776,7 @@ unsafe impl ::windows::core::Abi for KBDTABLE_DESC {
 }
 impl ::core::cmp::PartialEq for KBDTABLE_DESC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBDTABLE_DESC>()) == 0 }
+        self.wszDllName == other.wszDllName && self.dwType == other.dwType && self.dwSubType == other.dwSubType
     }
 }
 impl ::core::cmp::Eq for KBDTABLE_DESC {}
@@ -1819,7 +1807,7 @@ unsafe impl ::windows::core::Abi for KBDTABLE_MULTI {
 }
 impl ::core::cmp::PartialEq for KBDTABLE_MULTI {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBDTABLE_MULTI>()) == 0 }
+        self.nTables == other.nTables && self.aKbdTables == other.aKbdTables
     }
 }
 impl ::core::cmp::Eq for KBDTABLE_MULTI {}
@@ -1851,7 +1839,7 @@ unsafe impl ::windows::core::Abi for KBD_TYPE_INFO {
 }
 impl ::core::cmp::PartialEq for KBD_TYPE_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBD_TYPE_INFO>()) == 0 }
+        self.dwVersion == other.dwVersion && self.dwType == other.dwType && self.dwSubType == other.dwSubType
     }
 }
 impl ::core::cmp::Eq for KBD_TYPE_INFO {}
@@ -1885,7 +1873,7 @@ unsafe impl ::windows::core::Abi for KEYBDINPUT {
 }
 impl ::core::cmp::PartialEq for KEYBDINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KEYBDINPUT>()) == 0 }
+        self.wVk == other.wVk && self.wScan == other.wScan && self.dwFlags == other.dwFlags && self.time == other.time && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 impl ::core::cmp::Eq for KEYBDINPUT {}
@@ -1916,7 +1904,7 @@ unsafe impl ::windows::core::Abi for LASTINPUTINFO {
 }
 impl ::core::cmp::PartialEq for LASTINPUTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LASTINPUTINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwTime == other.dwTime
     }
 }
 impl ::core::cmp::Eq for LASTINPUTINFO {}
@@ -1948,7 +1936,7 @@ unsafe impl ::windows::core::Abi for LIGATURE1 {
 }
 impl ::core::cmp::PartialEq for LIGATURE1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE1>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.ModificationNumber == other.ModificationNumber && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for LIGATURE1 {}
@@ -1980,7 +1968,7 @@ unsafe impl ::windows::core::Abi for LIGATURE2 {
 }
 impl ::core::cmp::PartialEq for LIGATURE2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE2>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.ModificationNumber == other.ModificationNumber && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for LIGATURE2 {}
@@ -2012,7 +2000,7 @@ unsafe impl ::windows::core::Abi for LIGATURE3 {
 }
 impl ::core::cmp::PartialEq for LIGATURE3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE3>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.ModificationNumber == other.ModificationNumber && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for LIGATURE3 {}
@@ -2044,7 +2032,7 @@ unsafe impl ::windows::core::Abi for LIGATURE4 {
 }
 impl ::core::cmp::PartialEq for LIGATURE4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE4>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.ModificationNumber == other.ModificationNumber && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for LIGATURE4 {}
@@ -2076,7 +2064,7 @@ unsafe impl ::windows::core::Abi for LIGATURE5 {
 }
 impl ::core::cmp::PartialEq for LIGATURE5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LIGATURE5>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.ModificationNumber == other.ModificationNumber && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for LIGATURE5 {}
@@ -2108,7 +2096,7 @@ unsafe impl ::windows::core::Abi for MODIFIERS {
 }
 impl ::core::cmp::PartialEq for MODIFIERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MODIFIERS>()) == 0 }
+        self.pVkToBit == other.pVkToBit && self.wMaxModBits == other.wMaxModBits && self.ModNumber == other.ModNumber
     }
 }
 impl ::core::cmp::Eq for MODIFIERS {}
@@ -2143,7 +2131,7 @@ unsafe impl ::windows::core::Abi for MOUSEINPUT {
 }
 impl ::core::cmp::PartialEq for MOUSEINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSEINPUT>()) == 0 }
+        self.dx == other.dx && self.dy == other.dy && self.mouseData == other.mouseData && self.dwFlags == other.dwFlags && self.time == other.time && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 impl ::core::cmp::Eq for MOUSEINPUT {}
@@ -2176,7 +2164,7 @@ unsafe impl ::windows::core::Abi for MOUSEMOVEPOINT {
 }
 impl ::core::cmp::PartialEq for MOUSEMOVEPOINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSEMOVEPOINT>()) == 0 }
+        self.x == other.x && self.y == other.y && self.time == other.time && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 impl ::core::cmp::Eq for MOUSEMOVEPOINT {}
@@ -2215,7 +2203,7 @@ unsafe impl ::windows::core::Abi for TRACKMOUSEEVENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TRACKMOUSEEVENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TRACKMOUSEEVENT>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.hwndTrack == other.hwndTrack && self.dwHoverTime == other.dwHoverTime
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2252,7 +2240,7 @@ unsafe impl ::windows::core::Abi for VK_F {
 }
 impl ::core::cmp::PartialEq for VK_F {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_F>()) == 0 }
+        self.Vk == other.Vk && self.NLSFEProcType == other.NLSFEProcType && self.NLSFEProcCurrent == other.NLSFEProcCurrent && self.NLSFEProcSwitch == other.NLSFEProcSwitch && self.NLSFEProc == other.NLSFEProc && self.NLSFEProcAlt == other.NLSFEProcAlt
     }
 }
 impl ::core::cmp::Eq for VK_F {}
@@ -2283,7 +2271,7 @@ unsafe impl ::windows::core::Abi for VK_FPARAM {
 }
 impl ::core::cmp::PartialEq for VK_FPARAM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_FPARAM>()) == 0 }
+        self.NLSFEProcIndex == other.NLSFEProcIndex && self.NLSFEProcParam == other.NLSFEProcParam
     }
 }
 impl ::core::cmp::Eq for VK_FPARAM {}
@@ -2314,7 +2302,7 @@ unsafe impl ::windows::core::Abi for VK_TO_BIT {
 }
 impl ::core::cmp::PartialEq for VK_TO_BIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_BIT>()) == 0 }
+        self.Vk == other.Vk && self.ModBits == other.ModBits
     }
 }
 impl ::core::cmp::Eq for VK_TO_BIT {}
@@ -2346,7 +2334,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS1 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS1 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS1>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS1 {}
@@ -2378,7 +2366,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS10 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS10 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS10>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS10 {}
@@ -2410,7 +2398,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS2 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS2>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS2 {}
@@ -2442,7 +2430,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS3 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS3 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS3>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS3 {}
@@ -2474,7 +2462,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS4 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS4 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS4>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS4 {}
@@ -2506,7 +2494,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS5 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS5 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS5>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS5 {}
@@ -2538,7 +2526,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS6 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS6 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS6>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS6 {}
@@ -2570,7 +2558,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS7 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS7 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS7>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS7 {}
@@ -2602,7 +2590,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS8 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS8 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS8>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS8 {}
@@ -2634,7 +2622,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHARS9 {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHARS9 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHARS9>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Attributes == other.Attributes && self.wch == other.wch
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHARS9 {}
@@ -2666,7 +2654,7 @@ unsafe impl ::windows::core::Abi for VK_TO_WCHAR_TABLE {
 }
 impl ::core::cmp::PartialEq for VK_TO_WCHAR_TABLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_TO_WCHAR_TABLE>()) == 0 }
+        self.pVkToWchars == other.pVkToWchars && self.nModifications == other.nModifications && self.cbSize == other.cbSize
     }
 }
 impl ::core::cmp::Eq for VK_TO_WCHAR_TABLE {}
@@ -2697,7 +2685,7 @@ unsafe impl ::windows::core::Abi for VK_VSC {
 }
 impl ::core::cmp::PartialEq for VK_VSC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VK_VSC>()) == 0 }
+        self.Vk == other.Vk && self.Vsc == other.Vsc
     }
 }
 impl ::core::cmp::Eq for VK_VSC {}
@@ -2728,7 +2716,7 @@ unsafe impl ::windows::core::Abi for VSC_LPWSTR {
 }
 impl ::core::cmp::PartialEq for VSC_LPWSTR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSC_LPWSTR>()) == 0 }
+        self.vsc == other.vsc && self.pwsz == other.pwsz
     }
 }
 impl ::core::cmp::Eq for VSC_LPWSTR {}
@@ -2759,7 +2747,7 @@ unsafe impl ::windows::core::Abi for VSC_VK {
 }
 impl ::core::cmp::PartialEq for VSC_VK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<VSC_VK>()) == 0 }
+        self.Vsc == other.Vsc && self.Vk == other.Vk
     }
 }
 impl ::core::cmp::Eq for VSC_VK {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
@@ -398,7 +398,7 @@ unsafe impl ::windows::core::Abi for INPUT_INJECTION_VALUE {
 }
 impl ::core::cmp::PartialEq for INPUT_INJECTION_VALUE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_INJECTION_VALUE>()) == 0 }
+        self.page == other.page && self.usage == other.usage && self.value == other.value && self.index == other.index
     }
 }
 impl ::core::cmp::Eq for INPUT_INJECTION_VALUE {}
@@ -421,12 +421,6 @@ impl ::core::clone::Clone for INPUT_TRANSFORM {
 unsafe impl ::windows::core::Abi for INPUT_TRANSFORM {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INPUT_TRANSFORM {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_TRANSFORM>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INPUT_TRANSFORM {}
 impl ::core::default::Default for INPUT_TRANSFORM {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -447,12 +441,6 @@ impl ::core::clone::Clone for INPUT_TRANSFORM_0 {
 unsafe impl ::windows::core::Abi for INPUT_TRANSFORM_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for INPUT_TRANSFORM_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_TRANSFORM_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for INPUT_TRANSFORM_0 {}
 impl ::core::default::Default for INPUT_TRANSFORM_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -494,7 +482,7 @@ unsafe impl ::windows::core::Abi for INPUT_TRANSFORM_0_0 {
 }
 impl ::core::cmp::PartialEq for INPUT_TRANSFORM_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_TRANSFORM_0_0>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._13 == other._13 && self._14 == other._14 && self._21 == other._21 && self._22 == other._22 && self._23 == other._23 && self._24 == other._24 && self._31 == other._31 && self._32 == other._32 && self._33 == other._33 && self._34 == other._34 && self._41 == other._41 && self._42 == other._42 && self._43 == other._43 && self._44 == other._44
     }
 }
 impl ::core::cmp::Eq for INPUT_TRANSFORM_0_0 {}
@@ -562,7 +550,7 @@ unsafe impl ::windows::core::Abi for POINTER_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for POINTER_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_INFO>()) == 0 }
+        self.pointerType == other.pointerType && self.pointerId == other.pointerId && self.frameId == other.frameId && self.pointerFlags == other.pointerFlags && self.sourceDevice == other.sourceDevice && self.hwndTarget == other.hwndTarget && self.ptPixelLocation == other.ptPixelLocation && self.ptHimetricLocation == other.ptHimetricLocation && self.ptPixelLocationRaw == other.ptPixelLocationRaw && self.ptHimetricLocationRaw == other.ptHimetricLocationRaw && self.dwTime == other.dwTime && self.historyCount == other.historyCount && self.InputData == other.InputData && self.dwKeyStates == other.dwKeyStates && self.PerformanceCount == other.PerformanceCount && self.ButtonChangeType == other.ButtonChangeType
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -606,7 +594,7 @@ unsafe impl ::windows::core::Abi for POINTER_PEN_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for POINTER_PEN_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_PEN_INFO>()) == 0 }
+        self.pointerInfo == other.pointerInfo && self.penFlags == other.penFlags && self.penMask == other.penMask && self.pressure == other.pressure && self.rotation == other.rotation && self.tiltX == other.tiltX && self.tiltY == other.tiltY
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -650,7 +638,7 @@ unsafe impl ::windows::core::Abi for POINTER_TOUCH_INFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for POINTER_TOUCH_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<POINTER_TOUCH_INFO>()) == 0 }
+        self.pointerInfo == other.pointerInfo && self.touchFlags == other.touchFlags && self.touchMask == other.touchMask && self.rcContact == other.rcContact && self.rcContactRaw == other.rcContactRaw && self.orientation == other.orientation && self.pressure == other.pressure
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -810,7 +810,7 @@ unsafe impl ::windows::core::Abi for GESTURECONFIG {
 }
 impl ::core::cmp::PartialEq for GESTURECONFIG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GESTURECONFIG>()) == 0 }
+        self.dwID == other.dwID && self.dwWant == other.dwWant && self.dwBlock == other.dwBlock
     }
 }
 impl ::core::cmp::Eq for GESTURECONFIG {}
@@ -854,7 +854,7 @@ unsafe impl ::windows::core::Abi for GESTUREINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GESTUREINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GESTUREINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.dwID == other.dwID && self.hwndTarget == other.hwndTarget && self.ptsLocation == other.ptsLocation && self.dwInstanceID == other.dwInstanceID && self.dwSequenceID == other.dwSequenceID && self.ullArguments == other.ullArguments && self.cbExtraArgs == other.cbExtraArgs
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -896,7 +896,7 @@ unsafe impl ::windows::core::Abi for GESTURENOTIFYSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GESTURENOTIFYSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GESTURENOTIFYSTRUCT>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.hwndTarget == other.hwndTarget && self.ptsLocation == other.ptsLocation && self.dwInstanceID == other.dwInstanceID
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1007,7 +1007,7 @@ unsafe impl ::windows::core::Abi for TOUCHINPUT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TOUCHINPUT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOUCHINPUT>()) == 0 }
+        self.x == other.x && self.y == other.y && self.hSource == other.hSource && self.dwID == other.dwID && self.dwFlags == other.dwFlags && self.dwMask == other.dwMask && self.dwTime == other.dwTime && self.dwExtraInfo == other.dwExtraInfo && self.cxContact == other.cxContact && self.cyContact == other.cyContact
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
@@ -582,7 +582,7 @@ unsafe impl ::windows::core::Abi for XINPUT_BATTERY_INFORMATION {
 }
 impl ::core::cmp::PartialEq for XINPUT_BATTERY_INFORMATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_BATTERY_INFORMATION>()) == 0 }
+        self.BatteryType == other.BatteryType && self.BatteryLevel == other.BatteryLevel
     }
 }
 impl ::core::cmp::Eq for XINPUT_BATTERY_INFORMATION {}
@@ -616,7 +616,7 @@ unsafe impl ::windows::core::Abi for XINPUT_CAPABILITIES {
 }
 impl ::core::cmp::PartialEq for XINPUT_CAPABILITIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_CAPABILITIES>()) == 0 }
+        self.Type == other.Type && self.SubType == other.SubType && self.Flags == other.Flags && self.Gamepad == other.Gamepad && self.Vibration == other.Vibration
     }
 }
 impl ::core::cmp::Eq for XINPUT_CAPABILITIES {}
@@ -652,7 +652,7 @@ unsafe impl ::windows::core::Abi for XINPUT_GAMEPAD {
 }
 impl ::core::cmp::PartialEq for XINPUT_GAMEPAD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_GAMEPAD>()) == 0 }
+        self.wButtons == other.wButtons && self.bLeftTrigger == other.bLeftTrigger && self.bRightTrigger == other.bRightTrigger && self.sThumbLX == other.sThumbLX && self.sThumbLY == other.sThumbLY && self.sThumbRX == other.sThumbRX && self.sThumbRY == other.sThumbRY
     }
 }
 impl ::core::cmp::Eq for XINPUT_GAMEPAD {}
@@ -686,7 +686,7 @@ unsafe impl ::windows::core::Abi for XINPUT_KEYSTROKE {
 }
 impl ::core::cmp::PartialEq for XINPUT_KEYSTROKE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_KEYSTROKE>()) == 0 }
+        self.VirtualKey == other.VirtualKey && self.Unicode == other.Unicode && self.Flags == other.Flags && self.UserIndex == other.UserIndex && self.HidCode == other.HidCode
     }
 }
 impl ::core::cmp::Eq for XINPUT_KEYSTROKE {}
@@ -717,7 +717,7 @@ unsafe impl ::windows::core::Abi for XINPUT_STATE {
 }
 impl ::core::cmp::PartialEq for XINPUT_STATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_STATE>()) == 0 }
+        self.dwPacketNumber == other.dwPacketNumber && self.Gamepad == other.Gamepad
     }
 }
 impl ::core::cmp::Eq for XINPUT_STATE {}
@@ -748,7 +748,7 @@ unsafe impl ::windows::core::Abi for XINPUT_VIBRATION {
 }
 impl ::core::cmp::PartialEq for XINPUT_VIBRATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<XINPUT_VIBRATION>()) == 0 }
+        self.wLeftMotorSpeed == other.wLeftMotorSpeed && self.wRightMotorSpeed == other.wRightMotorSpeed
     }
 }
 impl ::core::cmp::Eq for XINPUT_VIBRATION {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
@@ -366,7 +366,7 @@ unsafe impl ::windows::core::Abi for INPUT_MESSAGE_SOURCE {
 }
 impl ::core::cmp::PartialEq for INPUT_MESSAGE_SOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INPUT_MESSAGE_SOURCE>()) == 0 }
+        self.deviceType == other.deviceType && self.originId == other.originId
     }
 }
 impl ::core::cmp::Eq for INPUT_MESSAGE_SOURCE {}
@@ -398,7 +398,7 @@ unsafe impl ::windows::core::Abi for RAWHID {
 }
 impl ::core::cmp::PartialEq for RAWHID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWHID>()) == 0 }
+        self.dwSizeHid == other.dwSizeHid && self.dwCount == other.dwCount && self.bRawData == other.bRawData
     }
 }
 impl ::core::cmp::Eq for RAWHID {}
@@ -427,14 +427,6 @@ unsafe impl ::windows::core::Abi for RAWINPUT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAWINPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWINPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAWINPUT {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAWINPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -460,14 +452,6 @@ impl ::core::clone::Clone for RAWINPUT_0 {
 unsafe impl ::windows::core::Abi for RAWINPUT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RAWINPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWINPUT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RAWINPUT_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RAWINPUT_0 {
     fn default() -> Self {
@@ -504,7 +488,7 @@ unsafe impl ::windows::core::Abi for RAWINPUTDEVICE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAWINPUTDEVICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWINPUTDEVICE>()) == 0 }
+        self.usUsagePage == other.usUsagePage && self.usUsage == other.usUsage && self.dwFlags == other.dwFlags && self.hwndTarget == other.hwndTarget
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -543,7 +527,7 @@ unsafe impl ::windows::core::Abi for RAWINPUTDEVICELIST {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAWINPUTDEVICELIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWINPUTDEVICELIST>()) == 0 }
+        self.hDevice == other.hDevice && self.dwType == other.dwType
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -584,7 +568,7 @@ unsafe impl ::windows::core::Abi for RAWINPUTHEADER {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RAWINPUTHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWINPUTHEADER>()) == 0 }
+        self.dwType == other.dwType && self.dwSize == other.dwSize && self.hDevice == other.hDevice && self.wParam == other.wParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -621,7 +605,7 @@ unsafe impl ::windows::core::Abi for RAWKEYBOARD {
 }
 impl ::core::cmp::PartialEq for RAWKEYBOARD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWKEYBOARD>()) == 0 }
+        self.MakeCode == other.MakeCode && self.Flags == other.Flags && self.Reserved == other.Reserved && self.VKey == other.VKey && self.Message == other.Message && self.ExtraInformation == other.ExtraInformation
     }
 }
 impl ::core::cmp::Eq for RAWKEYBOARD {}
@@ -649,12 +633,6 @@ impl ::core::clone::Clone for RAWMOUSE {
 unsafe impl ::windows::core::Abi for RAWMOUSE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAWMOUSE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWMOUSE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAWMOUSE {}
 impl ::core::default::Default for RAWMOUSE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -675,12 +653,6 @@ impl ::core::clone::Clone for RAWMOUSE_0 {
 unsafe impl ::windows::core::Abi for RAWMOUSE_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RAWMOUSE_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWMOUSE_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for RAWMOUSE_0 {}
 impl ::core::default::Default for RAWMOUSE_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -708,7 +680,7 @@ unsafe impl ::windows::core::Abi for RAWMOUSE_0_0 {
 }
 impl ::core::cmp::PartialEq for RAWMOUSE_0_0 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RAWMOUSE_0_0>()) == 0 }
+        self.usButtonFlags == other.usButtonFlags && self.usButtonData == other.usButtonData
     }
 }
 impl ::core::cmp::Eq for RAWMOUSE_0_0 {}
@@ -738,14 +710,6 @@ unsafe impl ::windows::core::Abi for RID_DEVICE_INFO {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RID_DEVICE_INFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RID_DEVICE_INFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RID_DEVICE_INFO {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RID_DEVICE_INFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -771,14 +735,6 @@ impl ::core::clone::Clone for RID_DEVICE_INFO_0 {
 unsafe impl ::windows::core::Abi for RID_DEVICE_INFO_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for RID_DEVICE_INFO_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RID_DEVICE_INFO_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for RID_DEVICE_INFO_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for RID_DEVICE_INFO_0 {
     fn default() -> Self {
@@ -810,7 +766,7 @@ unsafe impl ::windows::core::Abi for RID_DEVICE_INFO_HID {
 }
 impl ::core::cmp::PartialEq for RID_DEVICE_INFO_HID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RID_DEVICE_INFO_HID>()) == 0 }
+        self.dwVendorId == other.dwVendorId && self.dwProductId == other.dwProductId && self.dwVersionNumber == other.dwVersionNumber && self.usUsagePage == other.usUsagePage && self.usUsage == other.usUsage
     }
 }
 impl ::core::cmp::Eq for RID_DEVICE_INFO_HID {}
@@ -845,7 +801,7 @@ unsafe impl ::windows::core::Abi for RID_DEVICE_INFO_KEYBOARD {
 }
 impl ::core::cmp::PartialEq for RID_DEVICE_INFO_KEYBOARD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RID_DEVICE_INFO_KEYBOARD>()) == 0 }
+        self.dwType == other.dwType && self.dwSubType == other.dwSubType && self.dwKeyboardMode == other.dwKeyboardMode && self.dwNumberOfFunctionKeys == other.dwNumberOfFunctionKeys && self.dwNumberOfIndicators == other.dwNumberOfIndicators && self.dwNumberOfKeysTotal == other.dwNumberOfKeysTotal
     }
 }
 impl ::core::cmp::Eq for RID_DEVICE_INFO_KEYBOARD {}
@@ -884,7 +840,7 @@ unsafe impl ::windows::core::Abi for RID_DEVICE_INFO_MOUSE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for RID_DEVICE_INFO_MOUSE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RID_DEVICE_INFO_MOUSE>()) == 0 }
+        self.dwId == other.dwId && self.dwNumberOfButtons == other.dwNumberOfButtons && self.dwSampleRate == other.dwSampleRate && self.fHasHorizontalWheel == other.fHasHorizontalWheel
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
@@ -864,7 +864,7 @@ unsafe impl ::windows::core::Abi for CROSS_SLIDE_PARAMETER {
 }
 impl ::core::cmp::PartialEq for CROSS_SLIDE_PARAMETER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CROSS_SLIDE_PARAMETER>()) == 0 }
+        self.threshold == other.threshold && self.distance == other.distance
     }
 }
 impl ::core::cmp::Eq for CROSS_SLIDE_PARAMETER {}
@@ -926,7 +926,7 @@ unsafe impl ::windows::core::Abi for INTERACTION_ARGUMENTS_CROSS_SLIDE {
 }
 impl ::core::cmp::PartialEq for INTERACTION_ARGUMENTS_CROSS_SLIDE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_ARGUMENTS_CROSS_SLIDE>()) == 0 }
+        self.flags == other.flags
     }
 }
 impl ::core::cmp::Eq for INTERACTION_ARGUMENTS_CROSS_SLIDE {}
@@ -959,7 +959,7 @@ unsafe impl ::windows::core::Abi for INTERACTION_ARGUMENTS_MANIPULATION {
 }
 impl ::core::cmp::PartialEq for INTERACTION_ARGUMENTS_MANIPULATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_ARGUMENTS_MANIPULATION>()) == 0 }
+        self.delta == other.delta && self.cumulative == other.cumulative && self.velocity == other.velocity && self.railsState == other.railsState
     }
 }
 impl ::core::cmp::Eq for INTERACTION_ARGUMENTS_MANIPULATION {}
@@ -989,7 +989,7 @@ unsafe impl ::windows::core::Abi for INTERACTION_ARGUMENTS_TAP {
 }
 impl ::core::cmp::PartialEq for INTERACTION_ARGUMENTS_TAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_ARGUMENTS_TAP>()) == 0 }
+        self.count == other.count
     }
 }
 impl ::core::cmp::Eq for INTERACTION_ARGUMENTS_TAP {}
@@ -1020,7 +1020,7 @@ unsafe impl ::windows::core::Abi for INTERACTION_CONTEXT_CONFIGURATION {
 }
 impl ::core::cmp::PartialEq for INTERACTION_CONTEXT_CONFIGURATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_CONTEXT_CONFIGURATION>()) == 0 }
+        self.interactionId == other.interactionId && self.enable == other.enable
     }
 }
 impl ::core::cmp::Eq for INTERACTION_CONTEXT_CONFIGURATION {}
@@ -1053,14 +1053,6 @@ unsafe impl ::windows::core::Abi for INTERACTION_CONTEXT_OUTPUT {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for INTERACTION_CONTEXT_OUTPUT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_CONTEXT_OUTPUT>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for INTERACTION_CONTEXT_OUTPUT {}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for INTERACTION_CONTEXT_OUTPUT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1086,14 +1078,6 @@ impl ::core::clone::Clone for INTERACTION_CONTEXT_OUTPUT_0 {
 unsafe impl ::windows::core::Abi for INTERACTION_CONTEXT_OUTPUT_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for INTERACTION_CONTEXT_OUTPUT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_CONTEXT_OUTPUT_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for INTERACTION_CONTEXT_OUTPUT_0 {}
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for INTERACTION_CONTEXT_OUTPUT_0 {
     fn default() -> Self {
@@ -1126,14 +1110,6 @@ unsafe impl ::windows::core::Abi for INTERACTION_CONTEXT_OUTPUT2 {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for INTERACTION_CONTEXT_OUTPUT2 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_CONTEXT_OUTPUT2>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for INTERACTION_CONTEXT_OUTPUT2 {}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for INTERACTION_CONTEXT_OUTPUT2 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1159,14 +1135,6 @@ impl ::core::clone::Clone for INTERACTION_CONTEXT_OUTPUT2_0 {
 unsafe impl ::windows::core::Abi for INTERACTION_CONTEXT_OUTPUT2_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for INTERACTION_CONTEXT_OUTPUT2_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INTERACTION_CONTEXT_OUTPUT2_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for INTERACTION_CONTEXT_OUTPUT2_0 {}
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for INTERACTION_CONTEXT_OUTPUT2_0 {
     fn default() -> Self {
@@ -1198,7 +1166,7 @@ unsafe impl ::windows::core::Abi for MANIPULATION_TRANSFORM {
 }
 impl ::core::cmp::PartialEq for MANIPULATION_TRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MANIPULATION_TRANSFORM>()) == 0 }
+        self.translationX == other.translationX && self.translationY == other.translationY && self.scale == other.scale && self.expansion == other.expansion && self.rotation == other.rotation
     }
 }
 impl ::core::cmp::Eq for MANIPULATION_TRANSFORM {}
@@ -1231,7 +1199,7 @@ unsafe impl ::windows::core::Abi for MANIPULATION_VELOCITY {
 }
 impl ::core::cmp::PartialEq for MANIPULATION_VELOCITY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MANIPULATION_VELOCITY>()) == 0 }
+        self.velocityX == other.velocityX && self.velocityY == other.velocityY && self.velocityExpansion == other.velocityExpansion && self.velocityAngular == other.velocityAngular
     }
 }
 impl ::core::cmp::Eq for MANIPULATION_VELOCITY {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Magnification/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Magnification/mod.rs
@@ -227,7 +227,7 @@ unsafe impl ::windows::core::Abi for MAGCOLOREFFECT {
 }
 impl ::core::cmp::PartialEq for MAGCOLOREFFECT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAGCOLOREFFECT>()) == 0 }
+        self.transform == other.transform
     }
 }
 impl ::core::cmp::Eq for MAGCOLOREFFECT {}
@@ -262,7 +262,7 @@ unsafe impl ::windows::core::Abi for MAGIMAGEHEADER {
 }
 impl ::core::cmp::PartialEq for MAGIMAGEHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAGIMAGEHEADER>()) == 0 }
+        self.width == other.width && self.height == other.height && self.format == other.format && self.stride == other.stride && self.offset == other.offset && self.cbSize == other.cbSize
     }
 }
 impl ::core::cmp::Eq for MAGIMAGEHEADER {}
@@ -292,7 +292,7 @@ unsafe impl ::windows::core::Abi for MAGTRANSFORM {
 }
 impl ::core::cmp::PartialEq for MAGTRANSFORM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MAGTRANSFORM>()) == 0 }
+        self.v == other.v
     }
 }
 impl ::core::cmp::Eq for MAGTRANSFORM {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
@@ -61,7 +61,7 @@ unsafe impl ::windows::core::Abi for NOTIFICATION_USER_INPUT_DATA {
 }
 impl ::core::cmp::PartialEq for NOTIFICATION_USER_INPUT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFICATION_USER_INPUT_DATA>()) == 0 }
+        self.Key == other.Key && self.Value == other.Value
     }
 }
 impl ::core::cmp::Eq for NOTIFICATION_USER_INPUT_DATA {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -1172,12 +1172,6 @@ impl ::core::clone::Clone for UI_EVENTPARAMS {
 unsafe impl ::windows::core::Abi for UI_EVENTPARAMS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UI_EVENTPARAMS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UI_EVENTPARAMS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UI_EVENTPARAMS {}
 impl ::core::default::Default for UI_EVENTPARAMS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1198,12 +1192,6 @@ impl ::core::clone::Clone for UI_EVENTPARAMS_0 {
 unsafe impl ::windows::core::Abi for UI_EVENTPARAMS_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UI_EVENTPARAMS_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UI_EVENTPARAMS_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for UI_EVENTPARAMS_0 {}
 impl ::core::default::Default for UI_EVENTPARAMS_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -1235,7 +1223,7 @@ unsafe impl ::windows::core::Abi for UI_EVENTPARAMS_COMMAND {
 }
 impl ::core::cmp::PartialEq for UI_EVENTPARAMS_COMMAND {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UI_EVENTPARAMS_COMMAND>()) == 0 }
+        self.CommandID == other.CommandID && self.CommandName == other.CommandName && self.ParentCommandID == other.ParentCommandID && self.ParentCommandName == other.ParentCommandName && self.SelectionIndex == other.SelectionIndex && self.Location == other.Location
     }
 }
 impl ::core::cmp::Eq for UI_EVENTPARAMS_COMMAND {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
@@ -350,7 +350,7 @@ unsafe impl ::windows::core::Abi for COMDLG_FILTERSPEC {
 }
 impl ::core::cmp::PartialEq for COMDLG_FILTERSPEC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<COMDLG_FILTERSPEC>()) == 0 }
+        self.pszName == other.pszName && self.pszSpec == other.pszSpec
     }
 }
 impl ::core::cmp::Eq for COMDLG_FILTERSPEC {}
@@ -373,12 +373,6 @@ impl ::core::clone::Clone for ITEMIDLIST {
 unsafe impl ::windows::core::Abi for ITEMIDLIST {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ITEMIDLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ITEMIDLIST>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for ITEMIDLIST {}
 impl ::core::default::Default for ITEMIDLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -400,12 +394,6 @@ impl ::core::clone::Clone for SHELLDETAILS {
 unsafe impl ::windows::core::Abi for SHELLDETAILS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHELLDETAILS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLDETAILS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHELLDETAILS {}
 impl ::core::default::Default for SHELLDETAILS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -426,12 +414,6 @@ impl ::core::clone::Clone for SHITEMID {
 unsafe impl ::windows::core::Abi for SHITEMID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHITEMID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHITEMID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHITEMID {}
 impl ::core::default::Default for SHITEMID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -452,12 +434,6 @@ impl ::core::clone::Clone for STRRET {
 unsafe impl ::windows::core::Abi for STRRET {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STRRET {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRRET>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STRRET {}
 impl ::core::default::Default for STRRET {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -479,12 +455,6 @@ impl ::core::clone::Clone for STRRET_0 {
 unsafe impl ::windows::core::Abi for STRRET_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for STRRET_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STRRET_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for STRRET_0 {}
 impl ::core::default::Default for STRRET_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -5449,7 +5449,7 @@ unsafe impl ::windows::core::Abi for PROPERTYKEY {
 }
 impl ::core::cmp::PartialEq for PROPERTYKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPERTYKEY>()) == 0 }
+        self.fmtid == other.fmtid && self.pid == other.pid
     }
 }
 impl ::core::cmp::Eq for PROPERTYKEY {}
@@ -5487,14 +5487,6 @@ impl ::core::clone::Clone for PROPPRG {
 unsafe impl ::windows::core::Abi for PROPPRG {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for PROPPRG {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPPRG>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for PROPPRG {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for PROPPRG {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -57003,7 +57003,7 @@ unsafe impl ::windows::core::Abi for AASHELLMENUFILENAME {
 }
 impl ::core::cmp::PartialEq for AASHELLMENUFILENAME {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AASHELLMENUFILENAME>()) == 0 }
+        self.cbTotal == other.cbTotal && self.rgbReserved == other.rgbReserved && self.szFileName == other.szFileName
     }
 }
 impl ::core::cmp::Eq for AASHELLMENUFILENAME {}
@@ -57037,7 +57037,7 @@ unsafe impl ::windows::core::Abi for AASHELLMENUITEM {
 }
 impl ::core::cmp::PartialEq for AASHELLMENUITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AASHELLMENUITEM>()) == 0 }
+        self.lpReserved1 == other.lpReserved1 && self.iReserved == other.iReserved && self.uiReserved == other.uiReserved && self.lpName == other.lpName && self.psz == other.psz
     }
 }
 impl ::core::cmp::Eq for AASHELLMENUITEM {}
@@ -57075,16 +57075,6 @@ unsafe impl ::windows::core::Abi for APPBARDATA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for APPBARDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPBARDATA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for APPBARDATA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for APPBARDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57119,16 +57109,6 @@ unsafe impl ::windows::core::Abi for APPBARDATA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for APPBARDATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPBARDATA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for APPBARDATA {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for APPBARDATA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57157,7 +57137,7 @@ unsafe impl ::windows::core::Abi for APPCATEGORYINFO {
 }
 impl ::core::cmp::PartialEq for APPCATEGORYINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPCATEGORYINFO>()) == 0 }
+        self.Locale == other.Locale && self.pszDescription == other.pszDescription && self.AppCategoryId == other.AppCategoryId
     }
 }
 impl ::core::cmp::Eq for APPCATEGORYINFO {}
@@ -57188,7 +57168,7 @@ unsafe impl ::windows::core::Abi for APPCATEGORYINFOLIST {
 }
 impl ::core::cmp::PartialEq for APPCATEGORYINFOLIST {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPCATEGORYINFOLIST>()) == 0 }
+        self.cCategory == other.cCategory && self.pCategoryInfo == other.pCategoryInfo
     }
 }
 impl ::core::cmp::Eq for APPCATEGORYINFOLIST {}
@@ -57258,7 +57238,26 @@ unsafe impl ::windows::core::Abi for APPINFODATA {
 }
 impl ::core::cmp::PartialEq for APPINFODATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<APPINFODATA>()) == 0 }
+        self.cbSize == other.cbSize
+            && self.dwMask == other.dwMask
+            && self.pszDisplayName == other.pszDisplayName
+            && self.pszVersion == other.pszVersion
+            && self.pszPublisher == other.pszPublisher
+            && self.pszProductID == other.pszProductID
+            && self.pszRegisteredOwner == other.pszRegisteredOwner
+            && self.pszRegisteredCompany == other.pszRegisteredCompany
+            && self.pszLanguage == other.pszLanguage
+            && self.pszSupportUrl == other.pszSupportUrl
+            && self.pszSupportTelephone == other.pszSupportTelephone
+            && self.pszHelpLink == other.pszHelpLink
+            && self.pszInstallLocation == other.pszInstallLocation
+            && self.pszInstallSource == other.pszInstallSource
+            && self.pszInstallDate == other.pszInstallDate
+            && self.pszContact == other.pszContact
+            && self.pszComments == other.pszComments
+            && self.pszImage == other.pszImage
+            && self.pszReadmeUrl == other.pszReadmeUrl
+            && self.pszUpdateInfoUrl == other.pszUpdateInfoUrl
     }
 }
 impl ::core::cmp::Eq for APPINFODATA {}
@@ -57293,16 +57292,6 @@ unsafe impl ::windows::core::Abi for ASSOCIATIONELEMENT {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::PartialEq for ASSOCIATIONELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASSOCIATIONELEMENT>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::Eq for ASSOCIATIONELEMENT {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
 impl ::core::default::Default for ASSOCIATIONELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57334,16 +57323,6 @@ unsafe impl ::windows::core::Abi for ASSOCIATIONELEMENT {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::PartialEq for ASSOCIATIONELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ASSOCIATIONELEMENT>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl ::core::cmp::Eq for ASSOCIATIONELEMENT {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
 impl ::core::default::Default for ASSOCIATIONELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57371,14 +57350,6 @@ impl ::core::clone::Clone for AUTO_SCROLL_DATA {
 unsafe impl ::windows::core::Abi for AUTO_SCROLL_DATA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for AUTO_SCROLL_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUTO_SCROLL_DATA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for AUTO_SCROLL_DATA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for AUTO_SCROLL_DATA {
     fn default() -> Self {
@@ -57464,7 +57435,7 @@ unsafe impl ::windows::core::Abi for BANDSITEINFO {
 }
 impl ::core::cmp::PartialEq for BANDSITEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BANDSITEINFO>()) == 0 }
+        self.dwMask == other.dwMask && self.dwState == other.dwState && self.dwStyle == other.dwStyle
     }
 }
 impl ::core::cmp::Eq for BANDSITEINFO {}
@@ -57496,7 +57467,7 @@ unsafe impl ::windows::core::Abi for BANNER_NOTIFICATION {
 }
 impl ::core::cmp::PartialEq for BANNER_NOTIFICATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BANNER_NOTIFICATION>()) == 0 }
+        self.event == other.event && self.providerIdentity == other.providerIdentity && self.contentId == other.contentId
     }
 }
 impl ::core::cmp::Eq for BANNER_NOTIFICATION {}
@@ -57813,21 +57784,13 @@ impl ::core::clone::Clone for BROWSEINFOA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::fmt::Debug for BROWSEINFOA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("BROWSEINFOA").field("hwndOwner", &self.hwndOwner).field("pidlRoot", &self.pidlRoot).field("pszDisplayName", &self.pszDisplayName).field("lpszTitle", &self.lpszTitle).field("ulFlags", &self.ulFlags).field("lpfn", &self.lpfn.map(|f| f as usize)).field("lParam", &self.lParam).field("iImage", &self.iImage).finish()
+        f.debug_struct("BROWSEINFOA").field("hwndOwner", &self.hwndOwner).field("pidlRoot", &self.pidlRoot).field("pszDisplayName", &self.pszDisplayName).field("lpszTitle", &self.lpszTitle).field("ulFlags", &self.ulFlags).field("lParam", &self.lParam).field("iImage", &self.iImage).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 unsafe impl ::windows::core::Abi for BROWSEINFOA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::PartialEq for BROWSEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BROWSEINFOA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::Eq for BROWSEINFOA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::default::Default for BROWSEINFOA {
     fn default() -> Self {
@@ -57858,21 +57821,13 @@ impl ::core::clone::Clone for BROWSEINFOW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::fmt::Debug for BROWSEINFOW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("BROWSEINFOW").field("hwndOwner", &self.hwndOwner).field("pidlRoot", &self.pidlRoot).field("pszDisplayName", &self.pszDisplayName).field("lpszTitle", &self.lpszTitle).field("ulFlags", &self.ulFlags).field("lpfn", &self.lpfn.map(|f| f as usize)).field("lParam", &self.lParam).field("iImage", &self.iImage).finish()
+        f.debug_struct("BROWSEINFOW").field("hwndOwner", &self.hwndOwner).field("pidlRoot", &self.pidlRoot).field("pszDisplayName", &self.pszDisplayName).field("lpszTitle", &self.lpszTitle).field("ulFlags", &self.ulFlags).field("lParam", &self.lParam).field("iImage", &self.iImage).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 unsafe impl ::windows::core::Abi for BROWSEINFOW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::PartialEq for BROWSEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BROWSEINFOW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::Eq for BROWSEINFOW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::default::Default for BROWSEINFOW {
     fn default() -> Self {
@@ -57896,12 +57851,6 @@ impl ::core::clone::Clone for CABINETSTATE {
 unsafe impl ::windows::core::Abi for CABINETSTATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CABINETSTATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CABINETSTATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CABINETSTATE {}
 impl ::core::default::Default for CABINETSTATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57929,7 +57878,7 @@ unsafe impl ::windows::core::Abi for CATEGORY_INFO {
 }
 impl ::core::cmp::PartialEq for CATEGORY_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CATEGORY_INFO>()) == 0 }
+        self.cif == other.cif && self.wszName == other.wszName
     }
 }
 impl ::core::cmp::Eq for CATEGORY_INFO {}
@@ -57953,12 +57902,6 @@ impl ::core::clone::Clone for CIDA {
 unsafe impl ::windows::core::Abi for CIDA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CIDA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CIDA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CIDA {}
 impl ::core::default::Default for CIDA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -57999,7 +57942,7 @@ unsafe impl ::windows::core::Abi for CMINVOKECOMMANDINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMINVOKECOMMANDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMINVOKECOMMANDINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.hwnd == other.hwnd && self.lpVerb == other.lpVerb && self.lpParameters == other.lpParameters && self.lpDirectory == other.lpDirectory && self.nShow == other.nShow && self.dwHotKey == other.dwHotKey && self.hIcon == other.hIcon
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58067,7 +58010,7 @@ unsafe impl ::windows::core::Abi for CMINVOKECOMMANDINFOEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMINVOKECOMMANDINFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMINVOKECOMMANDINFOEX>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.hwnd == other.hwnd && self.lpVerb == other.lpVerb && self.lpParameters == other.lpParameters && self.lpDirectory == other.lpDirectory && self.nShow == other.nShow && self.dwHotKey == other.dwHotKey && self.hIcon == other.hIcon && self.lpTitle == other.lpTitle && self.lpVerbW == other.lpVerbW && self.lpParametersW == other.lpParametersW && self.lpDirectoryW == other.lpDirectoryW && self.lpTitleW == other.lpTitleW && self.ptInvoke == other.ptInvoke
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58137,7 +58080,7 @@ unsafe impl ::windows::core::Abi for CMINVOKECOMMANDINFOEX_REMOTE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CMINVOKECOMMANDINFOEX_REMOTE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CMINVOKECOMMANDINFOEX_REMOTE>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.hwnd == other.hwnd && self.lpVerbString == other.lpVerbString && self.lpParameters == other.lpParameters && self.lpDirectory == other.lpDirectory && self.nShow == other.nShow && self.dwHotKey == other.dwHotKey && self.lpTitle == other.lpTitle && self.lpVerbWString == other.lpVerbWString && self.lpParametersW == other.lpParametersW && self.lpDirectoryW == other.lpDirectoryW && self.lpTitleW == other.lpTitleW && self.ptInvoke == other.ptInvoke && self.lpVerbInt == other.lpVerbInt && self.lpVerbWInt == other.lpVerbWInt
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58175,7 +58118,7 @@ unsafe impl ::windows::core::Abi for CM_COLUMNINFO {
 }
 impl ::core::cmp::PartialEq for CM_COLUMNINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CM_COLUMNINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.dwState == other.dwState && self.uWidth == other.uWidth && self.uDefaultWidth == other.uDefaultWidth && self.uIdealWidth == other.uIdealWidth && self.wszName == other.wszName
     }
 }
 impl ::core::cmp::Eq for CM_COLUMNINFO {}
@@ -58247,7 +58190,7 @@ unsafe impl ::windows::core::Abi for CONFIRM_CONFLICT_RESULT_INFO {
 }
 impl ::core::cmp::PartialEq for CONFIRM_CONFLICT_RESULT_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CONFIRM_CONFLICT_RESULT_INFO>()) == 0 }
+        self.pszNewName == other.pszNewName && self.iItemIndex == other.iItemIndex
     }
 }
 impl ::core::cmp::Eq for CONFIRM_CONFLICT_RESULT_INFO {}
@@ -58273,12 +58216,6 @@ impl ::core::clone::Clone for CPLINFO {
 unsafe impl ::windows::core::Abi for CPLINFO {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CPLINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CPLINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for CPLINFO {}
 impl ::core::default::Default for CPLINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58308,7 +58245,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATIO
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION>()) == 0 }
+        self.ulAuthenticationPackage == other.ulAuthenticationPackage && self.clsidCredentialProvider == other.clsidCredentialProvider && self.cbSerialization == other.cbSerialization && self.rgbSerialization == other.rgbSerialization
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION {}
@@ -58341,7 +58278,7 @@ unsafe impl ::windows::core::Abi for CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {
 }
 impl ::core::cmp::PartialEq for CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR>()) == 0 }
+        self.dwFieldID == other.dwFieldID && self.cpft == other.cpft && self.pszLabel == other.pszLabel && self.guidFieldType == other.guidFieldType
     }
 }
 impl ::core::cmp::Eq for CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {}
@@ -58379,21 +58316,13 @@ impl ::core::clone::Clone for CSFV {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl ::core::fmt::Debug for CSFV {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("CSFV").field("cbSize", &self.cbSize).field("pshf", &self.pshf).field("psvOuter", &self.psvOuter).field("pidl", &self.pidl).field("lEvents", &self.lEvents).field("pfnCallback", &self.pfnCallback.map(|f| f as usize)).field("fvm", &self.fvm).finish()
+        f.debug_struct("CSFV").field("cbSize", &self.cbSize).field("pshf", &self.pshf).field("psvOuter", &self.psvOuter).field("pidl", &self.pidl).field("lEvents", &self.lEvents).field("fvm", &self.fvm).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 unsafe impl ::windows::core::Abi for CSFV {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::PartialEq for CSFV {
-    fn eq(&self, other: &Self) -> bool {
-        self.cbSize == other.cbSize && self.pshf == other.pshf && self.psvOuter == other.psvOuter && self.pidl == other.pidl && self.lEvents == other.lEvents && self.pfnCallback.map(|f| f as usize) == other.pfnCallback.map(|f| f as usize) && self.fvm == other.fvm
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::Eq for CSFV {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl ::core::default::Default for CSFV {
     fn default() -> Self {
@@ -58415,12 +58344,6 @@ impl ::core::clone::Clone for DATABLOCK_HEADER {
 unsafe impl ::windows::core::Abi for DATABLOCK_HEADER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DATABLOCK_HEADER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DATABLOCK_HEADER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DATABLOCK_HEADER {}
 impl ::core::default::Default for DATABLOCK_HEADER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58497,12 +58420,6 @@ impl ::core::clone::Clone for DELEGATEITEMID {
 unsafe impl ::windows::core::Abi for DELEGATEITEMID {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DELEGATEITEMID {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DELEGATEITEMID>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DELEGATEITEMID {}
 impl ::core::default::Default for DELEGATEITEMID {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58542,7 +58459,7 @@ unsafe impl ::windows::core::Abi for DESKBANDINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DESKBANDINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DESKBANDINFO>()) == 0 }
+        self.dwMask == other.dwMask && self.ptMinSize == other.ptMinSize && self.ptMaxSize == other.ptMaxSize && self.ptIntegral == other.ptIntegral && self.ptActual == other.ptActual && self.wszTitle == other.wszTitle && self.dwModeFlags == other.dwModeFlags && self.crBkgnd == other.crBkgnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -58575,14 +58492,6 @@ impl ::core::clone::Clone for DETAILSINFO {
 unsafe impl ::windows::core::Abi for DETAILSINFO {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl ::core::cmp::PartialEq for DETAILSINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DETAILSINFO>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl ::core::cmp::Eq for DETAILSINFO {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ::core::default::Default for DETAILSINFO {
     fn default() -> Self {
@@ -58664,7 +58573,7 @@ unsafe impl ::windows::core::Abi for DLLVERSIONINFO {
 }
 impl ::core::cmp::PartialEq for DLLVERSIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLLVERSIONINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMajorVersion == other.dwMajorVersion && self.dwMinorVersion == other.dwMinorVersion && self.dwBuildNumber == other.dwBuildNumber && self.dwPlatformID == other.dwPlatformID
     }
 }
 impl ::core::cmp::Eq for DLLVERSIONINFO {}
@@ -58696,7 +58605,7 @@ unsafe impl ::windows::core::Abi for DLLVERSIONINFO2 {
 }
 impl ::core::cmp::PartialEq for DLLVERSIONINFO2 {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLLVERSIONINFO2>()) == 0 }
+        self.info1 == other.info1 && self.dwFlags == other.dwFlags && self.ullVersion == other.ullVersion
     }
 }
 impl ::core::cmp::Eq for DLLVERSIONINFO2 {}
@@ -58733,16 +58642,6 @@ unsafe impl ::windows::core::Abi for DRAGINFOA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRAGINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAGINFOA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRAGINFOA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRAGINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58776,16 +58675,6 @@ unsafe impl ::windows::core::Abi for DRAGINFOA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRAGINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAGINFOA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRAGINFOA {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRAGINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58819,16 +58708,6 @@ unsafe impl ::windows::core::Abi for DRAGINFOW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRAGINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAGINFOW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRAGINFOW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRAGINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58862,16 +58741,6 @@ unsafe impl ::windows::core::Abi for DRAGINFOW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DRAGINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DRAGINFOW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DRAGINFOW {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DRAGINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58893,12 +58762,6 @@ impl ::core::clone::Clone for DROPDESCRIPTION {
 unsafe impl ::windows::core::Abi for DROPDESCRIPTION {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DROPDESCRIPTION {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DROPDESCRIPTION>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DROPDESCRIPTION {}
 impl ::core::default::Default for DROPDESCRIPTION {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58926,14 +58789,6 @@ unsafe impl ::windows::core::Abi for DROPFILES {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for DROPFILES {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DROPFILES>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for DROPFILES {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for DROPFILES {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58960,14 +58815,6 @@ unsafe impl ::windows::core::Abi for EXP_DARWIN_LINK {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EXP_DARWIN_LINK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXP_DARWIN_LINK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EXP_DARWIN_LINK {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EXP_DARWIN_LINK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -58989,12 +58836,6 @@ impl ::core::clone::Clone for EXP_PROPERTYSTORAGE {
 unsafe impl ::windows::core::Abi for EXP_PROPERTYSTORAGE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EXP_PROPERTYSTORAGE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXP_PROPERTYSTORAGE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EXP_PROPERTYSTORAGE {}
 impl ::core::default::Default for EXP_PROPERTYSTORAGE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59017,12 +58858,6 @@ impl ::core::clone::Clone for EXP_SPECIAL_FOLDER {
 unsafe impl ::windows::core::Abi for EXP_SPECIAL_FOLDER {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EXP_SPECIAL_FOLDER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXP_SPECIAL_FOLDER>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for EXP_SPECIAL_FOLDER {}
 impl ::core::default::Default for EXP_SPECIAL_FOLDER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59049,14 +58884,6 @@ impl ::core::clone::Clone for EXP_SZ_LINK {
 unsafe impl ::windows::core::Abi for EXP_SZ_LINK {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for EXP_SZ_LINK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXP_SZ_LINK>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for EXP_SZ_LINK {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for EXP_SZ_LINK {
     fn default() -> Self {
@@ -59086,7 +58913,7 @@ unsafe impl ::windows::core::Abi for EXTRASEARCH {
 }
 impl ::core::cmp::PartialEq for EXTRASEARCH {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EXTRASEARCH>()) == 0 }
+        self.guidSearch == other.guidSearch && self.wszFriendlyName == other.wszFriendlyName && self.wszUrl == other.wszUrl
     }
 }
 impl ::core::cmp::Eq for EXTRASEARCH {}
@@ -59124,14 +58951,6 @@ unsafe impl ::windows::core::Abi for FILEDESCRIPTORA {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILEDESCRIPTORA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEDESCRIPTORA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILEDESCRIPTORA {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILEDESCRIPTORA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59166,14 +58985,6 @@ unsafe impl ::windows::core::Abi for FILEDESCRIPTORW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILEDESCRIPTORW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEDESCRIPTORW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILEDESCRIPTORW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILEDESCRIPTORW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59198,14 +59009,6 @@ impl ::core::clone::Clone for FILEGROUPDESCRIPTORA {
 unsafe impl ::windows::core::Abi for FILEGROUPDESCRIPTORA {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILEGROUPDESCRIPTORA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEGROUPDESCRIPTORA>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILEGROUPDESCRIPTORA {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILEGROUPDESCRIPTORA {
     fn default() -> Self {
@@ -59232,14 +59035,6 @@ unsafe impl ::windows::core::Abi for FILEGROUPDESCRIPTORW {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for FILEGROUPDESCRIPTORW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILEGROUPDESCRIPTORW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for FILEGROUPDESCRIPTORW {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for FILEGROUPDESCRIPTORW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59262,12 +59057,6 @@ impl ::core::clone::Clone for FILE_ATTRIBUTES_ARRAY {
 unsafe impl ::windows::core::Abi for FILE_ATTRIBUTES_ARRAY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FILE_ATTRIBUTES_ARRAY {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FILE_ATTRIBUTES_ARRAY>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for FILE_ATTRIBUTES_ARRAY {}
 impl ::core::default::Default for FILE_ATTRIBUTES_ARRAY {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59296,7 +59085,7 @@ unsafe impl ::windows::core::Abi for FOLDERSETDATA {
 }
 impl ::core::cmp::PartialEq for FOLDERSETDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FOLDERSETDATA>()) == 0 }
+        self._fs == other._fs && self._vidRestore == other._vidRestore && self._dwViewPriority == other._dwViewPriority
     }
 }
 impl ::core::cmp::Eq for FOLDERSETDATA {}
@@ -59327,7 +59116,7 @@ unsafe impl ::windows::core::Abi for FOLDERSETTINGS {
 }
 impl ::core::cmp::PartialEq for FOLDERSETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FOLDERSETTINGS>()) == 0 }
+        self.ViewMode == other.ViewMode && self.fFlags == other.fFlags
     }
 }
 impl ::core::cmp::Eq for FOLDERSETTINGS {}
@@ -59400,7 +59189,7 @@ unsafe impl ::windows::core::Abi for HELPINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HELPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HELPINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.iContextType == other.iContextType && self.iCtrlId == other.iCtrlId && self.hItemHandle == other.hItemHandle && self.dwContextId == other.dwContextId && self.MousePos == other.MousePos
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -59444,7 +59233,7 @@ unsafe impl ::windows::core::Abi for HELPWININFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HELPWININFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HELPWININFOA>()) == 0 }
+        self.wStructSize == other.wStructSize && self.x == other.x && self.y == other.y && self.dx == other.dx && self.dy == other.dy && self.wMax == other.wMax && self.rgchMember == other.rgchMember
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -59482,7 +59271,7 @@ unsafe impl ::windows::core::Abi for HELPWININFOW {
 }
 impl ::core::cmp::PartialEq for HELPWININFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HELPWININFOW>()) == 0 }
+        self.wStructSize == other.wStructSize && self.x == other.x && self.y == other.y && self.dx == other.dx && self.dy == other.dy && self.wMax == other.wMax && self.rgchMember == other.rgchMember
     }
 }
 impl ::core::cmp::Eq for HELPWININFOW {}
@@ -59522,7 +59311,7 @@ unsafe impl ::windows::core::Abi for HLBWINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HLBWINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HLBWINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.grfHLBWIF == other.grfHLBWIF && self.rcFramePos == other.rcFramePos && self.rcDocPos == other.rcDocPos && self.hltbinfo == other.hltbinfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -59555,7 +59344,7 @@ unsafe impl ::windows::core::Abi for HLITEM {
 }
 impl ::core::cmp::PartialEq for HLITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HLITEM>()) == 0 }
+        self.uHLID == other.uHLID && self.pwzFriendlyName == other.pwzFriendlyName
     }
 }
 impl ::core::cmp::Eq for HLITEM {}
@@ -59592,7 +59381,7 @@ unsafe impl ::windows::core::Abi for HLTBINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HLTBINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HLTBINFO>()) == 0 }
+        self.uDockType == other.uDockType && self.rcTbPos == other.rcTbPos
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -59659,7 +59448,7 @@ unsafe impl ::windows::core::Abi for ITEMSPACING {
 }
 impl ::core::cmp::PartialEq for ITEMSPACING {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ITEMSPACING>()) == 0 }
+        self.cxSmall == other.cxSmall && self.cySmall == other.cySmall && self.cxLarge == other.cxLarge && self.cyLarge == other.cyLarge
     }
 }
 impl ::core::cmp::Eq for ITEMSPACING {}
@@ -59715,7 +59504,7 @@ unsafe impl ::windows::core::Abi for KNOWNFOLDER_DEFINITION {
 }
 impl ::core::cmp::PartialEq for KNOWNFOLDER_DEFINITION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KNOWNFOLDER_DEFINITION>()) == 0 }
+        self.category == other.category && self.pszName == other.pszName && self.pszDescription == other.pszDescription && self.fidParent == other.fidParent && self.pszRelativePath == other.pszRelativePath && self.pszParsingName == other.pszParsingName && self.pszTooltip == other.pszTooltip && self.pszLocalizedName == other.pszLocalizedName && self.pszIcon == other.pszIcon && self.pszSecurity == other.pszSecurity && self.dwAttributes == other.dwAttributes && self.kfdFlags == other.kfdFlags && self.ftidType == other.ftidType
     }
 }
 impl ::core::cmp::Eq for KNOWNFOLDER_DEFINITION {}
@@ -59753,7 +59542,7 @@ unsafe impl ::windows::core::Abi for MULTIKEYHELPA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MULTIKEYHELPA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MULTIKEYHELPA>()) == 0 }
+        self.mkSize == other.mkSize && self.mkKeylist == other.mkKeylist && self.szKeyphrase == other.szKeyphrase
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -59787,7 +59576,7 @@ unsafe impl ::windows::core::Abi for MULTIKEYHELPW {
 }
 impl ::core::cmp::PartialEq for MULTIKEYHELPW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MULTIKEYHELPW>()) == 0 }
+        self.mkSize == other.mkSize && self.mkKeylist == other.mkKeylist && self.szKeyphrase == other.szKeyphrase
     }
 }
 impl ::core::cmp::Eq for MULTIKEYHELPW {}
@@ -59819,7 +59608,7 @@ unsafe impl ::windows::core::Abi for NC_ADDRESS {
 }
 impl ::core::cmp::PartialEq for NC_ADDRESS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NC_ADDRESS>()) == 0 }
+        self.pAddrInfo == other.pAddrInfo && self.PortNumber == other.PortNumber && self.PrefixLength == other.PrefixLength
     }
 }
 impl ::core::cmp::Eq for NC_ADDRESS {}
@@ -59856,14 +59645,6 @@ unsafe impl ::windows::core::Abi for NEWCPLINFOA {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NEWCPLINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWCPLINFOA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NEWCPLINFOA {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NEWCPLINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59894,14 +59675,6 @@ impl ::core::clone::Clone for NEWCPLINFOW {
 unsafe impl ::windows::core::Abi for NEWCPLINFOW {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for NEWCPLINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NEWCPLINFOW>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for NEWCPLINFOW {}
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for NEWCPLINFOW {
     fn default() -> Self {
@@ -59946,16 +59719,6 @@ unsafe impl ::windows::core::Abi for NOTIFYICONDATAA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -59984,16 +59747,6 @@ impl ::core::clone::Clone for NOTIFYICONDATAA_0 {
 unsafe impl ::windows::core::Abi for NOTIFYICONDATAA_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAA_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAA_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAA_0 {
@@ -60039,16 +59792,6 @@ unsafe impl ::windows::core::Abi for NOTIFYICONDATAA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAA {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60077,16 +59820,6 @@ impl ::core::clone::Clone for NOTIFYICONDATAA_0 {
 unsafe impl ::windows::core::Abi for NOTIFYICONDATAA_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAA_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAA_0 {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAA_0 {
@@ -60132,16 +59865,6 @@ unsafe impl ::windows::core::Abi for NOTIFYICONDATAW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60170,16 +59893,6 @@ impl ::core::clone::Clone for NOTIFYICONDATAW_0 {
 unsafe impl ::windows::core::Abi for NOTIFYICONDATAW_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAW_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAW_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAW_0 {
@@ -60225,16 +59938,6 @@ unsafe impl ::windows::core::Abi for NOTIFYICONDATAW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60263,16 +59966,6 @@ impl ::core::clone::Clone for NOTIFYICONDATAW_0 {
 unsafe impl ::windows::core::Abi for NOTIFYICONDATAW_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for NOTIFYICONDATAW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONDATAW_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for NOTIFYICONDATAW_0 {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for NOTIFYICONDATAW_0 {
@@ -60307,16 +60000,6 @@ unsafe impl ::windows::core::Abi for NOTIFYICONIDENTIFIER {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NOTIFYICONIDENTIFIER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONIDENTIFIER>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NOTIFYICONIDENTIFIER {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NOTIFYICONIDENTIFIER {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60347,16 +60030,6 @@ impl ::core::clone::Clone for NOTIFYICONIDENTIFIER {
 unsafe impl ::windows::core::Abi for NOTIFYICONIDENTIFIER {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for NOTIFYICONIDENTIFIER {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NOTIFYICONIDENTIFIER>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for NOTIFYICONIDENTIFIER {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for NOTIFYICONIDENTIFIER {
@@ -60392,7 +60065,7 @@ unsafe impl ::windows::core::Abi for NRESARRAY {
 #[cfg(feature = "Win32_NetworkManagement_WNet")]
 impl ::core::cmp::PartialEq for NRESARRAY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NRESARRAY>()) == 0 }
+        self.cItems == other.cItems && self.nr == other.nr
     }
 }
 #[cfg(feature = "Win32_NetworkManagement_WNet")]
@@ -60494,14 +60167,6 @@ unsafe impl ::windows::core::Abi for NT_CONSOLE_PROPS {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
-impl ::core::cmp::PartialEq for NT_CONSOLE_PROPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_CONSOLE_PROPS>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
-impl ::core::cmp::Eq for NT_CONSOLE_PROPS {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Console"))]
 impl ::core::default::Default for NT_CONSOLE_PROPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60522,12 +60187,6 @@ impl ::core::clone::Clone for NT_FE_CONSOLE_PROPS {
 unsafe impl ::windows::core::Abi for NT_FE_CONSOLE_PROPS {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NT_FE_CONSOLE_PROPS {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NT_FE_CONSOLE_PROPS>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for NT_FE_CONSOLE_PROPS {}
 impl ::core::default::Default for NT_FE_CONSOLE_PROPS {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60556,7 +60215,7 @@ unsafe impl ::windows::core::Abi for OPENASINFO {
 }
 impl ::core::cmp::PartialEq for OPENASINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPENASINFO>()) == 0 }
+        self.pcszFile == other.pcszFile && self.pcszClass == other.pcszClass && self.oaifInFlags == other.oaifInFlags
     }
 }
 impl ::core::cmp::Eq for OPENASINFO {}
@@ -60593,16 +60252,6 @@ unsafe impl ::windows::core::Abi for OPEN_PRINTER_PROPS_INFOA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_PRINTER_PROPS_INFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_PRINTER_PROPS_INFOA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_PRINTER_PROPS_INFOA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_PRINTER_PROPS_INFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60636,16 +60285,6 @@ unsafe impl ::windows::core::Abi for OPEN_PRINTER_PROPS_INFOA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_PRINTER_PROPS_INFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_PRINTER_PROPS_INFOA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_PRINTER_PROPS_INFOA {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_PRINTER_PROPS_INFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60677,16 +60316,6 @@ impl ::core::clone::Clone for OPEN_PRINTER_PROPS_INFOW {
 unsafe impl ::windows::core::Abi for OPEN_PRINTER_PROPS_INFOW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_PRINTER_PROPS_INFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_PRINTER_PROPS_INFOW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_PRINTER_PROPS_INFOW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_PRINTER_PROPS_INFOW {
@@ -60722,16 +60351,6 @@ unsafe impl ::windows::core::Abi for OPEN_PRINTER_PROPS_INFOW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for OPEN_PRINTER_PROPS_INFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<OPEN_PRINTER_PROPS_INFOW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for OPEN_PRINTER_PROPS_INFOW {}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for OPEN_PRINTER_PROPS_INFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -60763,7 +60382,7 @@ unsafe impl ::windows::core::Abi for PARSEDURLA {
 }
 impl ::core::cmp::PartialEq for PARSEDURLA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARSEDURLA>()) == 0 }
+        self.cbSize == other.cbSize && self.pszProtocol == other.pszProtocol && self.cchProtocol == other.cchProtocol && self.pszSuffix == other.pszSuffix && self.cchSuffix == other.cchSuffix && self.nScheme == other.nScheme
     }
 }
 impl ::core::cmp::Eq for PARSEDURLA {}
@@ -60798,7 +60417,7 @@ unsafe impl ::windows::core::Abi for PARSEDURLW {
 }
 impl ::core::cmp::PartialEq for PARSEDURLW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PARSEDURLW>()) == 0 }
+        self.cbSize == other.cbSize && self.pszProtocol == other.pszProtocol && self.cchProtocol == other.cchProtocol && self.pszSuffix == other.pszSuffix && self.cchSuffix == other.cchSuffix && self.nScheme == other.nScheme
     }
 }
 impl ::core::cmp::Eq for PARSEDURLW {}
@@ -60838,7 +60457,7 @@ unsafe impl ::windows::core::Abi for PERSIST_FOLDER_TARGET_INFO {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ::core::cmp::PartialEq for PERSIST_FOLDER_TARGET_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PERSIST_FOLDER_TARGET_INFO>()) == 0 }
+        self.pidlTargetFolder == other.pidlTargetFolder && self.szTargetParsingName == other.szTargetParsingName && self.szNetworkProvider == other.szNetworkProvider && self.dwAttributes == other.dwAttributes && self.csidl == other.csidl
     }
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -60877,7 +60496,7 @@ unsafe impl ::windows::core::Abi for PREVIEWHANDLERFRAMEINFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for PREVIEWHANDLERFRAMEINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PREVIEWHANDLERFRAMEINFO>()) == 0 }
+        self.haccel == other.haccel && self.cAccelEntries == other.cAccelEntries
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -60922,7 +60541,7 @@ unsafe impl ::windows::core::Abi for PROFILEINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROFILEINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILEINFOA>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.lpUserName == other.lpUserName && self.lpProfilePath == other.lpProfilePath && self.lpDefaultPath == other.lpDefaultPath && self.lpServerName == other.lpServerName && self.lpPolicyPath == other.lpPolicyPath && self.hProfile == other.hProfile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -60967,7 +60586,7 @@ unsafe impl ::windows::core::Abi for PROFILEINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PROFILEINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROFILEINFOW>()) == 0 }
+        self.dwSize == other.dwSize && self.dwFlags == other.dwFlags && self.lpUserName == other.lpUserName && self.lpProfilePath == other.lpProfilePath && self.lpDefaultPath == other.lpDefaultPath && self.lpServerName == other.lpServerName && self.lpPolicyPath == other.lpPolicyPath && self.hProfile == other.hProfile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -61011,7 +60630,7 @@ unsafe impl ::windows::core::Abi for PUBAPPINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for PUBAPPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PUBAPPINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.dwMask == other.dwMask && self.pszSource == other.pszSource && self.stAssigned == other.stAssigned && self.stPublished == other.stPublished && self.stScheduled == other.stScheduled && self.stExpire == other.stExpire
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -61053,7 +60672,7 @@ unsafe impl ::windows::core::Abi for QCMINFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for QCMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QCMINFO>()) == 0 }
+        self.hmenu == other.hmenu && self.indexMenu == other.indexMenu && self.idCmdFirst == other.idCmdFirst && self.idCmdLast == other.idCmdLast && self.pIdMap == other.pIdMap
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -61086,7 +60705,7 @@ unsafe impl ::windows::core::Abi for QCMINFO_IDMAP {
 }
 impl ::core::cmp::PartialEq for QCMINFO_IDMAP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QCMINFO_IDMAP>()) == 0 }
+        self.nMaxIds == other.nMaxIds && self.pIdList == other.pIdList
     }
 }
 impl ::core::cmp::Eq for QCMINFO_IDMAP {}
@@ -61117,7 +60736,7 @@ unsafe impl ::windows::core::Abi for QCMINFO_IDMAP_PLACEMENT {
 }
 impl ::core::cmp::PartialEq for QCMINFO_IDMAP_PLACEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QCMINFO_IDMAP_PLACEMENT>()) == 0 }
+        self.id == other.id && self.fFlags == other.fFlags
     }
 }
 impl ::core::cmp::Eq for QCMINFO_IDMAP_PLACEMENT {}
@@ -61148,7 +60767,7 @@ unsafe impl ::windows::core::Abi for QITAB {
 }
 impl ::core::cmp::PartialEq for QITAB {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<QITAB>()) == 0 }
+        self.piid == other.piid && self.dwOffset == other.dwOffset
     }
 }
 impl ::core::cmp::Eq for QITAB {}
@@ -61179,7 +60798,7 @@ unsafe impl ::windows::core::Abi for SFVM_HELPTOPIC_DATA {
 }
 impl ::core::cmp::PartialEq for SFVM_HELPTOPIC_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SFVM_HELPTOPIC_DATA>()) == 0 }
+        self.wszHelpFile == other.wszHelpFile && self.wszHelpTopic == other.wszHelpTopic
     }
 }
 impl ::core::cmp::Eq for SFVM_HELPTOPIC_DATA {}
@@ -61207,21 +60826,13 @@ impl ::core::clone::Clone for SFVM_PROPPAGE_DATA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::fmt::Debug for SFVM_PROPPAGE_DATA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SFVM_PROPPAGE_DATA").field("dwReserved", &self.dwReserved).field("pfn", &self.pfn.map(|f| f as usize)).field("lParam", &self.lParam).finish()
+        f.debug_struct("SFVM_PROPPAGE_DATA").field("dwReserved", &self.dwReserved).field("lParam", &self.lParam).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 unsafe impl ::windows::core::Abi for SFVM_PROPPAGE_DATA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for SFVM_PROPPAGE_DATA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SFVM_PROPPAGE_DATA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for SFVM_PROPPAGE_DATA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for SFVM_PROPPAGE_DATA {
     fn default() -> Self {
@@ -61295,7 +60906,7 @@ unsafe impl ::windows::core::Abi for SFV_SETITEMPOS {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::cmp::PartialEq for SFV_SETITEMPOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SFV_SETITEMPOS>()) == 0 }
+        self.pidl == other.pidl && self.pt == other.pt
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
@@ -61315,12 +60926,6 @@ pub struct SHARDAPPIDINFO {
 unsafe impl ::windows::core::Abi for SHARDAPPIDINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for SHARDAPPIDINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARDAPPIDINFO>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHARDAPPIDINFO {}
 impl ::core::default::Default for SHARDAPPIDINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61346,14 +60951,6 @@ unsafe impl ::windows::core::Abi for SHARDAPPIDINFOIDLIST {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
-impl ::core::cmp::PartialEq for SHARDAPPIDINFOIDLIST {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARDAPPIDINFOIDLIST>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl ::core::cmp::Eq for SHARDAPPIDINFOIDLIST {}
-#[cfg(feature = "Win32_UI_Shell_Common")]
 impl ::core::default::Default for SHARDAPPIDINFOIDLIST {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61368,12 +60965,6 @@ pub struct SHARDAPPIDINFOLINK {
 unsafe impl ::windows::core::Abi for SHARDAPPIDINFOLINK {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for SHARDAPPIDINFOLINK {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHARDAPPIDINFOLINK>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHARDAPPIDINFOLINK {}
 impl ::core::default::Default for SHARDAPPIDINFOLINK {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61404,7 +60995,7 @@ unsafe impl ::windows::core::Abi for SHCOLUMNDATA {
 }
 impl ::core::cmp::PartialEq for SHCOLUMNDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHCOLUMNDATA>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwFileAttributes == other.dwFileAttributes && self.dwReserved == other.dwReserved && self.pwszExt == other.pwszExt && self.wszFile == other.wszFile
     }
 }
 impl ::core::cmp::Eq for SHCOLUMNDATA {}
@@ -61438,14 +61029,6 @@ unsafe impl ::windows::core::Abi for SHCOLUMNINFO {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::PartialEq for SHCOLUMNINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHCOLUMNINFO>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl ::core::cmp::Eq for SHCOLUMNINFO {}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ::core::default::Default for SHCOLUMNINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61474,7 +61057,7 @@ unsafe impl ::windows::core::Abi for SHCOLUMNINIT {
 }
 impl ::core::cmp::PartialEq for SHCOLUMNINIT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHCOLUMNINIT>()) == 0 }
+        self.dwFlags == other.dwFlags && self.dwReserved == other.dwReserved && self.wszFolder == other.wszFolder
     }
 }
 impl ::core::cmp::Eq for SHCOLUMNINIT {}
@@ -61519,16 +61102,6 @@ unsafe impl ::windows::core::Abi for SHCREATEPROCESSINFOW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for SHCREATEPROCESSINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHCREATEPROCESSINFOW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for SHCREATEPROCESSINFOW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for SHCREATEPROCESSINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61570,16 +61143,6 @@ unsafe impl ::windows::core::Abi for SHCREATEPROCESSINFOW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl ::core::cmp::PartialEq for SHCREATEPROCESSINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHCREATEPROCESSINFOW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl ::core::cmp::Eq for SHCREATEPROCESSINFOW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Threading"))]
 impl ::core::default::Default for SHCREATEPROCESSINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61602,12 +61165,6 @@ impl ::core::clone::Clone for SHChangeDWORDAsIDList {
 unsafe impl ::windows::core::Abi for SHChangeDWORDAsIDList {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHChangeDWORDAsIDList {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHChangeDWORDAsIDList>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHChangeDWORDAsIDList {}
 impl ::core::default::Default for SHChangeDWORDAsIDList {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61633,14 +61190,6 @@ unsafe impl ::windows::core::Abi for SHChangeNotifyEntry {
     type Abi = Self;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::PartialEq for SHChangeNotifyEntry {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHChangeNotifyEntry>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
-impl ::core::cmp::Eq for SHChangeNotifyEntry {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ::core::default::Default for SHChangeNotifyEntry {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61662,12 +61211,6 @@ impl ::core::clone::Clone for SHChangeProductKeyAsIDList {
 unsafe impl ::windows::core::Abi for SHChangeProductKeyAsIDList {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHChangeProductKeyAsIDList {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHChangeProductKeyAsIDList>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHChangeProductKeyAsIDList {}
 impl ::core::default::Default for SHChangeProductKeyAsIDList {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61693,12 +61236,6 @@ impl ::core::clone::Clone for SHChangeUpdateImageIDList {
 unsafe impl ::windows::core::Abi for SHChangeUpdateImageIDList {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHChangeUpdateImageIDList {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHChangeUpdateImageIDList>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHChangeUpdateImageIDList {}
 impl ::core::default::Default for SHChangeUpdateImageIDList {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61726,7 +61263,7 @@ unsafe impl ::windows::core::Abi for SHDESCRIPTIONID {
 }
 impl ::core::cmp::PartialEq for SHDESCRIPTIONID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHDESCRIPTIONID>()) == 0 }
+        self.dwDescriptionId == other.dwDescriptionId && self.clsid == other.clsid
     }
 }
 impl ::core::cmp::Eq for SHDESCRIPTIONID {}
@@ -61765,7 +61302,7 @@ unsafe impl ::windows::core::Abi for SHDRAGIMAGE {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for SHDRAGIMAGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHDRAGIMAGE>()) == 0 }
+        self.sizeDragImage == other.sizeDragImage && self.ptOffset == other.ptOffset && self.hbmpDragImage == other.hbmpDragImage && self.crColorKey == other.crColorKey
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -61814,16 +61351,6 @@ unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61852,16 +61379,6 @@ impl ::core::clone::Clone for SHELLEXECUTEINFOA_0 {
 unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOA_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOA_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOA_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOA_0 {
@@ -61907,16 +61424,6 @@ unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOA {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOA {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -61945,16 +61452,6 @@ impl ::core::clone::Clone for SHELLEXECUTEINFOA_0 {
 unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOA_0 {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOA_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOA_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOA_0 {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOA_0 {
@@ -62000,16 +61497,6 @@ unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62038,16 +61525,6 @@ impl ::core::clone::Clone for SHELLEXECUTEINFOW_0 {
 unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOW_0 {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOW_0>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOW_0 {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOW_0 {
@@ -62093,16 +61570,6 @@ unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOW {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOW {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62133,16 +61600,6 @@ unsafe impl ::windows::core::Abi for SHELLEXECUTEINFOW_0 {
 }
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::PartialEq for SHELLEXECUTEINFOW_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLEXECUTEINFOW_0>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
-impl ::core::cmp::Eq for SHELLEXECUTEINFOW_0 {}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ::core::default::Default for SHELLEXECUTEINFOW_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62162,12 +61619,6 @@ impl ::core::clone::Clone for SHELLFLAGSTATE {
 unsafe impl ::windows::core::Abi for SHELLFLAGSTATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHELLFLAGSTATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLFLAGSTATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHELLFLAGSTATE {}
 impl ::core::default::Default for SHELLFLAGSTATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62194,12 +61645,6 @@ impl ::core::clone::Clone for SHELLSTATEA {
 unsafe impl ::windows::core::Abi for SHELLSTATEA {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHELLSTATEA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLSTATEA>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHELLSTATEA {}
 impl ::core::default::Default for SHELLSTATEA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62226,12 +61671,6 @@ impl ::core::clone::Clone for SHELLSTATEW {
 unsafe impl ::windows::core::Abi for SHELLSTATEW {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SHELLSTATEW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLSTATEW>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for SHELLSTATEW {}
 impl ::core::default::Default for SHELLSTATEW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62259,7 +61698,7 @@ unsafe impl ::windows::core::Abi for SHELL_ITEM_RESOURCE {
 }
 impl ::core::cmp::PartialEq for SHELL_ITEM_RESOURCE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELL_ITEM_RESOURCE>()) == 0 }
+        self.guidType == other.guidType && self.szName == other.szName
     }
 }
 impl ::core::cmp::Eq for SHELL_ITEM_RESOURCE {}
@@ -62296,16 +61735,6 @@ unsafe impl ::windows::core::Abi for SHFILEINFOA {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for SHFILEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEINFOA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for SHFILEINFOA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for SHFILEINFOA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62337,16 +61766,6 @@ impl ::core::clone::Clone for SHFILEINFOA {
 unsafe impl ::windows::core::Abi for SHFILEINFOA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::PartialEq for SHFILEINFOA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEINFOA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
-impl ::core::cmp::Eq for SHFILEINFOA {}
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::default::Default for SHFILEINFOA {
@@ -62382,16 +61801,6 @@ unsafe impl ::windows::core::Abi for SHFILEINFOW {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for SHFILEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEINFOW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for SHFILEINFOW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for SHFILEINFOW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62423,16 +61832,6 @@ impl ::core::clone::Clone for SHFILEINFOW {
 unsafe impl ::windows::core::Abi for SHFILEINFOW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for SHFILEINFOW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEINFOW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for SHFILEINFOW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for SHFILEINFOW {
@@ -62469,16 +61868,6 @@ impl ::core::clone::Clone for SHFILEOPSTRUCTA {
 unsafe impl ::windows::core::Abi for SHFILEOPSTRUCTA {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SHFILEOPSTRUCTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEOPSTRUCTA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SHFILEOPSTRUCTA {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SHFILEOPSTRUCTA {
@@ -62515,16 +61904,6 @@ impl ::core::clone::Clone for SHFILEOPSTRUCTA {
 unsafe impl ::windows::core::Abi for SHFILEOPSTRUCTA {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SHFILEOPSTRUCTA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEOPSTRUCTA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SHFILEOPSTRUCTA {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SHFILEOPSTRUCTA {
@@ -62561,16 +61940,6 @@ impl ::core::clone::Clone for SHFILEOPSTRUCTW {
 unsafe impl ::windows::core::Abi for SHFILEOPSTRUCTW {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SHFILEOPSTRUCTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEOPSTRUCTW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SHFILEOPSTRUCTW {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SHFILEOPSTRUCTW {
@@ -62607,16 +61976,6 @@ impl ::core::clone::Clone for SHFILEOPSTRUCTW {
 unsafe impl ::windows::core::Abi for SHFILEOPSTRUCTW {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for SHFILEOPSTRUCTW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFILEOPSTRUCTW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for SHFILEOPSTRUCTW {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for SHFILEOPSTRUCTW {
@@ -62675,7 +62034,7 @@ unsafe impl ::windows::core::Abi for SHFOLDERCUSTOMSETTINGS {
 }
 impl ::core::cmp::PartialEq for SHFOLDERCUSTOMSETTINGS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHFOLDERCUSTOMSETTINGS>()) == 0 }
+        self.dwSize == other.dwSize && self.dwMask == other.dwMask && self.pvid == other.pvid && self.pszWebViewTemplate == other.pszWebViewTemplate && self.cchWebViewTemplate == other.cchWebViewTemplate && self.pszWebViewTemplateVersion == other.pszWebViewTemplateVersion && self.pszInfoTip == other.pszInfoTip && self.cchInfoTip == other.cchInfoTip && self.pclsid == other.pclsid && self.dwFlags == other.dwFlags && self.pszIconFile == other.pszIconFile && self.cchIconFile == other.cchIconFile && self.iIconIndex == other.iIconIndex && self.pszLogo == other.pszLogo && self.cchLogo == other.cchLogo
     }
 }
 impl ::core::cmp::Eq for SHFOLDERCUSTOMSETTINGS {}
@@ -62706,14 +62065,6 @@ unsafe impl ::windows::core::Abi for SHNAMEMAPPINGA {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SHNAMEMAPPINGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHNAMEMAPPINGA>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SHNAMEMAPPINGA {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SHNAMEMAPPINGA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62741,14 +62092,6 @@ unsafe impl ::windows::core::Abi for SHNAMEMAPPINGA {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SHNAMEMAPPINGA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHNAMEMAPPINGA>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SHNAMEMAPPINGA {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SHNAMEMAPPINGA {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62776,14 +62119,6 @@ unsafe impl ::windows::core::Abi for SHNAMEMAPPINGW {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SHNAMEMAPPINGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHNAMEMAPPINGW>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SHNAMEMAPPINGW {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SHNAMEMAPPINGW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62811,14 +62146,6 @@ unsafe impl ::windows::core::Abi for SHNAMEMAPPINGW {
     type Abi = Self;
 }
 #[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SHNAMEMAPPINGW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHNAMEMAPPINGW>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SHNAMEMAPPINGW {}
-#[cfg(target_arch = "x86")]
 impl ::core::default::Default for SHNAMEMAPPINGW {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62845,14 +62172,6 @@ unsafe impl ::windows::core::Abi for SHQUERYRBINFO {
     type Abi = Self;
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::PartialEq for SHQUERYRBINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHQUERYRBINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-impl ::core::cmp::Eq for SHQUERYRBINFO {}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl ::core::default::Default for SHQUERYRBINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -62878,14 +62197,6 @@ impl ::core::clone::Clone for SHQUERYRBINFO {
 unsafe impl ::windows::core::Abi for SHQUERYRBINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::PartialEq for SHQUERYRBINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHQUERYRBINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-impl ::core::cmp::Eq for SHQUERYRBINFO {}
 #[cfg(target_arch = "x86")]
 impl ::core::default::Default for SHQUERYRBINFO {
     fn default() -> Self {
@@ -62918,16 +62229,6 @@ impl ::core::clone::Clone for SHSTOCKICONINFO {
 unsafe impl ::windows::core::Abi for SHSTOCKICONINFO {
     type Abi = Self;
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for SHSTOCKICONINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHSTOCKICONINFO>()) == 0 }
-    }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for SHSTOCKICONINFO {}
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for SHSTOCKICONINFO {
@@ -62961,16 +62262,6 @@ impl ::core::clone::Clone for SHSTOCKICONINFO {
 unsafe impl ::windows::core::Abi for SHSTOCKICONINFO {
     type Abi = Self;
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::PartialEq for SHSTOCKICONINFO {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHSTOCKICONINFO>()) == 0 }
-    }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl ::core::cmp::Eq for SHSTOCKICONINFO {}
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::default::Default for SHSTOCKICONINFO {
@@ -63008,7 +62299,7 @@ unsafe impl ::windows::core::Abi for SLOWAPPINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SLOWAPPINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SLOWAPPINFO>()) == 0 }
+        self.ullSize == other.ullSize && self.ftLastUsed == other.ftLastUsed && self.iTimesUsed == other.iTimesUsed && self.pszImage == other.pszImage
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -63048,7 +62339,7 @@ unsafe impl ::windows::core::Abi for SMCSHCHANGENOTIFYSTRUCT {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ::core::cmp::PartialEq for SMCSHCHANGENOTIFYSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMCSHCHANGENOTIFYSTRUCT>()) == 0 }
+        self.lEvent == other.lEvent && self.pidl1 == other.pidl1 && self.pidl2 == other.pidl2
     }
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -63143,7 +62434,7 @@ unsafe impl ::windows::core::Abi for SMINFO {
 }
 impl ::core::cmp::PartialEq for SMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SMINFO>()) == 0 }
+        self.dwMask == other.dwMask && self.dwType == other.dwType && self.dwFlags == other.dwFlags && self.iIcon == other.iIcon
     }
 }
 impl ::core::cmp::Eq for SMINFO {}
@@ -63180,7 +62471,7 @@ unsafe impl ::windows::core::Abi for SORTCOLUMN {
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ::core::cmp::PartialEq for SORTCOLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SORTCOLUMN>()) == 0 }
+        self.propkey == other.propkey && self.direction == other.direction
     }
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -63271,7 +62562,7 @@ unsafe impl ::windows::core::Abi for SYNCMGRHANDLERINFO {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for SYNCMGRHANDLERINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNCMGRHANDLERINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hIcon == other.hIcon && self.SyncMgrHandlerFlags == other.SyncMgrHandlerFlags && self.wszHandlerName == other.wszHandlerName
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -63315,7 +62606,7 @@ unsafe impl ::windows::core::Abi for SYNCMGRITEM {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ::core::cmp::PartialEq for SYNCMGRITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNCMGRITEM>()) == 0 }
+        self.cbSize == other.cbSize && self.dwFlags == other.dwFlags && self.ItemID == other.ItemID && self.dwItemState == other.dwItemState && self.hIcon == other.hIcon && self.wszItemName == other.wszItemName && self.ftLastUpdate == other.ftLastUpdate
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -63351,7 +62642,7 @@ unsafe impl ::windows::core::Abi for SYNCMGRLOGERRORINFO {
 }
 impl ::core::cmp::PartialEq for SYNCMGRLOGERRORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNCMGRLOGERRORINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.mask == other.mask && self.dwSyncMgrErrorFlags == other.dwSyncMgrErrorFlags && self.ErrorID == other.ErrorID && self.ItemID == other.ItemID
     }
 }
 impl ::core::cmp::Eq for SYNCMGRLOGERRORINFO {}
@@ -63386,7 +62677,7 @@ unsafe impl ::windows::core::Abi for SYNCMGRPROGRESSITEM {
 }
 impl ::core::cmp::PartialEq for SYNCMGRPROGRESSITEM {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNCMGRPROGRESSITEM>()) == 0 }
+        self.cbSize == other.cbSize && self.mask == other.mask && self.lpcStatusText == other.lpcStatusText && self.dwStatusType == other.dwStatusType && self.iProgValue == other.iProgValue && self.iMaxValue == other.iMaxValue
     }
 }
 impl ::core::cmp::Eq for SYNCMGRPROGRESSITEM {}
@@ -63423,7 +62714,7 @@ unsafe impl ::windows::core::Abi for SYNCMGR_CONFLICT_ID_INFO {
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::cmp::PartialEq for SYNCMGR_CONFLICT_ID_INFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYNCMGR_CONFLICT_ID_INFO>()) == 0 }
+        self.pblobID == other.pblobID && self.pblobExtra == other.pblobExtra
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -63488,7 +62779,7 @@ unsafe impl ::windows::core::Abi for TBINFO {
 }
 impl ::core::cmp::PartialEq for TBINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TBINFO>()) == 0 }
+        self.cbuttons == other.cbuttons && self.uFlags == other.uFlags
     }
 }
 impl ::core::cmp::Eq for TBINFO {}
@@ -63529,7 +62820,7 @@ unsafe impl ::windows::core::Abi for THUMBBUTTON {
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ::core::cmp::PartialEq for THUMBBUTTON {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<THUMBBUTTON>()) == 0 }
+        self.dwMask == other.dwMask && self.iId == other.iId && self.iBitmap == other.iBitmap && self.hIcon == other.hIcon && self.szTip == other.szTip && self.dwFlags == other.dwFlags
     }
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -63610,7 +62901,7 @@ unsafe impl ::windows::core::Abi for URLINVOKECOMMANDINFOA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for URLINVOKECOMMANDINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URLINVOKECOMMANDINFOA>()) == 0 }
+        self.dwcbSize == other.dwcbSize && self.dwFlags == other.dwFlags && self.hwndParent == other.hwndParent && self.pcszVerb == other.pcszVerb
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -63651,7 +62942,7 @@ unsafe impl ::windows::core::Abi for URLINVOKECOMMANDINFOW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for URLINVOKECOMMANDINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<URLINVOKECOMMANDINFOW>()) == 0 }
+        self.dwcbSize == other.dwcbSize && self.dwFlags == other.dwFlags && self.hwndParent == other.hwndParent && self.pcszVerb == other.pcszVerb
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -63694,7 +62985,7 @@ unsafe impl ::windows::core::Abi for WINDOWDATA {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ::core::cmp::PartialEq for WINDOWDATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWDATA>()) == 0 }
+        self.dwWindowID == other.dwWindowID && self.uiCP == other.uiCP && self.pidl == other.pidl && self.lpszUrl == other.lpszUrl && self.lpszUrlLocation == other.lpszUrlLocation && self.lpszTitle == other.lpszTitle
     }
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -63726,7 +63017,7 @@ unsafe impl ::windows::core::Abi for WTS_THUMBNAILID {
 }
 impl ::core::cmp::PartialEq for WTS_THUMBNAILID {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WTS_THUMBNAILID>()) == 0 }
+        self.rgbKey == other.rgbKey
     }
 }
 impl ::core::cmp::Eq for WTS_THUMBNAILID {}

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -13736,7 +13736,7 @@ unsafe impl ::windows::core::Abi for CHARACTER_RANGE {
 }
 impl ::core::cmp::PartialEq for CHARACTER_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHARACTER_RANGE>()) == 0 }
+        self.wcLow == other.wcLow && self.cChars == other.cChars
     }
 }
 impl ::core::cmp::Eq for CHARACTER_RANGE {}
@@ -13796,7 +13796,7 @@ unsafe impl ::windows::core::Abi for FLICK_DATA {
 }
 impl ::core::cmp::PartialEq for FLICK_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLICK_DATA>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for FLICK_DATA {}
@@ -13826,7 +13826,7 @@ unsafe impl ::windows::core::Abi for FLICK_POINT {
 }
 impl ::core::cmp::PartialEq for FLICK_POINT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLICK_POINT>()) == 0 }
+        self._bitfield == other._bitfield
     }
 }
 impl ::core::cmp::Eq for FLICK_POINT {}
@@ -13858,7 +13858,7 @@ unsafe impl ::windows::core::Abi for GESTURE_DATA {
 }
 impl ::core::cmp::PartialEq for GESTURE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GESTURE_DATA>()) == 0 }
+        self.gestureId == other.gestureId && self.recoConfidence == other.recoConfidence && self.strokeCount == other.strokeCount
     }
 }
 impl ::core::cmp::Eq for GESTURE_DATA {}
@@ -14047,14 +14047,6 @@ unsafe impl ::windows::core::Abi for IEC_GESTUREINFO {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::PartialEq for IEC_GESTUREINFO {
-    fn eq(&self, other: &Self) -> bool {
-        self.nmhdr == other.nmhdr && self.Cursor == other.Cursor && self.Strokes == other.Strokes && self.Gestures == other.Gestures
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls"))]
-impl ::core::cmp::Eq for IEC_GESTUREINFO {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls"))]
 impl ::core::default::Default for IEC_GESTUREINFO {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -14166,7 +14158,7 @@ unsafe impl ::windows::core::Abi for INKMETRIC {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for INKMETRIC {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<INKMETRIC>()) == 0 }
+        self.iHeight == other.iHeight && self.iFontAscent == other.iFontAscent && self.iFontDescent == other.iFontDescent && self.dwFlags == other.dwFlags && self.color == other.color
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14208,7 +14200,7 @@ unsafe impl ::windows::core::Abi for InkRecoGuide {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for InkRecoGuide {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<InkRecoGuide>()) == 0 }
+        self.rectWritingBox == other.rectWritingBox && self.rectDrawnBox == other.rectDrawnBox && self.cRows == other.cRows && self.cColumns == other.cColumns && self.midline == other.midline
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14247,7 +14239,7 @@ unsafe impl ::windows::core::Abi for LATTICE_METRICS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LATTICE_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LATTICE_METRICS>()) == 0 }
+        self.lsBaseline == other.lsBaseline && self.iMidlineOffset == other.iMidlineOffset
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14286,7 +14278,7 @@ unsafe impl ::windows::core::Abi for LINE_SEGMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for LINE_SEGMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<LINE_SEGMENT>()) == 0 }
+        self.PtA == other.PtA && self.PtB == other.PtB
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -14322,7 +14314,7 @@ unsafe impl ::windows::core::Abi for PACKET_DESCRIPTION {
 }
 impl ::core::cmp::PartialEq for PACKET_DESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKET_DESCRIPTION>()) == 0 }
+        self.cbPacketSize == other.cbPacketSize && self.cPacketProperties == other.cPacketProperties && self.pPacketProperties == other.pPacketProperties && self.cButtons == other.cButtons && self.pguidButtons == other.pguidButtons
     }
 }
 impl ::core::cmp::Eq for PACKET_DESCRIPTION {}
@@ -14353,7 +14345,7 @@ unsafe impl ::windows::core::Abi for PACKET_PROPERTY {
 }
 impl ::core::cmp::PartialEq for PACKET_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PACKET_PROPERTY>()) == 0 }
+        self.guid == other.guid && self.PropertyMetrics == other.PropertyMetrics
     }
 }
 impl ::core::cmp::Eq for PACKET_PROPERTY {}
@@ -14386,7 +14378,7 @@ unsafe impl ::windows::core::Abi for PROPERTY_METRICS {
 }
 impl ::core::cmp::PartialEq for PROPERTY_METRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<PROPERTY_METRICS>()) == 0 }
+        self.nLogicalMin == other.nLogicalMin && self.nLogicalMax == other.nLogicalMax && self.Units == other.Units && self.fResolution == other.fResolution
     }
 }
 impl ::core::cmp::Eq for PROPERTY_METRICS {}
@@ -14419,7 +14411,7 @@ unsafe impl ::windows::core::Abi for RECO_ATTRS {
 }
 impl ::core::cmp::PartialEq for RECO_ATTRS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_ATTRS>()) == 0 }
+        self.dwRecoCapabilityFlags == other.dwRecoCapabilityFlags && self.awcVendorName == other.awcVendorName && self.awcFriendlyName == other.awcFriendlyName && self.awLanguageId == other.awLanguageId
     }
 }
 impl ::core::cmp::Eq for RECO_ATTRS {}
@@ -14457,7 +14449,7 @@ unsafe impl ::windows::core::Abi for RECO_GUIDE {
 }
 impl ::core::cmp::PartialEq for RECO_GUIDE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_GUIDE>()) == 0 }
+        self.xOrigin == other.xOrigin && self.yOrigin == other.yOrigin && self.cxBox == other.cxBox && self.cyBox == other.cyBox && self.cxBase == other.cxBase && self.cyBase == other.cyBase && self.cHorzBox == other.cHorzBox && self.cVertBox == other.cVertBox && self.cyMid == other.cyMid
     }
 }
 impl ::core::cmp::Eq for RECO_GUIDE {}
@@ -14493,7 +14485,7 @@ unsafe impl ::windows::core::Abi for RECO_LATTICE {
 }
 impl ::core::cmp::PartialEq for RECO_LATTICE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_LATTICE>()) == 0 }
+        self.ulColumnCount == other.ulColumnCount && self.pLatticeColumns == other.pLatticeColumns && self.ulPropertyCount == other.ulPropertyCount && self.pGuidProperties == other.pGuidProperties && self.ulBestResultColumnCount == other.ulBestResultColumnCount && self.pulBestResultColumns == other.pulBestResultColumns && self.pulBestResultIndexes == other.pulBestResultIndexes
     }
 }
 impl ::core::cmp::Eq for RECO_LATTICE {}
@@ -14528,7 +14520,7 @@ unsafe impl ::windows::core::Abi for RECO_LATTICE_COLUMN {
 }
 impl ::core::cmp::PartialEq for RECO_LATTICE_COLUMN {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_LATTICE_COLUMN>()) == 0 }
+        self.key == other.key && self.cpProp == other.cpProp && self.cStrokes == other.cStrokes && self.pStrokes == other.pStrokes && self.cLatticeElements == other.cLatticeElements && self.pLatticeElements == other.pLatticeElements
     }
 }
 impl ::core::cmp::Eq for RECO_LATTICE_COLUMN {}
@@ -14563,7 +14555,7 @@ unsafe impl ::windows::core::Abi for RECO_LATTICE_ELEMENT {
 }
 impl ::core::cmp::PartialEq for RECO_LATTICE_ELEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_LATTICE_ELEMENT>()) == 0 }
+        self.score == other.score && self.r#type == other.r#type && self.pData == other.pData && self.ulNextColumn == other.ulNextColumn && self.ulStrokeNumber == other.ulStrokeNumber && self.epProp == other.epProp
     }
 }
 impl ::core::cmp::Eq for RECO_LATTICE_ELEMENT {}
@@ -14594,7 +14586,7 @@ unsafe impl ::windows::core::Abi for RECO_LATTICE_PROPERTIES {
 }
 impl ::core::cmp::PartialEq for RECO_LATTICE_PROPERTIES {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_LATTICE_PROPERTIES>()) == 0 }
+        self.cProperties == other.cProperties && self.apProps == other.apProps
     }
 }
 impl ::core::cmp::Eq for RECO_LATTICE_PROPERTIES {}
@@ -14626,7 +14618,7 @@ unsafe impl ::windows::core::Abi for RECO_LATTICE_PROPERTY {
 }
 impl ::core::cmp::PartialEq for RECO_LATTICE_PROPERTY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_LATTICE_PROPERTY>()) == 0 }
+        self.guidProperty == other.guidProperty && self.cbPropertyValue == other.cbPropertyValue && self.pPropertyValue == other.pPropertyValue
     }
 }
 impl ::core::cmp::Eq for RECO_LATTICE_PROPERTY {}
@@ -14657,7 +14649,7 @@ unsafe impl ::windows::core::Abi for RECO_RANGE {
 }
 impl ::core::cmp::PartialEq for RECO_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<RECO_RANGE>()) == 0 }
+        self.iwcBegin == other.iwcBegin && self.cCount == other.cCount
     }
 }
 impl ::core::cmp::Eq for RECO_RANGE {}
@@ -14688,7 +14680,7 @@ unsafe impl ::windows::core::Abi for STROKE_RANGE {
 }
 impl ::core::cmp::PartialEq for STROKE_RANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STROKE_RANGE>()) == 0 }
+        self.iStrokeBegin == other.iStrokeBegin && self.iStrokeEnd == other.iStrokeEnd
     }
 }
 impl ::core::cmp::Eq for STROKE_RANGE {}
@@ -14723,7 +14715,7 @@ unsafe impl ::windows::core::Abi for SYSTEM_EVENT_DATA {
 }
 impl ::core::cmp::PartialEq for SYSTEM_EVENT_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SYSTEM_EVENT_DATA>()) == 0 }
+        self.bModifier == other.bModifier && self.wKey == other.wKey && self.xPos == other.xPos && self.yPos == other.yPos && self.bCursorMode == other.bCursorMode && self.dwButtonState == other.dwButtonState
     }
 }
 impl ::core::cmp::Eq for SYSTEM_EVENT_DATA {}
@@ -14761,7 +14753,7 @@ unsafe impl ::windows::core::Abi for StylusInfo {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for StylusInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<StylusInfo>()) == 0 }
+        self.tcid == other.tcid && self.cid == other.cid && self.bIsInvertedCursor == other.bIsInvertedCursor
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -11961,14 +11961,6 @@ unsafe impl ::windows::core::Abi for TF_DA_COLOR {
     type Abi = Self;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TF_DA_COLOR {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_DA_COLOR>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TF_DA_COLOR {}
-#[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TF_DA_COLOR {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11993,14 +11985,6 @@ impl ::core::clone::Clone for TF_DA_COLOR_0 {
 unsafe impl ::windows::core::Abi for TF_DA_COLOR_0 {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TF_DA_COLOR_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_DA_COLOR_0>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TF_DA_COLOR_0 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TF_DA_COLOR_0 {
     fn default() -> Self {
@@ -12030,14 +12014,6 @@ impl ::core::clone::Clone for TF_DISPLAYATTRIBUTE {
 unsafe impl ::windows::core::Abi for TF_DISPLAYATTRIBUTE {
     type Abi = Self;
 }
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::PartialEq for TF_DISPLAYATTRIBUTE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_DISPLAYATTRIBUTE>()) == 0 }
-    }
-}
-#[cfg(feature = "Win32_Foundation")]
-impl ::core::cmp::Eq for TF_DISPLAYATTRIBUTE {}
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::default::Default for TF_DISPLAYATTRIBUTE {
     fn default() -> Self {
@@ -12104,7 +12080,7 @@ unsafe impl ::windows::core::Abi for TF_INPUTPROCESSORPROFILE {
 }
 impl ::core::cmp::PartialEq for TF_INPUTPROCESSORPROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_INPUTPROCESSORPROFILE>()) == 0 }
+        self.dwProfileType == other.dwProfileType && self.langid == other.langid && self.clsid == other.clsid && self.guidProfile == other.guidProfile && self.catid == other.catid && self.hklSubstitute == other.hklSubstitute && self.dwCaps == other.dwCaps && self.hkl == other.hkl && self.dwFlags == other.dwFlags
     }
 }
 impl ::core::cmp::Eq for TF_INPUTPROCESSORPROFILE {}
@@ -12138,7 +12114,7 @@ unsafe impl ::windows::core::Abi for TF_LANGBARITEMINFO {
 }
 impl ::core::cmp::PartialEq for TF_LANGBARITEMINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_LANGBARITEMINFO>()) == 0 }
+        self.clsidService == other.clsidService && self.guidItem == other.guidItem && self.dwStyle == other.dwStyle && self.ulSort == other.ulSort && self.szDescription == other.szDescription
     }
 }
 impl ::core::cmp::Eq for TF_LANGBARITEMINFO {}
@@ -12178,7 +12154,7 @@ unsafe impl ::windows::core::Abi for TF_LANGUAGEPROFILE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TF_LANGUAGEPROFILE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_LANGUAGEPROFILE>()) == 0 }
+        self.clsid == other.clsid && self.langid == other.langid && self.catid == other.catid && self.fActive == other.fActive && self.guidProfile == other.guidProfile
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12236,12 +12212,6 @@ impl ::core::clone::Clone for TF_LMLATTELEMENT {
 unsafe impl ::windows::core::Abi for TF_LMLATTELEMENT {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-impl ::core::cmp::PartialEq for TF_LMLATTELEMENT {
-    fn eq(&self, other: &Self) -> bool {
-        self.dwFrameStart == other.dwFrameStart && self.dwFrameLen == other.dwFrameLen && self.dwFlags == other.dwFlags && self.Anonymous == other.Anonymous && self.bstrText == other.bstrText
-    }
-}
-impl ::core::cmp::Eq for TF_LMLATTELEMENT {}
 impl ::core::default::Default for TF_LMLATTELEMENT {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12261,12 +12231,6 @@ impl ::core::clone::Clone for TF_LMLATTELEMENT_0 {
 unsafe impl ::windows::core::Abi for TF_LMLATTELEMENT_0 {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TF_LMLATTELEMENT_0 {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_LMLATTELEMENT_0>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for TF_LMLATTELEMENT_0 {}
 impl ::core::default::Default for TF_LMLATTELEMENT_0 {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12298,7 +12262,7 @@ unsafe impl ::windows::core::Abi for TF_PERSISTENT_PROPERTY_HEADER_ACP {
 }
 impl ::core::cmp::PartialEq for TF_PERSISTENT_PROPERTY_HEADER_ACP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_PERSISTENT_PROPERTY_HEADER_ACP>()) == 0 }
+        self.guidType == other.guidType && self.ichStart == other.ichStart && self.cch == other.cch && self.cb == other.cb && self.dwPrivate == other.dwPrivate && self.clsidTIP == other.clsidTIP
     }
 }
 impl ::core::cmp::Eq for TF_PERSISTENT_PROPERTY_HEADER_ACP {}
@@ -12329,7 +12293,7 @@ unsafe impl ::windows::core::Abi for TF_PRESERVEDKEY {
 }
 impl ::core::cmp::PartialEq for TF_PRESERVEDKEY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_PRESERVEDKEY>()) == 0 }
+        self.uVKey == other.uVKey && self.uModifiers == other.uModifiers
     }
 }
 impl ::core::cmp::Eq for TF_PRESERVEDKEY {}
@@ -12355,14 +12319,6 @@ impl ::core::clone::Clone for TF_PROPERTYVAL {
 unsafe impl ::windows::core::Abi for TF_PROPERTYVAL {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for TF_PROPERTYVAL {
-    fn eq(&self, other: &Self) -> bool {
-        self.guidId == other.guidId && self.varValue == other.varValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for TF_PROPERTYVAL {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for TF_PROPERTYVAL {
     fn default() -> Self {
@@ -12434,7 +12390,7 @@ unsafe impl ::windows::core::Abi for TF_SELECTIONSTYLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TF_SELECTIONSTYLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TF_SELECTIONSTYLE>()) == 0 }
+        self.ase == other.ase && self.fInterimChar == other.fInterimChar
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12464,14 +12420,6 @@ unsafe impl ::windows::core::Abi for TS_ATTRVAL {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::PartialEq for TS_ATTRVAL {
-    fn eq(&self, other: &Self) -> bool {
-        self.idAttr == other.idAttr && self.dwOverlapId == other.dwOverlapId && self.varValue == other.varValue
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl ::core::cmp::Eq for TS_ATTRVAL {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ::core::default::Default for TS_ATTRVAL {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -12499,7 +12447,7 @@ unsafe impl ::windows::core::Abi for TS_RUNINFO {
 }
 impl ::core::cmp::PartialEq for TS_RUNINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TS_RUNINFO>()) == 0 }
+        self.uCount == other.uCount && self.r#type == other.r#type
     }
 }
 impl ::core::cmp::Eq for TS_RUNINFO {}
@@ -12536,7 +12484,7 @@ unsafe impl ::windows::core::Abi for TS_SELECTIONSTYLE {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TS_SELECTIONSTYLE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TS_SELECTIONSTYLE>()) == 0 }
+        self.ase == other.ase && self.fInterimChar == other.fInterimChar
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12576,7 +12524,7 @@ unsafe impl ::windows::core::Abi for TS_SELECTION_ACP {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TS_SELECTION_ACP {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TS_SELECTION_ACP>()) == 0 }
+        self.acpStart == other.acpStart && self.acpEnd == other.acpEnd && self.style == other.style
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12647,7 +12595,7 @@ unsafe impl ::windows::core::Abi for TS_STATUS {
 }
 impl ::core::cmp::PartialEq for TS_STATUS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TS_STATUS>()) == 0 }
+        self.dwDynamicFlags == other.dwDynamicFlags && self.dwStaticFlags == other.dwStaticFlags
     }
 }
 impl ::core::cmp::Eq for TS_STATUS {}
@@ -12679,7 +12627,7 @@ unsafe impl ::windows::core::Abi for TS_TEXTCHANGE {
 }
 impl ::core::cmp::PartialEq for TS_TEXTCHANGE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TS_TEXTCHANGE>()) == 0 }
+        self.acpStart == other.acpStart && self.acpOldEnd == other.acpOldEnd && self.acpNewEnd == other.acpNewEnd
     }
 }
 impl ::core::cmp::Eq for TS_TEXTCHANGE {}

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -10787,7 +10787,7 @@ unsafe impl ::windows::core::Abi for ACCEL {
 }
 impl ::core::cmp::PartialEq for ACCEL {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ACCEL>()) == 0 }
+        self.fVirt == other.fVirt && self.key == other.key && self.cmd == other.cmd
     }
 }
 impl ::core::cmp::Eq for ACCEL {}
@@ -10831,7 +10831,7 @@ unsafe impl ::windows::core::Abi for ALTTABINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for ALTTABINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ALTTABINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.cItems == other.cItems && self.cColumns == other.cColumns && self.cRows == other.cRows && self.iColFocus == other.iColFocus && self.iRowFocus == other.iRowFocus && self.cxItem == other.cxItem && self.cyItem == other.cyItem && self.ptStart == other.ptStart
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10864,7 +10864,7 @@ unsafe impl ::windows::core::Abi for ANIMATIONINFO {
 }
 impl ::core::cmp::PartialEq for ANIMATIONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ANIMATIONINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.iMinAnimate == other.iMinAnimate
     }
 }
 impl ::core::cmp::Eq for ANIMATIONINFO {}
@@ -10902,7 +10902,7 @@ unsafe impl ::windows::core::Abi for AUDIODESCRIPTION {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for AUDIODESCRIPTION {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<AUDIODESCRIPTION>()) == 0 }
+        self.cbSize == other.cbSize && self.Enabled == other.Enabled && self.Locale == other.Locale
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10941,7 +10941,7 @@ unsafe impl ::windows::core::Abi for CBTACTIVATESTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CBTACTIVATESTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CBTACTIVATESTRUCT>()) == 0 }
+        self.fMouse == other.fMouse && self.hWndActive == other.hWndActive
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -10980,7 +10980,7 @@ unsafe impl ::windows::core::Abi for CBT_CREATEWNDA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CBT_CREATEWNDA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CBT_CREATEWNDA>()) == 0 }
+        self.lpcs == other.lpcs && self.hwndInsertAfter == other.hwndInsertAfter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11019,7 +11019,7 @@ unsafe impl ::windows::core::Abi for CBT_CREATEWNDW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CBT_CREATEWNDW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CBT_CREATEWNDW>()) == 0 }
+        self.lpcs == other.lpcs && self.hwndInsertAfter == other.hwndInsertAfter
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11052,7 +11052,7 @@ unsafe impl ::windows::core::Abi for CHANGEFILTERSTRUCT {
 }
 impl ::core::cmp::PartialEq for CHANGEFILTERSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CHANGEFILTERSTRUCT>()) == 0 }
+        self.cbSize == other.cbSize && self.ExtStatus == other.ExtStatus
     }
 }
 impl ::core::cmp::Eq for CHANGEFILTERSTRUCT {}
@@ -11089,7 +11089,7 @@ unsafe impl ::windows::core::Abi for CLIENTCREATESTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CLIENTCREATESTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CLIENTCREATESTRUCT>()) == 0 }
+        self.hWindowMenu == other.hWindowMenu && self.idFirstChild == other.idFirstChild
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11138,7 +11138,7 @@ unsafe impl ::windows::core::Abi for CREATESTRUCTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREATESTRUCTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATESTRUCTA>()) == 0 }
+        self.lpCreateParams == other.lpCreateParams && self.hInstance == other.hInstance && self.hMenu == other.hMenu && self.hwndParent == other.hwndParent && self.cy == other.cy && self.cx == other.cx && self.y == other.y && self.x == other.x && self.style == other.style && self.lpszName == other.lpszName && self.lpszClass == other.lpszClass && self.dwExStyle == other.dwExStyle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11187,7 +11187,7 @@ unsafe impl ::windows::core::Abi for CREATESTRUCTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CREATESTRUCTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CREATESTRUCTW>()) == 0 }
+        self.lpCreateParams == other.lpCreateParams && self.hInstance == other.hInstance && self.hMenu == other.hMenu && self.hwndParent == other.hwndParent && self.cy == other.cy && self.cx == other.cx && self.y == other.y && self.x == other.x && self.style == other.style && self.lpszName == other.lpszName && self.lpszClass == other.lpszClass && self.dwExStyle == other.dwExStyle
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11228,7 +11228,7 @@ unsafe impl ::windows::core::Abi for CURSORINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CURSORINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CURSORINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.flags == other.flags && self.hCursor == other.hCursor && self.ptScreenPos == other.ptScreenPos
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11266,7 +11266,7 @@ unsafe impl ::windows::core::Abi for CURSORSHAPE {
 }
 impl ::core::cmp::PartialEq for CURSORSHAPE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CURSORSHAPE>()) == 0 }
+        self.xHotSpot == other.xHotSpot && self.yHotSpot == other.yHotSpot && self.cx == other.cx && self.cy == other.cy && self.cbWidth == other.cbWidth && self.Planes == other.Planes && self.BitsPixel == other.BitsPixel
     }
 }
 impl ::core::cmp::Eq for CURSORSHAPE {}
@@ -11306,7 +11306,7 @@ unsafe impl ::windows::core::Abi for CWPRETSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CWPRETSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CWPRETSTRUCT>()) == 0 }
+        self.lResult == other.lResult && self.lParam == other.lParam && self.wParam == other.wParam && self.message == other.message && self.hwnd == other.hwnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11347,7 +11347,7 @@ unsafe impl ::windows::core::Abi for CWPSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for CWPSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<CWPSTRUCT>()) == 0 }
+        self.lParam == other.lParam && self.wParam == other.wParam && self.message == other.message && self.hwnd == other.hwnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11389,7 +11389,7 @@ unsafe impl ::windows::core::Abi for DEBUGHOOKINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DEBUGHOOKINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DEBUGHOOKINFO>()) == 0 }
+        self.idThread == other.idThread && self.idThreadInstaller == other.idThreadInstaller && self.lParam == other.lParam && self.wParam == other.wParam && self.code == other.code
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11420,12 +11420,6 @@ impl ::core::clone::Clone for DLGITEMTEMPLATE {
 unsafe impl ::windows::core::Abi for DLGITEMTEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DLGITEMTEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLGITEMTEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DLGITEMTEMPLATE {}
 impl ::core::default::Default for DLGITEMTEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11451,12 +11445,6 @@ impl ::core::clone::Clone for DLGTEMPLATE {
 unsafe impl ::windows::core::Abi for DLGTEMPLATE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DLGTEMPLATE {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DLGTEMPLATE>()) == 0 }
-    }
-}
-impl ::core::cmp::Eq for DLGTEMPLATE {}
 impl ::core::default::Default for DLGTEMPLATE {
     fn default() -> Self {
         unsafe { ::core::mem::zeroed() }
@@ -11494,7 +11482,7 @@ unsafe impl ::windows::core::Abi for DROPSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for DROPSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<DROPSTRUCT>()) == 0 }
+        self.hwndSource == other.hwndSource && self.hwndSink == other.hwndSink && self.wFmt == other.wFmt && self.dwData == other.dwData && self.ptDrop == other.ptDrop && self.dwControlData == other.dwControlData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11536,7 +11524,7 @@ unsafe impl ::windows::core::Abi for EVENTMSG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for EVENTMSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<EVENTMSG>()) == 0 }
+        self.message == other.message && self.paramL == other.paramL && self.paramH == other.paramH && self.time == other.time && self.hwnd == other.hwnd
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11578,7 +11566,7 @@ unsafe impl ::windows::core::Abi for FLASHWINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for FLASHWINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<FLASHWINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hwnd == other.hwnd && self.dwFlags == other.dwFlags && self.uCount == other.uCount && self.dwTimeout == other.dwTimeout
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11624,7 +11612,7 @@ unsafe impl ::windows::core::Abi for GUITHREADINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for GUITHREADINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<GUITHREADINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.flags == other.flags && self.hwndActive == other.hwndActive && self.hwndFocus == other.hwndFocus && self.hwndCapture == other.hwndCapture && self.hwndMenuOwner == other.hwndMenuOwner && self.hwndMoveSize == other.hwndMoveSize && self.hwndCaret == other.hwndCaret && self.rcCaret == other.rcCaret
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11697,7 +11685,7 @@ unsafe impl ::windows::core::Abi for HARDWAREHOOKSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for HARDWAREHOOKSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<HARDWAREHOOKSTRUCT>()) == 0 }
+        self.hwnd == other.hwnd && self.message == other.message && self.wParam == other.wParam && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -11904,7 +11892,7 @@ unsafe impl ::windows::core::Abi for ICONINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICONINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICONINFO>()) == 0 }
+        self.fIcon == other.fIcon && self.xHotspot == other.xHotspot && self.yHotspot == other.yHotspot && self.hbmMask == other.hbmMask && self.hbmColor == other.hbmColor
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11950,7 +11938,7 @@ unsafe impl ::windows::core::Abi for ICONINFOEXA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICONINFOEXA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICONINFOEXA>()) == 0 }
+        self.cbSize == other.cbSize && self.fIcon == other.fIcon && self.xHotspot == other.xHotspot && self.yHotspot == other.yHotspot && self.hbmMask == other.hbmMask && self.hbmColor == other.hbmColor && self.wResID == other.wResID && self.szModName == other.szModName && self.szResName == other.szResName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -11996,7 +11984,7 @@ unsafe impl ::windows::core::Abi for ICONINFOEXW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICONINFOEXW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICONINFOEXW>()) == 0 }
+        self.cbSize == other.cbSize && self.fIcon == other.fIcon && self.xHotspot == other.xHotspot && self.yHotspot == other.yHotspot && self.hbmMask == other.hbmMask && self.hbmColor == other.hbmColor && self.wResID == other.wResID && self.szModName == other.szModName && self.szResName == other.szResName
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -12038,7 +12026,7 @@ unsafe impl ::windows::core::Abi for ICONMETRICSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for ICONMETRICSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICONMETRICSA>()) == 0 }
+        self.cbSize == other.cbSize && self.iHorzSpacing == other.iHorzSpacing && self.iVertSpacing == other.iVertSpacing && self.iTitleWrap == other.iTitleWrap && self.lfFont == other.lfFont
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -12080,7 +12068,7 @@ unsafe impl ::windows::core::Abi for ICONMETRICSW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for ICONMETRICSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ICONMETRICSW>()) == 0 }
+        self.cbSize == other.cbSize && self.iHorzSpacing == other.iHorzSpacing && self.iVertSpacing == other.iVertSpacing && self.iTitleWrap == other.iTitleWrap && self.lfFont == other.lfFont
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12113,7 +12101,7 @@ unsafe impl ::windows::core::Abi for IndexedResourceQualifier {
 }
 impl ::core::cmp::PartialEq for IndexedResourceQualifier {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<IndexedResourceQualifier>()) == 0 }
+        self.name == other.name && self.value == other.value
     }
 }
 impl ::core::cmp::Eq for IndexedResourceQualifier {}
@@ -12147,7 +12135,7 @@ unsafe impl ::windows::core::Abi for KBDLLHOOKSTRUCT {
 }
 impl ::core::cmp::PartialEq for KBDLLHOOKSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<KBDLLHOOKSTRUCT>()) == 0 }
+        self.vkCode == other.vkCode && self.scanCode == other.scanCode && self.flags == other.flags && self.time == other.time && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 impl ::core::cmp::Eq for KBDLLHOOKSTRUCT {}
@@ -12191,7 +12179,7 @@ unsafe impl ::windows::core::Abi for MDICREATESTRUCTA {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MDICREATESTRUCTA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDICREATESTRUCTA>()) == 0 }
+        self.szClass == other.szClass && self.szTitle == other.szTitle && self.hOwner == other.hOwner && self.x == other.x && self.y == other.y && self.cx == other.cx && self.cy == other.cy && self.style == other.style && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12237,7 +12225,7 @@ unsafe impl ::windows::core::Abi for MDICREATESTRUCTW {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MDICREATESTRUCTW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDICREATESTRUCTW>()) == 0 }
+        self.szClass == other.szClass && self.szTitle == other.szTitle && self.hOwner == other.hOwner && self.x == other.x && self.y == other.y && self.cx == other.cx && self.cy == other.cy && self.style == other.style && self.lParam == other.lParam
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12277,7 +12265,7 @@ unsafe impl ::windows::core::Abi for MDINEXTMENU {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MDINEXTMENU {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MDINEXTMENU>()) == 0 }
+        self.hmenuIn == other.hmenuIn && self.hmenuNext == other.hmenuNext && self.hwndNext == other.hwndNext
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12319,7 +12307,7 @@ unsafe impl ::windows::core::Abi for MENUBARINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MENUBARINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUBARINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcBar == other.rcBar && self.hMenu == other.hMenu && self.hwndMenu == other.hwndMenu && self._bitfield == other._bitfield
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12355,7 +12343,7 @@ unsafe impl ::windows::core::Abi for MENUGETOBJECTINFO {
 }
 impl ::core::cmp::PartialEq for MENUGETOBJECTINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUGETOBJECTINFO>()) == 0 }
+        self.dwFlags == other.dwFlags && self.uPos == other.uPos && self.hmenu == other.hmenu && self.riid == other.riid && self.pvObj == other.pvObj
     }
 }
 impl ::core::cmp::Eq for MENUGETOBJECTINFO {}
@@ -12397,7 +12385,7 @@ unsafe impl ::windows::core::Abi for MENUINFO {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for MENUINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.dwStyle == other.dwStyle && self.cyMax == other.cyMax && self.hbrBack == other.hbrBack && self.dwContextHelpID == other.dwContextHelpID && self.dwMenuData == other.dwMenuData
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12446,7 +12434,7 @@ unsafe impl ::windows::core::Abi for MENUITEMINFOA {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for MENUITEMINFOA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUITEMINFOA>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.fType == other.fType && self.fState == other.fState && self.wID == other.wID && self.hSubMenu == other.hSubMenu && self.hbmpChecked == other.hbmpChecked && self.hbmpUnchecked == other.hbmpUnchecked && self.dwItemData == other.dwItemData && self.dwTypeData == other.dwTypeData && self.cch == other.cch && self.hbmpItem == other.hbmpItem
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12495,7 +12483,7 @@ unsafe impl ::windows::core::Abi for MENUITEMINFOW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for MENUITEMINFOW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUITEMINFOW>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.fType == other.fType && self.fState == other.fState && self.wID == other.wID && self.hSubMenu == other.hSubMenu && self.hbmpChecked == other.hbmpChecked && self.hbmpUnchecked == other.hbmpUnchecked && self.dwItemData == other.dwItemData && self.dwTypeData == other.dwTypeData && self.cch == other.cch && self.hbmpItem == other.hbmpItem
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12529,7 +12517,7 @@ unsafe impl ::windows::core::Abi for MENUITEMTEMPLATE {
 }
 impl ::core::cmp::PartialEq for MENUITEMTEMPLATE {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUITEMTEMPLATE>()) == 0 }
+        self.mtOption == other.mtOption && self.mtID == other.mtID && self.mtString == other.mtString
     }
 }
 impl ::core::cmp::Eq for MENUITEMTEMPLATE {}
@@ -12560,7 +12548,7 @@ unsafe impl ::windows::core::Abi for MENUITEMTEMPLATEHEADER {
 }
 impl ::core::cmp::PartialEq for MENUITEMTEMPLATEHEADER {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MENUITEMTEMPLATEHEADER>()) == 0 }
+        self.versionNumber == other.versionNumber && self.offset == other.offset
     }
 }
 impl ::core::cmp::Eq for MENUITEMTEMPLATEHEADER {}
@@ -12592,7 +12580,7 @@ unsafe impl ::windows::core::Abi for MESSAGE_RESOURCE_BLOCK {
 }
 impl ::core::cmp::PartialEq for MESSAGE_RESOURCE_BLOCK {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MESSAGE_RESOURCE_BLOCK>()) == 0 }
+        self.LowId == other.LowId && self.HighId == other.HighId && self.OffsetToEntries == other.OffsetToEntries
     }
 }
 impl ::core::cmp::Eq for MESSAGE_RESOURCE_BLOCK {}
@@ -12623,7 +12611,7 @@ unsafe impl ::windows::core::Abi for MESSAGE_RESOURCE_DATA {
 }
 impl ::core::cmp::PartialEq for MESSAGE_RESOURCE_DATA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MESSAGE_RESOURCE_DATA>()) == 0 }
+        self.NumberOfBlocks == other.NumberOfBlocks && self.Blocks == other.Blocks
     }
 }
 impl ::core::cmp::Eq for MESSAGE_RESOURCE_DATA {}
@@ -12655,7 +12643,7 @@ unsafe impl ::windows::core::Abi for MESSAGE_RESOURCE_ENTRY {
 }
 impl ::core::cmp::PartialEq for MESSAGE_RESOURCE_ENTRY {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MESSAGE_RESOURCE_ENTRY>()) == 0 }
+        self.Length == other.Length && self.Flags == other.Flags && self.Text == other.Text
     }
 }
 impl ::core::cmp::Eq for MESSAGE_RESOURCE_ENTRY {}
@@ -12689,7 +12677,7 @@ unsafe impl ::windows::core::Abi for MINIMIZEDMETRICS {
 }
 impl ::core::cmp::PartialEq for MINIMIZEDMETRICS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINIMIZEDMETRICS>()) == 0 }
+        self.cbSize == other.cbSize && self.iWidth == other.iWidth && self.iHorzGap == other.iHorzGap && self.iVertGap == other.iVertGap && self.iArrange == other.iArrange
     }
 }
 impl ::core::cmp::Eq for MINIMIZEDMETRICS {}
@@ -12729,7 +12717,7 @@ unsafe impl ::windows::core::Abi for MINMAXINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MINMAXINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MINMAXINFO>()) == 0 }
+        self.ptReserved == other.ptReserved && self.ptMaxSize == other.ptMaxSize && self.ptMaxPosition == other.ptMaxPosition && self.ptMinTrackSize == other.ptMinTrackSize && self.ptMaxTrackSize == other.ptMaxTrackSize
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12770,7 +12758,7 @@ unsafe impl ::windows::core::Abi for MOUSEHOOKSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOUSEHOOKSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSEHOOKSTRUCT>()) == 0 }
+        self.pt == other.pt && self.hwnd == other.hwnd && self.wHitTestCode == other.wHitTestCode && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12809,7 +12797,7 @@ unsafe impl ::windows::core::Abi for MOUSEHOOKSTRUCTEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MOUSEHOOKSTRUCTEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MOUSEHOOKSTRUCTEX>()) == 0 }
+        self.Base == other.Base && self.mouseData == other.mouseData
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12852,7 +12840,7 @@ unsafe impl ::windows::core::Abi for MSG {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSG {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSG>()) == 0 }
+        self.hwnd == other.hwnd && self.message == other.message && self.wParam == other.wParam && self.lParam == other.lParam && self.time == other.time && self.pt == other.pt
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -12889,21 +12877,13 @@ impl ::core::clone::Clone for MSGBOXPARAMSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::fmt::Debug for MSGBOXPARAMSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MSGBOXPARAMSA").field("cbSize", &self.cbSize).field("hwndOwner", &self.hwndOwner).field("hInstance", &self.hInstance).field("lpszText", &self.lpszText).field("lpszCaption", &self.lpszCaption).field("dwStyle", &self.dwStyle).field("lpszIcon", &self.lpszIcon).field("dwContextHelpId", &self.dwContextHelpId).field("lpfnMsgBoxCallback", &self.lpfnMsgBoxCallback.map(|f| f as usize)).field("dwLanguageId", &self.dwLanguageId).finish()
+        f.debug_struct("MSGBOXPARAMSA").field("cbSize", &self.cbSize).field("hwndOwner", &self.hwndOwner).field("hInstance", &self.hInstance).field("lpszText", &self.lpszText).field("lpszCaption", &self.lpszCaption).field("dwStyle", &self.dwStyle).field("lpszIcon", &self.lpszIcon).field("dwContextHelpId", &self.dwContextHelpId).field("dwLanguageId", &self.dwLanguageId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 unsafe impl ::windows::core::Abi for MSGBOXPARAMSA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::PartialEq for MSGBOXPARAMSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSGBOXPARAMSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::Eq for MSGBOXPARAMSA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::default::Default for MSGBOXPARAMSA {
     fn default() -> Self {
@@ -12936,21 +12916,13 @@ impl ::core::clone::Clone for MSGBOXPARAMSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::fmt::Debug for MSGBOXPARAMSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("MSGBOXPARAMSW").field("cbSize", &self.cbSize).field("hwndOwner", &self.hwndOwner).field("hInstance", &self.hInstance).field("lpszText", &self.lpszText).field("lpszCaption", &self.lpszCaption).field("dwStyle", &self.dwStyle).field("lpszIcon", &self.lpszIcon).field("dwContextHelpId", &self.dwContextHelpId).field("lpfnMsgBoxCallback", &self.lpfnMsgBoxCallback.map(|f| f as usize)).field("dwLanguageId", &self.dwLanguageId).finish()
+        f.debug_struct("MSGBOXPARAMSW").field("cbSize", &self.cbSize).field("hwndOwner", &self.hwndOwner).field("hInstance", &self.hInstance).field("lpszText", &self.lpszText).field("lpszCaption", &self.lpszCaption).field("dwStyle", &self.dwStyle).field("lpszIcon", &self.lpszIcon).field("dwContextHelpId", &self.dwContextHelpId).field("dwLanguageId", &self.dwLanguageId).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 unsafe impl ::windows::core::Abi for MSGBOXPARAMSW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::PartialEq for MSGBOXPARAMSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSGBOXPARAMSW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
-impl ::core::cmp::Eq for MSGBOXPARAMSW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell"))]
 impl ::core::default::Default for MSGBOXPARAMSW {
     fn default() -> Self {
@@ -12988,7 +12960,7 @@ unsafe impl ::windows::core::Abi for MSLLHOOKSTRUCT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for MSLLHOOKSTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MSLLHOOKSTRUCT>()) == 0 }
+        self.pt == other.pt && self.mouseData == other.mouseData && self.flags == other.flags && self.time == other.time && self.dwExtraInfo == other.dwExtraInfo
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13020,7 +12992,7 @@ unsafe impl ::windows::core::Abi for MrmResourceIndexerHandle {
 }
 impl ::core::cmp::PartialEq for MrmResourceIndexerHandle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MrmResourceIndexerHandle>()) == 0 }
+        self.handle == other.handle
     }
 }
 impl ::core::cmp::Eq for MrmResourceIndexerHandle {}
@@ -13052,7 +13024,7 @@ unsafe impl ::windows::core::Abi for MrmResourceIndexerMessage {
 }
 impl ::core::cmp::PartialEq for MrmResourceIndexerMessage {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MrmResourceIndexerMessage>()) == 0 }
+        self.severity == other.severity && self.id == other.id && self.text == other.text
     }
 }
 impl ::core::cmp::Eq for MrmResourceIndexerMessage {}
@@ -13089,7 +13061,7 @@ unsafe impl ::windows::core::Abi for NCCALCSIZE_PARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for NCCALCSIZE_PARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NCCALCSIZE_PARAMS>()) == 0 }
+        self.rgrc == other.rgrc && self.lppos == other.lppos
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13159,7 +13131,7 @@ unsafe impl ::windows::core::Abi for NONCLIENTMETRICSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for NONCLIENTMETRICSA {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NONCLIENTMETRICSA>()) == 0 }
+        self.cbSize == other.cbSize && self.iBorderWidth == other.iBorderWidth && self.iScrollWidth == other.iScrollWidth && self.iScrollHeight == other.iScrollHeight && self.iCaptionWidth == other.iCaptionWidth && self.iCaptionHeight == other.iCaptionHeight && self.lfCaptionFont == other.lfCaptionFont && self.iSmCaptionWidth == other.iSmCaptionWidth && self.iSmCaptionHeight == other.iSmCaptionHeight && self.lfSmCaptionFont == other.lfSmCaptionFont && self.iMenuWidth == other.iMenuWidth && self.iMenuHeight == other.iMenuHeight && self.lfMenuFont == other.lfMenuFont && self.lfStatusFont == other.lfStatusFont && self.lfMessageFont == other.lfMessageFont && self.iPaddedBorderWidth == other.iPaddedBorderWidth
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13229,7 +13201,7 @@ unsafe impl ::windows::core::Abi for NONCLIENTMETRICSW {
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl ::core::cmp::PartialEq for NONCLIENTMETRICSW {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<NONCLIENTMETRICSW>()) == 0 }
+        self.cbSize == other.cbSize && self.iBorderWidth == other.iBorderWidth && self.iScrollWidth == other.iScrollWidth && self.iScrollHeight == other.iScrollHeight && self.iCaptionWidth == other.iCaptionWidth && self.iCaptionHeight == other.iCaptionHeight && self.lfCaptionFont == other.lfCaptionFont && self.iSmCaptionWidth == other.iSmCaptionWidth && self.iSmCaptionHeight == other.iSmCaptionHeight && self.lfSmCaptionFont == other.lfSmCaptionFont && self.iMenuWidth == other.iMenuWidth && self.iMenuHeight == other.iMenuHeight && self.lfMenuFont == other.lfMenuFont && self.lfStatusFont == other.lfStatusFont && self.lfMessageFont == other.lfMessageFont && self.iPaddedBorderWidth == other.iPaddedBorderWidth
     }
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -13273,7 +13245,7 @@ unsafe impl ::windows::core::Abi for SCROLLBARINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SCROLLBARINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCROLLBARINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcScrollBar == other.rcScrollBar && self.dxyLineButton == other.dxyLineButton && self.xyThumbTop == other.xyThumbTop && self.xyThumbBottom == other.xyThumbBottom && self.reserved == other.reserved && self.rgstate == other.rgstate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13311,7 +13283,7 @@ unsafe impl ::windows::core::Abi for SCROLLINFO {
 }
 impl ::core::cmp::PartialEq for SCROLLINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SCROLLINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.fMask == other.fMask && self.nMin == other.nMin && self.nMax == other.nMax && self.nPage == other.nPage && self.nPos == other.nPos && self.nTrackPos == other.nTrackPos
     }
 }
 impl ::core::cmp::Eq for SCROLLINFO {}
@@ -13348,7 +13320,7 @@ unsafe impl ::windows::core::Abi for SHELLHOOKINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for SHELLHOOKINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<SHELLHOOKINFO>()) == 0 }
+        self.hwnd == other.hwnd && self.rc == other.rc
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13381,7 +13353,7 @@ unsafe impl ::windows::core::Abi for STYLESTRUCT {
 }
 impl ::core::cmp::PartialEq for STYLESTRUCT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<STYLESTRUCT>()) == 0 }
+        self.styleOld == other.styleOld && self.styleNew == other.styleNew
     }
 }
 impl ::core::cmp::Eq for STYLESTRUCT {}
@@ -13419,7 +13391,7 @@ unsafe impl ::windows::core::Abi for TITLEBARINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TITLEBARINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TITLEBARINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcTitleBar == other.rcTitleBar && self.rgstate == other.rgstate
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13460,7 +13432,7 @@ unsafe impl ::windows::core::Abi for TITLEBARINFOEX {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TITLEBARINFOEX {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TITLEBARINFOEX>()) == 0 }
+        self.cbSize == other.cbSize && self.rcTitleBar == other.rcTitleBar && self.rgstate == other.rgstate && self.rgrect == other.rgrect
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13495,7 +13467,7 @@ unsafe impl ::windows::core::Abi for TOUCHPREDICTIONPARAMETERS {
 }
 impl ::core::cmp::PartialEq for TOUCHPREDICTIONPARAMETERS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TOUCHPREDICTIONPARAMETERS>()) == 0 }
+        self.cbSize == other.cbSize && self.dwLatency == other.dwLatency && self.dwSampleTime == other.dwSampleTime && self.bUseHWTimeStamp == other.bUseHWTimeStamp
     }
 }
 impl ::core::cmp::Eq for TOUCHPREDICTIONPARAMETERS {}
@@ -13532,7 +13504,7 @@ unsafe impl ::windows::core::Abi for TPMPARAMS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for TPMPARAMS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<TPMPARAMS>()) == 0 }
+        self.cbSize == other.cbSize && self.rcExclude == other.rcExclude
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13579,7 +13551,7 @@ unsafe impl ::windows::core::Abi for UPDATELAYEREDWINDOWINFO {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::cmp::PartialEq for UPDATELAYEREDWINDOWINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<UPDATELAYEREDWINDOWINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.hdcDst == other.hdcDst && self.pptDst == other.pptDst && self.psize == other.psize && self.hdcSrc == other.hdcSrc && self.pptSrc == other.pptSrc && self.crKey == other.crKey && self.pblend == other.pblend && self.dwFlags == other.dwFlags && self.prcDirty == other.prcDirty
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13626,7 +13598,7 @@ unsafe impl ::windows::core::Abi for WINDOWINFO {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWINFO {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWINFO>()) == 0 }
+        self.cbSize == other.cbSize && self.rcWindow == other.rcWindow && self.rcClient == other.rcClient && self.dwStyle == other.dwStyle && self.dwExStyle == other.dwExStyle && self.dwWindowStatus == other.dwWindowStatus && self.cxWindowBorders == other.cxWindowBorders && self.cyWindowBorders == other.cyWindowBorders && self.atomWindowType == other.atomWindowType && self.wCreatorVersion == other.wCreatorVersion
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13669,7 +13641,7 @@ unsafe impl ::windows::core::Abi for WINDOWPLACEMENT {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWPLACEMENT {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWPLACEMENT>()) == 0 }
+        self.length == other.length && self.flags == other.flags && self.showCmd == other.showCmd && self.ptMinPosition == other.ptMinPosition && self.ptMaxPosition == other.ptMaxPosition && self.rcNormalPosition == other.rcNormalPosition
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13713,7 +13685,7 @@ unsafe impl ::windows::core::Abi for WINDOWPOS {
 #[cfg(feature = "Win32_Foundation")]
 impl ::core::cmp::PartialEq for WINDOWPOS {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WINDOWPOS>()) == 0 }
+        self.hwnd == other.hwnd && self.hwndInsertAfter == other.hwndInsertAfter && self.x == other.x && self.y == other.y && self.cx == other.cx && self.cy == other.cy && self.flags == other.flags
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -13750,21 +13722,13 @@ impl ::core::clone::Clone for WNDCLASSA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for WNDCLASSA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WNDCLASSA").field("style", &self.style).field("lpfnWndProc", &self.lpfnWndProc.map(|f| f as usize)).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).finish()
+        f.debug_struct("WNDCLASSA").field("style", &self.style).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for WNDCLASSA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for WNDCLASSA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNDCLASSA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for WNDCLASSA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for WNDCLASSA {
     fn default() -> Self {
@@ -13799,34 +13763,13 @@ impl ::core::clone::Clone for WNDCLASSEXA {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for WNDCLASSEXA {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WNDCLASSEXA")
-            .field("cbSize", &self.cbSize)
-            .field("style", &self.style)
-            .field("lpfnWndProc", &self.lpfnWndProc.map(|f| f as usize))
-            .field("cbClsExtra", &self.cbClsExtra)
-            .field("cbWndExtra", &self.cbWndExtra)
-            .field("hInstance", &self.hInstance)
-            .field("hIcon", &self.hIcon)
-            .field("hCursor", &self.hCursor)
-            .field("hbrBackground", &self.hbrBackground)
-            .field("lpszMenuName", &self.lpszMenuName)
-            .field("lpszClassName", &self.lpszClassName)
-            .field("hIconSm", &self.hIconSm)
-            .finish()
+        f.debug_struct("WNDCLASSEXA").field("cbSize", &self.cbSize).field("style", &self.style).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).field("hIconSm", &self.hIconSm).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for WNDCLASSEXA {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for WNDCLASSEXA {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNDCLASSEXA>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for WNDCLASSEXA {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for WNDCLASSEXA {
     fn default() -> Self {
@@ -13861,34 +13804,13 @@ impl ::core::clone::Clone for WNDCLASSEXW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for WNDCLASSEXW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WNDCLASSEXW")
-            .field("cbSize", &self.cbSize)
-            .field("style", &self.style)
-            .field("lpfnWndProc", &self.lpfnWndProc.map(|f| f as usize))
-            .field("cbClsExtra", &self.cbClsExtra)
-            .field("cbWndExtra", &self.cbWndExtra)
-            .field("hInstance", &self.hInstance)
-            .field("hIcon", &self.hIcon)
-            .field("hCursor", &self.hCursor)
-            .field("hbrBackground", &self.hbrBackground)
-            .field("lpszMenuName", &self.lpszMenuName)
-            .field("lpszClassName", &self.lpszClassName)
-            .field("hIconSm", &self.hIconSm)
-            .finish()
+        f.debug_struct("WNDCLASSEXW").field("cbSize", &self.cbSize).field("style", &self.style).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).field("hIconSm", &self.hIconSm).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for WNDCLASSEXW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for WNDCLASSEXW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNDCLASSEXW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for WNDCLASSEXW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for WNDCLASSEXW {
     fn default() -> Self {
@@ -13921,21 +13843,13 @@ impl ::core::clone::Clone for WNDCLASSW {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::fmt::Debug for WNDCLASSW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("WNDCLASSW").field("style", &self.style).field("lpfnWndProc", &self.lpfnWndProc.map(|f| f as usize)).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).finish()
+        f.debug_struct("WNDCLASSW").field("style", &self.style).field("cbClsExtra", &self.cbClsExtra).field("cbWndExtra", &self.cbWndExtra).field("hInstance", &self.hInstance).field("hIcon", &self.hIcon).field("hCursor", &self.hCursor).field("hbrBackground", &self.hbrBackground).field("lpszMenuName", &self.lpszMenuName).field("lpszClassName", &self.lpszClassName).finish()
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 unsafe impl ::windows::core::Abi for WNDCLASSW {
     type Abi = Self;
 }
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::PartialEq for WNDCLASSW {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<WNDCLASSW>()) == 0 }
-    }
-}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
-impl ::core::cmp::Eq for WNDCLASSW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ::core::default::Default for WNDCLASSW {
     fn default() -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -1209,7 +1209,7 @@ unsafe impl ::windows::core::Abi for MILMatrixF {
 }
 impl ::core::cmp::PartialEq for MILMatrixF {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MILMatrixF>()) == 0 }
+        self._11 == other._11 && self._12 == other._12 && self._13 == other._13 && self._14 == other._14 && self._21 == other._21 && self._22 == other._22 && self._23 == other._23 && self._24 == other._24 && self._31 == other._31 && self._32 == other._32 && self._33 == other._33 && self._34 == other._34 && self._41 == other._41 && self._42 == other._42 && self._43 == other._43 && self._44 == other._44
     }
 }
 impl ::core::cmp::Eq for MILMatrixF {}
@@ -1240,7 +1240,7 @@ unsafe impl ::windows::core::Abi for MilPoint2D {
 }
 impl ::core::cmp::PartialEq for MilPoint2D {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MilPoint2D>()) == 0 }
+        self.X == other.X && self.Y == other.Y
     }
 }
 impl ::core::cmp::Eq for MilPoint2D {}
@@ -1273,7 +1273,7 @@ unsafe impl ::windows::core::Abi for MilRectD {
 }
 impl ::core::cmp::PartialEq for MilRectD {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<MilRectD>()) == 0 }
+        self.left == other.left && self.top == other.top && self.right == other.right && self.bottom == other.bottom
     }
 }
 impl ::core::cmp::Eq for MilRectD {}

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
@@ -810,7 +810,7 @@ unsafe impl ::windows::core::Abi for BitmapDescription {
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ::core::cmp::PartialEq for BitmapDescription {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<BitmapDescription>()) == 0 }
+        self.Width == other.Width && self.Height == other.Height && self.Format == other.Format && self.AlphaMode == other.AlphaMode
     }
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -914,7 +914,7 @@ unsafe impl ::windows::core::Abi for ParentChildRelation {
 }
 impl ::core::cmp::PartialEq for ParentChildRelation {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { ::windows::core::memcmp(self as *const _ as _, other as *const _ as _, core::mem::size_of::<ParentChildRelation>()) == 0 }
+        self.Parent == other.Parent && self.Child == other.Child && self.ChildIndex == other.ChildIndex
     }
 }
 impl ::core::cmp::Eq for ParentChildRelation {}

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -78,11 +78,6 @@ pub use windows_implement::implement;
 #[cfg(feature = "interface")]
 pub use windows_interface::interface;
 
-extern "C" {
-    #[doc(hidden)]
-    pub fn memcmp(left: *const std::ffi::c_void, right: *const std::ffi::c_void, len: usize) -> i32;
-}
-
 #[doc(hidden)]
 pub extern crate alloc;
 


### PR DESCRIPTION
This update provides a more reliable implementation of `PartialEq` for structs that directly compares fields. Note that this requires eliminating `PartialEq` support for unions as well as structs with custom packing function pointer fields, as those are all unsupported or unsafe in Rust. 

Fixes: #2155
