### PR TITLE
`verbatim` modifier is now stable

### DIFF
--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -5,7 +5,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![no_std]
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations)]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib, native_link_modifiers_verbatim))]
+#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 extern crate self as windows_sys;
 mod Windows;

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -5,7 +5,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations)]
 #![cfg_attr(windows_debugger_visualizer, feature(debugger_visualizer), debugger_visualizer(natvis_file = "../windows.natvis"))]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib, native_link_modifiers_verbatim))]
+#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 extern crate self as windows;
 mod Windows;


### PR DESCRIPTION
This just updates `windows-rs` to avoid requesting this feature since it is now stable. 

https://github.com/rust-lang/rust/pull/104360