### PR TITLE
Remove any `.dll` suffix from non-Windows link import file names

### DIFF
--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -64,6 +64,7 @@ fn gen_win_function(gen: &Gen, def: MethodDef) -> TokenStream {
                 ::windows::core::link!(#link #extern_abi fn #name(#(#abi_params),*) #abi_return_type);
             }
         } else {
+            let link = link.trim_end_matches(".dll");
             quote! {
                 #[link(name = #link)]
                 extern #extern_abi {


### PR DESCRIPTION
This allows non-Windows imports to fallback to using the traditional Rust link attribute that expects a lib rather than a dll. 

Unfortunately, I don't have an easy way to test this. 