### PR TITLE
Don't run `debugger_visualizer` test if option is not enabled

### DIFF
--- a/crates/tests/debugger_visualizer/tests/test.rs
+++ b/crates/tests/debugger_visualizer/tests/test.rs
@@ -1,3 +1,5 @@
+#![cfg(windows_debugger_visualizer)]
+
 use debugger_test::*;
 use windows::core::*;
 use windows::Win32::Foundation::*;


### PR DESCRIPTION
This just lets us run `cargo test --all` even when the `windows_debugger_visualizer` is not enabled. 