### PR TITLE
Ensure bindings are warning-free

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -23,9 +23,9 @@ use tokens::*;
 pub fn namespace(gen: &Gen, tree: &Tree) -> String {
     let mut tokens = TokenStream::new();
 
-    if tree.namespace == "Windows" {
+    if tree.namespace == "Windows" || !tree.namespace.starts_with("Windows.") {
         tokens.combine(&quote! {
-            #![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
+            #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
         });
     }
 

--- a/crates/libs/sys/src/Windows/mod.rs
+++ b/crates/libs/sys/src/Windows/mod.rs
@@ -1,3 +1,3 @@
-#![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[cfg(feature = "Win32")]
 pub mod Win32;

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -4,7 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![no_std]
 #![doc(html_no_source)]
-#![allow(non_snake_case)]
+#![allow(non_snake_case, clashing_extern_declarations)]
 #![cfg_attr(windows_raw_dylib, feature(raw_dylib, native_link_modifiers_verbatim))]
 
 extern crate self as windows_sys;

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -4,7 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![no_std]
 #![doc(html_no_source)]
-#![allow(non_snake_case, clashing_extern_declarations)]
+#![allow(non_snake_case)]
 #![cfg_attr(windows_raw_dylib, feature(raw_dylib, native_link_modifiers_verbatim))]
 
 extern crate self as windows_sys;

--- a/crates/libs/windows/src/Windows/mod.rs
+++ b/crates/libs/windows/src/Windows/mod.rs
@@ -1,4 +1,4 @@
-#![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[cfg(feature = "AI")]
 pub mod AI;
 #[cfg(feature = "ApplicationModel")]

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[doc(hidden)]
 #[repr(transparent)]
 pub struct IClass(::windows::core::IUnknown);
@@ -5,7 +6,7 @@ unsafe impl ::windows::core::Vtable for IClass {
     type Vtable = IClass_Vtbl;
 }
 unsafe impl ::windows::core::Interface for IClass {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ce9054d_f33d_515f_b891_29e6cb101073);
+    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25aa41cb_1aae_5c2e_a14a_48b91fd98f1e);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -13,6 +14,7 @@ pub struct IClass_Vtbl {
     pub base__: ::windows::core::IInspectable_Vtbl,
     pub Property: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT,
+    pub Flags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut Flags) -> ::windows::core::HRESULT,
     pub Int32Array: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const i32, b_array_size: u32, b: *mut i32, c_array_size: *mut u32, c: *mut *mut i32, result_size__: *mut u32, result__: *mut *mut i32) -> ::windows::core::HRESULT,
     pub StringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const ::core::mem::ManuallyDrop<::windows::core::HSTRING>, b_array_size: u32, b: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, c_array_size: *mut u32, c: *mut *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, result_size__: *mut u32, result__: *mut *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT,
 }
@@ -36,6 +38,13 @@ impl Class {
     pub fn SetProperty(&self, value: i32) -> ::windows::core::Result<()> {
         let this = self;
         unsafe { (::windows::core::Vtable::vtable(this).SetProperty)(::windows::core::Vtable::as_raw(this), value).ok() }
+    }
+    pub fn Flags(&self) -> ::windows::core::Result<Flags> {
+        let this = self;
+        unsafe {
+            let mut result__ = ::core::mem::MaybeUninit::zeroed();
+            (::windows::core::Vtable::vtable(this).Flags)(::windows::core::Vtable::as_raw(this), result__.as_mut_ptr()).from_abi::<Flags>(result__)
+        }
     }
     pub fn Int32Array(&self, a: &[i32], b: &mut [i32], c: &mut ::windows::core::Array<i32>) -> ::windows::core::Result<::windows::core::Array<i32>> {
         let this = self;
@@ -69,7 +78,7 @@ impl ::core::fmt::Debug for Class {
     }
 }
 unsafe impl ::windows::core::RuntimeType for Class {
-    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{4ce9054d-f33d-515f-b891-29e6cb101073})");
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{25aa41cb-1aae-5c2e-a14a-48b91fd98f1e})");
     type DefaultType = ::core::option::Option<Self>;
     fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
         from.as_ref().cloned().ok_or(::windows::core::Error::OK)
