### PR TITLE
Restructure lib testing

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -21,8 +21,28 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat" x86
           cargo run -p tool_msvc
-      - name: Check
+      - name: Check baseline
         shell: bash
         run: |
           git add -N .
           git diff --exit-code crates/targets/baseline || (echo '::error::Generated target libs are out-of-date.'; exit 1)
+      - name: Check dumpbin
+        shell: pwsh
+        run: |
+          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
+          $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
+            Select -ExpandProperty Path -First 1
+          $Tests = @(
+            [Tuple]::Create("aarch64_msvc","AA64"),
+            [Tuple]::Create("x86_64_msvc","8664"),
+            [Tuple]::Create("i686_msvc","14C")
+          )
+          foreach($Test in $Tests) {
+            $Target = $Test.Item1
+            $Magic = $Test.Item2
+            $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
+            if($Output -match "Machine\s*: $Magic" -ne $True) {
+              Write-Error "Import lib check failed for $Target ($Magic)."
+              Exit 1
+            }
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,25 +180,3 @@ jobs:
           cargo test --target ${{ matrix.target }} -p windows_x86_64_gnu &&
           cargo test --target ${{ matrix.target }} -p windows_x86_64_gnullvm &&
           cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc
-
-      - name: Check import libs
-        shell: pwsh
-        run: |
-          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
-          $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
-            Select -ExpandProperty Path -First 1
-          $Tests = @(
-            [Tuple]::Create("aarch64_msvc","AA64"),
-            [Tuple]::Create("x86_64_msvc","8664"),
-            [Tuple]::Create("i686_msvc","14C")
-          )
-          foreach($Test in $Tests) {
-            $Target = $Test.Item1
-            $Magic = $Test.Item2
-            $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
-            if($Output -match "Machine\s*: $Magic" -ne $True) {
-              Write-Error "Import lib check failed for $Target ($Magic)."
-              Exit 1
-            }
-          }
-        if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -108,34 +108,6 @@ jobs:
     }
 
     yml.truncate(yml.len() - 3);
-
-    yml.push_str(
-        r#"
-
-      - name: Check import libs
-        shell: pwsh
-        run: |
-          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
-          $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
-            Select -ExpandProperty Path -First 1
-          $Tests = @(
-            [Tuple]::Create("aarch64_msvc","AA64"),
-            [Tuple]::Create("x86_64_msvc","8664"),
-            [Tuple]::Create("i686_msvc","14C")
-          )
-          foreach($Test in $Tests) {
-            $Target = $Test.Item1
-            $Magic = $Test.Item2
-            $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
-            if($Output -match "Machine\s*: $Magic" -ne $True) {
-              Write-Error "Import lib check failed for $Target ($Magic)."
-              Exit 1
-            }
-          }
-        if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'
-"#,
-    );
-
     std::fs::write(".github/workflows/test.yml", yml.as_bytes()).unwrap();
 }
 


### PR DESCRIPTION
The yml tool generates test yml scripts but also contained a single hand-written test for libs. This update just moves this to the dedicated `lib.yml` for sanity. 