### PR TITLE
Fix new `clippy` warning `uninlined_format_args`

### DIFF
--- a/crates/tools/gnu/src/main.rs
+++ b/crates/tools/gnu/src/main.rs
@@ -63,10 +63,9 @@ fn build_library(output: &std::path::Path, dlltool: &str, library: &str, functio
     def.write_all(
         format!(
             r#"
-LIBRARY {}
+LIBRARY {library}
 EXPORTS
-"#,
-            library
+"#
         )
         .as_bytes(),
     )

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -87,10 +87,9 @@ fn build_library(output: &std::path::Path, library: &str, functions: &BTreeMap<S
     def.write_all(
         format!(
             r#"
-LIBRARY {}
+LIBRARY {library}
 EXPORTS
-"#,
-            library
+"#
         )
         .as_bytes(),
     )


### PR DESCRIPTION
Fix new (?) `clippy` warning `uninlined_format_args`.

Probably related to https://github.com/rust-lang/rust-clippy/pull/9945