@@ -87,9 +96,70 @@ impl ::windows::core::RuntimeName for Class {
 ::windows::core::interface_hierarchy!(Class, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Class {}
 unsafe impl ::core::marker::Sync for Class {}
+#[repr(transparent)]
+#[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]
+pub struct Flags(pub u32);
+impl Flags {
+    pub const Ok: Self = Self(0u32);
+}
+impl ::core::marker::Copy for Flags {}
+impl ::core::clone::Clone for Flags {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::core::default::Default for Flags {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+unsafe impl ::windows::core::Abi for Flags {
+    type Abi = Self;
+}
+impl ::core::fmt::Debug for Flags {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_tuple("Flags").field(&self.0).finish()
+    }
+}
+impl ::core::ops::BitOr for Flags {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+impl ::core::ops::BitAnd for Flags {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+}
+impl ::core::ops::BitOrAssign for Flags {
+    fn bitor_assign(&mut self, other: Self) {
+        self.0.bitor_assign(other.0)
+    }
+}
+impl ::core::ops::BitAndAssign for Flags {
+    fn bitand_assign(&mut self, other: Self) {
+        self.0.bitand_assign(other.0)
+    }
+}
+impl ::core::ops::Not for Flags {
+    type Output = Self;
+    fn not(self) -> Self {
+        Self(self.0.not())
+    }
+}
+unsafe impl ::windows::core::RuntimeType for Flags {
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"enum(test_component.Flags;u4)");
+    type DefaultType = Self;
+    fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
+        Ok(*from)
+    }
+}
 pub trait IClass_Impl: Sized {
     fn Property(&self) -> ::windows::core::Result<i32>;
     fn SetProperty(&self, value: i32) -> ::windows::core::Result<()>;
+    fn Flags(&self) -> ::windows::core::Result<Flags>;
     fn Int32Array(&self, a: &[i32], b: &mut [i32], c: &mut ::windows::core::Array<i32>) -> ::windows::core::Result<::windows::core::Array<i32>>;
     fn StringArray(&self, a: &[::windows::core::HSTRING], b: &mut [::windows::core::HSTRING], c: &mut ::windows::core::Array<::windows::core::HSTRING>) -> ::windows::core::Result<::windows::core::Array<::windows::core::HSTRING>>;
 }
@@ -114,6 +184,18 @@ impl IClass_Vtbl {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             this.SetProperty(value).into()
+        }
+        unsafe extern "system" fn Flags<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut Flags) -> ::windows::core::HRESULT {
+            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
+            let this = (*this).get_impl();
+            match this.Flags() {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
+                    ::core::mem::forget(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Int32Array<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const i32, b_array_size: u32, b: *mut i32, c_array_size: *mut u32, c: *mut *mut i32, result_size__: *mut u32, result__: *mut *mut i32) -> ::windows::core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -145,6 +227,7 @@ impl IClass_Vtbl {
             base__: ::windows::core::IInspectable_Vtbl::new::<Identity, IClass, OFFSET>(),
             Property: Property::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
+            Flags: Flags::<Identity, Impl, OFFSET>,
             Int32Array: Int32Array::<Identity, Impl, OFFSET>,
             StringArray: StringArray::<Identity, Impl, OFFSET>,
         }

--- a/crates/tests/component/src/component.idl
+++ b/crates/tests/component/src/component.idl
@@ -4,7 +4,13 @@ namespace test_component
     {
         Class();
         Int32 Property;
+        Flags Flags { get; };
         Int32[] Int32Array(Int32[] a, ref Int32[] b, out Int32[] c);
         String[] StringArray(String[] a, ref String[] b, out String[] c);
     }
+
+    [flags] enum Flags
+    {
+        Ok = 0x00,
+    };
 }

--- a/crates/tests/component/src/lib.rs
+++ b/crates/tests/component/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code, clippy::all)]
-
 mod bindings;
 use std::mem::*;
 use std::sync::*;
@@ -17,6 +15,9 @@ impl bindings::IClass_Impl for Class {
         let mut writer = self.0.write().unwrap();
         *writer = value;
         Ok(())
+    }
+    fn Flags(&self) -> Result<bindings::Flags> {
+        Ok(bindings::Flags::Ok)
     }
     fn Int32Array(&self, a: &[i32], b: &mut [i32], c: &mut Array<i32>) -> Result<Array<i32>> {
         assert_eq!(a.len(), b.len());

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[doc(hidden)]
 #[repr(transparent)]
 pub struct IClass(::windows::core::IUnknown);
@@ -5,7 +6,7 @@ unsafe impl ::windows::core::Vtable for IClass {
     type Vtable = IClass_Vtbl;
 }
 unsafe impl ::windows::core::Interface for IClass {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ce9054d_f33d_515f_b891_29e6cb101073);
+    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25aa41cb_1aae_5c2e_a14a_48b91fd98f1e);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -13,6 +14,7 @@ pub struct IClass_Vtbl {
     pub base__: ::windows::core::IInspectable_Vtbl,
     pub Property: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT,
+    pub Flags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut Flags) -> ::windows::core::HRESULT,
     pub Int32Array: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const i32, b_array_size: u32, b: *mut i32, c_array_size: *mut u32, c: *mut *mut i32, result_size__: *mut u32, result__: *mut *mut i32) -> ::windows::core::HRESULT,
     pub StringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const ::core::mem::ManuallyDrop<::windows::core::HSTRING>, b_array_size: u32, b: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, c_array_size: *mut u32, c: *mut *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, result_size__: *mut u32, result__: *mut *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT,
 }
