### PR TITLE
Downgrade target crates versions to 0.42.1

### DIFF
--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -16,7 +16,7 @@ targets = []
 all-features = true
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
-windows-targets = { path = "../targets",  version = "0.43.0" }
+windows-targets = { path = "../targets",  version = "0.42.1" }
 
 [features]
 default = []

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-targets"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,37 +10,37 @@ repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://microsoft.github.io/windows-docs-rs/"
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.43.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.42.1" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.43.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.42.1" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.43.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.42.1" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.43.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.42.1" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.43.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.42.1" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.43.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.42.1" }
 
 [target.aarch64-pc-windows-gnullvm.dependencies]
-windows_aarch64_gnullvm = { path = "../../targets/aarch64_gnullvm", version = "0.43.0" }
+windows_aarch64_gnullvm = { path = "../../targets/aarch64_gnullvm", version = "0.42.1" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.43.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.42.1" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.43.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.42.1" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.43.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.42.1" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.43.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.42.1" }
 
 [target.x86_64-pc-windows-gnullvm.dependencies]
-windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.43.0" }
+windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.42.1" }

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
-windows-targets = { path = "../targets",  version = "0.43.0" }
+windows-targets = { path = "../targets",  version = "0.42.1" }
 
 [dependencies]
 windows-implement = { path = "../implement",  version = "0.43.0", optional = true }

--- a/crates/targets/aarch64_gnullvm/Cargo.toml
+++ b/crates/targets/aarch64_gnullvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_gnullvm"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnullvm/Cargo.toml
+++ b/crates/targets/x86_64_gnullvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnullvm"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.43.0"
+version = "0.42.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -59,7 +59,7 @@ targets = []
 all-features = true
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
-windows-targets = { path = "../targets",  version = "0.43.0" }
+windows-targets = { path = "../targets",  version = "0.42.1" }
 
 [features]
 default = []

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -57,7 +57,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
-windows-targets = { path = "../targets",  version = "0.43.0" }
+windows-targets = { path = "../targets",  version = "0.42.1" }
 
 [dependencies]
 windows-implement = { path = "../implement",  version = "0.43.0", optional = true }


### PR DESCRIPTION
New imports were added, but that didn't necessitate the semver incompatible version bump. Fortunately, version 0.43.0 of those crates or crates that depend on them have never been published, so we can pretend the bump never happened.

What's this all about?

Fixes: #2384 ⬅️ Be sure to refer to an existing issue here!
