### PR TITLE
Direct3D12 sample - fix copy_nonoverlapping size

### DIFF
--- a/crates/samples/direct3d12/src/main.rs
+++ b/crates/samples/direct3d12/src/main.rs
@@ -741,11 +741,7 @@ mod d3d12_hello_triangle {
         unsafe {
             let mut data = std::ptr::null_mut();
             vertex_buffer.Map(0, None, Some(&mut data))?;
-            std::ptr::copy_nonoverlapping(
-                vertices.as_ptr(),
-                data as *mut Vertex,
-                std::mem::size_of_val(&vertices),
-            );
+            std::ptr::copy_nonoverlapping(vertices.as_ptr(), data as *mut Vertex, vertices.len());
             vertex_buffer.Unmap(0, None);
         }
 


### PR DESCRIPTION
copy_nonoverlapping expects size to be the number of elements in the array, but the previous code was providing the size in bytes.

Fixes: #2180.