@@ -36,6 +38,13 @@ impl Class {
     pub fn SetProperty(&self, value: i32) -> ::windows::core::Result<()> {
         let this = self;
         unsafe { (::windows::core::Vtable::vtable(this).SetProperty)(::windows::core::Vtable::as_raw(this), value).ok() }
+    }
+    pub fn Flags(&self) -> ::windows::core::Result<Flags> {
+        let this = self;
+        unsafe {
+            let mut result__ = ::core::mem::MaybeUninit::zeroed();
+            (::windows::core::Vtable::vtable(this).Flags)(::windows::core::Vtable::as_raw(this), result__.as_mut_ptr()).from_abi::<Flags>(result__)
+        }
     }
     pub fn Int32Array(&self, a: &[i32], b: &mut [i32], c: &mut ::windows::core::Array<i32>) -> ::windows::core::Result<::windows::core::Array<i32>> {
         let this = self;
@@ -69,7 +78,7 @@ impl ::core::fmt::Debug for Class {
     }
 }
 unsafe impl ::windows::core::RuntimeType for Class {
-    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{4ce9054d-f33d-515f-b891-29e6cb101073})");
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{25aa41cb-1aae-5c2e-a14a-48b91fd98f1e})");
     type DefaultType = ::core::option::Option<Self>;
     fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
         from.as_ref().cloned().ok_or(::windows::core::Error::OK)
@@ -87,9 +96,70 @@ impl ::windows::core::RuntimeName for Class {
 ::windows::core::interface_hierarchy!(Class, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Class {}
 unsafe impl ::core::marker::Sync for Class {}
+#[repr(transparent)]
+#[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]
+pub struct Flags(pub u32);
+impl Flags {
+    pub const Ok: Self = Self(0u32);
+}
+impl ::core::marker::Copy for Flags {}
+impl ::core::clone::Clone for Flags {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::core::default::Default for Flags {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+unsafe impl ::windows::core::Abi for Flags {
+    type Abi = Self;
+}
+impl ::core::fmt::Debug for Flags {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_tuple("Flags").field(&self.0).finish()
+    }
+}
+impl ::core::ops::BitOr for Flags {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+impl ::core::ops::BitAnd for Flags {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+}
+impl ::core::ops::BitOrAssign for Flags {
+    fn bitor_assign(&mut self, other: Self) {
+        self.0.bitor_assign(other.0)
+    }
+}
+impl ::core::ops::BitAndAssign for Flags {
+    fn bitand_assign(&mut self, other: Self) {
+        self.0.bitand_assign(other.0)
+    }
+}
+impl ::core::ops::Not for Flags {
+    type Output = Self;
+    fn not(self) -> Self {
+        Self(self.0.not())
+    }
+}
+unsafe impl ::windows::core::RuntimeType for Flags {
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"enum(test_component.Flags;u4)");
+    type DefaultType = Self;
+    fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
+        Ok(*from)
+    }
+}
 pub trait IClass_Impl: Sized {
     fn Property(&self) -> ::windows::core::Result<i32>;
     fn SetProperty(&self, value: i32) -> ::windows::core::Result<()>;
+    fn Flags(&self) -> ::windows::core::Result<Flags>;
     fn Int32Array(&self, a: &[i32], b: &mut [i32], c: &mut ::windows::core::Array<i32>) -> ::windows::core::Result<::windows::core::Array<i32>>;
     fn StringArray(&self, a: &[::windows::core::HSTRING], b: &mut [::windows::core::HSTRING], c: &mut ::windows::core::Array<::windows::core::HSTRING>) -> ::windows::core::Result<::windows::core::Array<::windows::core::HSTRING>>;
 }
@@ -114,6 +184,18 @@ impl IClass_Vtbl {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             this.SetProperty(value).into()
+        }
+        unsafe extern "system" fn Flags<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut Flags) -> ::windows::core::HRESULT {
+            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
+            let this = (*this).get_impl();
+            match this.Flags() {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
+                    ::core::mem::forget(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Int32Array<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, a_array_size: u32, a: *const i32, b_array_size: u32, b: *mut i32, c_array_size: *mut u32, c: *mut *mut i32, result_size__: *mut u32, result__: *mut *mut i32) -> ::windows::core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -145,6 +227,7 @@ impl IClass_Vtbl {
             base__: ::windows::core::IInspectable_Vtbl::new::<Identity, IClass, OFFSET>(),
             Property: Property::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
+            Flags: Flags::<Identity, Impl, OFFSET>,
             Int32Array: Int32Array::<Identity, Impl, OFFSET>,
             StringArray: StringArray::<Identity, Impl, OFFSET>,
         }

--- a/crates/tests/component_client/src/lib.rs
+++ b/crates/tests/component_client/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code)]
 #![cfg(test)]
 
 mod bindings;
@@ -10,6 +9,7 @@ fn test() -> Result<()> {
     let class = Class::new()?;
     class.SetProperty(123)?;
     assert_eq!(class.Property()?, 123);
+    assert_eq!(class.Flags()?, Flags::Ok);
 
     // Blittable array parameter passing.
     let a = [1, 2, 3];


### PR DESCRIPTION
Previously, the bindings generated by the `windows-bindgen` crate expected the consumer to suppress any warnings that may result. This is now taken care of by the bindings themselves. 

Fixes: #2170