### PR TITLE
Introduce signature parameter kinds

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -848,6 +848,7 @@ impl<'a> Gen<'a> {
             quote! { -> () }
         }
     }
+    // TODO: consolidate both WinRT and Win32 generation once SignatureParamKind is rich enough
     pub fn win32_args(&self, params: &[SignatureParam], kind: SignatureKind) -> TokenStream {
         let mut tokens = quote! {};
 
@@ -867,9 +868,9 @@ impl<'a> Gen<'a> {
                 }
                 _ => {
                     let name = self.param_name(param.def);
-                    match param.array_info {
-                        ArrayInfo::Fixed(_) | ArrayInfo::RelativeLen(_) | ArrayInfo::RelativeByteLen(_) => {
-                            let flags = self.reader.param_flags(param.def);
+                    let flags = self.reader.param_flags(param.def);
+                    match param.kind {
+                        SignatureParamKind::ArrayFixed(_) | SignatureParamKind::ArrayRelativeLen(_) | SignatureParamKind::ArrayRelativeByteLen(_) => {
                             let map = if flags.optional() {
                                 quote! { #name.as_deref().map_or(::core::ptr::null(), |slice|slice.as_ptr()) }
                             } else {
@@ -877,7 +878,7 @@ impl<'a> Gen<'a> {
                             };
                             quote! { ::core::mem::transmute(#map), }
                         }
-                        ArrayInfo::RelativePtr(relative) => {
+                        SignatureParamKind::ArrayRelativePtr(relative) => {
                             let name = self.param_name(params[relative].def);
                             let flags = self.reader.param_flags(params[relative].def);
                             if flags.optional() {
@@ -886,21 +887,25 @@ impl<'a> Gen<'a> {
                                 quote! { #name.len() as _, }
                             }
                         }
-                        _ => {
-                            let flags = self.reader.param_flags(param.def);
-                            if self.reader.signature_param_is_convertible(param) {
-                                if self.reader.signature_param_is_borrowed(param) {
-                                    quote! { #name.into().abi(), }
-                                } else {
-                                    quote! { #name.into(), }
-                                }
-                            } else if param.ty.is_pointer() && (flags.optional() || self.reader.param_is_reserved(param.def)) {
-                                if flags.output() {
-                                    quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null_mut())), }
-                                } else {
-                                    quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null())), }
-                                }
-                            } else if self.reader.type_is_primitive(&param.ty) && !param.ty.is_pointer() {
+                        SignatureParamKind::TryInto => {
+                            quote! { #name.try_into().map_err(|e| e.into())?.abi(), }
+                        }
+                        SignatureParamKind::IntoParam => {
+                            quote! { #name.into().abi(), }
+                        }
+                        SignatureParamKind::Into => {
+                            quote! { #name.into(), }
+                        }
+                        SignatureParamKind::OptionalPointer => {
+                            if flags.output() {
+                                quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null_mut())), }
+                            } else {
+                                quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null())), }
+                            }
+                        }
+                        // TODO: remove catch all once all kinds are covered
+                        SignatureParamKind::Unknown => {
+                            if self.reader.type_is_primitive(&param.ty) && !param.ty.is_pointer() {
                                 quote! { #name, }
                             } else if self.reader.type_is_blittable(&param.ty) {
                                 quote! { ::core::mem::transmute(#name), }
@@ -935,72 +940,67 @@ impl<'a> Gen<'a> {
 
             let name = self.param_name(param.def);
 
-            if let ArrayInfo::Fixed(fixed) = param.array_info {
-                let ty = param.ty.deref();
-                let ty = self.type_default_name(&ty);
-                let len = Literal::u32_unsuffixed(fixed as _);
-                let ty = if self.reader.param_flags(param.def).output() {
-                    quote! { &mut [#ty; #len] }
-                } else {
-                    quote! { &[#ty; #len] }
-                };
-                if self.reader.param_flags(param.def).optional() {
-                    tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
-                } else {
-                    tokens.combine(&quote! { #name: #ty, });
+            match param.kind {
+                SignatureParamKind::ArrayFixed(fixed) => {
+                    let ty = param.ty.deref();
+                    let ty = self.type_default_name(&ty);
+                    let len = Literal::u32_unsuffixed(fixed as _);
+                    let ty = if self.reader.param_flags(param.def).output() {
+                        quote! { &mut [#ty; #len] }
+                    } else {
+                        quote! { &[#ty; #len] }
+                    };
+                    if self.reader.param_flags(param.def).optional() {
+                        tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
+                    } else {
+                        tokens.combine(&quote! { #name: #ty, });
+                    }
                 }
-                continue;
-            }
-
-            if let ArrayInfo::RelativeLen(_) = param.array_info {
-                let ty = param.ty.deref();
-                let ty = self.type_default_name(&ty);
-                let ty = if self.reader.param_flags(param.def).output() {
-                    quote! { &mut [#ty] }
-                } else {
-                    quote! { &[#ty] }
-                };
-                if self.reader.param_flags(param.def).optional() {
-                    tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
-                } else {
-                    tokens.combine(&quote! { #name: #ty, });
+                SignatureParamKind::ArrayRelativeLen(_) => {
+                    let ty = param.ty.deref();
+                    let ty = self.type_default_name(&ty);
+                    let ty = if self.reader.param_flags(param.def).output() {
+                        quote! { &mut [#ty] }
+                    } else {
+                        quote! { &[#ty] }
+                    };
+                    if self.reader.param_flags(param.def).optional() {
+                        tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
+                    } else {
+                        tokens.combine(&quote! { #name: #ty, });
+                    }
                 }
-                continue;
-            }
-
-            if let ArrayInfo::RelativeByteLen(_) = param.array_info {
-                let ty = if self.reader.param_flags(param.def).output() {
-                    quote! { &mut [u8] }
-                } else {
-                    quote! { &[u8] }
-                };
-                if self.reader.param_flags(param.def).optional() {
-                    tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
-                } else {
-                    tokens.combine(&quote! { #name: #ty, });
+                SignatureParamKind::ArrayRelativeByteLen(_) => {
+                    let ty = if self.reader.param_flags(param.def).output() {
+                        quote! { &mut [u8] }
+                    } else {
+                        quote! { &[u8] }
+                    };
+                    if self.reader.param_flags(param.def).optional() {
+                        tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
+                    } else {
+                        tokens.combine(&quote! { #name: #ty, });
+                    }
                 }
-                continue;
-            }
+                SignatureParamKind::ArrayRelativePtr(_) => {}
+                SignatureParamKind::TryInto | SignatureParamKind::IntoParam | SignatureParamKind::Into => {
+                    let (position, _) = generic_params.next().unwrap();
+                    let kind: TokenStream = format!("P{position}").into();
+                    tokens.combine(&quote! { #name: #kind, });
+                }
+                SignatureParamKind::OptionalPointer => {
+                    let kind = self.type_default_name(&param.ty);
+                    tokens.combine(&quote! { #name: ::core::option::Option<#kind>, });
+                }
+                SignatureParamKind::Unknown => {
+                    let kind = self.type_default_name(&param.ty);
 
-            if let ArrayInfo::RelativePtr(_) = param.array_info {
-                continue;
-            }
-
-            if self.reader.signature_param_is_convertible(param) {
-                let (position, _) = generic_params.next().unwrap();
-                let kind: TokenStream = format!("P{position}").into();
-                tokens.combine(&quote! { #name: #kind, });
-                continue;
-            }
-
-            let kind = self.type_default_name(&param.ty);
-
-            if param.ty.is_pointer() && (self.reader.param_flags(param.def).optional() || self.reader.param_is_reserved(param.def)) {
-                tokens.combine(&quote! { #name: ::core::option::Option<#kind>, });
-            } else if self.reader.type_is_blittable(&param.ty) {
-                tokens.combine(&quote! { #name: #kind, });
-            } else {
-                tokens.combine(&quote! { #name: &#kind, });
+                    if self.reader.type_is_blittable(&param.ty) {
+                        tokens.combine(&quote! { #name: #kind, });
+                    } else {
+                        tokens.combine(&quote! { #name: &#kind, });
+                    }
+                }
             }
         }
 

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -41,15 +41,6 @@ tables! {
     TypeSpec,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub enum ArrayInfo {
-    Fixed(usize),
-    RelativeLen(usize),
-    RelativeByteLen(usize),
-    RelativePtr(usize),
-    None,
-}
-
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Interface {
     pub ty: Type,
@@ -80,6 +71,25 @@ pub enum SignatureKind {
     ReturnStruct,
     ReturnVoid,
     PreserveSig,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum SignatureParamKind {
+    ArrayFixed(usize),
+    ArrayRelativeLen(usize),
+    ArrayRelativeByteLen(usize),
+    ArrayRelativePtr(usize),
+    TryInto,
+    IntoParam,
+    Into,
+    OptionalPointer,
+    Unknown,
+}
+
+impl SignatureParamKind {
+    fn is_array(&self) -> bool {
+        matches!(self, Self::ArrayFixed(_) | Self::ArrayRelativeLen(_) | Self::ArrayRelativeByteLen(_) | Self::ArrayRelativePtr(_))
+    }
 }
 
 #[derive(PartialEq, Eq)]
@@ -125,7 +135,7 @@ pub struct Signature {
 pub struct SignatureParam {
     pub def: Param,
     pub ty: Type,
-    pub array_info: ArrayInfo,
+    pub kind: SignatureParamKind,
 }
 
 #[derive(Default, Clone)]
@@ -549,26 +559,26 @@ impl<'a> Reader<'a> {
                 } else {
                     let ty = self.type_from_blob(&mut blob, None, generics).expect("Parameter type not found");
                     let ty = if !self.param_flags(param).output() { ty.to_const() } else { ty };
-                    let array_info = self.param_array_info(param);
-                    Some(SignatureParam { def: param, ty, array_info })
+                    let kind = self.param_kind(param);
+                    Some(SignatureParam { def: param, ty, kind })
                 }
             })
             .collect();
 
         for position in 0..params.len() {
             // Point len params back to the corresponding ptr params.
-            match params[position].array_info {
-                ArrayInfo::RelativeLen(relative) | ArrayInfo::RelativeByteLen(relative) => {
+            match params[position].kind {
+                SignatureParamKind::ArrayRelativeLen(relative) | SignatureParamKind::ArrayRelativeByteLen(relative) => {
                     // The len params must be input only.
                     if !self.param_flags(params[relative].def).output() && position != relative && !params[relative].ty.is_pointer() {
-                        params[relative].array_info = ArrayInfo::RelativePtr(position);
+                        params[relative].kind = SignatureParamKind::ArrayRelativePtr(position);
                     } else {
-                        params[position].array_info = ArrayInfo::None;
+                        params[position].kind = SignatureParamKind::Unknown;
                     }
                 }
-                ArrayInfo::Fixed(_) => {
+                SignatureParamKind::ArrayFixed(_) => {
                     if self.param_free_with(params[position].def).is_some() {
-                        params[position].array_info = ArrayInfo::None;
+                        params[position].kind = SignatureParamKind::Unknown;
                     }
                 }
                 _ => {}
@@ -579,8 +589,8 @@ impl<'a> Reader<'a> {
 
         // Finds sets of ptr params pointing at the same len param.
         for (position, param) in params.iter().enumerate() {
-            match param.array_info {
-                ArrayInfo::RelativeLen(relative) | ArrayInfo::RelativeByteLen(relative) => {
+            match param.kind {
+                SignatureParamKind::ArrayRelativeLen(relative) | SignatureParamKind::ArrayRelativeByteLen(relative) => {
                     sets.entry(relative).or_default().push(position);
                 }
                 _ => {}
@@ -590,19 +600,38 @@ impl<'a> Reader<'a> {
         // Remove all sets.
         for (len, ptrs) in sets {
             if ptrs.len() > 1 {
-                params[len].array_info = ArrayInfo::None;
+                params[len].kind = SignatureParamKind::Unknown;
                 for ptr in ptrs {
-                    params[ptr].array_info = ArrayInfo::None;
+                    params[ptr].kind = SignatureParamKind::Unknown;
                 }
             }
         }
 
         // Remove any byte arrays that aren't byte-sized types.
         for position in 0..params.len() {
-            if let ArrayInfo::RelativeByteLen(relative) = params[position].array_info {
+            if let SignatureParamKind::ArrayRelativeByteLen(relative) = params[position].kind {
                 if !params[position].ty.is_byte_size() {
-                    params[position].array_info = ArrayInfo::None;
-                    params[relative].array_info = ArrayInfo::None;
+                    params[position].kind = SignatureParamKind::Unknown;
+                    params[relative].kind = SignatureParamKind::Unknown;
+                }
+            }
+        }
+
+        for position in 0..params.len() {
+            if params[position].kind == SignatureParamKind::Unknown {
+                if self.signature_param_is_convertible(&params[position]) {
+                    if self.signature_param_is_failible_param(&params[position]) {
+                        params[position].kind = SignatureParamKind::TryInto;
+                    } else if self.signature_param_is_borrowed(&params[position]) {
+                        params[position].kind = SignatureParamKind::IntoParam;
+                    } else {
+                        params[position].kind = SignatureParamKind::Into;
+                    }
+                } else {
+                    let flags = self.param_flags(params[position].def);
+                    if params[position].ty.is_pointer() && (flags.optional() || self.param_is_reserved(params[position].def)) {
+                        params[position].kind = SignatureParamKind::OptionalPointer;
+                    }
                 }
             }
         }
@@ -702,14 +731,14 @@ impl<'a> Reader<'a> {
     pub fn param_is_com_out_ptr(&self, row: Param) -> bool {
         self.param_attributes(row).any(|attribute| self.attribute_name(attribute) == "ComOutPtrAttribute")
     }
-    pub fn param_array_info(&self, row: Param) -> ArrayInfo {
+    fn param_kind(&self, row: Param) -> SignatureParamKind {
         for attribute in self.param_attributes(row) {
             match self.attribute_name(attribute) {
                 "NativeArrayInfoAttribute" => {
                     for (_, value) in self.attribute_args(attribute) {
                         match value {
-                            Value::I16(value) => return ArrayInfo::RelativeLen(value as _),
-                            Value::I32(value) => return ArrayInfo::Fixed(value as _),
+                            Value::I16(value) => return SignatureParamKind::ArrayRelativeLen(value as _),
+                            Value::I32(value) => return SignatureParamKind::ArrayFixed(value as _),
                             _ => {}
                         }
                     }
@@ -717,14 +746,14 @@ impl<'a> Reader<'a> {
                 "MemorySizeAttribute" => {
                     for (_, value) in self.attribute_args(attribute) {
                         if let Value::I16(value) = value {
-                            return ArrayInfo::RelativeByteLen(value as _);
+                            return SignatureParamKind::ArrayRelativeByteLen(value as _);
                         }
                     }
                 }
                 _ => {}
             }
         }
-        ArrayInfo::None
+        SignatureParamKind::Unknown
     }
     pub fn param_is_retval(&self, row: Param) -> bool {
         self.param_attributes(row).any(|attribute| self.attribute_name(attribute) == "RetValAttribute")
@@ -1265,7 +1294,7 @@ impl<'a> Reader<'a> {
         self.type_is_trivially_convertible(&param.ty)
     }
     pub fn signature_param_is_convertible(&self, param: &SignatureParam) -> bool {
-        !self.param_flags(param.def).output() && !param.ty.is_winrt_array() && !param.ty.is_pointer() && param.array_info == ArrayInfo::None && (self.type_is_borrowed(&param.ty) || self.type_is_non_exclusive_winrt_interface(&param.ty) || self.type_is_trivially_convertible(&param.ty))
+        !self.param_flags(param.def).output() && !param.ty.is_winrt_array() && !param.ty.is_pointer() && !param.kind.is_array() && (self.type_is_borrowed(&param.ty) || self.type_is_non_exclusive_winrt_interface(&param.ty) || self.type_is_trivially_convertible(&param.ty))
     }
     pub fn signature_param_is_retval(&self, param: &SignatureParam) -> bool {
         // The Win32 metadata uses `RetValAttribute` to call out retval methods but it is employed
@@ -1280,10 +1309,10 @@ impl<'a> Reader<'a> {
             return false;
         }
         let flags = self.param_flags(param.def);
-        if flags.input() || !flags.output() || param.array_info != ArrayInfo::None {
+        if flags.input() || !flags.output() || param.kind.is_array() {
             return false;
         }
-        if self.param_array_info(param.def) != ArrayInfo::None {
+        if self.param_kind(param.def).is_array() {
             return false;
         }
         // TODO: find a way to treat this like COM interface result values.


### PR DESCRIPTION
Continuing from #2214 this more carefully categorizes parameters to make it easier to generate and adapt consistent layers of type transformations. I intentionally avoided changing code gen to ensure it faithfully captured the original semantics, but now I can more easily optimize the code generation based on these categories. 