### PR TITLE
Propagate error information through `HRESULT`'s `ok` method

### DIFF
--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -33,11 +33,11 @@ impl HRESULT {
 
     /// Converts the [`HRESULT`] to [`Result<()>`][Result<_>].
     #[inline]
-    pub const fn ok(self) -> Result<()> {
+    pub fn ok(self) -> Result<()> {
         if self.is_ok() {
             Ok(())
         } else {
-            Err(Error { code: self, info: None })
+            Err(Error::from(self))
         }
     }
 

--- a/crates/tests/core/tests/hresult.rs
+++ b/crates/tests/core/tests/hresult.rs
@@ -1,0 +1,12 @@
+use windows::{core::*, Win32::Foundation::*};
+
+#[test]
+fn ok() {
+    let error = Error::new(E_FAIL, "test info".into());
+    let code: HRESULT = error.into(); // SetErrorInfo is called before dropping the Error object.
+    let result: Result<()> = code.ok(); // GetErrorInfo is called to retrieve the error info.
+
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), E_FAIL);
+    assert_eq!(error.message(), "test info");
+}


### PR DESCRIPTION
Fixes: #2221